### PR TITLE
refactor: GithubProject / IssueTracker 추상화 분리

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -152,7 +152,7 @@ type EcosystemOptions = {
 
 export type EcosystemResult = {
   projectId: string;
-  projectTitle: string;
+  githubProjectTitle: string;
   runtime: string;
   skillsDir: string | null;
   contextYamlWritten: boolean;
@@ -215,7 +215,7 @@ export async function writeEcosystem(
     const result = await writeAllSkills(cwd, runtime, ALL_SKILL_TEMPLATES, {
       runtime,
       projectId: projectDetail.id,
-      projectTitle: projectDetail.title,
+      githubProjectTitle: projectDetail.title,
       repositories: projectDetail.linkedRepositories.map((r) => ({
         owner: r.owner,
         name: r.name,
@@ -235,7 +235,7 @@ export async function writeEcosystem(
 
   return {
     projectId: projectDetail.id,
-    projectTitle: projectDetail.title,
+    githubProjectTitle: projectDetail.title,
     runtime,
     skillsDir,
     contextYamlWritten,
@@ -256,7 +256,7 @@ function printEcosystemSummary(
   const relWorkflow = relative(cwd, workflowPath) || "WORKFLOW.md";
 
   const lines: string[] = [];
-  lines.push(`Project   ${result.projectTitle}  (${result.projectId})`);
+  lines.push(`GitHub Project   ${result.githubProjectTitle}  (${result.projectId})`);
   lines.push(`Runtime   ${result.runtime}`);
   lines.push("");
   lines.push("Generated files");
@@ -334,7 +334,7 @@ async function runNonInteractive(
 
   // Find project
   const projects = await listUserProjects(client);
-  let project: ProjectDetail | undefined;
+  let githubProject: ProjectDetail | undefined;
 
   if (flags.project) {
     const match = projects.find(
@@ -345,9 +345,9 @@ async function runNonInteractive(
       process.exitCode = 1;
       return;
     }
-    project = await getProjectDetail(client, match.id);
+    githubProject = await getProjectDetail(client, match.id);
   } else if (projects.length === 1) {
-    project = await getProjectDetail(client, projects[0]!.id);
+    githubProject = await getProjectDetail(client, projects[0]!.id);
   } else {
     process.stderr.write(
       "Error: --project is required when multiple projects exist.\n"
@@ -358,8 +358,8 @@ async function runNonInteractive(
 
   // Auto-map with smart defaults
   const statusField =
-    project.statusFields.find((f) => f.name.toLowerCase() === "status") ??
-    project.statusFields[0];
+    githubProject.statusFields.find((f) => f.name.toLowerCase() === "status") ??
+    githubProject.statusFields[0];
 
   if (!statusField) {
     process.stderr.write("Error: No status field found on the project.\n");
@@ -389,7 +389,7 @@ async function runNonInteractive(
   const outputPath = resolve(flags.output ?? "WORKFLOW.md");
 
   const workflowMd = generateWorkflowMarkdown({
-    projectId: project.id,
+    projectId: githubProject.id,
     stateFieldName: statusField.name,
     mappings,
     lifecycle: lifecycleConfig,
@@ -400,7 +400,7 @@ async function runNonInteractive(
 
   const ecosystemResult = await writeEcosystem({
     cwd: process.cwd(),
-    projectDetail: project,
+    projectDetail: githubProject,
     statusField,
     runtime: "codex",
     skipSkills: flags.skipSkills,
@@ -493,9 +493,9 @@ async function runInteractiveStandalone(
     return;
   }
 
-  const selectedProjectId = await abortIfCancelled(
+  const selectedGithubProjectId = await abortIfCancelled(
     p.select({
-      message: "Step 1/2 — Select a GitHub Project:",
+      message: "Step 1/2 — Select a GitHub Project board:",
       options: projects.map((proj) => ({
         value: proj.id,
         label: `${proj.owner.login}/${proj.title}`,
@@ -509,7 +509,7 @@ async function runInteractiveStandalone(
   s2d.start("Loading project details...");
   let projectDetail: ProjectDetail;
   try {
-    projectDetail = await getProjectDetail(client, selectedProjectId);
+    projectDetail = await getProjectDetail(client, selectedGithubProjectId);
     s2d.stop(`Loaded: ${projectDetail.title}`);
   } catch (error) {
     s2d.stop("Failed to load project details.");
@@ -653,10 +653,10 @@ export async function writeConfig(
 }
 
 export function generateProjectId(
-  projectTitle: string,
+  githubProjectTitle: string,
   uniqueKey: string
 ): string {
-  const slug = projectTitle
+  const slug = githubProjectTitle
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-|-$/g, "")

--- a/packages/cli/src/commands/project.ts
+++ b/packages/cli/src/commands/project.ts
@@ -257,7 +257,7 @@ async function projectAddInteractive(options: GlobalOptions): Promise<void> {
   }
 
   const s2 = p.spinner();
-  s2.start("Loading GitHub Projects...");
+  s2.start("Loading GitHub Project boards...");
   let projects: ProjectSummary[];
   try {
     projects = await listUserProjects(client);
@@ -285,7 +285,7 @@ async function projectAddInteractive(options: GlobalOptions): Promise<void> {
 
   const selectedProjectId = await abortIfCancelled(
     p.select({
-      message: "Step 1/4 - Select a GitHub Project:",
+      message: "Step 1/4 - Select a GitHub Project board:",
       options: projects.map((project) => ({
         value: project.id,
         label: `${project.owner.login}/${project.title}`,

--- a/packages/cli/src/skills/skill-writer.test.ts
+++ b/packages/cli/src/skills/skill-writer.test.ts
@@ -51,7 +51,7 @@ describe("skill-writer", () => {
       const context: SkillTemplateContext = {
         runtime: "claude-code",
         projectId: "proj-123",
-        projectTitle: "Test Project",
+        githubProjectTitle: "Test Project",
         repositories: [{ owner: "acme", name: "platform" }],
         statusColumns: [
           { id: "col-1", name: "Todo", role: "active" },
@@ -84,7 +84,7 @@ describe("skill-writer", () => {
       const context: SkillTemplateContext = {
         runtime: "claude-code",
         projectId: "proj-123",
-        projectTitle: "Test Project",
+        githubProjectTitle: "Test Project",
         repositories: [],
         statusColumns: [],
         statusFieldId: "field-123",
@@ -118,7 +118,7 @@ describe("skill-writer", () => {
       const context: SkillTemplateContext = {
         runtime: "claude-code",
         projectId: "proj-123",
-        projectTitle: "Test Project",
+        githubProjectTitle: "Test Project",
         repositories: [],
         statusColumns: [],
         statusFieldId: "field-123",
@@ -159,7 +159,7 @@ describe("skill-writer", () => {
       const context: SkillTemplateContext = {
         runtime: "claude-code",
         projectId: "proj-123",
-        projectTitle: "Test Project",
+        githubProjectTitle: "Test Project",
         repositories: [],
         statusColumns: [],
         statusFieldId: "field-123",
@@ -194,7 +194,7 @@ describe("skill-writer", () => {
       const context: SkillTemplateContext = {
         runtime: "codex",
         projectId: "proj-123",
-        projectTitle: "Test Project",
+        githubProjectTitle: "Test Project",
         repositories: [],
         statusColumns: [],
         statusFieldId: "field-123",
@@ -222,7 +222,7 @@ describe("skill-writer", () => {
       const context: SkillTemplateContext = {
         runtime: "unknown",
         projectId: "proj-123",
-        projectTitle: "Test Project",
+        githubProjectTitle: "Test Project",
         repositories: [],
         statusColumns: [],
         statusFieldId: "field-123",
@@ -260,7 +260,7 @@ describe("skill-writer", () => {
       const context: SkillTemplateContext = {
         runtime: "claude-code",
         projectId: "proj-123",
-        projectTitle: "Test Project",
+        githubProjectTitle: "Test Project",
         repositories: [],
         statusColumns: [],
         statusFieldId: "field-123",

--- a/packages/cli/src/skills/templates/commit.test.ts
+++ b/packages/cli/src/skills/templates/commit.test.ts
@@ -5,7 +5,7 @@ import type { SkillTemplateContext } from "../types.js";
 const mockCtx: SkillTemplateContext = {
   runtime: "claude-code",
   projectId: "PVT_test",
-  projectTitle: "Test",
+  githubProjectTitle: "Test",
   repositories: [{ owner: "acme", name: "platform" }],
   statusColumns: [{ id: "opt_todo", name: "Todo", role: "active" }],
   statusFieldId: "PVTF_field",

--- a/packages/cli/src/skills/templates/gh-project.test.ts
+++ b/packages/cli/src/skills/templates/gh-project.test.ts
@@ -5,7 +5,7 @@ import type { SkillTemplateContext } from "../types.js";
 const mockCtx: SkillTemplateContext = {
   runtime: "claude-code",
   projectId: "PVT_test123",
-  projectTitle: "Test Project",
+  githubProjectTitle: "Test Project",
   repositories: [{ owner: "acme", name: "platform" }],
   statusColumns: [
     { id: "opt_todo", name: "Todo", role: "active" },

--- a/packages/cli/src/skills/templates/gh-symphony.test.ts
+++ b/packages/cli/src/skills/templates/gh-symphony.test.ts
@@ -5,7 +5,7 @@ import type { SkillTemplateContext } from "../types.js";
 const mockCtx: SkillTemplateContext = {
   runtime: "claude-code",
   projectId: "PVT_test123",
-  projectTitle: "Test Project",
+  githubProjectTitle: "Test Project",
   repositories: [{ owner: "acme", name: "platform" }],
   statusColumns: [
     { id: "opt_todo", name: "Todo", role: "active" },

--- a/packages/cli/src/skills/templates/land.test.ts
+++ b/packages/cli/src/skills/templates/land.test.ts
@@ -5,7 +5,7 @@ import type { SkillTemplateContext } from "../types.js";
 const mockCtx: SkillTemplateContext = {
   runtime: "claude-code",
   projectId: "PVT_test",
-  projectTitle: "Test",
+  githubProjectTitle: "Test",
   repositories: [{ owner: "acme", name: "platform" }],
   statusColumns: [{ id: "opt_todo", name: "Todo", role: "active" }],
   statusFieldId: "PVTF_field",

--- a/packages/cli/src/skills/templates/pull.test.ts
+++ b/packages/cli/src/skills/templates/pull.test.ts
@@ -5,7 +5,7 @@ import type { SkillTemplateContext } from "../types.js";
 const mockCtx: SkillTemplateContext = {
   runtime: "claude-code",
   projectId: "PVT_test",
-  projectTitle: "Test",
+  githubProjectTitle: "Test",
   repositories: [{ owner: "acme", name: "platform" }],
   statusColumns: [{ id: "opt_todo", name: "Todo", role: "active" }],
   statusFieldId: "PVTF_field",

--- a/packages/cli/src/skills/templates/push.test.ts
+++ b/packages/cli/src/skills/templates/push.test.ts
@@ -5,7 +5,7 @@ import type { SkillTemplateContext } from "../types.js";
 const mockCtx: SkillTemplateContext = {
   runtime: "claude-code",
   projectId: "PVT_test",
-  projectTitle: "Test",
+  githubProjectTitle: "Test",
   repositories: [{ owner: "acme", name: "platform" }],
   statusColumns: [{ id: "opt_todo", name: "Todo", role: "active" }],
   statusFieldId: "PVTF_field",

--- a/packages/cli/src/skills/types.ts
+++ b/packages/cli/src/skills/types.ts
@@ -3,7 +3,7 @@ export type SkillRuntime = "claude-code" | "codex";
 export type SkillTemplateContext = {
   runtime: SkillRuntime | string; // string for custom
   projectId: string;
-  projectTitle: string;
+  githubProjectTitle: string;
   repositories: Array<{ owner: string; name: string }>;
   statusColumns: Array<{
     id: string; // option ID (needed for GitHub Project mutations)

--- a/packages/tracker-github/src/adapter.ts
+++ b/packages/tracker-github/src/adapter.ts
@@ -111,19 +111,22 @@ export class GitHubTrackerHttpError extends GitHubTrackerError {
 
 export class GitHubTrackerQueryError extends GitHubTrackerError {}
 
-export function normalizeProjectItem(
-  projectId: string,
-  item: GraphQLProjectItem,
+export function normalizeGithubProjectItem(
+  githubProjectId: string,
+  githubProjectItem: GraphQLProjectItem,
   lifecycle: WorkflowLifecycleConfig = DEFAULT_WORKFLOW_LIFECYCLE
 ): GitHubTrackedIssue | null {
-  if (item.content?.__typename !== "Issue") {
+  if (githubProjectItem.content?.__typename !== "Issue") {
     return null;
   }
 
-  const fieldValues = extractFieldValues(item.fieldValues?.nodes ?? []);
+  const fieldValues = extractFieldValues(
+    githubProjectItem.fieldValues?.nodes ?? []
+  );
   const state = fieldValues[lifecycle.stateFieldName] ?? "Unknown";
-  const repository = item.content.repository;
-  const blockedBy = (item.content.blockedBy?.nodes ?? []).flatMap((node) =>
+  const repository = githubProjectItem.content.repository;
+  const blockedBy = (githubProjectItem.content.blockedBy?.nodes ?? []).flatMap(
+    (node) =>
     node
       ? [
           `${node.repository.owner.login}/${node.repository.name}#${node.number}`,
@@ -132,21 +135,21 @@ export function normalizeProjectItem(
   );
 
   return {
-    id: item.content.id,
-    identifier: `${repository.owner.login}/${repository.name}#${item.content.number}`,
-    number: item.content.number,
-    title: item.content.title,
-    description: item.content.body,
+    id: githubProjectItem.content.id,
+    identifier: `${repository.owner.login}/${repository.name}#${githubProjectItem.content.number}`,
+    number: githubProjectItem.content.number,
+    title: githubProjectItem.content.title,
+    description: githubProjectItem.content.body,
     priority: null,
     state,
     branchName: null,
-    url: item.content.url,
-    labels: (item.content.labels?.nodes ?? [])
+    url: githubProjectItem.content.url,
+    labels: (githubProjectItem.content.labels?.nodes ?? [])
       .flatMap((label) => (label?.name ? [label.name.toLowerCase()] : []))
       .sort(),
     blockedBy,
-    createdAt: item.content.createdAt,
-    updatedAt: item.content.updatedAt ?? item.updatedAt,
+    createdAt: githubProjectItem.content.createdAt,
+    updatedAt: githubProjectItem.content.updatedAt ?? githubProjectItem.updatedAt,
     repository: {
       owner: repository.owner.login,
       name: repository.name,
@@ -155,14 +158,14 @@ export function normalizeProjectItem(
     },
     tracker: {
       adapter: "github-project",
-      bindingId: projectId,
-      itemId: item.id,
+      bindingId: githubProjectId,
+      itemId: githubProjectItem.id,
     },
     metadata: fieldValues,
   };
 }
 
-export async function fetchProjectIssues(
+export async function fetchGithubProjectIssues(
   config: GitHubTrackerConfig,
   fetchImpl: FetchLike = fetch
 ): Promise<GitHubTrackedIssue[]> {
@@ -181,7 +184,7 @@ export async function fetchProjectIssues(
           return [];
         }
 
-        const normalized = normalizeProjectItem(
+        const normalized = normalizeGithubProjectItem(
           config.projectId,
           item,
           config.lifecycle
@@ -221,7 +224,7 @@ export async function fetchActionableIssues(
   config: GitHubTrackerConfig,
   fetchImpl: FetchLike = fetch
 ): Promise<GitHubTrackedIssue[]> {
-  const issues = await fetchProjectIssues(config, fetchImpl);
+  const issues = await fetchGithubProjectIssues(config, fetchImpl);
   const lifecycle = config.lifecycle ?? DEFAULT_WORKFLOW_LIFECYCLE;
   return issues.filter((issue) => {
     const normalized = issue.state.trim().toLowerCase();

--- a/packages/tracker-github/src/orchestrator-adapter.ts
+++ b/packages/tracker-github/src/orchestrator-adapter.ts
@@ -2,9 +2,9 @@ import type {
   OrchestratorTrackerAdapter,
   OrchestratorTrackerConfig,
 } from "@gh-symphony/core";
-import { fetchProjectIssues } from "./adapter.js";
+import { fetchGithubProjectIssues } from "./adapter.js";
 
-export const githubProjectAdapter: OrchestratorTrackerAdapter = {
+export const githubProjectTrackerAdapter: OrchestratorTrackerAdapter = {
   async listIssues(project, dependencies = {}) {
     const token = dependencies.token ?? process.env.GITHUB_GRAPHQL_TOKEN;
 
@@ -14,11 +14,11 @@ export const githubProjectAdapter: OrchestratorTrackerAdapter = {
       );
     }
 
-    const projectId = requireTrackerSetting(project.tracker, "projectId");
+    const githubProjectId = requireTrackerSetting(project.tracker, "projectId");
 
-    return fetchProjectIssues(
+    return fetchGithubProjectIssues(
       {
-        projectId,
+        projectId: githubProjectId,
         token,
         apiUrl: project.tracker.apiUrl,
         assignedOnly: readBooleanTrackerSetting(project.tracker, "assignedOnly"),
@@ -60,7 +60,7 @@ export const githubProjectAdapter: OrchestratorTrackerAdapter = {
 };
 
 const trackerAdapters: Record<string, OrchestratorTrackerAdapter> = {
-  "github-project": githubProjectAdapter,
+  "github-project": githubProjectTrackerAdapter,
 };
 
 export function resolveTrackerAdapter(

--- a/packages/worker/src/github-tracker.test.ts
+++ b/packages/worker/src/github-tracker.test.ts
@@ -5,7 +5,7 @@ import {
   GitHubTrackerQueryError,
   isActionableState,
   isTrackedIssueActionable,
-  normalizeProjectItem,
+  normalizeGithubProjectItem,
   normalizeStateName
 } from "./github-tracker.js";
 import { DEFAULT_WORKFLOW_LIFECYCLE } from "./workflow-lifecycle.js";
@@ -23,9 +23,9 @@ describe("isActionableState", () => {
   });
 });
 
-describe("normalizeProjectItem", () => {
+describe("normalizeGithubProjectItem", () => {
   it("maps a GitHub project issue into the worker issue model", () => {
-    const issue = normalizeProjectItem("project-123", {
+    const issue = normalizeGithubProjectItem("project-123", {
       id: "item-1",
       updatedAt: "2026-03-07T10:00:00.000Z",
       fieldValues: {

--- a/packages/worker/src/github-tracker.ts
+++ b/packages/worker/src/github-tracker.ts
@@ -3,8 +3,8 @@ export {
   GitHubTrackerHttpError,
   GitHubTrackerQueryError,
   fetchActionableIssues,
-  fetchProjectIssues,
-  normalizeProjectItem,
+  fetchGithubProjectIssues,
+  normalizeGithubProjectItem,
   type GitHubRepositoryRef,
   type GitHubTrackedIssue,
   type GitHubTrackerConfig


### PR DESCRIPTION
## Issues

- Fixes #14

## Summary

- GitHub Projects를 가리키는 tracker-github 공개 API와 adapter 명칭을 `GithubProject` 기준으로 정리했습니다.
- CLI와 worker에서 오케스트레이션 단위 `project`와 GitHub Projects 용어가 섞이지 않도록 관련 식별자와 안내 문구를 명확히 분리했습니다.

## Changes

- `fetchProjectIssues`/`normalizeProjectItem`/`githubProjectAdapter`를 `fetchGithubProjectIssues`/`normalizeGithubProjectItem`/`githubProjectTrackerAdapter`로 변경하고 호출부를 갱신했습니다.
- `packages/worker`의 재수출과 테스트를 새 tracker-github export 이름에 맞게 정리했습니다.
- CLI ecosystem/skill context의 `projectTitle`을 `githubProjectTitle`로 바꾸고, `init` 및 `project add` wizard 문구를 `GitHub Project board` 기준으로 수정했습니다.
- 루트 검증을 위해 `pnpm prisma generate`를 실행해 control-plane Prisma client를 재생성했습니다.

## Evidence

- `pnpm lint`
- `pnpm test`
- `pnpm typecheck`
- `pnpm build`
- `pnpm prisma generate`

## Human Validation

- [ ] Confirm the main user flow works as expected
- [ ] Confirm there is no obvious regression in adjacent behavior
- [ ] Confirm reviewer-visible behavior matches the issue requirements

## Risks

- core 계약의 `IssueTracker` 명칭 정리는 영향 범위를 넓힐 수 있어 이번 변경에서는 포함하지 않았습니다.
