### PR TITLE
fix(orchestrator): use fixed continuation retry delay

### DIFF
--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -498,6 +498,7 @@ describe("OrchestratorService", () => {
       }) as never,
       now: () => new Date("2026-03-08T00:00:00.000Z"),
     });
+    const loadRetryPolicySpy = vi.spyOn(service as never, "loadRetryPolicy");
 
     await service.runOnce();
     const updatedRun = await store.loadRun("run-1");
@@ -506,6 +507,7 @@ describe("OrchestratorService", () => {
     expect(updatedRun?.nextRetryAt).toBe("2026-03-08T00:00:01.000Z");
     expect(updatedRun?.retryKind).toBe("continuation");
     expect(updatedRun?.lastError).toBeNull();
+    expect(loadRetryPolicySpy).not.toHaveBeenCalled();
   });
 
   it("does not execute after_run while waiting for a retry schedule", async () => {

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -942,7 +942,6 @@ export class OrchestratorService {
 
     // Determine retry kind: continuation (issue still actionable) vs failure
     const retryKind = await this.classifyRetryKind(tenant, run);
-    const retryOptions = await this.loadRetryPolicy(tenant, run.repository);
 
     let nextRetryAt: string;
     if (retryKind === "continuation") {
@@ -950,6 +949,7 @@ export class OrchestratorService {
         now.getTime() + CONTINUATION_RETRY_DELAY_MS
       ).toISOString();
     } else {
+      const retryOptions = await this.loadRetryPolicy(tenant, run.repository);
       // Exponential backoff for failure retries
       const backoffMs =
         this.dependencies.retryBackoffMs ?? DEFAULT_RETRY_BACKOFF_MS;


### PR DESCRIPTION
## Issues

- Fixes #29

## Summary

- continuation retry가 spec 고정값 `1000ms`를 유지하면서 불필요한 workflow retry policy 재조회도 하지 않도록 정리했습니다.
- failure retry의 backoff 계산 경로는 그대로 유지했습니다.

## Changes

- `packages/orchestrator/src/service.ts`에서 `loadRetryPolicy()` 호출을 failure 분기 안으로 이동해 continuation retry 시 추가 workflow 조회를 제거했습니다.
- `packages/orchestrator/src/service.test.ts`에서 continuation retry가 `1000ms`를 사용하고 `loadRetryPolicy()`를 호출하지 않는지 검증하도록 회귀 테스트를 보강했습니다.

## Evidence

- `pnpm --filter @gh-symphony/orchestrator exec vitest run src/service.test.ts`

## Human Validation

- [x] 정상 종료 후 retry queued 상태의 다음 재시도 시각이 약 1초 후로 기록되는지 확인
- [x] worker failure 경로의 backoff 동작이 기존과 동일한지 확인
- [x] reviewer-visible 동작이 이슈 요구사항과 일치하는지 확인

## Risks

- continuation/failure 분기 기준은 그대로이므로, reviewer는 continuation 경로에서 workflow retry policy 조회가 제거된 점과 failure 경로 회귀 여부를 중심으로 보면 됩니다.
