### PR TITLE
feat(orchestrator): implement stall detection

### DIFF
--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -793,7 +793,114 @@ describe("OrchestratorService", () => {
     expect(killImpl).not.toHaveBeenCalled();
     expect(snapshot.activeRuns[0]?.status).toBe("running");
     expect(updatedRun?.status).toBe("running");
+    expect(updatedRun?.lastEventAt).toBe("2026-03-08T00:04:00.000Z");
     expect(updatedRun?.runtimeSession?.sessionId).toBe("thread-1-turn-xyz");
+  });
+
+  it("preserves the persisted lastEventAt when live worker state omits timestamps", async () => {
+    process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
+    const tempRoot = await mkdtemp(
+      join(tmpdir(), "orchestrator-stall-preserve-")
+    );
+    const repository = await createRepositoryFixture(
+      tempRoot,
+      "acme",
+      "platform",
+      {
+        stallTimeoutMs: 300000,
+      }
+    );
+    const store = new OrchestratorFsStore(tempRoot);
+    const projectConfig = createProjectConfig(tempRoot, repository);
+    await store.saveProjectConfig(projectConfig);
+    await store.saveProjectIssueOrchestrations("tenant-1", [
+      {
+        issueId: "issue-1",
+        identifier: "acme/platform#1",
+        workspaceKey: "acme_platform_1",
+        state: "running",
+        currentRunId: "run-1",
+        retryEntry: null,
+        updatedAt: "2026-03-08T00:00:00.000Z",
+      },
+    ]);
+    await store.saveRun({
+      runId: "run-1",
+      projectId: "tenant-1",
+      projectSlug: "tenant-1",
+      issueId: "issue-1",
+      issueSubjectId: "issue-1",
+      issueIdentifier: "acme/platform#1",
+      issueState: "Todo",
+      repository,
+      status: "running",
+      attempt: 1,
+      processId: 4109,
+      port: 4601,
+      workingDirectory: join(tempRoot, "active-run"),
+      issueWorkspaceKey: null,
+      workspaceRuntimeDir: join(tempRoot, "active-run", "workspace-runtime"),
+      workflowPath: null,
+      retryKind: null,
+      createdAt: "2026-03-08T00:00:00.000Z",
+      updatedAt: "2026-03-08T00:04:00.000Z",
+      startedAt: "2026-03-08T00:00:00.000Z",
+      completedAt: null,
+      lastError: null,
+      nextRetryAt: null,
+      lastEventAt: "2026-03-08T00:04:00.000Z",
+    });
+
+    const killImpl = vi.fn();
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/api/v1/state")) {
+        return {
+          ok: true,
+          json: async () => ({
+            status: "running",
+            executionPhase: "implementation",
+            tokenUsage: {
+              inputTokens: 10,
+              outputTokens: 4,
+              totalTokens: 14,
+            },
+            sessionInfo: {
+              threadId: "thread-1",
+              turnId: "turn-xyz",
+              turnCount: 2,
+              sessionId: "thread-1-turn-xyz",
+            },
+            run: {
+              lastError: null,
+            },
+          }),
+        } as Response;
+      }
+      return createTrackerResponseWithState(repository, "Todo");
+    });
+    let currentTime = new Date("2026-03-08T00:06:00.000Z");
+    const service = new OrchestratorService(store, projectConfig, {
+      fetchImpl: fetchImpl as typeof fetch,
+      spawnImpl: vi.fn().mockReturnValue({
+        pid: 4209,
+        unref: vi.fn(),
+      }) as never,
+      killImpl,
+      isProcessRunning: (pid) => pid === 4109,
+      now: () => currentTime,
+    });
+
+    await service.runOnce();
+
+    currentTime = new Date("2026-03-08T00:08:00.000Z");
+    await service.runOnce();
+
+    const updatedRun = await store.loadRun("run-1");
+
+    expect(killImpl).not.toHaveBeenCalled();
+    expect(updatedRun?.status).toBe("running");
+    expect(updatedRun?.lastEventAt).toBe("2026-03-08T00:04:00.000Z");
   });
 
   it("disables workflow stall detection when stall_timeout_ms <= 0 but keeps the 30 minute fallback", async () => {

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -952,7 +952,7 @@ export class OrchestratorService {
           turnCount: liveState.turnCount ?? undefined,
           tokenUsage: liveState.tokenUsage ?? run.tokenUsage,
           lastEvent: liveState.lastEvent ?? undefined,
-          lastEventAt: liveState.lastEventAt ?? undefined,
+          lastEventAt: liveState.lastEventAt ?? run.lastEventAt ?? undefined,
           executionPhase: liveState.executionPhase ?? run.executionPhase ?? null,
           runPhase: liveState.runPhase ?? run.runPhase ?? "streaming_turn",
         };


### PR DESCRIPTION
## Issues

- Fixes #37

## Summary

- orchestrator가 실행 중인 run의 `lastEventAt ?? startedAt` 기준으로 stall 여부를 판정하도록 변경했습니다
- live state poll이 timestamp를 주지 않아도 저장된 `lastEventAt`를 유지해 false stall을 막습니다
- repository workflow의 `codex.stall_timeout_ms`를 읽어 stall detection을 적용하고, `<= 0`이면 workflow stall detection을 비활성화합니다

## Changes

- `loadRetryPolicy()`가 retry backoff와 함께 `stallTimeoutMs`를 로드하도록 확장했습니다
- `reconcileRun()`에 workflow stall timeout 검사와 30분 stuck fallback 검사를 추가했습니다
- 실행 중 worker 상태 저장 시 live payload에 timestamp가 없으면 기존 `lastEventAt`를 보존하도록 수정했습니다
- orchestrator 테스트에 last activity 기준 판정, persisted `lastEventAt` 보존, `stall_timeout_ms <= 0` 비활성화, 30분 fallback 유지 케이스를 추가했습니다

## Evidence

- `npx vitest run packages/orchestrator/src/service.test.ts`
- `pnpm typecheck`

## Human Validation

- [ ] 실행 중 worker가 `lastEventAt` 기준으로 stall 처리되는지 확인
- [ ] live state poll 이후에도 최근 `lastEventAt`가 유지되는지 확인
- [ ] `codex.stall_timeout_ms <= 0` 설정 시 workflow stall detection이 비활성화되는지 확인
- [ ] 30분 fallback 동작이 기존과 동일하게 유지되는지 확인

## Risks

- worker state API가 event timestamp를 직접 노출하지 않는 동안에는 persisted `lastEventAt`의 갱신 시점이 orchestrator 저장 이벤트에 의존합니다
