### PR TITLE
fix(orchestrator): ignore before_remove cleanup failures

### DIFF
--- a/e2e/scenarios/05-before-remove-hook-failure.md
+++ b/e2e/scenarios/05-before-remove-hook-failure.md
@@ -1,0 +1,122 @@
+# TC-05: `before_remove` Hook Failure Does Not Block Cleanup
+
+## Setup
+
+```bash
+echo "[]" > e2e/fixtures/issues.json
+docker compose -f docker-compose.e2e.yml up -d --build
+curl --retry 10 --retry-delay 2 http://localhost:4680/healthz
+```
+
+## Steps
+
+1. Seed a failing `before_remove` hook into the E2E repository.
+   ```bash
+   docker exec symphony-e2e sh -lc '
+     cd /e2e/repos/test-owner/test-repo &&
+     mkdir -p hooks &&
+     cat > hooks/before_remove.sh <<'"'"'EOF'"'"'
+#!/usr/bin/env bash
+set -eu
+printf "cleanup hook failed" >&2
+exit 1
+EOF
+     chmod +x hooks/before_remove.sh &&
+     awk '
+       !inserted && /^polling:$/ {
+         print "hooks:"
+         print "  before_remove: hooks/before_remove.sh"
+         inserted = 1
+       }
+       { print }
+     ' WORKFLOW.md > WORKFLOW.md.tmp &&
+     mv WORKFLOW.md.tmp WORKFLOW.md &&
+     git add WORKFLOW.md hooks/before_remove.sh &&
+     git commit -m "Add failing before_remove hook for E2E"
+   '
+   ```
+
+2. Inject an active issue and trigger reconciliation.
+   ```bash
+   cp e2e/fixtures/happy-path.json e2e/fixtures/issues.json
+   curl -X POST http://localhost:4680/api/v1/refresh
+   ```
+
+3. Wait until the issue workspace is created.
+   ```bash
+   docker exec symphony-e2e sh -lc '
+      for i in $(seq 1 20); do
+        find /app/.runtime/projects -name workspace.json | grep -q . && exit 0
+       sleep 1
+     done
+     exit 1
+   '
+   ```
+
+4. Mark the same issue as terminal and trigger reconciliation again.
+   ```bash
+   cat > e2e/fixtures/issues.json <<'EOF'
+   [{
+     "id": "issue-happy-1",
+     "identifier": "test-owner/test-repo#1",
+     "number": 1,
+     "title": "Happy path test issue",
+     "description": "This issue should be dispatched and completed successfully.",
+     "priority": null,
+     "state": "Done",
+     "branchName": null,
+     "url": null,
+     "labels": [],
+     "blockedBy": [],
+     "createdAt": "2026-03-17T00:00:00Z",
+     "updatedAt": "2026-03-17T00:00:00Z",
+     "repository": {
+       "owner": "test-owner",
+       "name": "test-repo",
+       "cloneUrl": "/e2e/repos/test-owner/test-repo"
+     },
+     "tracker": {
+       "adapter": "file",
+       "bindingId": "e2e-test",
+       "itemId": "issue-happy-1"
+     },
+     "metadata": {}
+   }]
+   EOF
+   curl -X POST http://localhost:4680/api/v1/refresh
+   ```
+
+5. Poll until cleanup finishes, then inspect the workspace record and logs.
+   ```bash
+   docker exec symphony-e2e sh -lc '
+      for i in $(seq 1 20); do
+        record=$(find /app/.runtime/projects -name workspace.json | head -n 1)
+       [ -n "$record" ] || { sleep 1; continue; }
+       python3 - "$record" <<'"'"'PY'"'"'
+import json, sys
+with open(sys.argv[1]) as fh:
+    data = json.load(fh)
+print(data["status"])
+sys.exit(0 if data["status"] == "removed" else 1)
+PY
+       [ $? -eq 0 ] && exit 0
+       sleep 1
+     done
+     exit 1
+   '
+   docker logs symphony-e2e 2>&1 | grep 'before_remove hook failed'
+   ```
+
+## Expected
+
+- `before_remove` hook exits non-zero, but cleanup continues.
+- Workspace record transitions to `removed`.
+- No `cleanup_blocked` transition appears.
+- Orchestrator logs a warning containing `continuing cleanup`.
+
+## Cleanup
+
+```bash
+docker compose -f docker-compose.e2e.yml down
+echo "[]" > e2e/fixtures/issues.json
+```

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -117,11 +117,12 @@ describe("OrchestratorService", () => {
     const output = stderr.write.mock.calls
       .map((call) => String(call[0]))
       .join("");
-    const runId = (await store.loadAllRuns())[0]?.runId;
+    const run = (await store.loadAllRuns())[0];
+    const runId = run?.runId;
 
     expect(runId).toBeTruthy();
     expect(output).toContain(
-      `[dispatch] Issue acme/platform#1 → run ${runId} (port=4601)\n`
+      `[dispatch] Issue acme/platform#1 → run ${runId} (port=${run?.port})\n`
     );
     expect(output).toContain(`[worker-started] ${runId} (pid=4102)\n`);
     expect(output).toContain(
@@ -201,6 +202,123 @@ describe("OrchestratorService", () => {
     const workspaceRecord = await store.loadIssueWorkspace("tenant-1", workspaceKey);
     await expect(readFile(sentinelPath, "utf8")).rejects.toThrow();
     expect(workspaceRecord?.status).toBe("removed");
+  });
+
+  it("logs and ignores before_remove hook failures during startup cleanup", async () => {
+    process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
+    const tempRoot = await mkdtemp(
+      join(tmpdir(), "orchestrator-startup-before-remove-failure-")
+    );
+    const repository = await createRepositoryFixture(
+      tempRoot,
+      "acme",
+      "platform",
+      {
+        rawWorkflow: `---
+tracker:
+  kind: github-project
+  project_id: project-123
+  state_field: Status
+  active_states:
+    - Todo
+    - In Progress
+  terminal_states:
+    - Done
+  blocker_check_states:
+    - Todo
+hooks:
+  after_create: hooks/after_create.sh
+  before_remove: hooks/before_remove.sh
+polling:
+  interval_ms: 30000
+workspace:
+  root: .runtime/symphony-workspaces
+agent:
+  max_concurrent_agents: 10
+  max_retry_backoff_ms: 30000
+  retry_base_delay_ms: 1000
+codex:
+  command: codex app-server
+  read_timeout_ms: 5000
+  stall_timeout_ms: 300000
+  turn_timeout_ms: 3600000
+---
+Prefer focused changes.
+`,
+      }
+    );
+    const store = new OrchestratorFsStore(tempRoot);
+    const projectConfig = createProjectConfig(tempRoot, repository);
+    await store.saveProjectConfig(projectConfig);
+
+    const workspaceKey = deriveIssueWorkspaceKey({
+      projectId: "tenant-1",
+      adapter: "github-project",
+      issueSubjectId: "issue-1",
+    });
+    const workspacePath = resolveIssueWorkspaceDirectory(
+      store.projectDir(projectConfig.projectId),
+      workspaceKey
+    );
+    const repositoryPath = join(workspacePath, "repository");
+    const sentinelPath = join(workspacePath, "sentinel.txt");
+
+    await mkdir(repositoryPath, { recursive: true });
+    await mkdir(join(repositoryPath, "hooks"), { recursive: true });
+    await writeFile(
+      join(repositoryPath, "hooks", "before_remove.sh"),
+      "#!/usr/bin/env bash\nset -eu\nprintf 'cleanup hook failed' >&2\nexit 1\n",
+      "utf8"
+    );
+    await writeFile(sentinelPath, "cleanup me", "utf8");
+    await store.saveProjectIssueOrchestrations("tenant-1", [
+      {
+        issueId: "issue-1",
+        identifier: "acme/platform#1",
+        workspaceKey,
+        state: "released",
+        currentRunId: null,
+        retryEntry: null,
+        updatedAt: "2026-03-08T00:00:00.000Z",
+      },
+    ]);
+    await store.saveIssueWorkspace({
+      workspaceKey,
+      projectId: "tenant-1",
+      adapter: "github-project",
+      issueSubjectId: "issue-1",
+      issueIdentifier: "acme/platform#1",
+      workspacePath,
+      repositoryPath,
+      status: "active",
+      createdAt: "2026-03-08T00:00:00.000Z",
+      updatedAt: "2026-03-08T00:00:00.000Z",
+      lastError: null,
+    });
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const service = new OrchestratorService(store, projectConfig, {
+      fetchImpl: vi
+        .fn()
+        .mockResolvedValueOnce(createTrackerResponseWithState(repository, "Done"))
+        .mockResolvedValueOnce(createTrackerResponse(repository)) as never,
+      spawnImpl: vi.fn().mockReturnValue({
+        pid: 4103,
+        unref: vi.fn(),
+      }) as never,
+      now: () => new Date("2026-03-08T00:00:00.000Z"),
+    });
+
+    await service.run({ once: true });
+
+    const workspaceRecord = await store.loadIssueWorkspace("tenant-1", workspaceKey);
+    await expect(readFile(sentinelPath, "utf8")).rejects.toThrow();
+    expect(workspaceRecord?.status).toBe("removed");
+    expect(workspaceRecord?.lastError).toBeNull();
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[orchestrator] before_remove hook failed for acme/platform#1; continuing cleanup: cleanup hook failed"
+    );
+    warnSpy.mockRestore();
   });
 
   it("logs a warning and continues startup when terminal issue fetch fails", async () => {

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -1964,10 +1964,10 @@ export class OrchestratorService {
   /**
    * Clean up the issue workspace for a terminal issue.
    *
-   * Runs the `before_remove` hook if configured. If the hook fails,
-   * the workspace transitions to `cleanup_blocked` (fail-closed per design
-   * decision 12). If it succeeds, the workspace directory is removed and
-   * the record set to `removed`. Orchestration records (runs) are preserved.
+   * Runs the `before_remove` hook if configured. Hook failures are logged and
+   * ignored so workspace cleanup still proceeds per spec 9.4. The workspace
+   * directory is removed and the record set to `removed`. Orchestration
+   * records (runs) are preserved.
    */
   private async cleanupTerminalIssueWorkspace(
     tenant: OrchestratorProjectConfig,
@@ -2017,7 +2017,7 @@ export class OrchestratorService {
     };
     await this.store.saveIssueWorkspace(pendingRecord);
 
-    // Run before_remove hook (fail-closed)
+    // Run before_remove hook. Failures are logged but do not block cleanup.
     const hookResult = await this.runHook(
       "before_remove",
       tenant,
@@ -2039,16 +2039,11 @@ export class OrchestratorService {
       hookResult.outcome !== "success" &&
       hookResult.outcome !== "skipped"
     ) {
-      // Fail closed: block cleanup, require operator intervention
-      const blockedRecord: IssueWorkspaceRecord = {
-        ...workspaceRecord,
-        status: "cleanup_blocked",
-        updatedAt: now.toISOString(),
-        lastError:
-          hookResult.error ?? `before_remove hook ${hookResult.outcome}`,
-      };
-      await this.store.saveIssueWorkspace(blockedRecord);
-      return;
+      const errorMessage =
+        hookResult.error ?? `before_remove hook ${hookResult.outcome}`;
+      console.warn(
+        `[orchestrator] before_remove hook failed for ${issue.identifier}; continuing cleanup: ${errorMessage}`
+      );
     }
 
     // Hook succeeded or was skipped — remove workspace directory


### PR DESCRIPTION
## Issues

- Fixes #58

## Summary

- make `before_remove` hook failures non-blocking during terminal workspace cleanup
- keep cleanup progressing to workspace removal while emitting a warning log per spec 9.4

## Changes

- remove the `cleanup_blocked` transition from `cleanupTerminalIssueWorkspace` when `before_remove` fails or times out
- add a startup-cleanup regression test that asserts warning logging and `removed` workspace status after hook failure
- add Docker E2E TC documentation for validating the cleanup path with a failing `before_remove` hook

## Evidence

- `pnpm --filter @gh-symphony/orchestrator test`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- Manual check: ran Docker E2E flow from `e2e/scenarios/05-before-remove-hook-failure.md`, confirmed `workspace.json` reached `status: "removed"` and container logs contained `before_remove hook failed ... continuing cleanup`

## Human Validation

- [ ] Confirm terminal issue cleanup still removes the workspace when `before_remove` exits non-zero
- [ ] Confirm no `cleanup_blocked` transition is produced for `before_remove` failure/timeout cases
- [ ] Confirm warning logs remain actionable without masking actual cleanup failures

## Risks

- Existing workspaces already stuck in historical `cleanup_blocked` state are still skipped by startup cleanup; this change only affects future failures during the hook run
