### PR TITLE
fix(core): align workspace key sanitization with spec §4.2

### DIFF
--- a/packages/core/src/core-conformance.test.ts
+++ b/packages/core/src/core-conformance.test.ts
@@ -53,7 +53,7 @@ describe("deriveIssueWorkspaceKey", () => {
     expect(keyA).not.toBe(keyC);
   });
 
-  it("produces the same key when normalized identifiers collide (spec 4.2: pure substitution)", () => {
+  it("distinguishes hyphens from underscores under spec 4.2 substitution", () => {
     const keyA = deriveIssueWorkspaceKey(
       {
         projectId: "ws-1",
@@ -71,10 +71,9 @@ describe("deriveIssueWorkspaceKey", () => {
       "acme/foo_bar#1"
     );
 
-    // Per spec 4.2, workspace key is pure identifier substitution.
-    // Collisions are handled by the directory layout (projectId/issues/key).
     expect(keyA).toBe("acme_foo-bar_1");
     expect(keyB).toBe("acme_foo_bar_1");
+    expect(keyA).not.toBe(keyB);
   });
 
   it("preserves uppercase letters, dots, and hyphens allowed by spec 4.2", () => {
@@ -101,6 +100,18 @@ describe("deriveIssueWorkspaceKey", () => {
     );
 
     expect(key).toBe("issue");
+  });
+
+  it("falls back to 'issue' for dot-only sanitized keys", () => {
+    const identity = {
+      projectId: "ws-1",
+      adapter: "github-project",
+      issueSubjectId: "issue-1",
+    };
+
+    expect(deriveIssueWorkspaceKey(identity, ".")).toBe("issue");
+    expect(deriveIssueWorkspaceKey(identity, "..")).toBe("issue");
+    expect(deriveIssueWorkspaceKey(identity, "...")).toBe("issue");
   });
 });
 

--- a/packages/core/src/workspace/identity.ts
+++ b/packages/core/src/workspace/identity.ts
@@ -33,7 +33,11 @@ export function deriveIssueWorkspaceKeyFromIdentifier(
     .replace(/[^A-Za-z0-9._-]+/g, "_")
     .replace(/^_+|_+$/g, "");
 
-  return sanitized || "issue";
+  if (!sanitized || /^[.]+$/.test(sanitized)) {
+    return "issue";
+  }
+
+  return sanitized;
 }
 
 export function deriveLegacyIssueWorkspaceKey(


### PR DESCRIPTION
## Issues

- Fixes #78

## Summary

- Align workspace key sanitization with spec §4.2 for newly created issue workspaces
- Preserve uppercase letters, dots, and hyphens while rejecting dot-only reserved path segments

## Changes

- Removed `.toLowerCase()` from `deriveIssueWorkspaceKeyFromIdentifier()`
- Kept `[A-Za-z0-9._-]` and replaced other character sequences with `_`
- Added a guard so dot-only sanitized keys such as `.`, `..`, and `...` fall back to `issue`
- Updated core conformance tests to cover hyphen preservation, uppercase/dot/hyphen preservation, and dot-only fallback semantics
- Reworded the affected test to describe actual spec §4.2 behavior without implying collisions are automatically safe

## Evidence

- `pnpm --filter @gh-symphony/core test`
- `pnpm lint`
- `pnpm test`
- `pnpm typecheck`
- `pnpm build`
- Manual check: re-read issue #78 and confirmed the implementation still applies only to newly created workspaces with no migration added

## Human Validation

- [ ] Confirm the main user flow works as expected
- [ ] Confirm there is no obvious regression in adjacent behavior
- [ ] Confirm reviewer-visible behavior matches the issue requirements

## Risks

- Existing issue workspaces are intentionally left unchanged and may remain as orphaned directories until cleanup, per the issue requirements
