### PR TITLE
fix(tracker-github): IssueStatesByIds 쿼리 $issueIds 타입 nullable 불일치 수정

### DIFF
--- a/packages/tracker-github/src/adapter.ts
+++ b/packages/tracker-github/src/adapter.ts
@@ -996,7 +996,7 @@ const PROJECT_FIELDS_QUERY = `
 `;
 
 const ISSUE_STATES_BY_IDS_QUERY = `
-  query IssueStatesByIds($issueIds: [ID!]) {
+  query IssueStatesByIds($issueIds: [ID!]!) {
     nodes(ids: $issueIds) {
       __typename
       ... on Issue {

--- a/packages/tracker-github/src/tracker-github.test.ts
+++ b/packages/tracker-github/src/tracker-github.test.ts
@@ -1441,7 +1441,7 @@ describe("resolveTrackerAdapter", () => {
             variables: { issueIds: string[] };
           };
 
-          expect(body.query).toContain("query IssueStatesByIds($issueIds: [ID!])");
+          expect(body.query).toContain("query IssueStatesByIds($issueIds: [ID!]!)");
           expect(body.query).toContain("nodes(ids: $issueIds)");
           expect(body.query).toContain("projectItems(first: 100, includeArchived: false)");
           expect(body.query).not.toContain("blockedBy(");


### PR DESCRIPTION
## Issues

- Fixes #89

## Summary

- GitHub tracker의 `IssueStatesByIds` GraphQL 쿼리에서 `$issueIds` 변수를 `nodes(ids:)` 시그니처와 동일한 non-null 리스트로 정렬했습니다.
- 관련 테스트 assertion도 같은 시그니처를 기대하도록 갱신했습니다.

## Changes

- `packages/tracker-github/src/adapter.ts`에서 `ISSUE_STATES_BY_IDS_QUERY` 변수 타입을 `[ID!]!`로 수정했습니다.
- `packages/tracker-github/src/tracker-github.test.ts`에서 쿼리 문자열 검증을 `[ID!]!` 기준으로 갱신했습니다.

## Evidence

- `pnpm lint`
- `pnpm test`
- `pnpm typecheck`
- `pnpm build`
- `./e2e/run-e2e.sh happy 40`
- Manual check: `git diff -- packages/tracker-github/src/adapter.ts packages/tracker-github/src/tracker-github.test.ts`로 이슈 본문의 변경 범위와 구현이 정확히 일치함을 재확인
- Note: Docker E2E harness는 file tracker/stub worker 경로를 사용하므로 GitHub GraphQL nullability 수정은 `packages/tracker-github` 단위 테스트가 직접 검증합니다.

## Human Validation

- [ ] Orchestrator status에서 더 이상 `Nullability mismatch on variable $issueIds and argument ids ([ID!] / [ID!]!)` 에러가 발생하지 않는지 확인
- [ ] GitHub tracker 기반 active-run reconciliation이 기존처럼 issue state를 정상 조회하는지 확인
- [ ] 변경 범위가 tracker-github query declaration과 해당 테스트 assertion으로 제한되는지 확인

## Risks

- 런타임 경로를 직접 재현하는 Docker E2E harness가 GitHub tracker를 사용하지 않아, 실제 GitHub GraphQL API 상호작용은 단위 테스트와 코드 검토에 의존합니다.
