### PR TITLE
fix(worker): handle turn failed and cancelled events

### DIFF
--- a/e2e/scenarios/06-worker-failure-lifecycle-regression.md
+++ b/e2e/scenarios/06-worker-failure-lifecycle-regression.md
@@ -10,8 +10,23 @@
 
 1. `fail` 시나리오로 E2E 환경을 기동한다.
 2. `happy-path` fixture를 주입하고 reconciliation을 트리거한다.
+
+```bash
+# happy-path fixture 주입
+cp e2e/fixtures/happy-path.json e2e/fixtures/issues.json
+
+# orchestrator에 refresh 요청을 보내 reconciliation 트리거
+ORCH_URL="${ORCH_URL:-http://localhost:8080}"
+curl -X POST "${ORCH_URL}/api/v1/refresh"
+```
+
 3. worker가 `starting`에서 `running`으로 진입한 뒤 실패하는지 관찰한다.
 4. orchestrator가 retry를 스케줄링하고, issue 제거 후 `idle`로 복귀하는지 확인한다.
+
+```bash
+# worker / orchestrator 상태를 폴링하여 상태 전이를 관찰
+watch -n 2 curl -s "${ORCH_URL:-http://localhost:8080}/api/v1/status"
+```
 
 ## Expected
 

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -344,7 +344,11 @@ async function runCodexClientProtocol(
         typeof value === "object" &&
         typeof (value as Record<string, unknown>).message === "string"
       ) {
-        return `${event.replace("/", "_")}: ${String((value as Record<string, unknown>).message).trim()}`;
+        const nested = value as Record<string, unknown>;
+        const nestedMessage = String(nested.message).trim();
+        if (nestedMessage) {
+          return `${event.replace("/", "_")}: ${nestedMessage}`;
+        }
       }
     }
 

--- a/packages/worker/src/worker-protocol.test.ts
+++ b/packages/worker/src/worker-protocol.test.ts
@@ -424,7 +424,11 @@ function createProtocolContext(options: {
         typeof value === "object" &&
         typeof (value as Record<string, unknown>).message === "string"
       ) {
-        return `${event.replace("/", "_")}: ${String((value as Record<string, unknown>).message).trim()}`;
+        const nested = value as Record<string, unknown>;
+        const nestedMessage = String(nested.message).trim();
+        if (nestedMessage) {
+          return `${event.replace("/", "_")}: ${nestedMessage}`;
+        }
       }
     }
 
@@ -1394,6 +1398,28 @@ describe("turn timeout (3.6)", () => {
     expect(ctx.runtimeState.status).toBe("failed");
     expect(ctx.runtimeState.runPhase).toBe("canceled_by_reconciliation");
     expect(ctx.runtimeState.run.lastError).toBe("turn_cancelled: superseded");
+  });
+
+  it("falls back when nested turn failure message is whitespace only", async () => {
+    const ctx = createProtocolContext({ turnTimeoutMs: 5000 });
+
+    const promise = ctx.waitForTurnWithTimeout();
+
+    setTimeout(() => {
+      ctx.handleServerMessage({
+        method: "turn/failed",
+        params: { error: { message: "   " }, code: "E_BACKEND" },
+      });
+    }, 100);
+
+    await vi.advanceTimersByTimeAsync(100);
+    await promise;
+
+    expect(ctx.runtimeState.status).toBe("failed");
+    expect(ctx.runtimeState.runPhase).toBe("failed");
+    expect(ctx.runtimeState.run.lastError).toBe(
+      'turn_failed: {"error":{"message":"   "},"code":"E_BACKEND"}'
+    );
   });
 
   it("preserves terminal failure details after child exit", async () => {


### PR DESCRIPTION
## Issues

- Fixes #81

## Summary

- worker가 `turn/failed`, `turn/cancelled`를 turn terminal failure로 즉시 처리하도록 맞췄습니다.
- turn 실패/취소 후 multi-turn loop가 timeout까지 기다리지 않고 바로 중단되도록 정리했습니다.

## Changes

- `handleServerMessage()`에 `turn/failed`, `turn/cancelled` 명시적 핸들러를 추가하고 `run.lastError`와 `runPhase`를 즉시 갱신했습니다.
- pending turn completion resolver를 공통 함수로 정리하고, turn terminal failure 이후 child exit가 기존 failure 상세를 덮어쓰지 않도록 보강했습니다.
- worker protocol 테스트에 turn failure/cancellation 해제, loop 중단, child exit 보존 시나리오를 추가했습니다.
- worker failure lifecycle 회귀 확인용 E2E TC 문서를 추가했습니다.

## Evidence

- `pnpm lint`
- `pnpm test`
- `pnpm typecheck`
- `pnpm build`
- `./e2e/run-e2e.sh fail 45`

## Human Validation

- [ ] `turn/failed` 수신 시 worker가 timeout 없이 실패 종료되는지 확인
- [ ] `turn/cancelled` 수신 시 worker가 즉시 중단되고 상태 API에 failure가 반영되는지 확인
- [ ] worker failure 이후 기존 retry/lifecycle 동작에 회귀가 없는지 확인

## Risks

- Docker E2E는 stub worker 기반이라 실제 Codex protocol의 `turn/failed`, `turn/cancelled` 프레임은 단위 테스트로만 직접 검증됩니다.
