### PR TITLE
feat(core): add completed issue set for bookkeeping (spec §4.1.8)

### DIFF
--- a/packages/core/src/contracts/issue-orchestration.ts
+++ b/packages/core/src/contracts/issue-orchestration.ts
@@ -19,6 +19,7 @@ export type IssueOrchestrationRecord = {
   issueId: string;
   identifier: string;
   workspaceKey: string;
+  completedOnce: boolean;
   state: IssueOrchestrationState;
   currentRunId: string | null;
   retryEntry: IssueRetryEntry | null;

--- a/packages/dashboard/src/server.test.ts
+++ b/packages/dashboard/src/server.test.ts
@@ -7,7 +7,7 @@ import {
 
 function createReader() {
   return {
-    loadProjectStatus: vi.fn().mockResolvedValue(null),
+    loadProjectState: vi.fn().mockResolvedValue(null),
     loadProjectIssueOrchestrations: vi.fn().mockResolvedValue([]),
     loadRun: vi.fn(),
     loadAllRuns: vi.fn(),
@@ -47,9 +47,22 @@ describe("GET /api/v1/state", () => {
         remaining: 42,
       },
       lastError: null,
+      completedCount: 1,
+      issues: [
+        {
+          issueId: "issue-123",
+          identifier: "acme/repo#123",
+          workspaceKey: "acme_repo_123",
+          completedOnce: true,
+          state: "released",
+          currentRunId: null,
+          retryEntry: null,
+          updatedAt: "2026-03-16T00:00:00.000Z",
+        },
+      ],
     } as const;
     const reader = createReader();
-    reader.loadProjectStatus.mockResolvedValue(snapshot);
+    reader.loadProjectState.mockResolvedValue(snapshot);
 
     const result = await resolveDashboardResponse({
       pathname: "/api/v1/state",
@@ -58,7 +71,7 @@ describe("GET /api/v1/state", () => {
 
     expect(result.status).toBe(200);
     expect(result.payload).toEqual(snapshot);
-    expect(reader.loadProjectStatus).toHaveBeenCalledOnce();
+    expect(reader.loadProjectState).toHaveBeenCalledOnce();
   });
 
   it("returns 405 for non-GET methods", async () => {
@@ -83,6 +96,7 @@ describe("GET /api/v1/<issue_identifier>", () => {
         issueId: "issue-123",
         identifier: "acme/repo#123",
         workspaceKey: "acme_repo_123",
+        completedOnce: true,
         state: "running",
         currentRunId: "run-1",
         retryEntry: null,
@@ -148,6 +162,7 @@ describe("GET /api/v1/<issue_identifier>", () => {
       issue_id: "issue-123",
       status: "running",
       workspace: { path: "/tmp/workspace" },
+      tracked: { completed_once: true },
     });
   });
 
@@ -190,7 +205,7 @@ describe("GET /api/v1/<issue_identifier>", () => {
 describe("startDashboardServer", () => {
   it("returns a 500 JSON payload when request handling throws", async () => {
     const reader = createReader();
-    reader.loadProjectStatus.mockRejectedValue(new Error("boom"));
+    reader.loadProjectState.mockRejectedValue(new Error("boom"));
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const server = startDashboardServer({
       host: "127.0.0.1",

--- a/packages/dashboard/src/server.ts
+++ b/packages/dashboard/src/server.ts
@@ -31,7 +31,7 @@ export async function resolveDashboardResponse(options: {
       };
     }
 
-    const snapshot = await options.reader.loadProjectStatus();
+    const snapshot = await options.reader.loadProjectState();
     if (!snapshot) {
       return {
         status: 404,

--- a/packages/dashboard/src/store.test.ts
+++ b/packages/dashboard/src/store.test.ts
@@ -63,6 +63,7 @@ describe("DashboardFsReader", () => {
           issueId: "issue-1",
           identifier: "acme/platform#1",
           workspaceKey: "acme_platform_1",
+          completedOnce: true,
           state: "retry_queued",
           currentRunId: "run-1",
           retryEntry: {
@@ -192,6 +193,7 @@ describe("DashboardFsReader", () => {
         issue_orchestration_state: "retry_queued",
         current_run_id: "run-1",
         workspace_key: "acme_platform_1",
+        completed_once: true,
         run_phase: "failed",
         execution_phase: "implementation",
       },
@@ -211,6 +213,7 @@ describe("DashboardFsReader", () => {
           issueId: "issue-1",
           identifier: "acme/platform#1",
           workspaceKey: "acme_platform_1",
+          completedOnce: false,
           state: "running",
           currentRunId: "missing-run",
           retryEntry: null,
@@ -265,6 +268,100 @@ describe("DashboardFsReader", () => {
         },
       }
     );
+  });
+
+  it("defaults completedOnce to false for legacy persisted issue records", async () => {
+    const runtimeRoot = await mkdtemp(join(tmpdir(), "dashboard-store-"));
+    const projectDir = join(runtimeRoot, "projects", "tenant-1");
+    await mkdir(projectDir, { recursive: true });
+    await writeFile(
+      join(projectDir, "issues.json"),
+      JSON.stringify([
+        {
+          issueId: "issue-1",
+          identifier: "acme/platform#1",
+          workspaceKey: "acme_platform_1",
+          state: "released",
+          currentRunId: null,
+          retryEntry: null,
+          updatedAt: "2026-03-20T00:02:00.000Z",
+        },
+      ]) + "\n",
+      "utf8"
+    );
+
+    const reader = new DashboardFsReader(runtimeRoot, "tenant-1");
+
+    await expect(reader.loadProjectIssueOrchestrations()).resolves.toEqual([
+      {
+        issueId: "issue-1",
+        identifier: "acme/platform#1",
+        workspaceKey: "acme_platform_1",
+        completedOnce: false,
+        state: "released",
+        currentRunId: null,
+        retryEntry: null,
+        updatedAt: "2026-03-20T00:02:00.000Z",
+      },
+    ]);
+  });
+
+  it("builds an aggregated state snapshot with completedCount", async () => {
+    const runtimeRoot = await mkdtemp(join(tmpdir(), "dashboard-store-"));
+    const projectDir = join(runtimeRoot, "projects", "tenant-1");
+    await mkdir(projectDir, { recursive: true });
+    await writeFile(
+      join(projectDir, "status.json"),
+      JSON.stringify({
+        projectId: "tenant-1",
+        slug: "tenant-1",
+        tracker: { adapter: "github-project", bindingId: "project-1" },
+        lastTickAt: "2026-03-20T00:00:00.000Z",
+        health: "idle",
+        summary: { dispatched: 0, suppressed: 0, recovered: 0, activeRuns: 0 },
+        activeRuns: [],
+        retryQueue: [],
+        lastError: null,
+      }) + "\n",
+      "utf8"
+    );
+    await writeFile(
+      join(projectDir, "issues.json"),
+      JSON.stringify([
+        {
+          issueId: "issue-1",
+          identifier: "acme/platform#1",
+          workspaceKey: "acme_platform_1",
+          completedOnce: true,
+          state: "released",
+          currentRunId: null,
+          retryEntry: null,
+          updatedAt: "2026-03-20T00:02:00.000Z",
+        },
+        {
+          issueId: "issue-2",
+          identifier: "acme/platform#2",
+          workspaceKey: "acme_platform_2",
+          completedOnce: false,
+          state: "unclaimed",
+          currentRunId: null,
+          retryEntry: null,
+          updatedAt: "2026-03-20T00:03:00.000Z",
+        },
+      ]) + "\n",
+      "utf8"
+    );
+
+    const reader = new DashboardFsReader(runtimeRoot, "tenant-1");
+
+    await expect(reader.loadProjectState()).resolves.toMatchObject({
+      projectId: "tenant-1",
+      completedCount: 1,
+      issues: [
+        { issueId: "issue-1", completedOnce: true },
+        { issueId: "issue-2", completedOnce: false },
+      ],
+    });
   });
 
   it("reads recent events from large ndjson logs without scanning the entire file", async () => {

--- a/packages/dashboard/src/store.ts
+++ b/packages/dashboard/src/store.ts
@@ -20,6 +20,13 @@ const RECENT_EVENT_CHUNK_SIZE = 4_096;
 const MAX_RECENT_EVENT_SCAN_BYTES = 64 * 1_024;
 const RUN_RECORD_LOAD_CONCURRENCY = 8;
 
+export type DashboardIssueSnapshot = IssueOrchestrationRecord;
+
+export type DashboardProjectStateSnapshot = ProjectStatusSnapshot & {
+  completedCount: number;
+  issues: DashboardIssueSnapshot[];
+};
+
 export class DashboardFsReader {
   private readonly resolvedRuntimeRoot: string;
 
@@ -46,13 +53,30 @@ export class DashboardFsReader {
     );
   }
 
+  async loadProjectState(): Promise<DashboardProjectStateSnapshot | null> {
+    const snapshot = await this.loadProjectStatus();
+    if (!snapshot) {
+      return null;
+    }
+
+    const issues = await this.loadProjectIssueOrchestrations();
+    return {
+      ...snapshot,
+      completedCount: issues.filter((issue) => issue.completedOnce).length,
+      issues,
+    };
+  }
+
   async loadProjectIssueOrchestrations(): Promise<IssueOrchestrationRecord[]> {
     const issues =
       await readJsonFile<IssueOrchestrationRecord[]>(
         join(this.projectDir(), "issues.json")
       );
     if (issues) {
-      return issues;
+      return issues.map((issue) => ({
+        ...issue,
+        completedOnce: issue.completedOnce ?? false,
+      }));
     }
 
     const legacyLeases =
@@ -72,6 +96,7 @@ export class DashboardFsReader {
       workspaceKey: deriveIssueWorkspaceKeyFromIdentifier(
         lease.issueIdentifier
       ),
+      completedOnce: false,
       state: lease.status === "active" ? "claimed" : "released",
       currentRunId: lease.status === "active" ? lease.runId : null,
       retryEntry: null,
@@ -245,14 +270,15 @@ export async function statusForIssue(
     },
     recent_events: recentEvents,
     last_error: currentRun?.lastError ?? issueRecord.retryEntry?.error ?? null,
-    tracked: {
-      issue_orchestration_state: issueRecord.state,
-      current_run_id: issueRecord.currentRunId,
-      workspace_key: issueRecord.workspaceKey,
-      run_phase: currentRun?.runPhase ?? null,
-      execution_phase: currentRun?.executionPhase ?? null,
-    },
-  };
+      tracked: {
+        issue_orchestration_state: issueRecord.state,
+        current_run_id: issueRecord.currentRunId,
+        workspace_key: issueRecord.workspaceKey,
+        completed_once: issueRecord.completedOnce,
+        run_phase: currentRun?.runPhase ?? null,
+        execution_phase: currentRun?.executionPhase ?? null,
+      },
+    };
 }
 
 async function findLatestRunForIssue(

--- a/packages/orchestrator/src/fs-store.test.ts
+++ b/packages/orchestrator/src/fs-store.test.ts
@@ -1,4 +1,11 @@
-import { appendFile, mkdtemp, mkdir, readFile, stat } from "node:fs/promises";
+import {
+  appendFile,
+  mkdtemp,
+  mkdir,
+  readFile,
+  stat,
+  writeFile,
+} from "node:fs/promises";
 import { chdir } from "node:process";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -268,5 +275,41 @@ describe("OrchestratorFsStore.loadRecentRunEvents", () => {
     } finally {
       warnSpy.mockRestore();
     }
+  });
+});
+
+describe("OrchestratorFsStore.loadProjectIssueOrchestrations", () => {
+  it("defaults completedOnce to false for legacy persisted issue records", async () => {
+    const runtimeRoot = await mkdtemp(join(tmpdir(), "orchestrator-store-"));
+    const store = new OrchestratorFsStore(runtimeRoot);
+    await mkdir(join(runtimeRoot, "projects", "project-1"), { recursive: true });
+    await writeFile(
+      join(runtimeRoot, "projects", "project-1", "issues.json"),
+      JSON.stringify([
+        {
+          issueId: "issue-1",
+          identifier: "acme/repo#1",
+          workspaceKey: "acme_repo_1",
+          state: "released",
+          currentRunId: null,
+          retryEntry: null,
+          updatedAt: "2026-03-16T00:00:00.000Z",
+        },
+      ]) + "\n",
+      "utf8"
+    );
+
+    await expect(store.loadProjectIssueOrchestrations("project-1")).resolves.toEqual([
+      {
+        issueId: "issue-1",
+        identifier: "acme/repo#1",
+        workspaceKey: "acme_repo_1",
+        completedOnce: false,
+        state: "released",
+        currentRunId: null,
+        retryEntry: null,
+        updatedAt: "2026-03-16T00:00:00.000Z",
+      },
+    ]);
   });
 });

--- a/packages/orchestrator/src/fs-store.ts
+++ b/packages/orchestrator/src/fs-store.ts
@@ -81,7 +81,10 @@ export class OrchestratorFsStore implements OrchestratorStateStore {
     const issuesPath = join(this.projectDir(projectId), "issues.json");
     const issues = await readJsonFile<IssueOrchestrationRecord[]>(issuesPath);
     if (issues) {
-      return issues;
+      return issues.map((issue) => ({
+        ...issue,
+        completedOnce: issue.completedOnce ?? false,
+      }));
     }
 
     const legacyLeases =
@@ -106,6 +109,7 @@ export class OrchestratorFsStore implements OrchestratorStateStore {
         workspaceKey: deriveIssueWorkspaceKeyFromIdentifier(
           lease.issueIdentifier
         ),
+        completedOnce: false,
         state: lease.status === "active" ? "claimed" : "released",
         currentRunId: lease.status === "active" ? lease.runId : null,
         retryEntry: null,

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -172,6 +172,7 @@ describe("OrchestratorService", () => {
         issueId: "issue-1",
         identifier: "acme/platform#1",
         workspaceKey,
+        completedOnce: false,
         state: "released",
         currentRunId: null,
         retryEntry: null,
@@ -283,6 +284,7 @@ Prefer focused changes.
         issueId: "issue-1",
         identifier: "acme/platform#1",
         workspaceKey,
+        completedOnce: false,
         state: "released",
         currentRunId: null,
         retryEntry: null,
@@ -1033,6 +1035,7 @@ Prefer focused changes.
         issueId: "issue-1",
         identifier: "acme/platform#1",
         workspaceKey: "acme_platform_1",
+        completedOnce: false,
         state: "running",
         currentRunId: "run-1",
         retryEntry: null,
@@ -1181,6 +1184,7 @@ Prefer focused changes.
         issueId: "issue-1",
         identifier: "acme/platform#1",
         workspaceKey: "acme_platform_1",
+        completedOnce: false,
         state: "retry_queued",
         currentRunId: "run-1",
         retryEntry: {
@@ -1263,6 +1267,7 @@ Prefer focused changes.
     );
     expect(issueRecords[0]).toMatchObject({
       issueId: "issue-1",
+      completedOnce: false,
       state: "released",
       currentRunId: null,
       retryEntry: null,
@@ -1287,6 +1292,7 @@ Prefer focused changes.
         issueId: "issue-1",
         identifier: "acme/platform#1",
         workspaceKey: "acme_platform_1",
+        completedOnce: false,
         state: "retry_queued",
         currentRunId: "run-1",
         retryEntry: {
@@ -1399,6 +1405,7 @@ Prefer focused changes.
         issueId: "issue-1",
         identifier: "acme/platform#1",
         workspaceKey: "acme_platform_1",
+        completedOnce: false,
         state: "retry_queued",
         currentRunId: "run-1",
         retryEntry: {
@@ -1535,6 +1542,7 @@ Prefer focused changes.
         issueId: "issue-1",
         identifier: "acme/platform#1",
         workspaceKey: "acme_platform_1",
+        completedOnce: false,
         state: "running",
         currentRunId: "run-1",
         retryEntry: null,
@@ -1880,6 +1888,7 @@ Prefer focused changes.
         issueId: "issue-1",
         identifier: "acme/platform#1",
         workspaceKey: "acme_platform_1",
+        completedOnce: false,
         state: "running",
         currentRunId: "run-1",
         retryEntry: null,
@@ -1951,6 +1960,7 @@ Prefer focused changes.
         issueId: "issue-1",
         identifier: "acme/platform#1",
         workspaceKey: "acme_platform_1",
+        completedOnce: false,
         state: "running",
         currentRunId: "run-1",
         retryEntry: null,
@@ -2038,6 +2048,7 @@ Prefer focused changes.
         issueId: "issue-1",
         identifier: "acme/platform#1",
         workspaceKey: "acme_platform_1",
+        completedOnce: false,
         state: "running",
         currentRunId: "run-1",
         retryEntry: null,
@@ -2084,11 +2095,13 @@ Prefer focused changes.
 
     await service.runOnce();
     const updatedRun = await store.loadRun("run-1");
+    const issueRecords = await store.loadProjectIssueOrchestrations("tenant-1");
 
     expect(updatedRun?.status).toBe("retrying");
     expect(updatedRun?.nextRetryAt).toBe("2026-03-08T00:00:01.000Z");
     expect(updatedRun?.retryKind).toBe("continuation");
     expect(updatedRun?.lastError).toBeNull();
+    expect(issueRecords[0]?.completedOnce).toBe(true);
     expect(loadRetryPolicySpy).not.toHaveBeenCalled();
   });
 
@@ -2113,6 +2126,7 @@ Prefer focused changes.
         issueId: "issue-1",
         identifier: "acme/platform#1",
         workspaceKey: "acme_platform_1",
+        completedOnce: false,
         state: "running",
         currentRunId: "run-1",
         retryEntry: null,
@@ -2195,6 +2209,7 @@ Prefer focused changes.
         issueId: "issue-1",
         identifier: "acme/platform#1",
         workspaceKey: "acme_platform_1",
+        completedOnce: false,
         state: "running",
         currentRunId: "run-1",
         retryEntry: null,
@@ -2278,6 +2293,7 @@ Prefer focused changes.
         issueId: "issue-1",
         identifier: "acme/platform#1",
         workspaceKey: "acme_platform_1",
+        completedOnce: false,
         state: "running",
         currentRunId: "run-1",
         retryEntry: null,
@@ -2365,6 +2381,7 @@ Prefer focused changes.
         issueId: "issue-1",
         identifier: "acme/platform#1",
         workspaceKey: "acme_platform_1",
+        completedOnce: false,
         state: "running",
         currentRunId: "run-1",
         retryEntry: null,
@@ -2472,6 +2489,7 @@ Prefer focused changes.
           issueId: "issue-1",
           identifier: "acme/platform#1",
           workspaceKey: "acme_platform_1",
+          completedOnce: false,
           state: "running",
           currentRunId: "run-1",
           retryEntry: null,
@@ -2565,6 +2583,7 @@ Prefer focused changes.
           issueId: "issue-1",
           identifier: "acme/platform#1",
           workspaceKey: "acme_platform_1",
+          completedOnce: false,
           state: "running",
           currentRunId: "run-1",
           retryEntry: null,
@@ -2667,6 +2686,7 @@ Prefer focused changes.
           issueId: "issue-1",
           identifier: "acme/platform#1",
           workspaceKey: "acme_platform_1",
+          completedOnce: false,
           state: "running",
           currentRunId: "run-1",
           retryEntry: null,
@@ -2754,6 +2774,7 @@ Prefer focused changes.
           issueId: "issue-1",
           identifier: "acme/platform#1",
           workspaceKey: "acme_platform_1",
+          completedOnce: false,
           state: "running",
           currentRunId: "run-1",
           retryEntry: null,
@@ -2929,6 +2950,7 @@ Prefer focused changes.
           issueId: "issue-1",
           identifier: "acme/platform#1",
           workspaceKey: "acme_platform_1",
+          completedOnce: false,
           state: "running",
           currentRunId: "run-1",
           retryEntry: null,
@@ -3663,6 +3685,7 @@ Prefer focused changes.
         issueId: "issue-1",
         identifier: "acme/platform#1",
         workspaceKey: "acme_platform_1",
+        completedOnce: false,
         state: "running",
         currentRunId: "run-1",
         retryEntry: null,
@@ -4085,6 +4108,7 @@ Prefer focused changes.
         issueId: "issue-1",
         identifier: "acme/platform#1",
         workspaceKey: "acme_platform_1",
+        completedOnce: false,
         state: "running",
         currentRunId: "run-1",
         retryEntry: null,
@@ -4192,6 +4216,7 @@ Prefer focused changes.
         issueId: "issue-1",
         identifier: "acme/platform#1",
         workspaceKey: "acme_platform_1",
+        completedOnce: false,
         state: "running",
         currentRunId: "run-1",
         retryEntry: null,
@@ -4257,6 +4282,7 @@ Prefer focused changes.
         issueId: "issue-1",
         identifier: "acme/platform#1",
         workspaceKey: "acme_platform_1",
+        completedOnce: false,
         state: "running",
         currentRunId: "run-1",
         retryEntry: null,
@@ -4352,6 +4378,7 @@ Prefer focused changes.
         issueId: "issue-1",
         identifier: "acme/platform#1",
         workspaceKey: "acme_platform_1",
+        completedOnce: false,
         state: "running",
         currentRunId: "run-1",
         retryEntry: null,
@@ -4440,6 +4467,7 @@ Prefer focused changes.
         issueId: "issue-1",
         identifier: "acme/platform#1",
         workspaceKey: "acme_platform_1",
+        completedOnce: false,
         state: "running",
         currentRunId: "run-1",
         retryEntry: null,
@@ -4525,6 +4553,7 @@ Prefer focused changes.
         issueId: "issue-1",
         identifier: "acme/platform#1",
         workspaceKey: "acme_platform_1",
+        completedOnce: false,
         state: "running",
         currentRunId: "run-1",
         retryEntry: null,
@@ -4615,6 +4644,7 @@ Prefer focused changes.
         issueId: "issue-1",
         identifier: "acme/platform#1",
         workspaceKey: "acme_platform_1",
+        completedOnce: false,
         state: "running",
         currentRunId: "run-1",
         retryEntry: null,
@@ -4751,6 +4781,7 @@ Prefer focused changes.
         issueId: "issue-1",
         identifier: "acme/platform#1",
         workspaceKey: "acme_platform_1",
+        completedOnce: false,
         state: "running",
         currentRunId: "run-1",
         retryEntry: null,
@@ -4859,6 +4890,7 @@ Prefer focused changes.
         issueId: "issue-record-1",
         identifier: "acme/platform#1",
         workspaceKey: "acme_platform_1",
+        completedOnce: true,
         state: "running",
         currentRunId: "run-1",
         retryEntry: null,
@@ -4938,6 +4970,7 @@ Prefer focused changes.
     const issueRecords = await store.loadProjectIssueOrchestrations("tenant-1");
     expect(issueRecords[0]).toMatchObject({
       issueId: "issue-record-1",
+      completedOnce: true,
       state: "released",
       currentRunId: null,
     });
@@ -4959,6 +4992,7 @@ Prefer focused changes.
         issueId: "issue-1",
         identifier: "acme/platform#1",
         workspaceKey: "acme_platform_1",
+        completedOnce: false,
         state: "running",
         currentRunId: "run-1",
         retryEntry: null,
@@ -5656,6 +5690,7 @@ Prefer focused changes.
         issueId: "issue-1",
         identifier: "acme/platform#1",
         workspaceKey: "acme_platform_1",
+        completedOnce: false,
         state: "running",
         currentRunId: "run-1",
         retryEntry: null,

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -1610,6 +1610,7 @@ export class OrchestratorService {
           run.issueIdentifier
         ),
       state: "retry_queued",
+      completedOnce: retryKind === "continuation" ? true : undefined,
       currentRunId: run.runId,
       retryEntry: {
         attempt: retryRecord.attempt,
@@ -2639,12 +2640,22 @@ function isIssueOrchestrationClaimed(
 
 function upsertIssueOrchestration(
   issueRecords: IssueOrchestrationRecord[],
-  nextRecord: IssueOrchestrationRecord
+  nextRecord: Omit<IssueOrchestrationRecord, "completedOnce"> & {
+    completedOnce?: boolean;
+  }
 ): IssueOrchestrationRecord[] {
+  const existingRecord =
+    issueRecords.find((record) => record.issueId === nextRecord.issueId) ?? null;
   const remaining = issueRecords.filter(
     (record) => record.issueId !== nextRecord.issueId
   );
-  return [...remaining, nextRecord];
+  return [
+    ...remaining,
+    {
+      ...nextRecord,
+      completedOnce: nextRecord.completedOnce ?? existingRecord?.completedOnce ?? false,
+    },
+  ];
 }
 
 function releaseIssueOrchestration(


### PR DESCRIPTION
## Issues

- Fixes #106

## Summary

- add `completedOnce` bookkeeping to issue orchestration records
- expose completed issue metadata from dashboard `/api/v1/state` without scanning run history

## Changes

- added `completedOnce: boolean` to `IssueOrchestrationRecord` and defaulted missing persisted values to `false` in orchestrator/dashboard filesystem readers
- marked issue records as completed when worker exit is classified as `continuation`, while preserving the flag across later `release` transitions
- extended dashboard state assembly to return `issues` plus top-level `completedCount`, and included `completed_once` in issue-specific tracked metadata
- added unit coverage for migration defaults, continuation bookkeeping, release preservation, and dashboard state aggregation

## Evidence

- `pnpm build`
- `pnpm typecheck`
- `pnpm test`
- `pnpm lint`
- `docker compose -f docker-compose.e2e.yml -f docker-compose.e2e.events.yml up -d --build`
- `curl --fail --retry-all-errors --retry 10 --retry-delay 2 http://localhost:4680/healthz`
- `cp e2e/fixtures/happy-path.json e2e/fixtures/issues.json`
- `docker exec symphony-e2e node /app/packages/orchestrator/dist/index.js run-once --runtime-root /app/.runtime --project-id e2e-project`
- `curl -s http://localhost:4680/api/v1/state | jq '{completedCount, issues: [.issues[] | {identifier, completedOnce, state, currentRunId}], retryQueue, activeRuns: .summary.activeRuns}'`
- Manual check: after the happy-path worker exited normally, `/api/v1/state` returned `completedCount=1`, `issues[0].completedOnce=true`, `issues[0].state=retry_queued`, and `retryQueue[0].retryKind=continuation`
- `docker compose -f docker-compose.e2e.yml -f docker-compose.e2e.events.yml down`

## Human Validation

- [ ] Confirm a normally completed worker session is counted once in the dashboard state response
- [ ] Confirm legacy runtime data without `completedOnce` still loads with `false`
- [ ] Confirm reviewer-visible state fields match issue #106 requirements

## Risks

- `completedCount` is derived from persisted `issues.json`, so pre-existing historical runs are intentionally not backfilled
