### PR TITLE
refactor(cli): start 명령의 수동 루프를 service.run() 기반으로 전환

### DIFF
--- a/packages/cli/src/commands/start.test.ts
+++ b/packages/cli/src/commands/start.test.ts
@@ -136,6 +136,59 @@ describe("start command foreground locking", () => {
     expect(shutdown).toHaveBeenCalledTimes(1);
     expect(exitSpy).toHaveBeenCalledWith(0);
   });
+
+  it("retries the foreground run loop after a service.run error", async () => {
+    const configDir = await createConfigFixture({
+      activeProject: "tenant-a",
+      projects: [createProject("tenant-a", "acme", "platform")],
+    });
+    const lock = {
+      lockPath: join(
+        configDir,
+        "projects",
+        "tenant-a",
+        ".lock"
+      ),
+      ownerToken: "owner",
+      pid: 1234,
+      startedAt: "2026-03-17T00:00:00.000Z",
+    };
+    acquireProjectLock.mockResolvedValue(lock);
+    status.mockResolvedValue(null);
+    let attempts = 0;
+    run.mockImplementation(async () => {
+      attempts += 1;
+      if (attempts === 1) {
+        throw new Error("transient failure");
+      }
+
+      const onTick = serviceDependencies.at(-1)?.onTick as
+        | ((snapshot: Record<string, unknown>) => Promise<void>)
+        | undefined;
+      await onTick?.({
+        projectId: "tenant-a",
+        slug: "tenant-a",
+        health: "idle",
+        lastTickAt: "2026-03-17T00:00:00.000Z",
+        summary: { dispatched: 0, suppressed: 0, recovered: 0, activeRuns: 0 },
+        activeRuns: [],
+        retryQueue: [],
+        lastError: null,
+      });
+      process.emit("SIGINT");
+    });
+
+    const exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation(((_code?: number) => undefined) as (code?: number) => never);
+
+    await startModule.default(["--project-id", "tenant-a"], baseOptions(configDir));
+
+    expect(run).toHaveBeenCalledTimes(2);
+    expect(releaseProjectLock).toHaveBeenCalledWith(lock);
+    expect(shutdown).toHaveBeenCalledTimes(1);
+    expect(exitSpy).toHaveBeenCalledWith(0);
+  });
 });
 
 function baseOptions(configDir: string) {

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -338,7 +338,23 @@ const handler = async (
     });
 
     try {
-      await service.run();
+      while (!shuttingDown) {
+        try {
+          await service.run();
+          break;
+        } catch (error) {
+          if (shuttingDown) {
+            break;
+          }
+
+          logLine(
+            red("\u2717"),
+            red(
+              `Run loop error: ${error instanceof Error ? error.message : "Unknown error"}`
+            )
+          );
+        }
+      }
     } finally {
       if (shutdownPromise) {
         await shutdownPromise;

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -144,39 +144,86 @@ describe("OrchestratorService", () => {
   it("invokes onTick with the reconciliation snapshot when run() completes a tick", async () => {
     process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
     const tempRoot = await mkdtemp(join(tmpdir(), "orchestrator-on-tick-"));
-    const repository = await createRepositoryFixture(
-      tempRoot,
-      "acme",
-      "platform"
-    );
-    const store = new OrchestratorFsStore(tempRoot);
-    const projectConfig = createProjectConfig(tempRoot, repository);
-    await store.saveProjectConfig(projectConfig);
+    try {
+      const repository = await createRepositoryFixture(
+        tempRoot,
+        "acme",
+        "platform"
+      );
+      const store = new OrchestratorFsStore(tempRoot);
+      const projectConfig = createProjectConfig(tempRoot, repository);
+      await store.saveProjectConfig(projectConfig);
 
-    const onTick = vi.fn();
-    const service = new OrchestratorService(store, projectConfig, {
-      fetchImpl: vi.fn().mockResolvedValue(createEmptyTrackerResponse()),
-      now: () => new Date("2026-03-08T00:00:00.000Z"),
-      onTick,
-    });
+      const onTick = vi.fn();
+      const service = new OrchestratorService(store, projectConfig, {
+        fetchImpl: vi.fn().mockResolvedValue(createEmptyTrackerResponse()),
+        now: () => new Date("2026-03-08T00:00:00.000Z"),
+        onTick,
+      });
 
-    await service.run({ once: true });
+      await service.run({ once: true });
 
-    expect(onTick).toHaveBeenCalledTimes(1);
-    expect(onTick).toHaveBeenCalledWith(
-      expect.objectContaining({
-        projectId: "tenant-1",
-        slug: "tenant-1",
-        health: "idle",
-        lastTickAt: "2026-03-08T00:00:00.000Z",
-        summary: expect.objectContaining({
-          activeRuns: 0,
-          dispatched: 0,
-          suppressed: 0,
-          recovered: 0,
-        }),
-      })
-    );
+      expect(onTick).toHaveBeenCalledTimes(1);
+      expect(onTick).toHaveBeenCalledWith(
+        expect.objectContaining({
+          projectId: "tenant-1",
+          slug: "tenant-1",
+          health: "idle",
+          lastTickAt: "2026-03-08T00:00:00.000Z",
+          summary: expect.objectContaining({
+            activeRuns: 0,
+            dispatched: 0,
+            suppressed: 0,
+            recovered: 0,
+          }),
+        })
+      );
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("continues polling when onTick throws during long-running mode", async () => {
+    process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
+    const tempRoot = await mkdtemp(join(tmpdir(), "orchestrator-on-tick-error-"));
+    try {
+      const repository = await createRepositoryFixture(
+        tempRoot,
+        "acme",
+        "platform"
+      );
+      const store = new OrchestratorFsStore(tempRoot);
+      const projectConfig = createProjectConfig(tempRoot, repository);
+      await store.saveProjectConfig(projectConfig);
+
+      const stderr = {
+        write: vi.fn().mockReturnValue(true),
+      };
+      let runningService: OrchestratorService | null = null;
+      const onTick = vi
+        .fn()
+        .mockRejectedValueOnce(new Error("tick boom"))
+        .mockImplementationOnce(async () => {
+          await runningService?.shutdown();
+        });
+      const service = new OrchestratorService(store, projectConfig, {
+        fetchImpl: vi.fn().mockResolvedValue(createEmptyTrackerResponse()),
+        now: () => new Date("2026-03-08T00:00:00.000Z"),
+        waitImpl: vi.fn().mockResolvedValue(undefined),
+        stderr,
+        onTick,
+      });
+      runningService = service;
+
+      await service.run();
+
+      expect(onTick).toHaveBeenCalledTimes(2);
+      expect(stderr.write).toHaveBeenCalledWith(
+        expect.stringContaining("[orchestrator] onTick callback failed: Error: tick boom")
+      );
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true });
+    }
   });
 
   it("cleans up terminal issue workspaces during startup before the first tick", async () => {

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -148,11 +148,21 @@ export class OrchestratorService {
     );
 
     while (this.running) {
-      const snapshot = await this.runOnceInternal(
-        options.issueIdentifier,
-        this.createTrackerDependencies()
-      );
-      await this.dependencies.onTick?.(snapshot);
+      try {
+        const snapshot = await this.runOnceInternal(
+          options.issueIdentifier,
+          this.createTrackerDependencies()
+        );
+        await this.notifyTick(snapshot);
+      } catch (error) {
+        if (options.once) {
+          throw error;
+        }
+
+        this.writeStderr(
+          `[orchestrator] run loop failed for ${this.projectConfig.projectId}: ${this.formatErrorMessage(error)}`
+        );
+      }
 
       if (options.once || !this.running) {
         return;
@@ -689,6 +699,28 @@ export class OrchestratorService {
         );
       }
     }
+  }
+
+  private async notifyTick(snapshot: ProjectStatusSnapshot): Promise<void> {
+    if (!this.dependencies.onTick) {
+      return;
+    }
+
+    try {
+      await this.dependencies.onTick(snapshot);
+    } catch (error) {
+      this.writeStderr(
+        `[orchestrator] onTick callback failed: ${this.formatErrorMessage(error)}`
+      );
+    }
+  }
+
+  private formatErrorMessage(error: unknown): string {
+    if (error instanceof Error) {
+      return error.stack ?? error.message;
+    }
+
+    return String(error);
   }
 
   private async resolveStartupCleanupTerminalStates(


### PR DESCRIPTION
## Issues

- Fixes #116

## Summary

- foreground `gh-symphony start` reuses `OrchestratorService.run()` while keeping the previous self-healing foreground behavior when unexpected run-loop errors escape
- CLI tick logging and completed worker log tailing still flow through the orchestrator tick callback, and `onTick` failures no longer abort the long-running orchestrator loop

## Changes

- add `onTick` error isolation inside `OrchestratorService.run()` so long-running polling logs callback failures to stderr and continues to the next poll
- keep foreground `start.ts` on `service.run()` but retry the foreground loop when `run()` rejects, preserving SIGINT/SIGTERM-driven shutdown and avoiding abrupt stoppage
- clean up the onTick service test fixture and add regression coverage for `onTick` failure recovery and foreground run-loop retry

## Evidence

- `pnpm --filter @gh-symphony/orchestrator test -- src/service.test.ts`
- `pnpm --filter @gh-symphony/cli test -- src/commands/start.test.ts`
- `pnpm lint && pnpm test && pnpm typecheck && pnpm build`
- `docker compose -f docker-compose.e2e.yml up -d --build`
- `docker exec symphony-e2e node /app/packages/orchestrator/dist/index.js run-once --runtime-root /app/.runtime --project-id e2e-project`
- `curl -s http://localhost:4680/api/v1/state | jq '{health, activeRuns: .summary.activeRuns, lastError}'`
- Manual check: Docker blackbox returned `health: running`, `activeRuns: 1`, and `lastError: null` after injecting `e2e/fixtures/happy-path.json`

## Human Validation

- [ ] Confirm `gh-symphony start --project-id <id>` still shows tick logs in foreground mode
- [ ] Confirm completed runs still print the worker log tail in foreground mode
- [ ] Confirm reviewer-visible behavior matches issue #116 requirements

## Risks

- The current Docker E2E harness still validates dispatch via `run-once`; it does not exercise a dashboard-triggered refresh path directly, so interrupt-by-refresh remains covered primarily by the shared `service.run()` path and automated tests
