### PR TITLE
feat(orchestrator): add requestReconcile() API

### DIFF
--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -231,6 +231,10 @@ describe("OrchestratorService", () => {
     const tempRoot = await mkdtemp(
       join(tmpdir(), "orchestrator-request-reconcile-")
     );
+    let service: OrchestratorService | null = null;
+    let runPromise: Promise<void> | null = null;
+    let releaseWait: (() => void) | null = null;
+    let reconcileRequested = false;
     try {
       const repository = await createRepositoryFixture(
         tempRoot,
@@ -245,12 +249,21 @@ describe("OrchestratorService", () => {
       await store.saveProjectConfig(projectConfig);
 
       const fetchImpl = vi.fn().mockResolvedValue(createEmptyTrackerResponse());
+      const waitImpl = vi.fn().mockImplementation(async () => {
+        if (!reconcileRequested) {
+          reconcileRequested = true;
+          setTimeout(() => {
+            serviceRef.current?.requestReconcile();
+          }, 10);
+        }
+        await new Promise<void>((resolve) => {
+          releaseWait = resolve;
+        });
+      });
       let tickCount = 0;
       let resolveSecondTick!: () => void;
-      let rejectSecondTick!: (error?: unknown) => void;
-      const secondTick = new Promise<void>((resolve, reject) => {
+      const secondTick = new Promise<void>((resolve) => {
         resolveSecondTick = resolve;
-        rejectSecondTick = reject;
       });
       const serviceRef: { current: OrchestratorService | null } = {
         current: null,
@@ -258,13 +271,6 @@ describe("OrchestratorService", () => {
       const onTick = vi.fn().mockImplementation(async () => {
         tickCount += 1;
         if (tickCount === 1) {
-          setTimeout(() => {
-            try {
-              serviceRef.current?.requestReconcile();
-            } catch (error) {
-              rejectSecondTick(error);
-            }
-          }, 10);
           return;
         }
 
@@ -273,14 +279,15 @@ describe("OrchestratorService", () => {
           await serviceRef.current?.shutdown();
         }
       });
-      const service = new OrchestratorService(store, projectConfig, {
+      service = new OrchestratorService(store, projectConfig, {
         fetchImpl,
         now: () => new Date("2026-03-08T00:00:00.000Z"),
+        waitImpl,
         onTick,
       });
       serviceRef.current = service;
 
-      const runPromise = service.run();
+      runPromise = service.run();
       await Promise.race([
         secondTick,
         new Promise<never>((_, reject) => {
@@ -295,16 +302,23 @@ describe("OrchestratorService", () => {
 
       expect(fetchImpl).toHaveBeenCalledTimes(2);
       expect(onTick).toHaveBeenCalledTimes(2);
+      expect(waitImpl).toHaveBeenCalledTimes(1);
     } finally {
+      releaseWait?.();
+      await service?.shutdown();
+      await runPromise?.catch(() => undefined);
       await rm(tempRoot, { recursive: true, force: true });
     }
   });
 
-  it("handles duplicate requestReconcile calls without scheduling duplicate ticks", async () => {
+  it("queues active-tick requestReconcile calls without scheduling duplicate ticks", async () => {
     process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
     const tempRoot = await mkdtemp(
       join(tmpdir(), "orchestrator-request-reconcile-duplicate-")
     );
+    let service: OrchestratorService | null = null;
+    let runPromise: Promise<void> | null = null;
+    let releaseFirstTick: (() => void) | null = null;
     try {
       const repository = await createRepositoryFixture(
         tempRoot,
@@ -320,6 +334,9 @@ describe("OrchestratorService", () => {
 
       const fetchImpl = vi.fn().mockResolvedValue(createEmptyTrackerResponse());
       let tickCount = 0;
+      const firstTickRelease = new Promise<void>((resolve) => {
+        releaseFirstTick = resolve;
+      });
       const serviceRef: { current: OrchestratorService | null } = {
         current: null,
       };
@@ -330,6 +347,7 @@ describe("OrchestratorService", () => {
             serviceRef.current?.requestReconcile();
             serviceRef.current?.requestReconcile();
           }, 10);
+          await firstTickRelease;
           return;
         }
 
@@ -337,15 +355,20 @@ describe("OrchestratorService", () => {
           await serviceRef.current?.shutdown();
         }
       });
-      const service = new OrchestratorService(store, projectConfig, {
+      service = new OrchestratorService(store, projectConfig, {
         fetchImpl,
         now: () => new Date("2026-03-08T00:00:00.000Z"),
         onTick,
       });
       serviceRef.current = service;
 
+      runPromise = service.run();
+      setTimeout(() => {
+        releaseFirstTick?.();
+      }, 25);
+
       await Promise.race([
-        service.run(),
+        runPromise,
         new Promise<never>((_, reject) => {
           setTimeout(() => {
             reject(
@@ -358,6 +381,9 @@ describe("OrchestratorService", () => {
       expect(fetchImpl).toHaveBeenCalledTimes(2);
       expect(onTick).toHaveBeenCalledTimes(2);
     } finally {
+      releaseFirstTick?.();
+      await service?.shutdown();
+      await runPromise?.catch(() => undefined);
       await rm(tempRoot, { recursive: true, force: true });
     }
   });

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -110,6 +110,7 @@ export class OrchestratorService {
   private sleepTimer: ReturnType<typeof setTimeout> | null = null;
   private sleepResolver: (() => void) | null = null;
   private reconcilePromise: Promise<void> = Promise.resolve();
+  private reconcileRequested = false;
 
   constructor(
     readonly store: OrchestratorStateStore,
@@ -300,6 +301,7 @@ export class OrchestratorService {
   }
 
   requestReconcile(): void {
+    this.reconcileRequested = true;
     this.cancelPendingSleep();
   }
 
@@ -1814,23 +1816,28 @@ export class OrchestratorService {
   }
 
   private async waitForNextPoll(): Promise<void> {
-    const customWait = this.dependencies.waitImpl;
-    if (customWait) {
-      await customWait(this.getEffectivePollIntervalMs());
+    if (this.consumePendingReconcileRequest()) {
       return;
     }
 
-    await new Promise<void>((resolve) => {
-      this.sleepResolver = () => {
-        this.sleepResolver = null;
-        this.sleepTimer = null;
-        resolve();
-      };
-      this.sleepTimer = setTimeout(
-        this.sleepResolver,
-        this.getEffectivePollIntervalMs()
-      );
-    });
+    const customWait = this.dependencies.waitImpl;
+    const pollIntervalMs = this.getEffectivePollIntervalMs();
+    const waitPromise = this.createPendingSleepPromise();
+
+    try {
+      if (customWait) {
+        await Promise.race([customWait(pollIntervalMs), waitPromise]);
+      } else {
+        this.sleepTimer = setTimeout(() => {
+          this.sleepResolver?.();
+        }, pollIntervalMs);
+        await waitPromise;
+      }
+    } finally {
+      this.cancelPendingSleep();
+    }
+
+    this.consumePendingReconcileRequest();
   }
 
   private cancelPendingSleep(): void {
@@ -1840,6 +1847,25 @@ export class OrchestratorService {
     }
     this.sleepResolver?.();
     this.sleepResolver = null;
+  }
+
+  private createPendingSleepPromise(): Promise<void> {
+    return new Promise<void>((resolve) => {
+      this.sleepResolver = () => {
+        this.sleepResolver = null;
+        this.sleepTimer = null;
+        resolve();
+      };
+    });
+  }
+
+  private consumePendingReconcileRequest(): boolean {
+    if (!this.reconcileRequested) {
+      return false;
+    }
+
+    this.reconcileRequested = false;
+    return true;
   }
 
   /**


### PR DESCRIPTION
## Issues

- Fixes #117

## Summary

- `OrchestratorService.requestReconcile()`가 active tick 중 호출돼도 즉시 후속 reconciliation이 이어지도록 보강했습니다.
- `waitImpl` 경로에서도 pending poll wait를 깨울 수 있도록 cancelable wait 흐름으로 정리했습니다.

## Changes

- `requestReconcile()`가 pending sleep 취소와 함께 reconcile 요청 플래그를 기록하도록 변경했습니다.
- `waitForNextPoll()`가 기본 timer 대기와 `waitImpl` 대기를 동일한 cancelable wait로 처리하고, queued reconcile 요청을 소비해 즉시 다음 tick으로 진행하도록 수정했습니다.
- 장기 실행 테스트를 보강해 `waitImpl` 사용 시 즉시 wake-up, active tick 중 중복 호출 collapse, 실패 시 cleanup 보장을 검증하도록 정리했습니다.

## Evidence

- `pnpm --filter @gh-symphony/orchestrator test -- src/service.test.ts`
- `pnpm lint`
- `pnpm test`
- `pnpm typecheck`
- `pnpm build`

## Human Validation

- [ ] `requestReconcile()` 호출 후 다음 poll interval을 기다리지 않고 후속 reconciliation이 실행되는지 확인
- [ ] active tick 중 중복 호출이 추가 tick 폭주 없이 한 번의 후속 reconciliation으로 수렴하는지 확인
- [ ] 기존 orchestrator 장기 실행 루프 동작에 인접 회귀가 없는지 확인

## Risks

- `waitImpl`는 외부 취소 API를 제공하지 않으므로, `Promise.race`에서 진 쪽이 장시간 리소스를 점유하지 않도록 주입 구현이 관리해야 합니다.
