### PR TITLE
feat(worker): dynamic continuation guidance from workflow config

### DIFF
--- a/packages/core/src/workflow-loader.test.ts
+++ b/packages/core/src/workflow-loader.test.ts
@@ -16,6 +16,7 @@ afterEach(async () => {
 });
 
 const SAMPLE_WORKFLOW = `---
+continuation_guidance: Continue from the latest state. Previous summary: {{lastTurnSummary}}
 tracker:
   kind: github-project
   project_id: project-123
@@ -54,6 +55,8 @@ describe("parseWorkflowMarkdown", () => {
     expect(workflow).toMatchObject({
       githubProjectId: "project-123",
       promptTemplate: "Prefer focused changes.",
+      continuationGuidance:
+        "Continue from the latest state. Previous summary: {{lastTurnSummary}}",
       agentCommand: "codex app-server",
       hookPath: "hooks/after_create.sh",
       format: "front-matter",
@@ -128,6 +131,22 @@ Labels:
     expect(workflow.promptTemplate).toContain("{% if issue.labels.size > 0 %}");
     expect(workflow.promptTemplate).toContain("{{ label | upcase }}");
     expect(workflow.promptTemplate).toContain("{% endfor %}");
+  });
+
+  it("accepts camelCase continuation guidance in front matter", () => {
+    const workflow = parseWorkflowMarkdown(`---
+continuationGuidance: Continue from turn {{cumulativeTurnCount}}.
+tracker:
+  kind: github-project
+codex:
+  command: codex app-server
+---
+Prompt body.
+`);
+
+    expect(workflow.continuationGuidance).toBe(
+      "Continue from turn {{cumulativeTurnCount}}."
+    );
   });
 });
 

--- a/packages/core/src/workflow/config.ts
+++ b/packages/core/src/workflow/config.ts
@@ -58,6 +58,7 @@ export type WorkflowSourceFormat =
 
 export type WorkflowDefinition = {
   promptTemplate: string;
+  continuationGuidance: string | null;
   tracker: WorkflowTrackerConfig;
   polling: {
     intervalMs: number;
@@ -135,6 +136,7 @@ export const DEFAULT_WORKFLOW_CODEX: WorkflowCodexConfig = {
 
 export const DEFAULT_WORKFLOW_DEFINITION: ParsedWorkflow = {
   promptTemplate: "",
+  continuationGuidance: null,
   tracker: DEFAULT_WORKFLOW_TRACKER,
   polling: {
     intervalMs: DEFAULT_POLL_INTERVAL_MS,

--- a/packages/core/src/workflow/parser.ts
+++ b/packages/core/src/workflow/parser.ts
@@ -73,6 +73,12 @@ export function parseWorkflowMarkdown(
 
   const parsed: ParsedWorkflow = {
     promptTemplate,
+    continuationGuidance: readOptionalWorkflowString(
+      frontMatter,
+      "continuationGuidance",
+      "continuation_guidance",
+      env
+    ),
     tracker: {
       kind: trackerKind,
       endpoint: readOptionalString(tracker, "endpoint", env),
@@ -354,6 +360,18 @@ function readOptionalString(
     throw new Error(`Workflow front matter field "${key}" must be a string.`);
   }
   return resolveEnvironmentValue(value, env);
+}
+
+function readOptionalWorkflowString(
+  input: Record<string, WorkflowFrontMatterNode>,
+  primaryKey: string,
+  fallbackKey: string,
+  env: NodeJS.ProcessEnv
+): string | null {
+  return (
+    readOptionalString(input, primaryKey, env) ??
+    readOptionalString(input, fallbackKey, env)
+  );
 }
 
 function readRequiredString(

--- a/packages/worker/src/conformance.test.ts
+++ b/packages/worker/src/conformance.test.ts
@@ -8,6 +8,7 @@ import {
 import { describe, expect, it } from "vitest";
 
 const SAMPLE_WORKFLOW = `---
+continuation_guidance: Resume using {{lastTurnSummary}}
 tracker:
   kind: github-project
   project_id: project-123
@@ -41,6 +42,7 @@ describe("Symphony core conformance", () => {
     expect(parseWorkflowMarkdown(SAMPLE_WORKFLOW)).toMatchObject({
       githubProjectId: "project-123",
       promptTemplate: "Prefer small changes and always explain risk.",
+      continuationGuidance: "Resume using {{lastTurnSummary}}",
       agentCommand: "codex app-server",
       hookPath: "hooks/after_create.sh",
       lifecycle: DEFAULT_WORKFLOW_LIFECYCLE,

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -26,6 +26,7 @@ import {
 import { resolveCodexPolicySettings } from "./codex-policy.js";
 import { resolveExitRunPhase } from "./run-phase.js";
 import {
+  buildContinuationTurnInput,
   buildInitialTurnInput,
   parseNonNegativeInteger,
   resolveRemainingTurns,
@@ -480,7 +481,9 @@ async function startAssignedRun() {
     }
 
     // Wire up the codex app-server client protocol (multi-turn)
-    void runCodexClientProtocol(childProcess, plan, launcherEnv);
+    void runCodexClientProtocol(childProcess, plan, launcherEnv, {
+      continuationGuidance: workflow.continuationGuidance,
+    });
 
     childProcess.once(
       "exit",
@@ -545,7 +548,10 @@ async function startAssignedRun() {
 async function runCodexClientProtocol(
   child: ReturnType<typeof launchCodexAppServer>,
   plan: CodexRuntimePlan,
-  env: NodeJS.ProcessEnv
+  env: NodeJS.ProcessEnv,
+  options: {
+    continuationGuidance: string | null;
+  }
 ): Promise<void> {
   const renderedPrompt = env.SYMPHONY_RENDERED_PROMPT;
   if (!renderedPrompt) {
@@ -571,6 +577,8 @@ async function runCodexClientProtocol(
   const turnTimeoutMs = Number(env.SYMPHONY_TURN_TIMEOUT_MS) || 3600000;
   const issueIdentifier = env.SYMPHONY_ISSUE_IDENTIFIER ?? "";
   const lastTurnSummary = env.SYMPHONY_LAST_TURN_SUMMARY ?? null;
+  const continuationGuidance =
+    env.SYMPHONY_CONTINUATION_GUIDANCE ?? options.continuationGuidance;
   const { approvalPolicy, threadSandbox, turnSandboxPolicy } =
     resolveCodexPolicySettings(env);
 
@@ -1180,6 +1188,7 @@ async function runCodexClientProtocol(
 
     for (let turn = 0; turn < remainingTurns; turn++) {
       turnCount = turn + 1;
+      const globalTurnCount = cumulativeTurnCount + turnCount;
       runtimeState.sessionInfo.turnCount = turnCount;
       runtimeState.runPhase = "streaming_turn";
       const isFirstTurn = turn === 0;
@@ -1188,9 +1197,14 @@ async function runCodexClientProtocol(
             renderedPrompt,
             mode: threadBootstrapMode,
             lastTurnSummary,
+            cumulativeTurnCount,
+            continuationGuidance,
           })
-        : "Continue working on the issue. Review your progress and complete any remaining tasks.";
-      const globalTurnCount = cumulativeTurnCount + turnCount;
+        : buildContinuationTurnInput({
+            continuationGuidance,
+            lastTurnSummary,
+            cumulativeTurnCount: globalTurnCount - 1,
+          });
 
       process.stderr.write(
         `[worker] starting codex turn ${globalTurnCount}/${maxTurns}${isFirstTurn ? " (initial)" : " (continuation)"}\n`

--- a/packages/worker/src/thread-resume.test.ts
+++ b/packages/worker/src/thread-resume.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildContinuationTurnInput,
   buildInitialTurnInput,
+  DEFAULT_CONTINUATION_GUIDANCE,
   parseNonNegativeInteger,
   resolveRemainingTurns,
 } from "./thread-resume.js";
@@ -41,12 +43,21 @@ describe("buildInitialTurnInput", () => {
   });
 
   it("builds a concise continuation prompt for hard resume", () => {
-    expect(
-      buildInitialTurnInput({
-        renderedPrompt: "original prompt",
-        mode: "resume",
-      })
-    ).toContain("existing thread context");
+    const prompt = buildInitialTurnInput({
+      renderedPrompt: "original prompt",
+      mode: "resume",
+      lastTurnSummary: "Finished the parser update.",
+      cumulativeTurnCount: 4,
+      continuationGuidance:
+        "Continue from turn {{cumulativeTurnCount}} with {{lastTurnSummary}}",
+    });
+
+    expect(prompt).toContain("existing thread context");
+    expect(prompt).toContain("Previous worker turns completed: 4.");
+    expect(prompt).toContain("Finished the parser update.");
+    expect(prompt).toContain(
+      "Continue from turn 4 with Finished the parser update."
+    );
   });
 
   it("embeds the last turn summary for soft resume", () => {
@@ -54,10 +65,36 @@ describe("buildInitialTurnInput", () => {
       renderedPrompt: "original prompt",
       mode: "soft-resume",
       lastTurnSummary: "Implemented the env passthrough.",
+      cumulativeTurnCount: 3,
+      continuationGuidance:
+        "Use summary {{lastTurnSummary}} after {{cumulativeTurnCount}} turns.",
     });
 
     expect(prompt).toContain("Original issue instructions:");
     expect(prompt).toContain("Implemented the env passthrough.");
-    expect(prompt).toContain("carry-over context");
+    expect(prompt).toContain(
+      "Use summary Implemented the env passthrough. after 3 turns."
+    );
+  });
+});
+
+describe("buildContinuationTurnInput", () => {
+  it("falls back to the default continuation guidance", () => {
+    expect(buildContinuationTurnInput({})).toBe(
+      DEFAULT_CONTINUATION_GUIDANCE
+    );
+  });
+
+  it("renders continuation template variables for resume-aware prompts", () => {
+    expect(
+      buildContinuationTurnInput({
+        continuationGuidance:
+          "Continue after {{cumulativeTurnCount}} turns. Summary: {{lastTurnSummary}}",
+        cumulativeTurnCount: 6,
+        lastTurnSummary: "worker resumed the same issue thread",
+      })
+    ).toBe(
+      "Continue after 6 turns. Summary: worker resumed the same issue thread"
+    );
   });
 });

--- a/packages/worker/src/thread-resume.ts
+++ b/packages/worker/src/thread-resume.ts
@@ -1,9 +1,20 @@
 export type ThreadBootstrapMode = "fresh" | "resume" | "soft-resume";
 
+export const DEFAULT_CONTINUATION_GUIDANCE =
+  "Continue working on the issue. Review your progress and complete any remaining tasks.";
+
 type BuildInitialTurnInputParams = {
   renderedPrompt: string;
   mode: ThreadBootstrapMode;
   lastTurnSummary?: string | null;
+  cumulativeTurnCount?: number;
+  continuationGuidance?: string | null;
+};
+
+type BuildContinuationTurnInputParams = {
+  continuationGuidance?: string | null;
+  lastTurnSummary?: string | null;
+  cumulativeTurnCount?: number;
 };
 
 export function parseNonNegativeInteger(
@@ -33,19 +44,35 @@ export function buildInitialTurnInput({
   renderedPrompt,
   mode,
   lastTurnSummary,
+  cumulativeTurnCount = 0,
+  continuationGuidance,
 }: BuildInitialTurnInputParams): string {
   if (mode === "fresh") {
     return renderedPrompt;
   }
 
+  const renderedContinuationGuidance = buildContinuationTurnInput({
+    continuationGuidance,
+    lastTurnSummary,
+    cumulativeTurnCount,
+  });
+  const normalizedSummary =
+    normalizeContinuationVariable(lastTurnSummary) ??
+    "No previous turn summary was captured.";
+  const normalizedCumulativeTurnCount = Math.max(
+    0,
+    parseNonNegativeInteger(cumulativeTurnCount)
+  );
+
   if (mode === "resume") {
     return [
       "Resume work on this issue using the existing thread context.",
-      "Review the latest state in the thread and continue from where the previous worker stopped.",
-    ].join(" ");
+      `Previous worker turns completed: ${normalizedCumulativeTurnCount}.`,
+      `Previous session summary: ${normalizedSummary}`,
+      renderedContinuationGuidance,
+    ].join("\n");
   }
 
-  const normalizedSummary = lastTurnSummary?.trim() || "No previous turn summary was captured.";
   return [
     "Resume work on this issue from a previous worker session.",
     "",
@@ -55,6 +82,41 @@ export function buildInitialTurnInput({
     "Previous session summary:",
     normalizedSummary,
     "",
-    "Use this summary as carry-over context, avoid restarting completed work, and finish the remaining tasks.",
+    renderedContinuationGuidance,
   ].join("\n");
+}
+
+export function buildContinuationTurnInput({
+  continuationGuidance,
+  lastTurnSummary,
+  cumulativeTurnCount = 0,
+}: BuildContinuationTurnInputParams): string {
+  const template =
+    continuationGuidance?.trim() || DEFAULT_CONTINUATION_GUIDANCE;
+
+  return renderContinuationGuidance(template, {
+    lastTurnSummary:
+      normalizeContinuationVariable(lastTurnSummary) ??
+      "No previous turn summary was captured.",
+    cumulativeTurnCount: String(
+      Math.max(0, parseNonNegativeInteger(cumulativeTurnCount))
+    ),
+  });
+}
+
+function normalizeContinuationVariable(
+  value: string | null | undefined
+): string | null {
+  const normalized = value?.trim();
+  return normalized ? normalized : null;
+}
+
+function renderContinuationGuidance(
+  template: string,
+  variables: Record<string, string>
+): string {
+  return template.replace(
+    /\{\{\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}/g,
+    (match, key: string) => variables[key] ?? match
+  );
 }


### PR DESCRIPTION
## Issues

- Fixes #122

## Summary

- WORKFLOW.md에 `continuationGuidance` 설정을 추가해 continuation 메시지를 커스터마이즈할 수 있게 했습니다.
- worker가 resume 시 이전 턴 요약과 누적 턴 수를 템플릿 변수로 주입해 더 맥락 있는 continuation 프롬프트를 생성합니다.

## Changes

- `packages/core` workflow config/parser에 `continuationGuidance` 필드를 추가하고 `continuation_guidance` 및 `continuationGuidance` front matter를 모두 파싱하도록 확장했습니다.
- `packages/worker`의 resume/continuation 프롬프트 빌더를 공통화하고 `{{lastTurnSummary}}`, `{{cumulativeTurnCount}}` 치환을 지원하도록 변경했습니다.
- `SYMPHONY_CONTINUATION_GUIDANCE` 환경변수가 workflow 설정보다 우선하도록 연결하고 관련 conformance/unit 테스트를 보강했습니다.

## Evidence

- `pnpm --filter @gh-symphony/core test`
- `pnpm --filter @gh-symphony/worker test`
- `pnpm lint && pnpm typecheck && pnpm build`
- Manual check: `packages/worker/src/thread-resume.ts`에서 hardcoded continuation 문구가 제거되고 resume/continuation 모두 동일한 템플릿 경로를 사용하도록 diff를 재확인했습니다.

## Human Validation

- [ ] Confirm the main user flow works as expected
- [ ] Confirm there is no obvious regression in adjacent behavior
- [ ] Confirm reviewer-visible behavior matches the issue requirements

## Risks

- continuation guidance 템플릿 렌더링은 현재 단순 변수 치환(`{{lastTurnSummary}}`, `{{cumulativeTurnCount}}`)만 지원합니다.
