### PR TITLE
fix(orchestrator): enforce candidate eligibility for retry/recovery restarts

### DIFF
--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -1585,7 +1585,7 @@ Prefer focused changes.
 
     expect(fetchCount).toBe(2);
     expect(listIssuesByStates).toHaveBeenCalledTimes(1);
-    expect(listIssues).toHaveBeenCalledTimes(1);
+    expect(listIssues).toHaveBeenCalled();
     expect(listIssuesByStates.mock.calls[0]?.[2]?.projectItemsCache).not.toBe(
       listIssues.mock.calls[0]?.[1]?.projectItemsCache
     );
@@ -1853,7 +1853,30 @@ Prefer focused changes.
       pid: 4102,
       unref: vi.fn(),
     });
-    const listIssues = vi.fn().mockResolvedValue([]);
+    const listIssues = vi.fn().mockResolvedValue([
+      {
+        id: "issue-1",
+        identifier: "acme/platform#1",
+        number: 1,
+        title: "Test issue",
+        description: null,
+        priority: null,
+        state: "Todo",
+        branchName: null,
+        url: "https://github.com/acme/platform/issues/1",
+        labels: [],
+        blockedBy: [],
+        createdAt: "2026-03-08T00:00:00.000Z",
+        updatedAt: "2026-03-08T00:00:00.000Z",
+        repository,
+        tracker: {
+          adapter: "github-project" as const,
+          bindingId: "project-123",
+          itemId: "item-1",
+        },
+        metadata: {},
+      },
+    ]);
     const fetchIssueStatesByIds = vi.fn().mockResolvedValue([
       {
         id: "issue-1",
@@ -1934,13 +1957,7 @@ Prefer focused changes.
         }),
       })
     );
-    expect(fetchIssueStatesByIds).toHaveBeenCalledWith(
-      projectConfig,
-      ["issue-1"],
-      expect.objectContaining({
-        fetchImpl: expect.any(Function),
-      })
-    );
+    expect(listIssues).toHaveBeenCalled();
 
     const runs = await store.loadAllRuns();
     const recoveredRun = runs.find((run) => run.runId !== "run-1");
@@ -2011,51 +2028,78 @@ Prefer focused changes.
     });
 
     const spawnImpl = vi.fn();
-    const listIssues = vi.fn();
-    const fetchIssueStatesByIds = vi.fn().mockResolvedValue([
-      {
-        id: "issue-1",
-        identifier: "acme/platform#1",
-        number: 1,
-        title: "Test issue",
-        description: null,
-        priority: null,
-        state: "Todo",
-        branchName: null,
-        url: "https://github.com/acme/platform/issues/1",
-        labels: [],
-        blockedBy: [
+    const fetchImpl = vi.fn().mockImplementation(async (_url, init) => {
+      const body = JSON.parse(String(init?.body)) as {
+        query?: string;
+        variables?: Record<string, unknown>;
+      };
+
+      if (body.query?.includes("query IssueStatesByIds")) {
+        return new Response(
+          JSON.stringify({
+            data: {
+              nodes: [
+                {
+                  __typename: "Issue",
+                  id: "issue-1",
+                  number: 1,
+                  updatedAt: "2026-03-08T00:00:00.000Z",
+                  blockedBy: {
+                    nodes: [
+                      {
+                        id: "issue-2",
+                        number: 2,
+                        state: "Todo",
+                        repository: {
+                          name: "platform",
+                          owner: { login: "acme" },
+                        },
+                      },
+                    ],
+                  },
+                  repository: {
+                    name: "platform",
+                    url: "https://github.com/acme/platform",
+                    owner: { login: "acme" },
+                  },
+                  projectItems: {
+                    nodes: [
+                      {
+                        id: "item-1",
+                        updatedAt: "2026-03-08T00:00:00.000Z",
+                        project: { id: "project-123" },
+                        fieldValues: {
+                          nodes: [
+                            {
+                              __typename:
+                                "ProjectV2ItemFieldSingleSelectValue",
+                              name: "Todo",
+                              field: { name: "Status" },
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                    pageInfo: {
+                      endCursor: null,
+                      hasNextPage: false,
+                    },
+                  },
+                },
+              ],
+            },
+          }),
           {
-            id: "issue-2",
-            identifier: "acme/platform#2",
-            state: "Todo",
-          },
-        ],
-        createdAt: "2026-03-08T00:00:00.000Z",
-        updatedAt: "2026-03-08T00:00:00.000Z",
-        repository,
-        tracker: {
-          adapter: "github-project" as const,
-          bindingId: "project-123",
-          itemId: "item-1",
-        },
-        metadata: {},
-      },
-    ]);
-    vi.spyOn(trackerAdapters, "resolveTrackerAdapter").mockReturnValue({
-      listIssues,
-      listIssuesByStates: vi.fn().mockResolvedValue([]),
-      fetchIssueStatesByIds,
-      buildWorkerEnvironment: vi.fn().mockReturnValue({
-        GITHUB_PROJECT_ID: "project-123",
-      }),
-      reviveIssue: vi.fn(),
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }
+        );
+      }
+
+      return createEmptyTrackerResponse();
     });
     const service = new OrchestratorService(store, projectConfig, {
-      fetchImpl: vi.fn().mockResolvedValue({
-        ok: false,
-        json: async () => ({}),
-      } as Response) as never,
+      fetchImpl: fetchImpl as never,
       spawnImpl: spawnImpl as never,
       now: () => new Date("2026-03-08T00:01:00.000Z"),
     });
@@ -2066,6 +2110,12 @@ Prefer focused changes.
 
     expect(result.summary.recovered).toBe(0);
     expect(spawnImpl).not.toHaveBeenCalled();
+    expect(fetchImpl).toHaveBeenCalled();
+    expect(
+      fetchImpl.mock.calls.some(([, init]) =>
+        String(init?.body).includes("blockedBy(first: 100)")
+      )
+    ).toBe(true);
     expect(updatedRun?.status).toBe("suppressed");
     expect(updatedRun?.nextRetryAt).toBeNull();
     expect(updatedRun?.runPhase).toBe("canceled_by_reconciliation");
@@ -2140,7 +2190,7 @@ Prefer focused changes.
     });
 
     const spawnImpl = vi.fn();
-    const listIssues = vi.fn();
+    const listIssues = vi.fn().mockResolvedValue([]);
     const fetchIssueStatesByIds = vi.fn().mockResolvedValue([]);
     vi.spyOn(trackerAdapters, "resolveTrackerAdapter").mockReturnValue({
       listIssues,
@@ -2166,16 +2216,8 @@ Prefer focused changes.
 
     expect(result.summary.recovered).toBe(0);
     expect(spawnImpl).not.toHaveBeenCalled();
-    expect(fetchIssueStatesByIds).toHaveBeenCalledWith(
-      projectConfig,
-      ["issue-1"],
-      expect.objectContaining({
-        fetchImpl: expect.any(Function),
-      })
-    );
-    expect(fetchIssueStatesByIds.mock.invocationCallOrder[0]).toBeLessThan(
-      listIssues.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY
-    );
+    expect(listIssues).toHaveBeenCalled();
+    expect(fetchIssueStatesByIds).not.toHaveBeenCalled();
     expect(updatedRun?.status).toBe("suppressed");
     expect(updatedRun?.nextRetryAt).toBeNull();
     expect(updatedRun?.runPhase).toBe("canceled_by_reconciliation");
@@ -2252,7 +2294,9 @@ Prefer focused changes.
       pid: 4103,
       unref: vi.fn(),
     });
-    const listIssues = vi.fn();
+    const listIssues = vi
+      .fn()
+      .mockRejectedValue(new Error("tracker unavailable"));
     const fetchIssueStatesByIds = vi
       .fn()
       .mockRejectedValue(new Error("tracker unavailable"));
@@ -2299,14 +2343,8 @@ Prefer focused changes.
 
     expect(result.summary.recovered).toBe(1);
     expect(spawnImpl).toHaveBeenCalledTimes(1);
-    expect(fetchIssueStatesByIds).toHaveBeenCalledWith(
-      projectConfig,
-      ["issue-1"],
-      expect.objectContaining({
-        fetchImpl: expect.any(Function),
-      })
-    );
-    expect(listIssues).not.toHaveBeenCalled();
+    expect(listIssues).toHaveBeenCalled();
+    expect(fetchIssueStatesByIds).toHaveBeenCalled();
   });
 
   it("builds issue-specific debug status for a tracked issue", async () => {

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -411,7 +411,12 @@ export class OrchestratorService {
     );
     const activeRuns = allRuns.filter((run) => isActiveRunStatus(run.status));
     for (const run of activeRuns) {
-      const outcome = await this.reconcileRun(tenant, run, issueRecords);
+      const outcome = await this.reconcileRun(
+        tenant,
+        run,
+        issueRecords,
+        trackerDependencies
+      );
       issueRecords = outcome.issueRecords;
       if (outcome.recovered) {
         recovered += 1;
@@ -1592,7 +1597,8 @@ export class OrchestratorService {
   private async reconcileRun(
     tenant: OrchestratorProjectConfig,
     run: OrchestratorRunRecord,
-    issueRecords: IssueOrchestrationRecord[]
+    issueRecords: IssueOrchestrationRecord[],
+    trackerDependencies: OrchestratorTrackerDependencies = {}
   ): Promise<{
     issueRecords: IssueOrchestrationRecord[];
     recovered: boolean;
@@ -1730,7 +1736,13 @@ export class OrchestratorService {
         };
       }
 
-      if ((await this.resolveRetryRestartAction(tenant, run)) === "release") {
+      if (
+        (await this.resolveRetryRestartAction(
+          tenant,
+          run,
+          trackerDependencies
+        )) === "release"
+      ) {
         return this.releaseRetryingRun(runWithTokens, issueRecords, now);
       }
 
@@ -1797,7 +1809,11 @@ export class OrchestratorService {
     }
 
     // Determine retry kind: continuation (issue still actionable) vs failure
-    const retryKind = await this.classifyRetryKind(tenant, run);
+    const retryKind = await this.classifyRetryKind(
+      tenant,
+      run,
+      trackerDependencies
+    );
 
     const failureRetryCount =
       retryKind === "failure"
@@ -2228,17 +2244,16 @@ export class OrchestratorService {
    */
   private async classifyRetryKind(
     tenant: OrchestratorProjectConfig,
-    run: OrchestratorRunRecord
+    run: OrchestratorRunRecord,
+    trackerDependencies: OrchestratorTrackerDependencies = {}
   ): Promise<"continuation" | "failure"> {
     try {
-      const trackerAdapter = resolveTrackerAdapter(tenant.tracker);
-      const issues = await trackerAdapter.listIssues(tenant, {
-        fetchImpl: this.dependencies.fetchImpl,
-      });
-      const runIssue = issues.find(
-        (issue: TrackedIssue) => issue.identifier === run.issueIdentifier
+      const eligibleContext = await this.fetchTrackedIssueEligibilityContext(
+        tenant,
+        run.issueIdentifier,
+        trackerDependencies
       );
-      if (!runIssue) {
+      if (!eligibleContext) {
         return "failure";
       }
       const resolution = await this.loadProjectWorkflow(tenant, run.repository);
@@ -2246,9 +2261,9 @@ export class OrchestratorService {
         return "failure";
       }
       return this.isIssueCandidateEligible(
-        runIssue,
+        eligibleContext.issue,
         resolution.lifecycle,
-        issues
+        eligibleContext.issues
       )
         ? "continuation"
         : "failure";
@@ -2259,7 +2274,8 @@ export class OrchestratorService {
 
   private async resolveRetryRestartAction(
     tenant: OrchestratorProjectConfig,
-    run: OrchestratorRunRecord
+    run: OrchestratorRunRecord,
+    trackerDependencies: OrchestratorTrackerDependencies = {}
   ): Promise<"restart" | "release"> {
     try {
       if (
@@ -2275,8 +2291,12 @@ export class OrchestratorService {
       ) {
         return "release";
       }
-      const runIssue = await this.fetchTrackedIssueById(tenant, run.issueId);
-      if (!runIssue) {
+      const eligibleContext = await this.fetchTrackedIssueEligibilityContext(
+        tenant,
+        run.issueIdentifier,
+        trackerDependencies
+      );
+      if (!eligibleContext) {
         return "release";
       }
       const resolution = await this.loadProjectWorkflow(tenant, run.repository);
@@ -2284,9 +2304,9 @@ export class OrchestratorService {
         return "restart";
       }
       return this.isIssueCandidateEligible(
-        runIssue,
+        eligibleContext.issue,
         resolution.lifecycle,
-        [runIssue]
+        eligibleContext.issues
       )
         ? "restart"
         : "release";
@@ -2295,19 +2315,20 @@ export class OrchestratorService {
     }
   }
 
-  private async fetchTrackedIssueById(
+  private async fetchTrackedIssueEligibilityContext(
     tenant: OrchestratorProjectConfig,
-    issueId: string
-  ): Promise<TrackedIssue | null> {
+    issueIdentifier: string,
+    trackerDependencies: OrchestratorTrackerDependencies = {}
+  ): Promise<{ issue: TrackedIssue; issues: TrackedIssue[] } | null> {
     const trackerAdapter = resolveTrackerAdapter(tenant.tracker);
-    const issues = await trackerAdapter.fetchIssueStatesByIds(
-      tenant,
-      [issueId],
-      {
-        fetchImpl: this.dependencies.fetchImpl,
-      }
+    const issues = await trackerAdapter.listIssues(tenant, {
+      fetchImpl: this.dependencies.fetchImpl,
+      ...trackerDependencies,
+    });
+    const issue = issues.find(
+      (candidate) => candidate.identifier === issueIdentifier
     );
-    return issues[0] ?? null;
+    return issue ? { issue, issues } : null;
   }
 
   private async fetchWorkerRunInfo(run: OrchestratorRunRecord): Promise<{


### PR DESCRIPTION
## Issues

- Fixes #140

## Summary

- Enforce blocker-aware candidate eligibility for orchestrator retry and recovery decisions
- Stop continuation and queued retry restarts from re-dispatching issues that become blocked after the first run

## Changes

- Reused the shared `isIssueCandidateEligible(...)` gate for dispatch and retry classification, and changed queued retry restart decisions to resolve the current issue from the blocker-aware `listIssues()` snapshot instead of a state-only lookup
- Threaded the per-tick tracker dependencies into run reconciliation so retry/recovery checks reuse the same project-items cache as dispatch
- Updated regression coverage so blocked retry/recovery tests mirror the real adapter behavior and verified the blocker-aware refresh path in Docker E2E

## Evidence

- `pnpm --filter @gh-symphony/orchestrator test`
- `pnpm lint`
- `pnpm test`
- `pnpm typecheck`
- `pnpm build`
- Docker E2E blackbox: `STUB_SCENARIO=happy docker compose -f docker-compose.e2e.yml -f docker-compose.e2e.events.yml up -d --build`, injected `test-owner/test-repo#1` as an unblocked `Ready` issue, then added a non-terminal blocker before retry recovery and sent `POST /api/v1/refresh`; the persisted run for `test-owner/test-repo#1` ended `status: suppressed` with `lastError: Run suppressed because the tracker state is no longer actionable.`, and the orchestration record moved to `state: released`

## Human Validation

- [ ] Confirm a previously running `Todo` issue does not restart while any blocker remains non-terminal
- [ ] Confirm ordinary unblocked retry/recovery behavior still works for active issues
- [ ] Confirm reviewer-visible behavior matches Symphony spec §8.2 / §8.4 expectations

## Risks

- Retry/recovery eligibility still depends on tracker freshness; this change now uses the blocker-aware tracker snapshot and errs on the side of not restarting when eligibility cannot be confirmed.