### PR TITLE
fix(worker): persist retry token usage as deltas

### DIFF
--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -87,7 +87,7 @@ describe("OrchestratorService", () => {
     );
   });
 
-  it("passes issue budget limits and cumulative usage baselines to worker env", async () => {
+  it("passes issue budget limits and cumulative delta usage baselines to worker env", async () => {
     process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
     process.env.SYMPHONY_GLOBAL_MAX_TURNS = "12";
     process.env.SYMPHONY_MAX_TOKENS = "900";
@@ -143,6 +143,47 @@ describe("OrchestratorService", () => {
           totalTokens: 150,
         },
       });
+      await store.saveRun({
+        runId: "run-retry",
+        projectId: projectConfig.projectId,
+        projectSlug: projectConfig.slug,
+        issueId: "issue-1",
+        issueSubjectId: "issue-1",
+        issueIdentifier: "acme/platform#1",
+        issueTitle: "Issue 1",
+        issueState: "Todo",
+        repository: {
+          cloneUrl: repository.cloneUrl,
+          owner: repository.owner,
+          name: repository.name,
+          url: `https://github.com/${repository.owner}/${repository.name}`,
+        },
+        status: "failed",
+        attempt: 3,
+        processId: null,
+        port: null,
+        workingDirectory: repository.path,
+        issueWorkspaceKey: "workspace-1",
+        workspaceRuntimeDir: join(tempRoot, "runtime-retry"),
+        workflowPath: join(repository.path, "WORKFLOW.md"),
+        retryKind: "failure",
+        threadId: "thread-retry",
+        cumulativeTurnCount: null,
+        turnCount: 1,
+        lastTurnSummary: "thread/tokenUsage/updated",
+        createdAt: "2026-03-08T00:00:10.000Z",
+        updatedAt: "2026-03-08T00:00:20.000Z",
+        startedAt: "2026-03-08T00:00:10.000Z",
+        completedAt: "2026-03-08T00:00:20.000Z",
+        lastError: "retry failure",
+        nextRetryAt: null,
+        runPhase: "failed",
+        tokenUsage: {
+          inputTokens: 12,
+          outputTokens: 8,
+          totalTokens: 20,
+        },
+      });
 
       const spawnImpl = vi.fn().mockReturnValue({
         pid: 4103,
@@ -163,10 +204,10 @@ describe("OrchestratorService", () => {
       expect(workerEnv?.SYMPHONY_MAX_TOKENS).toBe("900");
       expect(workerEnv?.SYMPHONY_MAX_NONPRODUCTIVE_TURNS).toBe("7");
       expect(workerEnv?.SYMPHONY_SESSION_TIMEOUT_MS).toBe("600000");
-      expect(workerEnv?.SYMPHONY_CUMULATIVE_TURN_COUNT).toBe("5");
-      expect(workerEnv?.SYMPHONY_CUMULATIVE_INPUT_TOKENS).toBe("100");
-      expect(workerEnv?.SYMPHONY_CUMULATIVE_OUTPUT_TOKENS).toBe("50");
-      expect(workerEnv?.SYMPHONY_CUMULATIVE_TOTAL_TOKENS).toBe("150");
+      expect(workerEnv?.SYMPHONY_CUMULATIVE_TURN_COUNT).toBe("6");
+      expect(workerEnv?.SYMPHONY_CUMULATIVE_INPUT_TOKENS).toBe("112");
+      expect(workerEnv?.SYMPHONY_CUMULATIVE_OUTPUT_TOKENS).toBe("58");
+      expect(workerEnv?.SYMPHONY_CUMULATIVE_TOTAL_TOKENS).toBe("170");
       expect(workerEnv?.SYMPHONY_SESSION_STARTED_AT).toBe(
         "2026-03-07T23:59:00.000Z"
       );

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -172,7 +172,7 @@ function shutdown(signal: NodeJS.Signals) {
 
     stopOrchestratorHeartbeatTimer();
     emitOrchestratorHeartbeat();
-    await persistTokenUsageArtifact(launcherEnv, runtimeState.tokenUsage);
+    await persistSessionTokenUsageArtifact(launcherEnv);
     await waitForPendingOrchestratorChannelFlush(
       resolveTerminalOrchestratorChannelFlushTimeoutMs()
     );
@@ -302,7 +302,7 @@ function emitOrchestratorHeartbeat(): void {
     type: "heartbeat",
     issueId,
     lastEventAt: runtimeState.lastEventAt,
-    tokenUsage: { ...runtimeState.tokenUsage },
+    tokenUsage: resolveSessionTokenUsageDelta(),
     rateLimits: runtimeState.rateLimits ? { ...runtimeState.rateLimits } : null,
     sessionInfo: { ...runtimeState.sessionInfo },
     executionPhase: runtimeState.executionPhase,
@@ -344,7 +344,7 @@ function emitOrchestratorChannelEvent(event?: string): void {
     type: "codex_update",
     issueId,
     lastEventAt,
-    tokenUsage: { ...runtimeState.tokenUsage },
+    tokenUsage: resolveSessionTokenUsageDelta(),
     sessionInfo: { ...runtimeState.sessionInfo },
     executionPhase: runtimeState.executionPhase,
     runPhase: runtimeState.runPhase,
@@ -382,6 +382,16 @@ function resolveTurnTokenUsageDelta(
       runtimeState.tokenUsage.totalTokens - baseline.totalTokens
     ),
   };
+}
+
+function resolveSessionTokenUsageDelta(): TokenUsageSnapshot {
+  return resolveTurnTokenUsageDelta(sessionBudgetState.tokenUsageBaseline);
+}
+
+async function persistSessionTokenUsageArtifact(
+  env: NodeJS.ProcessEnv
+): Promise<void> {
+  await persistTokenUsageArtifact(env, resolveSessionTokenUsageDelta());
 }
 
 function emitTurnStartedEvent(turn: ActiveTurnTelemetry): void {
@@ -515,7 +525,7 @@ async function startAssignedRun() {
                 : `codex app-server exited with ${signal ?? code ?? "unknown"}`;
           }
         }
-        void persistTokenUsageArtifact(launcherEnv, runtimeState.tokenUsage);
+        void persistSessionTokenUsageArtifact(launcherEnv);
       }
     );
     childProcess.once("error", (error: Error) => {
@@ -525,7 +535,7 @@ async function startAssignedRun() {
       if (runtimeState.run) {
         runtimeState.run.lastError = error.message;
       }
-      void persistTokenUsageArtifact(launcherEnv, runtimeState.tokenUsage);
+      void persistSessionTokenUsageArtifact(launcherEnv);
     });
   } catch (error) {
     runtimeState.status = "failed";
@@ -535,7 +545,7 @@ async function startAssignedRun() {
       runtimeState.run.lastError =
         error instanceof Error ? error.message : "Unknown worker startup error";
     }
-    await persistTokenUsageArtifact(launcherEnv, runtimeState.tokenUsage);
+    await persistSessionTokenUsageArtifact(launcherEnv);
   }
 }
 
@@ -1127,7 +1137,7 @@ async function runCodexClientProtocol(
       });
       stopOrchestratorHeartbeatTimer();
       emitOrchestratorHeartbeat();
-      await persistTokenUsageArtifact(env, runtimeState.tokenUsage);
+      await persistSessionTokenUsageArtifact(env);
       await waitForPendingOrchestratorChannelFlush(
         resolveTerminalOrchestratorChannelFlushTimeoutMs()
       );
@@ -1400,7 +1410,7 @@ async function runCodexClientProtocol(
     });
     stopOrchestratorHeartbeatTimer();
     emitOrchestratorHeartbeat();
-    await persistTokenUsageArtifact(env, runtimeState.tokenUsage);
+    await persistSessionTokenUsageArtifact(env);
     await waitForPendingOrchestratorChannelFlush(
       resolveTerminalOrchestratorChannelFlushTimeoutMs()
     );
@@ -1447,7 +1457,7 @@ async function runCodexClientProtocol(
 
     stopOrchestratorHeartbeatTimer();
     emitOrchestratorHeartbeat();
-    await persistTokenUsageArtifact(env, runtimeState.tokenUsage);
+    await persistSessionTokenUsageArtifact(env);
     await waitForPendingOrchestratorChannelFlush(
       resolveTerminalOrchestratorChannelFlushTimeoutMs()
     );

--- a/packages/worker/src/worker-protocol.test.ts
+++ b/packages/worker/src/worker-protocol.test.ts
@@ -90,6 +90,7 @@ function createProtocolContext(options: {
   readTimeoutMs?: number;
   turnTimeoutMs?: number;
   maxTurns?: number;
+  tokenUsageBaseline?: TokenUsageSnapshot;
   orchestratorChannelWriter?: {
     write: (chunk: string) => boolean;
     once: (event: "drain", listener: () => void) => unknown;
@@ -101,6 +102,11 @@ function createProtocolContext(options: {
     readTimeoutMs = 5000,
     turnTimeoutMs = 3600000,
     maxTurns = 20,
+    tokenUsageBaseline = {
+      inputTokens: 0,
+      outputTokens: 0,
+      totalTokens: 0,
+    },
     orchestratorChannelWriter,
   } = options;
   const fake = createFakeChild();
@@ -146,7 +152,7 @@ function createProtocolContext(options: {
       issueId: "issue-1",
       lastError: null as string | null,
     },
-    tokenUsage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+    tokenUsage: { ...tokenUsageBaseline },
     lastEventAt: null as string | null,
     rateLimits: null as Record<string, unknown> | null,
     sessionInfo: {
@@ -243,7 +249,7 @@ function createProtocolContext(options: {
       type: "codex_update",
       issueId: runtimeState.run.issueId,
       lastEventAt: runtimeState.lastEventAt,
-      tokenUsage: { ...runtimeState.tokenUsage },
+      tokenUsage: resolveSessionTokenUsageDelta(),
       sessionInfo: { ...runtimeState.sessionInfo },
       executionPhase: runtimeState.executionPhase,
       runPhase: runtimeState.runPhase,
@@ -281,6 +287,10 @@ function createProtocolContext(options: {
         runtimeState.tokenUsage.totalTokens - baseline.totalTokens
       ),
     };
+  }
+
+  function resolveSessionTokenUsageDelta(): TokenUsageSnapshot {
+    return resolveTurnTokenUsageDelta(tokenUsageBaseline);
   }
 
   function emitTurnStartedEvent(turn: ActiveTurnTelemetry): void {
@@ -346,7 +356,7 @@ function createProtocolContext(options: {
       type: "heartbeat",
       issueId: runtimeState.run.issueId,
       lastEventAt: runtimeState.lastEventAt,
-      tokenUsage: { ...runtimeState.tokenUsage },
+      tokenUsage: resolveSessionTokenUsageDelta(),
       rateLimits: runtimeState.rateLimits
         ? { ...runtimeState.rateLimits }
         : null,
@@ -2517,6 +2527,47 @@ describe("token usage tracking", () => {
       inputTokens: 200,
       outputTokens: 100,
       totalTokens: 300,
+    });
+  });
+
+  it("emits session token usage deltas on orchestrator channel events", () => {
+    const ctx = createProtocolContext({
+      tokenUsageBaseline: {
+        inputTokens: 100,
+        outputTokens: 50,
+        totalTokens: 150,
+      },
+    });
+
+    ctx.handleServerMessage({
+      method: "thread/tokenUsage/updated",
+      params: { input_tokens: 140, output_tokens: 70, total_tokens: 210 },
+    });
+
+    expect(ctx.runtimeState.tokenUsage).toEqual({
+      inputTokens: 140,
+      outputTokens: 70,
+      totalTokens: 210,
+    });
+    expect(ctx.orchestratorEvents.at(-1)).toMatchObject({
+      type: "codex_update",
+      event: "thread/tokenUsage/updated",
+      tokenUsage: {
+        inputTokens: 40,
+        outputTokens: 20,
+        totalTokens: 60,
+      },
+    });
+
+    ctx.emitOrchestratorHeartbeat();
+
+    expect(ctx.orchestratorEvents.at(-1)).toMatchObject({
+      type: "heartbeat",
+      tokenUsage: {
+        inputTokens: 40,
+        outputTokens: 20,
+        totalTokens: 60,
+      },
     });
   });
 


### PR DESCRIPTION
## Issues

- Fixes #147

## Summary

- worker가 baseline을 포함한 absolute token usage를 그대로 저장/전파하던 경로를 세션 delta 기준으로 정렬했습니다
- retry가 반복되어도 orchestrator의 누적 `totalTokens`가 이전 세션 baseline을 다시 합산하지 않도록 회귀를 막았습니다

## Changes

- `packages/worker/src/index.ts`에서 heartbeat, `codex_update`, `token-usage.json` 저장 시 `SYMPHONY_CUMULATIVE_*` baseline을 제외한 세션 delta만 내보내도록 변경했습니다
- `packages/worker/src/worker-protocol.test.ts`에 baseline이 있는 세션에서도 orchestrator channel payload가 delta를 유지하는 회귀 테스트를 추가했습니다
- `packages/orchestrator/src/service.test.ts`에 이전 run delta들을 다음 worker env baseline으로 정확히 합산하는 회귀 테스트를 추가했습니다

## Evidence

- `pnpm --filter @gh-symphony/worker test -- worker-protocol.test.ts token-usage.test.ts session-budget.test.ts`
- `pnpm --filter @gh-symphony/orchestrator test -- service.test.ts`
- `pnpm lint && pnpm test && pnpm typecheck && pnpm build`
- Manual check: Docker E2E fail scenario에서 `/api/v1/state`의 `codexTotals.totalTokens`가 `192`로 유지되고 `token-usage.json`도 `192`만 저장되는 것을 확인했습니다

## Human Validation

- [ ] 재시도 run이 여러 번 발생해도 `totalTokens`가 2배씩 증가하지 않는지 확인
- [ ] dashboard/status에서 현재 run token usage와 전체 누적 합산이 기대값과 일치하는지 확인
- [ ] 실패 후 retry queue 진입 시에도 token artifact가 정상 저장되는지 확인

## Risks

- e2e stub worker는 baseline 누적 env를 해석하지 않으므로, absolute→delta 변환 자체는 단위/서비스 테스트가 주 검증 경로입니다
