### PR TITLE
feat(cli): add doctor --fix remediation mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Validate the local prerequisites before setup:
 
 ```bash
 gh-symphony doctor
+gh-symphony doctor --fix
 gh-symphony doctor --json
 ```
 
@@ -155,6 +156,7 @@ Managing projects:
 
 ```bash
 gh-symphony doctor                   # Validate local prerequisites, auth, config, WORKFLOW.md, and runtime command
+gh-symphony doctor --fix             # Create safe missing paths and print/run remediation follow-ups
 gh-symphony project list             # List all configured projects
 gh-symphony project remove <id>      # Remove a project
 gh-symphony project switch           # Switch the active project
@@ -226,7 +228,15 @@ gh-symphony config edit             # Open config in $EDITOR
 
 ### Diagnostics
 
-`gh-symphony doctor` runs a single first-run diagnostic pass and exits non-zero if any required prerequisite is missing. It checks local runtime prerequisites as well as GitHub setup:
+`gh-symphony doctor` runs a single first-run diagnostic pass and exits non-zero if any required prerequisite is missing. `gh-symphony doctor --fix` adds a remediation pass on top of the same checks. It can:
+
+- create missing config, runtime, and workspace directories
+- launch `gh auth login` / `gh auth refresh` in TTY environments, or print the exact command in non-interactive environments
+- launch `gh-symphony init` when `WORKFLOW.md` is missing or invalid
+- launch `gh-symphony project add` when the managed project or GitHub Project binding must be reconfigured
+- print environment-specific runtime install guidance when the configured command is missing from `PATH`
+
+The diagnostic checks cover:
 
 - the active GitHub auth source (`GITHUB_GRAPHQL_TOKEN` first, otherwise `gh`) and required scopes (`repo`, `read:org`, `project`)
 - Node.js runtime version against the documented minimum (`v24+`) and the current `process.version`
@@ -236,10 +246,11 @@ gh-symphony config edit             # Open config in $EDITOR
 - repository `WORKFLOW.md` presence and parse validity
 - configured runtime command availability on `PATH`
 
-Use `--json` for setup automation and smoke checks:
+Use `--json` for setup automation and smoke checks. When combined with `--fix`, the JSON report also includes a structured remediation step list with `applied`, `skipped`, or `manual` outcomes.
 
 ```bash
 gh-symphony doctor --json
+gh-symphony doctor --fix --json
 gh-symphony start --once
 ```
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -34,6 +34,7 @@ Validate the machine and repo prerequisites before first use:
 
 ```bash
 gh-symphony doctor
+gh-symphony doctor --fix
 gh-symphony doctor --json
 GITHUB_GRAPHQL_TOKEN=ghp_your_classic_token gh-symphony doctor --json
 ```
@@ -159,6 +160,7 @@ gh-symphony project add
 
 ```bash
 gh-symphony doctor                   # Validate local prerequisites, auth, config, WORKFLOW.md, and runtime command
+gh-symphony doctor --fix             # Apply safe fixes and guide/launch follow-up recovery commands
 gh-symphony project list             # List all configured projects
 gh-symphony project remove <id>      # Remove a project
 gh-symphony repo sync                # Add newly linked repositories from the GitHub Project
@@ -214,7 +216,15 @@ gh-symphony recover --dry-run       # Preview what would be recovered
 
 ## Diagnostics
 
-`gh-symphony doctor` validates the most common first-run prerequisites in one pass:
+`gh-symphony doctor` validates the most common first-run prerequisites in one pass. `gh-symphony doctor --fix` extends that flow with safe remediation and guided follow-up:
+
+- creates missing config/runtime/workspace directories
+- launches `gh auth login` or `gh auth refresh` when a TTY is available, otherwise prints the exact command to run
+- launches `gh-symphony init` when `WORKFLOW.md` is missing or invalid
+- launches `gh-symphony project add` when managed project setup or GitHub Project binding must be repaired
+- prints concrete runtime install guidance when the configured command is missing on `PATH`
+
+The diagnostic checks cover:
 
 - the active GitHub auth source (`GITHUB_GRAPHQL_TOKEN` first, otherwise `gh`) and required scopes
 - Node.js runtime version against the documented minimum (`v24+`) and the current `process.version`
@@ -225,12 +235,11 @@ gh-symphony recover --dry-run       # Preview what would be recovered
 - repository `WORKFLOW.md` presence and parse validity
 - runtime command availability on `PATH`
 
-This makes `doctor` useful before the first `init` or sync step, not just for GitHub auth troubleshooting.
-
-Use JSON output for scripts and CI smoke checks:
+Use JSON output for scripts and CI smoke checks. `--fix --json` includes a remediation section where each step is reported as `applied`, `skipped`, or `manual`.
 
 ```bash
 gh-symphony doctor --json
+gh-symphony doctor --fix --json
 gh-symphony start --once
 ```
 
@@ -243,7 +252,7 @@ Setup:
   workflow init       Interactive repository setup wizard
   workflow validate   Parse and strictly validate WORKFLOW.md
   workflow preview    Render the final worker prompt from a sample issue
-  doctor              Run first-run diagnostics
+  doctor              Run diagnostics and optional first-run remediation
   config show         Show current configuration
   config set          Set a configuration value
   config edit         Open config in $EDITOR

--- a/packages/cli/src/commands/doctor.test.ts
+++ b/packages/cli/src/commands/doctor.test.ts
@@ -1,9 +1,11 @@
-import { chmod, mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import { access, chmod, mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import { constants } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { CliProjectConfig } from "../config.js";
 import type { GlobalOptions } from "../index.js";
+import { resolveRuntimeRoot } from "../orchestrator-runtime.js";
 import doctorCommand, {
   type DoctorDependencies,
   runDoctorCommand,
@@ -139,6 +141,16 @@ async function withCwd<T>(cwd: string, action: () => Promise<T>): Promise<T> {
   }
 }
 
+async function prepareDoctorPaths(
+  configDir: string,
+  workspaceDir?: string
+): Promise<void> {
+  await mkdir(resolveRuntimeRoot(configDir), { recursive: true });
+  if (workspaceDir) {
+    await mkdir(workspaceDir, { recursive: true });
+  }
+}
+
 afterEach(() => {
   vi.restoreAllMocks();
   if (originalGraphQlToken === undefined) {
@@ -157,7 +169,7 @@ describe("runDoctorDiagnostics", () => {
   it("reports success when all required checks pass", async () => {
     const configDir = await mkdtemp(join(tmpdir(), "doctor-config-"));
     const workspaceDir = join(configDir, "workspaces");
-    await mkdir(workspaceDir, { recursive: true });
+    await prepareDoctorPaths(configDir, workspaceDir);
     const { repoDir, pathEnv } = await createWorkflowFixture();
 
     const report = await withCwd(repoDir, () =>
@@ -477,6 +489,7 @@ describe("runDoctorDiagnostics", () => {
   it("reports missing scopes with a refresh command", async () => {
     const configDir = await mkdtemp(join(tmpdir(), "doctor-config-"));
     const workspaceDir = join(configDir, "workspaces");
+    await prepareDoctorPaths(configDir, workspaceDir);
     const { repoDir } = await createWorkflowFixture();
 
     const report = await withCwd(repoDir, () =>
@@ -624,20 +637,67 @@ describe("runDoctorDiagnostics", () => {
       report.checks.find((check) => check.id === "config_directory")
     ).toMatchObject({
       status: "fail",
-      summary: expect.stringContaining("not writable"),
+      summary: expect.stringContaining("not a directory"),
     });
     expect(
       report.checks.find((check) => check.id === "workspace_root")
     ).toMatchObject({
       status: "fail",
-      summary: expect.stringContaining("not writable"),
+      summary: expect.stringContaining("not a directory"),
+    });
+  });
+
+  it("does not create missing directories during diagnostics", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "doctor-missing-paths-"));
+    const configDir = join(rootDir, "config");
+    const workspaceDir = join(rootDir, "workspace");
+    const { repoDir, pathEnv } = await createWorkflowFixture();
+
+    const report = await withCwd(repoDir, () =>
+      runDoctorDiagnostics(baseOptions(configDir), [], {
+        checkGhInstalled: () => true,
+        checkGhAuthenticated: () => ({ authenticated: true, login: "tester" }),
+        checkGhScopes: () => ({
+          valid: true,
+          missing: [],
+          scopes: ["repo", "read:org", "project"],
+        }),
+        getGhToken: () => "ghp_test",
+        inspectManagedProjectSelection: async () => ({
+          kind: "resolved",
+          projectId: "tenant-a",
+          projectConfig: createProjectConfig(workspaceDir),
+        }),
+        createClient: ((token: string) => ({ token })) as never,
+        getProjectDetail: (async () =>
+          ({
+            id: "PVT_test",
+            title: "Acme Platform",
+            url: "https://github.com/orgs/acme/projects/1",
+            statusFields: [],
+            textFields: [],
+            linkedRepositories: [],
+          }) as never) as never,
+        pathEnv,
+      })
+    );
+
+    expect(report.ok).toBe(false);
+    await expect(access(configDir, constants.F_OK)).rejects.toBeDefined();
+    await expect(access(workspaceDir, constants.F_OK)).rejects.toBeDefined();
+    expect(
+      report.checks.find((check) => check.id === "config_directory")
+    ).toMatchObject({
+      status: "fail",
+      summary: expect.stringContaining("does not exist"),
+      remediation: expect.stringContaining("mkdir -p"),
     });
   });
 
   it("reports token retrieval errors distinctly from auth failures", async () => {
     const configDir = await mkdtemp(join(tmpdir(), "doctor-config-"));
     const workspaceDir = join(configDir, "workspaces");
-    await mkdir(workspaceDir, { recursive: true });
+    await prepareDoctorPaths(configDir, workspaceDir);
     const { repoDir } = await createWorkflowFixture();
 
     const report = await withCwd(repoDir, () =>
@@ -669,7 +729,7 @@ describe("runDoctorDiagnostics", () => {
   it("reports a missing GitHub project binding with targeted remediation", async () => {
     const configDir = await mkdtemp(join(tmpdir(), "doctor-config-"));
     const workspaceDir = join(configDir, "workspaces");
-    await mkdir(workspaceDir, { recursive: true });
+    await prepareDoctorPaths(configDir, workspaceDir);
     const { repoDir } = await createWorkflowFixture();
 
     const report = await withCwd(repoDir, () =>
@@ -696,7 +756,7 @@ describe("runDoctorDiagnostics", () => {
   it("detects Windows runtime commands via PATHEXT", async () => {
     const configDir = await mkdtemp(join(tmpdir(), "doctor-config-"));
     const workspaceDir = join(configDir, "workspaces");
-    await mkdir(workspaceDir, { recursive: true });
+    await prepareDoctorPaths(configDir, workspaceDir);
     const { repoDir, pathEnv } = await createWindowsWorkflowFixture("agent");
 
     const report = await withCwd(repoDir, () =>
@@ -735,7 +795,7 @@ describe("doctor command handler", () => {
   it("prints JSON output and exits 0 on success", async () => {
     const configDir = await mkdtemp(join(tmpdir(), "doctor-config-"));
     const workspaceDir = join(configDir, "workspaces");
-    await mkdir(workspaceDir, { recursive: true });
+    await prepareDoctorPaths(configDir, workspaceDir);
     const { repoDir, pathEnv } = await createWorkflowFixture();
     const stdout = captureWrites(process.stdout);
 
@@ -795,5 +855,213 @@ describe("doctor command handler", () => {
 
     expect(process.exitCode).toBe(2);
     expect(stderr.output()).toContain("Usage: gh-symphony doctor");
+  });
+
+  it("applies missing directory fixes and reports structured JSON remediation steps", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "doctor-fix-paths-"));
+    const configDir = join(rootDir, "config");
+    const workspaceDir = join(rootDir, "workspace");
+    const { repoDir, pathEnv } = await createWorkflowFixture();
+    const stdout = captureWrites(process.stdout);
+
+    try {
+      await withCwd(repoDir, () =>
+        runDoctorCommand(["--fix"], { ...baseOptions(configDir), json: true }, {
+          ...authDependencies(),
+          inspectManagedProjectSelection: async () => ({
+            kind: "resolved",
+            projectId: "tenant-a",
+            projectConfig: createProjectConfig(workspaceDir),
+          }),
+          getProjectDetail: (async () =>
+            ({
+              id: "PVT_test",
+              title: "Acme Platform",
+              url: "https://github.com/orgs/acme/projects/1",
+              statusFields: [],
+              textFields: [],
+              linkedRepositories: [],
+            }) as never) as never,
+          pathEnv,
+        })
+      );
+    } finally {
+      stdout.restore();
+    }
+
+    const report = JSON.parse(stdout.output()) as {
+      ok: boolean;
+      remediation?: { attempted: boolean; steps: Array<{ checkId: string; status: string }> };
+      checks: Array<{ id: string; status: string }>;
+    };
+    expect(report.ok).toBe(true);
+    expect(report.remediation).toMatchObject({
+      attempted: true,
+    });
+    expect(report.remediation?.steps).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          checkId: "config_directory",
+          status: "applied",
+        }),
+        expect.objectContaining({
+          checkId: "runtime_root",
+          status: "applied",
+        }),
+        expect.objectContaining({
+          checkId: "workspace_root",
+          status: "applied",
+        }),
+      ])
+    );
+    expect(
+      report.checks.find((check) => check.id === "config_directory")
+    ).toMatchObject({ status: "pass" });
+  });
+
+  it("reports manual remediation commands in non-interactive fix mode", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "doctor-config-"));
+    const { repoDir } = await createWorkflowFixture();
+    const stdout = captureWrites(process.stdout);
+
+    try {
+      await withCwd(repoDir, () =>
+        runDoctorCommand(["--fix"], { ...baseOptions(configDir), json: true }, {
+          checkGhInstalled: () => true,
+          checkGhAuthenticated: () => ({ authenticated: false }),
+          inspectManagedProjectSelection: async () => ({
+            kind: "no_projects",
+            message:
+              "No managed projects are configured. Run 'gh-symphony project add' first.",
+          }),
+          stdinIsTTY: false,
+          stdoutIsTTY: false,
+        })
+      );
+    } finally {
+      stdout.restore();
+    }
+
+    const report = JSON.parse(stdout.output()) as {
+      ok: boolean;
+      remediation?: {
+        steps: Array<{ checkId: string; status: string; command?: string }>;
+      };
+    };
+    expect(report.ok).toBe(false);
+    expect(report.remediation?.steps).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          checkId: "gh_authentication",
+          status: "manual",
+          command: "gh auth login --scopes repo,read:org,project",
+        }),
+        expect.objectContaining({
+          checkId: "managed_project",
+          status: "manual",
+          command: `gh-symphony --config ${configDir} project add`,
+        }),
+      ])
+    );
+  });
+
+  it("does not launch remediation subprocesses while preserving JSON-only stdout", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "doctor-json-fix-"));
+    const { repoDir } = await createWorkflowFixture();
+    const stdout = captureWrites(process.stdout);
+    const spawnSync = vi.fn(() => ({
+      status: 0,
+      pid: 1,
+      signal: null,
+      stdout: "",
+      stderr: "",
+      output: [null, "", ""],
+    })) as never;
+
+    try {
+      await withCwd(repoDir, () =>
+        runDoctorCommand(["--fix"], { ...baseOptions(configDir), json: true }, {
+          checkGhInstalled: () => true,
+          checkGhAuthenticated: () => ({ authenticated: false }),
+          inspectManagedProjectSelection: async () => ({
+            kind: "no_projects",
+            message:
+              "No managed projects are configured. Run 'gh-symphony project add' first.",
+          }),
+          stdinIsTTY: true,
+          stdoutIsTTY: true,
+          spawnSync,
+        })
+      );
+    } finally {
+      stdout.restore();
+    }
+
+    expect(spawnSync).not.toHaveBeenCalled();
+    const report = JSON.parse(stdout.output()) as {
+      remediation?: { steps: Array<{ checkId: string; status: string }> };
+    };
+    expect(report.remediation?.steps).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          checkId: "gh_authentication",
+          status: "manual",
+        }),
+        expect.objectContaining({
+          checkId: "managed_project",
+          status: "manual",
+        }),
+      ])
+    );
+  });
+
+  it("forwards config context to interactive remediation subprocesses", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "doctor-fix-config-"));
+    const { repoDir } = await createWorkflowFixture();
+    const stdout = captureWrites(process.stdout);
+    const spawnSync = vi
+      .fn()
+      .mockReturnValueOnce({
+        status: 0,
+        pid: 1,
+        signal: null,
+        stdout: "",
+        stderr: "",
+        output: [null, "", ""],
+      })
+      .mockReturnValue({
+        status: 0,
+        pid: 2,
+        signal: null,
+        stdout: "",
+        stderr: "",
+        output: [null, "", ""],
+      }) as never;
+
+    try {
+      await withCwd(repoDir, () =>
+        runDoctorCommand(["--fix"], baseOptions(configDir), {
+          ...authDependencies(),
+          inspectManagedProjectSelection: async () => ({
+            kind: "no_projects",
+            message:
+              "No managed projects are configured. Run 'gh-symphony project add' first.",
+          }),
+          stdinIsTTY: true,
+          stdoutIsTTY: true,
+          execPath: process.execPath,
+          cliArgv: [process.execPath, "/tmp/gh-symphony.js"],
+          spawnSync,
+        })
+      );
+    } finally {
+      stdout.restore();
+    }
+
+    expect(spawnSync).toHaveBeenCalledWith(
+      process.execPath,
+      ["/tmp/gh-symphony.js", "--config", configDir, "project", "add"],
+      { stdio: "inherit" }
+    );
   });
 });

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -1,12 +1,8 @@
 import { constants } from "node:fs";
-import { execFileSync } from "node:child_process";
-import {
-  access,
-  mkdir,
-  readFile,
-  stat,
-} from "node:fs/promises";
+import { execFileSync, spawnSync } from "node:child_process";
+import { access, mkdir, readFile, stat } from "node:fs/promises";
 import { delimiter, isAbsolute, join, resolve } from "node:path";
+import { parseWorkflowMarkdown } from "@gh-symphony/core";
 import {
   createClient,
   getProjectDetail,
@@ -22,13 +18,15 @@ import {
   type ResolvedGitHubAuth,
   REQUIRED_GH_SCOPES,
   validateGitHubToken,
+  runGhAuthLogin,
+  runGhAuthRefresh,
 } from "../github/gh-auth.js";
 import type { GlobalOptions } from "../index.js";
 import { resolveRuntimeRoot } from "../orchestrator-runtime.js";
 import { inspectManagedProjectSelection } from "../project-selection.js";
-import { parseWorkflowMarkdown } from "@gh-symphony/core";
 
 type DoctorStatus = "pass" | "fail";
+type DoctorRemediationStatus = "applied" | "skipped" | "manual";
 
 type DoctorCheckId =
   | "node_runtime"
@@ -44,6 +42,14 @@ type DoctorCheckId =
   | "workflow_file"
   | "runtime_command";
 
+type PathCheckReason = "missing" | "not_directory" | "not_writable";
+type WorkflowCheckReason = "missing" | "invalid";
+type ProjectResolutionReason =
+  | "token_unavailable"
+  | "missing_binding"
+  | "api_error"
+  | "selection_failed";
+
 export type DoctorCheckResult = {
   id: DoctorCheckId;
   title: string;
@@ -51,6 +57,16 @@ export type DoctorCheckResult = {
   required: true;
   summary: string;
   remediation?: string;
+  details?: Record<string, unknown>;
+};
+
+export type DoctorRemediationStep = {
+  id: string;
+  checkId: DoctorCheckId;
+  title: string;
+  status: DoctorRemediationStatus;
+  summary: string;
+  command?: string;
   details?: Record<string, unknown>;
 };
 
@@ -62,10 +78,15 @@ export type DoctorReport = {
   authSource: GitHubAuthSource | null;
   authLogin: string | null;
   checks: DoctorCheckResult[];
+  remediation?: {
+    attempted: boolean;
+    steps: DoctorRemediationStep[];
+  };
 };
 
 type ParsedDoctorArgs = {
   projectId?: string;
+  fix: boolean;
   error?: string;
 };
 
@@ -78,11 +99,19 @@ type WorkflowCheckState =
     }
   | {
       status: "fail";
+      reason: WorkflowCheckReason;
       summary: string;
       remediation: string;
       workflowPath: string;
       error?: string;
     };
+
+type PathState = {
+  exists: boolean;
+  isDirectory: boolean;
+  writable: boolean;
+  code?: string;
+};
 
 export type DoctorDependencies = {
   checkGhInstalled: typeof checkGhInstalled;
@@ -100,10 +129,17 @@ export type DoctorDependencies = {
   stat: typeof stat;
   parseWorkflowMarkdown: typeof parseWorkflowMarkdown;
   execFileSync: typeof execFileSync;
+  runGhAuthLogin: typeof runGhAuthLogin;
+  runGhAuthRefresh: typeof runGhAuthRefresh;
+  spawnSync: typeof spawnSync;
   pathEnv: string | undefined;
   pathExtEnv: string | undefined;
   platform: NodeJS.Platform;
   processVersion: string;
+  stdinIsTTY: boolean;
+  stdoutIsTTY: boolean;
+  execPath: string;
+  cliArgv: string[];
 };
 
 const DEFAULT_DEPENDENCIES: DoctorDependencies = {
@@ -122,10 +158,17 @@ const DEFAULT_DEPENDENCIES: DoctorDependencies = {
   stat,
   parseWorkflowMarkdown,
   execFileSync,
+  runGhAuthLogin,
+  runGhAuthRefresh,
+  spawnSync,
   pathEnv: process.env.PATH,
   pathExtEnv: process.env.PATHEXT,
   platform: process.platform,
   processVersion: process.version,
+  stdinIsTTY: process.stdin.isTTY === true,
+  stdoutIsTTY: process.stdout.isTTY === true,
+  execPath: process.execPath,
+  cliArgv: [...process.argv],
 };
 
 const MINIMUM_NODE_MAJOR = 24;
@@ -142,7 +185,7 @@ type GitInstallationState =
     };
 
 function parseDoctorArgs(args: string[]): ParsedDoctorArgs {
-  const parsed: ParsedDoctorArgs = {};
+  const parsed: ParsedDoctorArgs = { fix: false };
 
   for (let i = 0; i < args.length; i += 1) {
     const arg = args[i];
@@ -154,6 +197,11 @@ function parseDoctorArgs(args: string[]): ParsedDoctorArgs {
       }
       parsed.projectId = value;
       i += 1;
+      continue;
+    }
+
+    if (arg === "--fix") {
+      parsed.fix = true;
       continue;
     }
 
@@ -197,24 +245,134 @@ function formatAuthSource(source: GitHubAuthSource): string {
   return source === "env" ? "GITHUB_GRAPHQL_TOKEN" : "gh CLI";
 }
 
-async function checkWritablePath(
+function remediationStep(
+  id: string,
+  checkId: DoctorCheckId,
+  title: string,
+  status: DoctorRemediationStatus,
+  summary: string,
+  command?: string,
+  details?: Record<string, unknown>
+): DoctorRemediationStep {
+  return { id, checkId, title, status, summary, command, details };
+}
+
+async function inspectPathState(
   targetPath: string,
-  deps: Pick<DoctorDependencies, "access" | "mkdir" | "stat">
-): Promise<boolean> {
+  deps: Pick<DoctorDependencies, "access" | "stat">
+): Promise<PathState> {
   try {
-    await deps.access(targetPath, constants.W_OK);
     const target = await deps.stat(targetPath);
-    return target.isDirectory();
-  } catch {
-    try {
-      await deps.mkdir(targetPath, { recursive: true });
-      await deps.access(targetPath, constants.W_OK);
-      const target = await deps.stat(targetPath);
-      return target.isDirectory();
-    } catch {
-      return false;
+    if (!target.isDirectory()) {
+      return {
+        exists: true,
+        isDirectory: false,
+        writable: false,
+      };
     }
+
+    try {
+      await deps.access(targetPath, constants.W_OK);
+      return {
+        exists: true,
+        isDirectory: true,
+        writable: true,
+      };
+    } catch (error) {
+      const err = error as NodeJS.ErrnoException;
+      return {
+        exists: true,
+        isDirectory: true,
+        writable: false,
+        code: err.code,
+      };
+    }
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException;
+    if (err.code === "ENOENT" || err.code === "ENOTDIR") {
+      return {
+        exists: false,
+        isDirectory: false,
+        writable: false,
+        code: err.code,
+      };
+    }
+    throw error;
   }
+}
+
+function buildPathCheck(
+  id: "config_directory" | "runtime_root" | "workspace_root",
+  title: string,
+  targetPath: string,
+  state: PathState,
+  createCommand: string,
+  fallbackRemediation: string
+): DoctorCheckResult {
+  if (state.exists && state.isDirectory && state.writable) {
+    return passCheck(id, title, `${title} is writable: ${targetPath}.`, {
+      path: targetPath,
+    });
+  }
+
+  let summary = `${title} is not writable: ${targetPath}.`;
+  let reason: PathCheckReason = "not_writable";
+  let remediation = fallbackRemediation;
+
+  if (!state.exists) {
+    summary = `${title} does not exist: ${targetPath}.`;
+    reason = "missing";
+    remediation = `Create the directory before re-running doctor with: ${createCommand}.`;
+  } else if (!state.isDirectory) {
+    summary = `${title} is not a directory: ${targetPath}.`;
+    reason = "not_directory";
+    remediation =
+      `Move or remove the conflicting file at '${targetPath}', then create the directory with: ${createCommand}.`;
+  }
+
+  return failCheck(id, title, summary, remediation, {
+    path: targetPath,
+    reason,
+  });
+}
+
+function quotePosixShellArg(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+function quotePowerShellArg(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
+function quoteCommandArg(value: string, platform: NodeJS.Platform): string {
+  if (/^[A-Za-z0-9_./:=+-]+$/.test(value)) {
+    return value;
+  }
+  return platform === "win32"
+    ? quotePowerShellArg(value)
+    : quotePosixShellArg(value);
+}
+
+function formatEnsureDirectoryCommand(
+  pathValue: string,
+  platform: NodeJS.Platform
+): string {
+  if (platform === "win32") {
+    return `powershell -NoProfile -Command "New-Item -ItemType Directory -Force -Path ${quotePowerShellArg(pathValue)} | Out-Null"`;
+  }
+
+  return `mkdir -p -- ${quotePosixShellArg(pathValue)}`;
+}
+
+function formatGhSymphonyCommand(
+  args: string[],
+  deps: Pick<DoctorDependencies, "platform">,
+  options: Pick<GlobalOptions, "configDir">
+): string {
+  const commandArgs = ["--config", options.configDir, ...args].map((arg) =>
+    quoteCommandArg(arg, deps.platform)
+  );
+  return `gh-symphony ${commandArgs.join(" ")}`;
 }
 
 function getCommandCandidates(
@@ -249,11 +407,7 @@ async function commandExistsOnPath(
   }
 
   const candidates = getCommandCandidates(binary, deps);
-  if (
-    isAbsolute(binary) ||
-    binary.includes("/") ||
-    binary.includes("\\")
-  ) {
+  if (isAbsolute(binary) || binary.includes("/") || binary.includes("\\")) {
     for (const candidate of candidates) {
       try {
         await deps.access(resolve(candidate), constants.X_OK);
@@ -370,10 +524,11 @@ async function checkWorkflow(
   } catch {
     return {
       status: "fail",
+      reason: "missing",
       workflowPath,
       summary: "WORKFLOW.md was not found in the repository root.",
       remediation:
-        "Run 'gh-symphony workflow init' in this repository or add a valid WORKFLOW.md at the repo root.",
+        "Run 'gh-symphony init' in this repository or add a valid WORKFLOW.md at the repo root.",
     };
   }
 
@@ -388,10 +543,11 @@ async function checkWorkflow(
   } catch (error) {
     return {
       status: "fail",
+      reason: "invalid",
       workflowPath,
       summary: "WORKFLOW.md could not be parsed.",
       remediation:
-        "Fix the WORKFLOW.md front matter or re-run 'gh-symphony workflow init' to regenerate it.",
+        "Fix the WORKFLOW.md front matter or re-run 'gh-symphony init' to regenerate it.",
       error: error instanceof Error ? error.message : "Unknown workflow parse error.",
     };
   }
@@ -406,7 +562,7 @@ export async function runDoctorDiagnostics(
   const parsedArgs = parseDoctorArgs(args);
   if (parsedArgs.error) {
     throw new Error(
-      `${parsedArgs.error}\nUsage: gh-symphony doctor [--project-id <project-id>]`
+      `${parsedArgs.error}\nUsage: gh-symphony doctor [--project-id <project-id>] [--fix]`
     );
   }
 
@@ -617,9 +773,12 @@ export async function runDoctorDiagnostics(
         "Managed project selection",
         resolvedProjectConfig.message,
         "Run 'gh-symphony project add' to register a project, or select one with 'gh-symphony project switch' / '--project-id'.",
-        resolvedProjectConfig.projectId
-          ? { projectId: resolvedProjectConfig.projectId }
-          : undefined
+        {
+          reason: resolvedProjectConfig.kind,
+          ...(resolvedProjectConfig.projectId
+            ? { projectId: resolvedProjectConfig.projectId }
+            : {}),
+        }
       )
     );
   }
@@ -657,7 +816,10 @@ export async function runDoctorDiagnostics(
         "GitHub project resolution",
         `Managed project "${resolvedProjectConfig.projectId}" is not bound to a GitHub Project.`,
         "Re-run 'gh-symphony project add' and select a valid GitHub Project binding, then run the doctor command again.",
-        { projectId: resolvedProjectConfig.projectId }
+        {
+          reason: "missing_binding" satisfies ProjectResolutionReason,
+          projectId: resolvedProjectConfig.projectId,
+        }
       )
     );
   } else if (
@@ -696,6 +858,7 @@ export async function runDoctorDiagnostics(
           `Failed to resolve configured project binding '${resolvedProjectConfig.projectConfig.tracker.bindingId}'.`,
           "Re-run 'gh-symphony project add' and select a valid GitHub Project, then run the doctor command again.",
           {
+            reason: "api_error" satisfies ProjectResolutionReason,
             bindingId: resolvedProjectConfig.projectConfig.tracker.bindingId,
             error: message,
           }
@@ -708,66 +871,51 @@ export async function runDoctorDiagnostics(
         "github_project_resolution",
         "GitHub project resolution",
         "GitHub project resolution could not run because managed project selection failed.",
-        "Fix the managed project selection check first, then re-run 'gh-symphony doctor'."
+        "Fix the managed project selection check first, then re-run 'gh-symphony doctor'.",
+        {
+          reason: "selection_failed" satisfies ProjectResolutionReason,
+        }
       )
     );
   }
 
-  const configDirWritable = await checkWritablePath(options.configDir, deps);
+  const configDirState = await inspectPathState(options.configDir, deps);
   checks.push(
-    configDirWritable
-      ? passCheck(
-          "config_directory",
-          "Config directory",
-          `Config directory is writable: ${options.configDir}.`,
-          { path: options.configDir }
-        )
-      : failCheck(
-          "config_directory",
-          "Config directory",
-          `Config directory is not writable: ${options.configDir}.`,
-          `Create the directory and ensure your user can write to it: 'mkdir -p ${options.configDir}' and fix ownership/permissions as needed.`,
-          { path: options.configDir }
-        )
+    buildPathCheck(
+      "config_directory",
+      "Config directory",
+      options.configDir,
+      configDirState,
+      formatEnsureDirectoryCommand(options.configDir, deps.platform),
+      `Ensure your user can write to '${options.configDir}'.`
+    )
   );
 
   const runtimeRoot = resolveRuntimeRoot(options.configDir);
-  const runtimeRootWritable = await checkWritablePath(runtimeRoot, deps);
+  const runtimeRootState = await inspectPathState(runtimeRoot, deps);
   checks.push(
-    runtimeRootWritable
-      ? passCheck(
-          "runtime_root",
-          "Runtime root",
-          `Runtime root is writable: ${runtimeRoot}.`,
-          { path: runtimeRoot }
-        )
-      : failCheck(
-          "runtime_root",
-          "Runtime root",
-          `Runtime root is not writable: ${runtimeRoot}.`,
-          `Create the runtime root and ensure your user can write to it: 'mkdir -p ${runtimeRoot}'.`,
-          { path: runtimeRoot }
-        )
+    buildPathCheck(
+      "runtime_root",
+      "Runtime root",
+      runtimeRoot,
+      runtimeRootState,
+      formatEnsureDirectoryCommand(runtimeRoot, deps.platform),
+      `Ensure your user can write to '${runtimeRoot}'.`
+    )
   );
 
   if (resolvedProjectConfig.kind === "resolved") {
     const workspaceDir = resolvedProjectConfig.projectConfig.workspaceDir;
-    const workspaceWritable = await checkWritablePath(workspaceDir, deps);
+    const workspaceState = await inspectPathState(workspaceDir, deps);
     checks.push(
-      workspaceWritable
-        ? passCheck(
-            "workspace_root",
-            "Workspace root",
-            `Workspace root is writable: ${workspaceDir}.`,
-            { path: workspaceDir }
-          )
-        : failCheck(
-            "workspace_root",
-            "Workspace root",
-            `Workspace root is not writable: ${workspaceDir}.`,
-            "Update the managed project workspaceDir to a writable path or fix the filesystem permissions.",
-            { path: workspaceDir }
-          )
+      buildPathCheck(
+        "workspace_root",
+        "Workspace root",
+        workspaceDir,
+        workspaceState,
+        formatEnsureDirectoryCommand(workspaceDir, deps.platform),
+        "Update the managed project workspaceDir to a writable path or fix the filesystem permissions."
+      )
     );
   } else {
     checks.push(
@@ -775,7 +923,8 @@ export async function runDoctorDiagnostics(
         "workspace_root",
         "Workspace root",
         "Workspace root could not be checked because no managed project was resolved.",
-        "Fix the managed project selection check first, then re-run 'gh-symphony doctor'."
+        "Fix the managed project selection check first, then re-run 'gh-symphony doctor'.",
+        { blockedBy: "managed_project" }
       )
     );
   }
@@ -799,6 +948,7 @@ export async function runDoctorDiagnostics(
         workflow.remediation,
         {
           path: workflow.workflowPath,
+          reason: workflow.reason,
           ...(workflow.error ? { error: workflow.error } : {}),
         }
       )
@@ -822,7 +972,7 @@ export async function runDoctorDiagnostics(
           "runtime_command",
           "Runtime command detection",
           `Configured runtime command could not be found on PATH: ${workflow.command}.`,
-          "Install the configured runtime binary or update the workflow/context configuration to a command that exists on this machine.",
+          buildRuntimeInstallGuidance(binary, deps.platform),
           { command: workflow.command, binary }
         )
       );
@@ -833,7 +983,8 @@ export async function runDoctorDiagnostics(
         "runtime_command",
         "Runtime command detection",
         "Runtime command detection could not run because WORKFLOW.md is missing or invalid.",
-        "Fix the WORKFLOW.md check first so the configured runtime command can be validated."
+        "Fix the WORKFLOW.md check first so the configured runtime command can be validated.",
+        { blockedBy: "workflow_file" }
       )
     );
   }
@@ -849,6 +1000,404 @@ export async function runDoctorDiagnostics(
   };
 }
 
+function buildRuntimeInstallGuidance(
+  binary: string | null | undefined,
+  platform: NodeJS.Platform
+): string {
+  if (binary === "codex") {
+    return "Install Codex CLI using its official installation instructions and ensure 'codex' is on PATH.";
+  }
+
+  if (binary === "claude" || binary === "claude-code") {
+    return "Install Claude Code using its official installation instructions and ensure the runtime binary is on PATH.";
+  }
+
+  if (platform === "win32" && binary) {
+    return `Install '${binary}' using its official installation instructions and ensure the directory containing '${binary}.exe' is on PATH.`;
+  }
+
+  if (binary) {
+    return `Install '${binary}' using its official installation instructions and ensure it is available on PATH.`;
+  }
+
+  return "Install the configured runtime command using its official installation instructions and ensure it is available on PATH.";
+}
+
+function isInteractiveTerminal(
+  deps: Pick<DoctorDependencies, "stdinIsTTY" | "stdoutIsTTY">
+): boolean {
+  return deps.stdinIsTTY && deps.stdoutIsTTY;
+}
+
+function runCliRemediation(
+  title: string,
+  checkId: DoctorCheckId,
+  args: string[],
+  deps: Pick<
+    DoctorDependencies,
+    | "spawnSync"
+    | "execPath"
+    | "cliArgv"
+    | "stdinIsTTY"
+    | "stdoutIsTTY"
+    | "platform"
+  >,
+  options: Pick<GlobalOptions, "configDir">,
+  interactive: boolean,
+  details?: Record<string, unknown>
+): DoctorRemediationStep {
+  const command = formatGhSymphonyCommand(args, deps, options);
+
+  if (!interactive) {
+    return remediationStep(
+      `remediate_${checkId}`,
+      checkId,
+      title,
+      "manual",
+      `Interactive terminal not available. Run this command manually: ${command}.`,
+      command,
+      details
+    );
+  }
+
+  const cliEntry = deps.cliArgv[1];
+  if (!cliEntry) {
+    return remediationStep(
+      `remediate_${checkId}`,
+      checkId,
+      title,
+      "manual",
+      `Could not determine the current CLI entrypoint. Run this command manually: ${command}.`,
+      command,
+      details
+    );
+  }
+
+  const result = deps.spawnSync(deps.execPath, [cliEntry, "--config", options.configDir, ...args], {
+    stdio: "inherit",
+  });
+  if ((result.status ?? 1) === 0) {
+    return remediationStep(
+      `remediate_${checkId}`,
+      checkId,
+      title,
+      "applied",
+      `Executed: ${command}.`,
+      command,
+      details
+    );
+  }
+
+  return remediationStep(
+    `remediate_${checkId}`,
+    checkId,
+    title,
+    "manual",
+    `Failed to complete this command automatically. Re-run it manually: ${command}.`,
+    command,
+    details
+  );
+}
+
+async function ensureDirectoryRemediation(
+  check: DoctorCheckResult,
+  deps: Pick<DoctorDependencies, "mkdir" | "access" | "stat" | "platform">
+): Promise<DoctorRemediationStep> {
+  const pathValue = typeof check.details?.path === "string" ? check.details.path : null;
+  const reason = typeof check.details?.reason === "string" ? check.details.reason : null;
+  const command =
+    pathValue === null
+      ? undefined
+      : formatEnsureDirectoryCommand(pathValue, deps.platform);
+
+  if (!pathValue) {
+    return remediationStep(
+      `remediate_${check.id}`,
+      check.id,
+      check.title,
+      "manual",
+      "No filesystem path was recorded for this failing check.",
+      command
+    );
+  }
+
+  if (reason === "not_directory") {
+    return remediationStep(
+      `remediate_${check.id}`,
+      check.id,
+      check.title,
+      "manual",
+      `A file already exists at '${pathValue}'. Remove or move it before creating the directory.`,
+      command,
+      { path: pathValue }
+    );
+  }
+
+  try {
+    await deps.mkdir(pathValue, { recursive: true });
+    await deps.access(pathValue, constants.W_OK);
+    const target = await deps.stat(pathValue);
+    if (!target.isDirectory()) {
+      return remediationStep(
+        `remediate_${check.id}`,
+        check.id,
+        check.title,
+        "manual",
+        `Created path '${pathValue}', but it is not a directory.`,
+        command,
+        { path: pathValue }
+      );
+    }
+
+    return remediationStep(
+      `remediate_${check.id}`,
+      check.id,
+      check.title,
+      "applied",
+      `Ensured writable directory '${pathValue}'.`,
+      command,
+      { path: pathValue }
+    );
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : "unknown error";
+    const summary =
+      reason === "not_writable"
+        ? `Directory '${pathValue}' exists but is not writable. Update its permissions or choose a writable location: ${errorMessage}.`
+        : `Failed to create '${pathValue}' automatically: ${errorMessage}.`;
+    return remediationStep(
+      `remediate_${check.id}`,
+      check.id,
+      check.title,
+      "manual",
+      summary,
+      command,
+      { path: pathValue }
+    );
+  }
+}
+
+async function runDoctorFixes(
+  report: DoctorReport,
+  deps: DoctorDependencies,
+  options: Pick<GlobalOptions, "configDir" | "json">
+): Promise<DoctorRemediationStep[]> {
+  const steps: DoctorRemediationStep[] = [];
+  const interactive = !options.json && isInteractiveTerminal(deps);
+  const failed = new Map(
+    report.checks
+      .filter((check) => check.status === "fail")
+      .map((check) => [check.id, check] as const)
+  );
+
+  for (const check of report.checks) {
+    if (check.status !== "fail") {
+      continue;
+    }
+
+    switch (check.id) {
+      case "gh_installation":
+        steps.push(
+          remediationStep(
+            "remediate_gh_installation",
+            check.id,
+            check.title,
+            "manual",
+            "Install GitHub CLI first. Automatic installation is not attempted by doctor.",
+            "https://cli.github.com"
+          )
+        );
+        break;
+      case "gh_authentication": {
+        if (failed.has("gh_installation")) {
+          steps.push(
+            remediationStep(
+              "remediate_gh_authentication",
+              check.id,
+              check.title,
+              "skipped",
+              "Skipped because gh CLI is not installed."
+            )
+          );
+          break;
+        }
+        const result = deps.runGhAuthLogin({
+          spawnImpl: deps.spawnSync,
+          interactive,
+        });
+        steps.push(
+          remediationStep(
+            "remediate_gh_authentication",
+            check.id,
+            check.title,
+            result.status,
+            result.summary,
+            result.command
+          )
+        );
+        break;
+      }
+      case "gh_scopes": {
+        if (failed.has("gh_installation") || failed.has("gh_authentication")) {
+          steps.push(
+            remediationStep(
+              "remediate_gh_scopes",
+              check.id,
+              check.title,
+              "skipped",
+              "Skipped because gh installation/authentication must be fixed first."
+            )
+          );
+          break;
+        }
+        const result = deps.runGhAuthRefresh({
+          spawnImpl: deps.spawnSync,
+          interactive,
+        });
+        steps.push(
+          remediationStep(
+            "remediate_gh_scopes",
+            check.id,
+            check.title,
+            result.status,
+            result.summary,
+            result.command,
+            check.details
+          )
+        );
+        break;
+      }
+      case "managed_project":
+        if (check.details?.reason === "multiple_projects_require_selection") {
+          steps.push(
+            runCliRemediation(
+              "Managed project selection",
+              check.id,
+              ["project", "switch"],
+              deps,
+              options,
+              interactive,
+              check.details
+            )
+          );
+          break;
+        }
+        steps.push(
+          runCliRemediation(
+            "Managed project setup",
+            check.id,
+            ["project", "add"],
+            deps,
+            options,
+            interactive,
+            check.details
+          )
+        );
+        break;
+      case "github_project_resolution": {
+        if (failed.has("managed_project")) {
+          steps.push(
+            remediationStep(
+              "remediate_github_project_resolution",
+              check.id,
+              check.title,
+              "skipped",
+              "Skipped because managed project selection must be fixed first."
+            )
+          );
+          break;
+        }
+        const reason =
+          typeof check.details?.reason === "string" ? check.details.reason : null;
+        if (reason === "missing_binding" || reason === "api_error") {
+          steps.push(
+            runCliRemediation(
+              "GitHub project binding setup",
+              check.id,
+              ["project", "add"],
+              deps,
+              options,
+              interactive,
+              check.details
+            )
+          );
+          break;
+        }
+        steps.push(
+          remediationStep(
+            "remediate_github_project_resolution",
+            check.id,
+            check.title,
+            "manual",
+            check.remediation ?? "Resolve the GitHub Project binding manually.",
+            formatGhSymphonyCommand(["project", "add"], deps, options),
+            check.details
+          )
+        );
+        break;
+      }
+      case "config_directory":
+      case "runtime_root":
+      case "workspace_root":
+        if (check.details?.blockedBy === "managed_project") {
+          steps.push(
+            remediationStep(
+              `remediate_${check.id}`,
+              check.id,
+              check.title,
+              "skipped",
+              "Skipped because managed project selection must be fixed first."
+            )
+          );
+          break;
+        }
+        steps.push(await ensureDirectoryRemediation(check, deps));
+        break;
+      case "workflow_file": {
+        const reason =
+          typeof check.details?.reason === "string" ? check.details.reason : null;
+        const title =
+          reason === "missing"
+            ? "Repository workflow initialization"
+            : "Repository workflow regeneration";
+        steps.push(
+          runCliRemediation(title, check.id, ["init"], deps, options, interactive, check.details)
+        );
+        break;
+      }
+      case "runtime_command": {
+        if (failed.has("workflow_file")) {
+          steps.push(
+            remediationStep(
+              "remediate_runtime_command",
+              check.id,
+              check.title,
+              "skipped",
+              "Skipped because WORKFLOW.md must be fixed first."
+            )
+          );
+          break;
+        }
+        steps.push(
+          remediationStep(
+            "remediate_runtime_command",
+            check.id,
+            check.title,
+            "manual",
+            check.remediation ?? "Install the configured runtime command manually.",
+            typeof check.details?.binary === "string"
+              ? String(check.details.binary)
+              : undefined,
+            check.details
+          )
+        );
+        break;
+      }
+    }
+  }
+
+  return steps;
+}
+
 function renderTextReport(report: DoctorReport): string {
   const lines = [
     `gh-symphony doctor`,
@@ -856,6 +1405,17 @@ function renderTextReport(report: DoctorReport): string {
     ...(report.authLogin ? [`Authenticated GitHub user: ${report.authLogin}`] : []),
     "",
   ];
+  if (report.remediation) {
+    lines.push("Remediation");
+    for (const step of report.remediation.steps) {
+      lines.push(`${step.status.toUpperCase()} ${step.title}`);
+      lines.push(`  ${step.summary}`);
+      if (step.command) {
+        lines.push(`  Command: ${step.command}`);
+      }
+    }
+    lines.push("");
+  }
   for (const check of report.checks) {
     lines.push(`${check.status === "pass" ? "PASS" : "FAIL"} ${check.title}`);
     lines.push(`  ${check.summary}`);
@@ -878,7 +1438,36 @@ export async function runDoctorCommand(
   dependencies: Partial<DoctorDependencies> = {}
 ): Promise<void> {
   try {
-    const report = await runDoctorDiagnostics(options, args, dependencies);
+    const deps = { ...DEFAULT_DEPENDENCIES, ...dependencies };
+    const parsedArgs = parseDoctorArgs(args);
+    if (parsedArgs.error) {
+      throw new Error(
+        `${parsedArgs.error}\nUsage: gh-symphony doctor [--project-id <project-id>] [--fix]`
+      );
+    }
+
+    const initialReport = await runDoctorDiagnostics(options, args, deps);
+    if (parsedArgs.fix) {
+      const remediation = {
+        attempted: true,
+        steps: await runDoctorFixes(initialReport, deps, options),
+      };
+      const report = await runDoctorDiagnostics(
+        options,
+        args.filter((arg) => arg !== "--fix"),
+        deps
+      );
+      report.remediation = remediation;
+      if (options.json) {
+        process.stdout.write(JSON.stringify(report, null, 2) + "\n");
+      } else {
+        process.stdout.write(renderTextReport(report) + "\n");
+      }
+      process.exitCode = report.ok ? 0 : 1;
+      return;
+    }
+
+    const report = initialReport;
     if (options.json) {
       process.stdout.write(JSON.stringify(report, null, 2) + "\n");
     } else {

--- a/packages/cli/src/commands/help.ts
+++ b/packages/cli/src/commands/help.ts
@@ -12,7 +12,7 @@ Setup:
                   Parse and strictly validate WORKFLOW.md
   workflow preview
                   Render the final worker prompt from a sample issue
-  doctor          Run first-run diagnostics
+  doctor          Run diagnostics and optional first-run remediation
   config show     Show current configuration
   config set      Set a configuration value
   config edit     Open config in $EDITOR
@@ -55,6 +55,7 @@ Examples:
   gh-symphony workflow preview --attempt 2
   gh-symphony project add              # Add a project (interactive)
   gh-symphony doctor                   # Validate local setup and prerequisites
+  gh-symphony doctor --fix             # Apply safe remediation and print manual follow-ups
   gh-symphony project add --non-interactive --project <id> --workspace-dir <path>
   gh-symphony project list             # List all projects
   gh-symphony project remove <id>      # Remove a project

--- a/packages/cli/src/github/gh-auth.test.ts
+++ b/packages/cli/src/github/gh-auth.test.ts
@@ -15,6 +15,8 @@ import {
   getGhTokenWithSource,
   resolveGitHubAuth,
   validateGitHubToken,
+  runGhAuthLogin,
+  runGhAuthRefresh,
 } from "./gh-auth.js";
 
 type ExecMock = ReturnType<typeof vi.fn> & typeof execFileSync;
@@ -461,5 +463,36 @@ describe("resolveGitHubAuth", () => {
       login: "gh-user",
       scopes: ["repo", "read:org", "project"],
     });
+  });
+});
+
+describe("runGhAuthLogin", () => {
+  it("returns manual when no interactive terminal is available", () => {
+    expect(runGhAuthLogin({ interactive: false })).toEqual({
+      mode: "login",
+      status: "manual",
+      command: "gh auth login --scopes repo,read:org,project",
+      summary:
+        "Interactive terminal not available. Run 'gh auth login --scopes repo,read:org,project' manually.",
+    });
+  });
+});
+
+describe("runGhAuthRefresh", () => {
+  it("runs gh auth refresh in interactive terminals", () => {
+    const spawnImpl = vi.fn(() => buildSpawnResult(0)) as SpawnMock;
+
+    expect(
+      runGhAuthRefresh({ spawnImpl, interactive: true })
+    ).toMatchObject({
+      mode: "refresh",
+      status: "applied",
+      command: "gh auth refresh --scopes repo,read:org,project",
+    });
+    expect(spawnImpl).toHaveBeenCalledWith(
+      "gh",
+      ["auth", "refresh", "--scopes", "repo,read:org,project"],
+      { stdio: "inherit" }
+    );
   });
 });

--- a/packages/cli/src/github/gh-auth.ts
+++ b/packages/cli/src/github/gh-auth.ts
@@ -20,6 +20,13 @@ type ExecError = Error & {
 export const REQUIRED_GH_SCOPES = ["repo", "read:org", "project"] as const;
 export type GitHubAuthSource = "env" | "gh";
 
+export type GhAuthRemediationResult = {
+  mode: "login" | "refresh";
+  status: "applied" | "manual";
+  command: string;
+  summary: string;
+};
+
 export class GhAuthError extends Error {
   constructor(
     public readonly code:
@@ -337,6 +344,66 @@ export function ensureGhAuth(opts?: {
     envToken: undefined,
   });
   return { login: auth.login ?? "unknown", token, source: "gh" };
+}
+
+function isInteractiveTerminal(): boolean {
+  return process.stdin.isTTY === true && process.stdout.isTTY === true;
+}
+
+function runGhAuthCommand(
+  mode: "login" | "refresh",
+  opts?: { spawnImpl?: SpawnImpl; interactive?: boolean }
+): GhAuthRemediationResult {
+  const spawnImpl = opts?.spawnImpl ?? spawnSync;
+  const command = `gh auth ${mode} --scopes ${REQUIRED_GH_SCOPES.join(",")}`;
+  const interactive = opts?.interactive ?? isInteractiveTerminal();
+
+  if (!interactive) {
+    return {
+      mode,
+      status: "manual",
+      command,
+      summary: `Interactive terminal not available. Run '${command}' manually.`,
+    };
+  }
+
+  const result = spawnImpl(
+    "gh",
+    ["auth", mode, "--scopes", REQUIRED_GH_SCOPES.join(",")],
+    {
+      stdio: "inherit",
+    }
+  );
+
+  if ((result.status ?? 1) === 0) {
+    return {
+      mode,
+      status: "applied",
+      command,
+      summary: `Executed '${command}'.`,
+    };
+  }
+
+  return {
+    mode,
+    status: "manual",
+    command,
+    summary: `Failed to complete '${command}' automatically. Re-run it manually.`,
+  };
+}
+
+export function runGhAuthLogin(opts?: {
+  spawnImpl?: SpawnImpl;
+  interactive?: boolean;
+}): GhAuthRemediationResult {
+  return runGhAuthCommand("login", opts);
+}
+
+export function runGhAuthRefresh(opts?: {
+  spawnImpl?: SpawnImpl;
+  interactive?: boolean;
+}): GhAuthRemediationResult {
+  return runGhAuthCommand("refresh", opts);
 }
 
 function parseLogin(output: string): string | undefined {

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -185,4 +185,20 @@ describe("Commander CLI entrypoint", () => {
     expect(output).toContain("--prune");
     expect(output).toContain("Sync repositories from the active GitHub Project");
   });
+
+  it("shows doctor remediation help", async () => {
+    const stdout = captureWrites(process.stdout);
+    const stderr = captureWrites(process.stderr);
+
+    try {
+      await runCli(["doctor", "--help"]);
+    } finally {
+      stdout.restore();
+      stderr.restore();
+    }
+
+    const output = stdout.output() + stderr.output();
+    expect(output).toContain("--fix");
+    expect(output).toContain("remediation");
+  });
 });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -45,6 +45,7 @@ type CliOptionValues = Partial<
     daemon?: boolean;
     dryRun?: boolean;
     file?: string;
+    fix?: boolean;
     follow?: boolean;
     force?: boolean;
     http?: string | boolean;
@@ -309,8 +310,9 @@ function createProgram(): { program: Command; wasInvoked: () => boolean } {
   addGlobalOptions(
     program
       .command("doctor")
-      .description("Run first-run diagnostics")
+      .description("Run diagnostics and optional first-run remediation")
       .option("--project-id <projectId>", "Project identifier")
+      .option("--fix", "Apply safe remediation steps and print manual follow-ups")
       .addOption(new Option("--project <projectId>").hideHelp())
       .allowExcessArguments(false)
   ).action(async function (this: Command) {
@@ -318,6 +320,7 @@ function createProgram(): { program: Command; wasInvoked: () => boolean } {
     const values = this.optsWithGlobals<CliOptionValues>();
     const args: string[] = [];
     pushOption(args, "--project-id", resolveProjectId(values));
+    pushOption(args, "--fix", values.fix);
     await invokeHandler("doctor", args, values);
   });
 


### PR DESCRIPTION
## Issues

- Fixes #169

## Summary

- `gh-symphony doctor --fix`가 진단 결과를 바탕으로 안전한 자동 복구와 수동 follow-up 안내를 함께 제공하도록 확장했습니다.
- 이번 rework에서는 `main` 충돌을 해소하고, remediation subprocess의 config context 전달, `--json` stdout 보존, 플랫폼별 command formatting, 중복 diagnostics 축소를 반영했습니다.

## Changes

- `doctor` 명령이 Node/Git 진단 확장을 유지한 채 `--fix` remediation flow를 계속 제공하도록 `main` 기준으로 재통합했습니다.
- interactive remediation subprocess가 항상 `--config`를 전달하도록 바꾸고, `--json`에서는 interactive auto-remediation을 비활성화해 JSON stdout을 깨지 않도록 했습니다.
- 경로 기반 remediation command를 플랫폼별 formatter로 통일하고, writable-path 실패 메시지와 runtime install guidance를 더 정확한 문장으로 다듬었습니다.
- `doctor.test.ts`, `gh-auth.test.ts`, `index.test.ts`, README 문서를 rebase 이후 동작에 맞게 갱신했습니다.

## Evidence

- `pnpm --filter @gh-symphony/cli test -- --run src/commands/doctor.test.ts src/github/gh-auth.test.ts src/index.test.ts`
- `pnpm --filter @gh-symphony/cli typecheck`
- `pnpm lint`
- `pnpm test`
- `pnpm typecheck`
- `pnpm build`
- Manual check: `node packages/cli/dist/index.js doctor --fix --json` 실행 시 remediation section에 `manual`/`skipped` 결과와 `--config`가 포함된 실행 명령이 구조화되어 출력되는 것을 확인

## Human Validation

- [ ] `gh-symphony doctor --fix`가 비기본 config 디렉터리에서도 후속 remediation을 같은 config context로 이어서 실행하는지 확인
- [ ] `gh-symphony doctor --fix --json`이 child command stdout 없이 단일 JSON 문서만 출력하는지 확인
- [ ] 공백이 있는 경로 또는 Windows 환경에서 디렉터리 remediation command가 그대로 실행 가능한지 확인

## Risks

- interactive remediation command formatter는 POSIX/PowerShell 기준으로 출력하므로, Windows의 비-PowerShell 셸에서는 사용자가 셸에 맞게 조정해야 할 수 있습니다.