### PR TITLE
feat(cli): add --web control-plane flag

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -46,6 +46,7 @@
     "liquidjs": "^10.25.0"
   },
   "devDependencies": {
+    "@gh-symphony/control-plane": "workspace:*",
     "@gh-symphony/core": "workspace:*",
     "@gh-symphony/dashboard": "workspace:*",
     "@gh-symphony/orchestrator": "workspace:*",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,12 +41,12 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
+    "@gh-symphony/control-plane": "workspace:*",
     "@clack/prompts": "^0.9.1",
     "commander": "^14.0.1",
     "liquidjs": "^10.25.0"
   },
   "devDependencies": {
-    "@gh-symphony/control-plane": "workspace:*",
     "@gh-symphony/core": "workspace:*",
     "@gh-symphony/dashboard": "workspace:*",
     "@gh-symphony/orchestrator": "workspace:*",

--- a/packages/cli/src/commands/start.test.ts
+++ b/packages/cli/src/commands/start.test.ts
@@ -886,7 +886,7 @@ async function waitForHttpUrl(
   throw new Error(`Timed out waiting for HTTP server log. Output: ${output()}`);
 }
 
-async function createMockControlPlaneStartResult(port: number): Promise<{
+async function createMockControlPlaneStartResult(_port: number): Promise<{
   server: ReturnType<typeof createServer>;
   port: number;
   url: string;
@@ -897,7 +897,7 @@ async function createMockControlPlaneStartResult(port: number): Promise<{
   });
 
   await new Promise<void>((resolve) => {
-    server.listen(port, "0.0.0.0", () => resolve());
+    server.listen(0, "0.0.0.0", () => resolve());
   });
 
   const address = server.address();

--- a/packages/cli/src/commands/start.test.ts
+++ b/packages/cli/src/commands/start.test.ts
@@ -13,6 +13,7 @@ const status = vi.fn();
 const shutdown = vi.fn();
 const requestReconcile = vi.fn();
 const resolveDashboardResponse = vi.fn();
+const startControlPlaneServer = vi.fn();
 const serviceDependencies: Array<Record<string, unknown>> = [];
 
 vi.mock("@gh-symphony/orchestrator", () => ({
@@ -46,6 +47,10 @@ vi.mock("@gh-symphony/dashboard", () => ({
   resolveDashboardResponse,
 }));
 
+vi.mock("@gh-symphony/control-plane", () => ({
+  startControlPlaneServer,
+}));
+
 const startModule = await import("./start.js");
 
 beforeEach(() => {
@@ -57,11 +62,15 @@ beforeEach(() => {
   shutdown.mockResolvedValue(undefined);
   requestReconcile.mockReset();
   resolveDashboardResponse.mockReset();
+  startControlPlaneServer.mockReset();
   resolveDashboardResponse.mockImplementation(
     async ({ pathname, method }: { pathname: string; method?: string }) => ({
       status: 200,
       payload: { pathname, method: method ?? "GET" },
     })
+  );
+  startControlPlaneServer.mockImplementation(async ({ port }: { port: number }) =>
+    createMockControlPlaneStartResult(port)
   );
   serviceDependencies.length = 0;
 });
@@ -177,6 +186,31 @@ describe("start command foreground locking", () => {
     );
     expect(acquireProjectLock).not.toHaveBeenCalled();
     expect(run).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(2);
+  });
+
+  it("rejects the conflicting --http --web combination", async () => {
+    const configDir = await createConfigFixture({
+      activeProject: "tenant-a",
+      projects: [createProject("tenant-a", "acme", "platform")],
+    });
+    const stderr = captureWrites(process.stderr);
+
+    try {
+      await startModule.default(
+        ["--project-id", "tenant-a", "--http", "--web"],
+        baseOptions(configDir)
+      );
+    } finally {
+      stderr.restore();
+    }
+
+    expect(stderr.output()).toContain(
+      "Options '--http' and '--web' cannot be used together"
+    );
+    expect(acquireProjectLock).not.toHaveBeenCalled();
+    expect(run).not.toHaveBeenCalled();
+    expect(startControlPlaneServer).not.toHaveBeenCalled();
     expect(process.exitCode).toBe(2);
   });
 
@@ -381,6 +415,150 @@ describe("start command foreground locking", () => {
 
     expect(exitSpy).toHaveBeenCalledWith(0);
     expect(releaseProjectLock).toHaveBeenCalledWith(lock);
+  });
+
+  it("starts the control plane server when --web is enabled", async () => {
+    const configDir = await createConfigFixture({
+      activeProject: "tenant-a",
+      projects: [createProject("tenant-a", "acme", "platform")],
+    });
+    const lock = {
+      lockPath: join(configDir, "projects", "tenant-a", ".lock"),
+      ownerToken: "owner",
+      pid: 1234,
+      startedAt: "2026-03-17T00:00:00.000Z",
+    };
+    acquireProjectLock.mockResolvedValue(lock);
+    let resolveRun: (() => void) | undefined;
+    run.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveRun = resolve;
+        })
+    );
+    shutdown.mockImplementation(async () => {
+      resolveRun?.();
+    });
+
+    const exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation(((_code?: number) => undefined) as (code?: number) => never);
+    const stdout = captureWrites(process.stdout);
+
+    try {
+      const startPromise = startModule.default(
+        ["--project-id", "tenant-a", "--web"],
+        baseOptions(configDir)
+      );
+
+      const url = await waitForHttpUrl(stdout.output);
+      expect(startControlPlaneServer).toHaveBeenCalledWith({
+        host: "0.0.0.0",
+        port: 4680,
+        runtimeRoot: configDir,
+        projectId: "tenant-a",
+        onRefreshRequest: expect.any(Function),
+      });
+
+      const httpState = JSON.parse(
+        await readFile(
+          join(
+            configDir,
+            "orchestrator",
+            "workspaces",
+            "tenant-a",
+            "http.json"
+          ),
+          "utf8"
+        )
+      ) as { host: string; port: number; endpoint: string };
+      expect(httpState).toEqual({
+        host: "0.0.0.0",
+        port: Number.parseInt(new URL(url).port, 10),
+        endpoint: url,
+      });
+      expect(stdout.output()).toContain("Web dashboard listening on");
+
+      const onRefreshRequest = (
+        startControlPlaneServer.mock.calls[0]?.[0] as
+          | { onRefreshRequest?: () => void }
+          | undefined
+      )?.onRefreshRequest;
+      if (!onRefreshRequest) {
+        throw new Error("Expected onRefreshRequest callback");
+      }
+      onRefreshRequest();
+      expect(requestReconcile).toHaveBeenCalledTimes(1);
+
+      process.emit("SIGINT");
+      await startPromise;
+      await expect(
+        readFile(
+          join(
+            configDir,
+            "orchestrator",
+            "workspaces",
+            "tenant-a",
+            "http.json"
+          ),
+          "utf8"
+        )
+      ).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      stdout.restore();
+    }
+
+    expect(exitSpy).toHaveBeenCalledWith(0);
+    expect(releaseProjectLock).toHaveBeenCalledWith(lock);
+    expect(resolveDashboardResponse).not.toHaveBeenCalled();
+  });
+
+  it("passes an explicit port to the control plane server", async () => {
+    const configDir = await createConfigFixture({
+      activeProject: "tenant-a",
+      projects: [createProject("tenant-a", "acme", "platform")],
+    });
+    const lock = {
+      lockPath: join(configDir, "projects", "tenant-a", ".lock"),
+      ownerToken: "owner",
+      pid: 1234,
+      startedAt: "2026-03-17T00:00:00.000Z",
+    };
+    acquireProjectLock.mockResolvedValue(lock);
+    let resolveRun: (() => void) | undefined;
+    run.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveRun = resolve;
+        })
+    );
+    shutdown.mockImplementation(async () => {
+      resolveRun?.();
+    });
+
+    const exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation(((_code?: number) => undefined) as (code?: number) => never);
+
+    const startPromise = startModule.default(
+      ["--project-id", "tenant-a", "--web", "4900"],
+      baseOptions(configDir)
+    );
+
+    await vi.waitFor(() => {
+      expect(startControlPlaneServer).toHaveBeenCalledWith({
+        host: "0.0.0.0",
+        port: 4900,
+        runtimeRoot: configDir,
+        projectId: "tenant-a",
+        onRefreshRequest: expect.any(Function),
+      });
+    });
+
+    process.emit("SIGINT");
+    await startPromise;
+
+    expect(exitSpy).toHaveBeenCalledWith(0);
   });
 
   it("keeps the HTTP dashboard available after a one-shot tick until interrupted", async () => {
@@ -697,15 +875,41 @@ async function waitForHttpUrl(
     const match = output()
       .replace(ansiPattern, "")
       .match(
-      /HTTP dashboard listening on .*?(http:\/\/[^\s]+)/
+      /(HTTP|Web) dashboard listening on .*?(http:\/\/[^\s]+)/
     );
-    if (match?.[1]) {
-      return match[1];
+    if (match?.[2]) {
+      return match[2];
     }
     await new Promise((resolve) => setTimeout(resolve, 20));
   }
 
   throw new Error(`Timed out waiting for HTTP server log. Output: ${output()}`);
+}
+
+async function createMockControlPlaneStartResult(port: number): Promise<{
+  server: ReturnType<typeof createServer>;
+  port: number;
+  url: string;
+}> {
+  const server = createServer((_, response) => {
+    response.writeHead(200, { "content-type": "application/json" });
+    response.end(JSON.stringify({ ok: true }));
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(port, "0.0.0.0", () => resolve());
+  });
+
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Expected TCP address");
+  }
+
+  return {
+    server,
+    port: address.port,
+    url: `http://localhost:${address.port}`,
+  };
 }
 
 async function fetchJsonWithRetry(

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -23,6 +23,7 @@ import {
   DashboardFsReader,
   resolveDashboardResponse,
 } from "@gh-symphony/dashboard";
+import { startControlPlaneServer } from "@gh-symphony/control-plane";
 import { resolveRuntimeRoot } from "../orchestrator-runtime.js";
 import {
   handleMissingManagedProjectConfig,
@@ -68,6 +69,7 @@ function parseStartArgs(args: string[]): {
   daemon: boolean;
   once: boolean;
   httpPort?: number;
+  webPort?: number;
   projectId?: string;
   logLevel?: string;
   error?: string;
@@ -76,6 +78,7 @@ function parseStartArgs(args: string[]): {
     daemon: boolean;
     once: boolean;
     httpPort?: number;
+    webPort?: number;
     projectId?: string;
     logLevel?: string;
     error?: string;
@@ -104,6 +107,16 @@ function parseStartArgs(args: string[]): {
       i += 1;
       continue;
     }
+    if (arg === "--web") {
+      const value = args[i + 1];
+      if (!value || value.startsWith("-")) {
+        parsed.webPort = DEFAULT_HTTP_PORT;
+        continue;
+      }
+      parsed.webPort = parsePort(value, arg);
+      i += 1;
+      continue;
+    }
     if (arg === "--project" || arg === "--project-id") {
       const value = args[i + 1];
       if (!value || value.startsWith("-")) {
@@ -128,6 +141,10 @@ function parseStartArgs(args: string[]): {
       parsed.error = `Unknown option '${arg}'`;
       return parsed;
     }
+  }
+
+  if (parsed.httpPort !== undefined && parsed.webPort !== undefined) {
+    parsed.error = "Options '--http' and '--web' cannot be used together";
   }
 
   return parsed;
@@ -426,7 +443,7 @@ const handler = async (
   if (parsed.error) {
     process.stderr.write(`${parsed.error}\n`);
     process.stderr.write(
-      "Usage: gh-symphony start --project-id <project-id> [--daemon] [--once] [--http [port]]\n"
+      "Usage: gh-symphony start --project-id <project-id> [--daemon] [--once] [--http [port]] [--web [port]]\n"
     );
     process.exitCode = 2;
     return;
@@ -460,7 +477,13 @@ const handler = async (
     return;
   }
   if (parsed.daemon) {
-    await startDaemon(options, projectId, parsed.logLevel, parsed.httpPort);
+    await startDaemon(
+      options,
+      projectId,
+      parsed.logLevel,
+      parsed.httpPort,
+      parsed.webPort
+    );
     return;
   }
 
@@ -520,7 +543,15 @@ const handler = async (
       },
     });
     const httpServer =
-      parsed.httpPort !== undefined
+      parsed.webPort !== undefined
+        ? await startControlPlaneServer({
+            host: HTTP_HOST,
+            port: parsed.webPort,
+            runtimeRoot,
+            projectId,
+            onRefreshRequest: () => service.requestReconcile(),
+          })
+        : parsed.httpPort !== undefined
         ? await startHttpServer({
             runtimeRoot,
             projectId,
@@ -554,7 +585,9 @@ const handler = async (
     if (httpServer) {
       logLine(
         cyan("\u25A1"),
-        `HTTP dashboard listening on ${httpServer.url}`
+        parsed.webPort !== undefined
+          ? `Web dashboard listening on ${httpServer.url}`
+          : `HTTP dashboard listening on ${httpServer.url}`
       );
     }
     logLine(
@@ -600,7 +633,9 @@ const handler = async (
             if (httpServer) {
               logLine(
                 cyan("\u25A1"),
-                "One-shot tick completed; HTTP dashboard remains available until Ctrl+C"
+                parsed.webPort !== undefined
+                  ? "One-shot tick completed; web dashboard remains available until Ctrl+C"
+                  : "One-shot tick completed; HTTP dashboard remains available until Ctrl+C"
               );
               await new Promise<void>((resolve) => {
                 keepHttpAliveResolve = resolve;
@@ -742,7 +777,8 @@ async function startDaemon(
   options: GlobalOptions,
   projectId: string,
   logLevel?: string,
-  httpPort?: number
+  httpPort?: number,
+  webPort?: number
 ): Promise<void> {
   const logPath = orchestratorLogPath(options.configDir, projectId);
   await mkdir(dirname(logPath), { recursive: true });
@@ -758,6 +794,7 @@ async function startDaemon(
       "--project",
       projectId,
       ...(httpPort !== undefined ? ["--http", String(httpPort)] : []),
+      ...(webPort !== undefined ? ["--web", String(webPort)] : []),
       ...(logLevel ? ["--log-level", logLevel] : []),
     ],
     {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -62,6 +62,7 @@ type CliOptionValues = Partial<
     skipContext?: boolean;
     skipSkills?: boolean;
     version?: boolean;
+    web?: string | boolean;
     workspaceDir?: string;
     watch?: boolean;
     sample?: string;
@@ -341,6 +342,10 @@ function createProgram(): { program: Command; wasInvoked: () => boolean } {
       .option("-d, --daemon", "Start in daemon mode")
       .option("--once", "Run a single orchestration tick and exit")
       .option("--http [port]", "Expose dashboard and refresh endpoints over HTTP")
+      .option(
+        "--web [port]",
+        "Expose the control plane web dashboard and API over HTTP"
+      )
       .option("--log-level <level>", "Orchestrator lifecycle log level")
       .option("--project-id <projectId>", "Project identifier")
       .addOption(new Option("--project <projectId>").hideHelp())
@@ -353,6 +358,7 @@ function createProgram(): { program: Command; wasInvoked: () => boolean } {
     pushOption(args, "--daemon", values.daemon);
     pushOption(args, "--once", values.once);
     pushOption(args, "--http", values.http);
+    pushOption(args, "--web", values.web);
     pushOption(args, "--log-level", values.logLevel);
     await invokeHandler("start", args, values);
   });
@@ -510,6 +516,10 @@ function createProgram(): { program: Command; wasInvoked: () => boolean } {
       .option("-d, --daemon", "Start in daemon mode")
       .option("--once", "Run a single orchestration tick and exit")
       .option("--http [port]", "Expose dashboard and refresh endpoints over HTTP")
+      .option(
+        "--web [port]",
+        "Expose the control plane web dashboard and API over HTTP"
+      )
       .option("--log-level <level>", "Orchestrator lifecycle log level")
       .option("--project-id <projectId>", "Project identifier")
       .addOption(new Option("--project <projectId>").hideHelp())
@@ -522,6 +532,7 @@ function createProgram(): { program: Command; wasInvoked: () => boolean } {
     pushOption(args, "--daemon", values.daemon);
     pushOption(args, "--once", values.once);
     pushOption(args, "--http", values.http);
+    pushOption(args, "--web", values.web);
     pushOption(args, "--log-level", values.logLevel);
     await invokeHandler("project", args, values);
   });

--- a/packages/control-plane/src/server.ts
+++ b/packages/control-plane/src/server.ts
@@ -16,6 +16,24 @@ const CLIENT_DIST_DIR = join(
   dirname(fileURLToPath(import.meta.url)),
   "../client/dist"
 );
+const BUNDLED_CLIENT_DIST_DIR = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../control-plane/client/dist"
+);
+const WORKSPACE_CLIENT_DIST_DIR = join(
+  process.cwd(),
+  "packages/control-plane/client/dist"
+);
+const NODE_MODULES_CLIENT_DIST_DIR = join(
+  process.cwd(),
+  "node_modules/@gh-symphony/control-plane/client/dist"
+);
+const CLIENT_DIST_DIR_CANDIDATES = [
+  CLIENT_DIST_DIR,
+  BUNDLED_CLIENT_DIST_DIR,
+  WORKSPACE_CLIENT_DIST_DIR,
+  NODE_MODULES_CLIENT_DIST_DIR,
+];
 
 const TEXT_CONTENT_TYPES = new Set([
   "application/javascript",
@@ -205,7 +223,12 @@ async function resolveStaticAsset(
   | { kind: "error"; status: 400 }
   | null
 > {
-  const indexPath = join(CLIENT_DIST_DIR, "index.html");
+  const clientDistDir = await resolveClientDistDir();
+  if (!clientDistDir) {
+    return null;
+  }
+
+  const indexPath = join(clientDistDir, "index.html");
   if (pathname === "/") {
     return (await existsAsFile(indexPath))
       ? { kind: "asset", path: indexPath, fallback: true }
@@ -219,8 +242,8 @@ async function resolveStaticAsset(
     return { kind: "error", status: 400 };
   }
 
-  const resolvedPath = resolve(CLIENT_DIST_DIR, `.${decodedPathname}`);
-  if (!isPathInsideClientDist(resolvedPath)) {
+  const resolvedPath = resolve(clientDistDir, `.${decodedPathname}`);
+  if (!isPathInsideClientDist(clientDistDir, resolvedPath)) {
     return null;
   }
 
@@ -237,8 +260,8 @@ async function resolveStaticAsset(
     : null;
 }
 
-function isPathInsideClientDist(path: string): boolean {
-  return path === CLIENT_DIST_DIR || path.startsWith(`${CLIENT_DIST_DIR}${sep}`);
+function isPathInsideClientDist(clientDistDir: string, path: string): boolean {
+  return path === clientDistDir || path.startsWith(`${clientDistDir}${sep}`);
 }
 
 function hasFileExtension(pathname: string): boolean {
@@ -252,6 +275,20 @@ async function existsAsFile(path: string): Promise<boolean> {
   } catch {
     return false;
   }
+}
+
+async function resolveClientDistDir(): Promise<string | null> {
+  for (const candidate of CLIENT_DIST_DIR_CANDIDATES) {
+    try {
+      if ((await stat(candidate)).isDirectory()) {
+        return candidate;
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  return null;
 }
 
 async function respondFile(

--- a/packages/control-plane/src/server.ts
+++ b/packages/control-plane/src/server.ts
@@ -34,6 +34,7 @@ const CLIENT_DIST_DIR_CANDIDATES = [
   WORKSPACE_CLIENT_DIST_DIR,
   NODE_MODULES_CLIENT_DIST_DIR,
 ];
+let clientDistDirPromise: Promise<string | null> | undefined;
 
 const TEXT_CONTENT_TYPES = new Set([
   "application/javascript",
@@ -278,17 +279,21 @@ async function existsAsFile(path: string): Promise<boolean> {
 }
 
 async function resolveClientDistDir(): Promise<string | null> {
-  for (const candidate of CLIENT_DIST_DIR_CANDIDATES) {
-    try {
-      if ((await stat(candidate)).isDirectory()) {
-        return candidate;
+  clientDistDirPromise ??= (async () => {
+    for (const candidate of CLIENT_DIST_DIR_CANDIDATES) {
+      try {
+        if ((await stat(candidate)).isDirectory()) {
+          return candidate;
+        }
+      } catch {
+        continue;
       }
-    } catch {
-      continue;
     }
-  }
 
-  return null;
+    return null;
+  })();
+
+  return clientDistDirPromise;
 }
 
 async function respondFile(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       '@clack/prompts':
         specifier: ^0.9.1
         version: 0.9.1
+      '@gh-symphony/control-plane':
+        specifier: workspace:*
+        version: link:../control-plane
       commander:
         specifier: ^14.0.1
         version: 14.0.3
@@ -54,9 +57,6 @@ importers:
         specifier: ^10.25.0
         version: 10.25.0
     devDependencies:
-      '@gh-symphony/control-plane':
-        specifier: workspace:*
-        version: link:../control-plane
       '@gh-symphony/core':
         specifier: workspace:*
         version: link:../core

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,9 @@ importers:
         specifier: ^10.25.0
         version: 10.25.0
     devDependencies:
+      '@gh-symphony/control-plane':
+        specifier: workspace:*
+        version: link:../control-plane
       '@gh-symphony/core':
         specifier: workspace:*
         version: link:../core


### PR DESCRIPTION
## Issues

- Fixes #189

## Summary

- `gh-symphony start`와 `gh-symphony project start`의 `--web [port]` 통합 구현 위에 리뷰 피드백을 반영해 published CLI 배포, control-plane 정적 자산 탐색 성능, 테스트 안정성을 보강했습니다.
- `--web`은 계속 `@gh-symphony/control-plane`을 기동하고, 기존 `--http`는 유지되며 두 플래그의 동시 사용은 파싱 에러로 막습니다.

## Changes

- `packages/cli/package.json`에서 `@gh-symphony/control-plane`를 `dependencies`로 승격하고 `pnpm-lock.yaml`을 갱신했습니다.
- `packages/control-plane/src/server.ts`에서 client dist 경로 해석 결과를 memoize해 정적 자산 요청마다 반복되던 `stat()` 탐색을 제거했습니다.
- `packages/cli/src/commands/start.test.ts`의 control-plane mock 서버를 ephemeral port로 바꿔 고정 포트 충돌 없이 `--web` 경로를 검증하도록 조정했습니다.
- 기존 `--web` 플래그 파싱, `--http`와의 상호배타 검증, control-plane 기동 로직은 유지합니다.

## Evidence

- `pnpm install --lockfile-only`
- `pnpm --filter @gh-symphony/control-plane test`
- `pnpm --filter @gh-symphony/cli test`
- `pnpm lint && pnpm test && pnpm typecheck && pnpm build`
- Manual check: PR review 지적사항 3건(런타임 dependency, static asset lookup cache, test port flakiness)이 각각 diff와 재검증 결과에 반영됨을 확인

## Human Validation

- [ ] `gh-symphony project start --web` 실행 시 브라우저에서 대시보드가 열린다
- [ ] published CLI 설치본에서도 `--web` 실행 시 control-plane 패키지 누락 없이 대시보드가 열린다
- [ ] `--http`와 `--web`을 함께 주면 에러 메시지가 요구사항과 일치한다

## Risks

- control-plane 정적 자산 경로는 첫 성공 후보를 프로세스 동안 재사용하므로, 런타임 중 dist 위치가 바뀌는 특이한 환경은 재시작이 필요합니다.
