### PR TITLE
feat(control-plane): Issue Detail 페이지 구현

### DIFF
--- a/packages/control-plane/client/src/hooks/useIssueDetail.ts
+++ b/packages/control-plane/client/src/hooks/useIssueDetail.ts
@@ -1,0 +1,15 @@
+import { useQuery } from "@tanstack/react-query";
+import type { IssueStatusSnapshot } from "@gh-symphony/core";
+import { api } from "../lib/api";
+import { queryKeys } from "../lib/query";
+
+export function useIssueDetail(identifier: string) {
+  return useQuery({
+    queryKey: queryKeys.issueDetail(identifier),
+    queryFn: () =>
+      api
+        .get<IssueStatusSnapshot>(`/api/v1/${encodeURIComponent(identifier)}`)
+        .then((response) => response.data),
+    refetchInterval: 10_000,
+  });
+}

--- a/packages/control-plane/client/src/hooks/useRefresh.ts
+++ b/packages/control-plane/client/src/hooks/useRefresh.ts
@@ -1,0 +1,11 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { api } from "../lib/api";
+
+export function useRefresh() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: () => api.post("/api/v1/refresh"),
+    onSuccess: () => queryClient.invalidateQueries(),
+  });
+}

--- a/packages/control-plane/client/src/index.css
+++ b/packages/control-plane/client/src/index.css
@@ -3,6 +3,7 @@
 
 @theme {
   --font-sans: Inter, ui-sans-serif, system-ui, sans-serif;
+  --font-mono: "JetBrains Mono", "SFMono-Regular", ui-monospace, monospace;
 
   --color-bg-default: #09090b;
   --color-bg-surface: #18181a;

--- a/packages/control-plane/client/src/issueDetail.test.tsx
+++ b/packages/control-plane/client/src/issueDetail.test.tsx
@@ -1,0 +1,170 @@
+import { Theme } from "@radix-ui/themes";
+import { renderToStaticMarkup } from "react-dom/server";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { IssueStatusEvent, IssueStatusSnapshot } from "@gh-symphony/core";
+import {
+  IssueDetailView,
+  classifyEventTone,
+  formatAttemptSummary,
+  mapStatusVariant,
+} from "./routes/issues/$identifier.js";
+
+const NOW = new Date("2026-04-10T12:00:00.000Z").valueOf();
+
+function createDetail(
+  overrides: Partial<IssueStatusSnapshot> = {}
+): IssueStatusSnapshot {
+  return {
+    issue_identifier: "gh-symphony#174",
+    issue_id: "issue-174",
+    status: "running",
+    workspace: {
+      path: "/workspace/gh-symphony-174",
+    },
+    attempts: {
+      restart_count: 1,
+      current_retry_attempt: 2,
+    },
+    running: {
+      session_id: "sess_a8f3c2d9e1b04f7a",
+      turn_count: 14,
+      state: "running",
+      started_at: "2026-04-08T07:13:36.000Z",
+      last_event: "worker_started",
+      last_message: "Worker started (attempt 2)",
+      last_event_at: "2026-04-10T11:59:28.000Z",
+      tokens: {
+        input_tokens: 42381,
+        output_tokens: 8914,
+        total_tokens: 51295,
+        cumulative_input_tokens: 70100,
+        cumulative_output_tokens: 38372,
+        cumulative_total_tokens: 108472,
+      },
+    },
+    retry: null,
+    logs: {
+      codex_session_logs: [],
+    },
+    recent_events: [
+      {
+        at: "2026-04-10T11:55:51.000Z",
+        event: "run-retried",
+        message: "Detected convergence state — re-entering implementation",
+      },
+      {
+        at: "2026-04-10T11:59:30.000Z",
+        event: "turn_started",
+        message: "Worker started (attempt 2)",
+      },
+    ],
+    last_error: null,
+    tracked: {
+      execution_phase: "implementation",
+      run_phase: "active",
+    },
+    ...overrides,
+  };
+}
+
+function renderIssueDetailView(
+  props: Parameters<typeof IssueDetailView>[0]
+) {
+  return renderToStaticMarkup(
+    <Theme appearance="dark" accentColor="blue" grayColor="gray" radius="medium">
+      <IssueDetailView {...props} />
+    </Theme>
+  );
+}
+
+describe("issue detail helpers", () => {
+  it("maps runtime statuses onto badge variants", () => {
+    expect(mapStatusVariant("running")).toBe("running");
+    expect(mapStatusVariant("retrying")).toBe("retry");
+    expect(mapStatusVariant("failed")).toBe("failed");
+    expect(mapStatusVariant("completed")).toBe("completed");
+    expect(mapStatusVariant("unknown")).toBe("idle");
+  });
+
+  it("formats attempt summary with restart count", () => {
+    expect(formatAttemptSummary(createDetail())).toBe("Attempt 2 · 1 restart");
+    expect(
+      formatAttemptSummary(
+        createDetail({
+          attempts: {
+            restart_count: 2,
+            current_retry_attempt: 3,
+          },
+        })
+      )
+    ).toBe("Attempt 3 · 2 restarts");
+  });
+
+  it("classifies recent events by freshness and message intent", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+
+    const successEvent: IssueStatusEvent = {
+      at: "2026-04-10T11:59:58.000Z",
+      event: "turn_started",
+      message: "Worker started (attempt 2)",
+    };
+    const warningEvent: IssueStatusEvent = {
+      at: "2026-04-10T11:59:40.000Z",
+      event: "run-retried",
+      message: "Detected convergence state — re-entering implementation",
+    };
+    const oldEvent: IssueStatusEvent = {
+      at: "2026-04-10T11:40:00.000Z",
+      event: "run-dispatched",
+      message: "Lease acquired",
+    };
+
+    expect(classifyEventTone(successEvent)).toBe("success");
+    expect(classifyEventTone(warningEvent)).toBe("warning");
+    expect(classifyEventTone(oldEvent)).toBe("muted");
+  });
+});
+
+describe("IssueDetailView", () => {
+  it("renders issue detail cards and recent event list", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+
+    const markup = renderIssueDetailView({
+      detail: createDetail(),
+      error: null,
+      isRefreshing: false,
+      lastUpdatedAt: NOW,
+      onRefresh: () => {},
+    });
+
+    expect(markup).toContain("gh-symphony#174");
+    expect(markup).toContain("Attempt 2 · 1 restart");
+    expect(markup).toContain("sess_a8f3c2d9e1b04f7a");
+    expect(markup).toContain("/workspace/gh-symphony-174");
+    expect(markup).toContain("108,472 (across 2 runs)");
+    expect(markup).toContain("Worker started (attempt 2)");
+    expect(markup).toContain("Detected convergence state");
+  });
+
+  it("renders stale-data warning when the query errors after a successful fetch", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+
+    const markup = renderIssueDetailView({
+      detail: createDetail(),
+      error: new Error("network down"),
+      isRefreshing: false,
+      lastUpdatedAt: NOW,
+      onRefresh: () => {},
+    });
+
+    expect(markup).toContain("Showing stale data due to a network error");
+    expect(markup).toContain("Last updated:");
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});

--- a/packages/control-plane/client/src/lib/api.ts
+++ b/packages/control-plane/client/src/lib/api.ts
@@ -1,0 +1,5 @@
+import axios from "axios";
+
+export const api = axios.create({
+  baseURL: "/",
+});

--- a/packages/control-plane/client/src/lib/query.ts
+++ b/packages/control-plane/client/src/lib/query.ts
@@ -1,0 +1,7 @@
+import { QueryClient } from "@tanstack/react-query";
+
+export const queryKeys = {
+  issueDetail: (identifier: string) => ["issue", identifier] as const,
+};
+
+export const queryClient = new QueryClient();

--- a/packages/control-plane/client/src/main.tsx
+++ b/packages/control-plane/client/src/main.tsx
@@ -1,13 +1,18 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { RouterProvider } from "@tanstack/react-router";
 import { Theme } from "@radix-ui/themes";
-import { FoundationsPage } from "./pages/FoundationsPage";
 import "./index.css";
+import { queryClient } from "./lib/query";
+import { router } from "./router";
 
 function App() {
   return (
     <Theme appearance="dark" accentColor="blue" grayColor="gray" radius="medium">
-      <FoundationsPage />
+      <QueryClientProvider client={queryClient}>
+        <RouterProvider router={router} />
+      </QueryClientProvider>
     </Theme>
   );
 }

--- a/packages/control-plane/client/src/router.tsx
+++ b/packages/control-plane/client/src/router.tsx
@@ -1,9 +1,5 @@
 import { createRouter } from "@tanstack/react-router";
-import { Route as rootRoute } from "./routes/__root";
-import { Route as indexRoute } from "./routes/index";
-import { Route as issueDetailRoute } from "./routes/issues/$identifier";
-
-const routeTree = rootRoute.addChildren([indexRoute, issueDetailRoute]);
+import { routeTree } from "./routeTree.gen";
 
 export const router = createRouter({
   routeTree,

--- a/packages/control-plane/client/src/router.tsx
+++ b/packages/control-plane/client/src/router.tsx
@@ -1,0 +1,17 @@
+import { createRouter } from "@tanstack/react-router";
+import { Route as rootRoute } from "./routes/__root";
+import { Route as indexRoute } from "./routes/index";
+import { Route as issueDetailRoute } from "./routes/issues/$identifier";
+
+const routeTree = rootRoute.addChildren([indexRoute, issueDetailRoute]);
+
+export const router = createRouter({
+  routeTree,
+  defaultPreload: "intent",
+});
+
+declare module "@tanstack/react-router" {
+  interface Register {
+    router: typeof router;
+  }
+}

--- a/packages/control-plane/client/src/routes/index.tsx
+++ b/packages/control-plane/client/src/routes/index.tsx
@@ -1,13 +1,10 @@
-import { createRoute, createFileRoute } from "@tanstack/react-router";
+import { createFileRoute } from "@tanstack/react-router";
 import { FoundationsPage } from "../pages/FoundationsPage";
-import { Route as RootRoute } from "./__root";
 
 function HomeRoute() {
   return <FoundationsPage />;
 }
 
-export const Route = createRoute("/")({
-  getParentRoute: () => RootRoute,
-  path: "/",
+export const Route = createFileRoute("/")({
   component: HomeRoute,
 });

--- a/packages/control-plane/client/src/routes/index.tsx
+++ b/packages/control-plane/client/src/routes/index.tsx
@@ -1,10 +1,13 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createRoute, createFileRoute } from "@tanstack/react-router";
 import { FoundationsPage } from "../pages/FoundationsPage";
+import { Route as RootRoute } from "./__root";
 
 function HomeRoute() {
   return <FoundationsPage />;
 }
 
-export const Route = createFileRoute("/")({
+export const Route = createRoute("/")({
+  getParentRoute: () => RootRoute,
+  path: "/",
   component: HomeRoute,
 });

--- a/packages/control-plane/client/src/routes/issues/$identifier.tsx
+++ b/packages/control-plane/client/src/routes/issues/$identifier.tsx
@@ -1,4 +1,4 @@
-import { createRoute, createFileRoute } from "@tanstack/react-router";
+import { createFileRoute } from "@tanstack/react-router";
 import { Tooltip } from "@radix-ui/themes";
 import { isAxiosError } from "axios";
 import type { ReactNode } from "react";
@@ -7,11 +7,8 @@ import { Badge, type BadgeVariant } from "../../components/Badge";
 import { Button } from "../../components/Button";
 import { useIssueDetail } from "../../hooks/useIssueDetail";
 import { useRefresh } from "../../hooks/useRefresh";
-import { Route as RootRoute } from "../__root";
 
-export const Route = createRoute("/issues/$identifier")({
-  getParentRoute: () => RootRoute,
-  path: "/issues/$identifier",
+export const Route = createFileRoute("/issues/$identifier")({
   component: IssueDetailRoute,
 });
 

--- a/packages/control-plane/client/src/routes/issues/$identifier.tsx
+++ b/packages/control-plane/client/src/routes/issues/$identifier.tsx
@@ -1,0 +1,477 @@
+import { createRoute, createFileRoute } from "@tanstack/react-router";
+import { Tooltip } from "@radix-ui/themes";
+import { isAxiosError } from "axios";
+import type { ReactNode } from "react";
+import type { IssueStatusEvent, IssueStatusSnapshot } from "@gh-symphony/core";
+import { Badge, type BadgeVariant } from "../../components/Badge";
+import { Button } from "../../components/Button";
+import { useIssueDetail } from "../../hooks/useIssueDetail";
+import { useRefresh } from "../../hooks/useRefresh";
+import { Route as RootRoute } from "../__root";
+
+export const Route = createRoute("/issues/$identifier")({
+  getParentRoute: () => RootRoute,
+  path: "/issues/$identifier",
+  component: IssueDetailRoute,
+});
+
+type EventTone = "default" | "success" | "warning" | "muted";
+
+const EVENT_STYLES: Record<EventTone, string> = {
+  default: "text-text-secondary",
+  success: "text-[#4dda80]",
+  warning: "text-status-retry-text",
+  muted: "text-text-muted",
+};
+
+function IssueDetailRoute() {
+  const { identifier } = Route.useParams();
+  const issueDetailQuery = useIssueDetail(identifier);
+  const refreshMutation = useRefresh();
+  const statusCode = getStatusCode(issueDetailQuery.error);
+
+  if (statusCode === 404) {
+    return <IssueNotFoundView identifier={identifier} />;
+  }
+
+  return (
+    <IssueDetailView
+      detail={issueDetailQuery.data ?? null}
+      error={issueDetailQuery.error}
+      isRefreshing={refreshMutation.isPending}
+      lastUpdatedAt={issueDetailQuery.dataUpdatedAt}
+      onRefresh={() => refreshMutation.mutate()}
+    />
+  );
+}
+
+export function IssueDetailView({
+  detail,
+  error,
+  isRefreshing,
+  lastUpdatedAt,
+  onRefresh,
+}: {
+  detail: IssueStatusSnapshot | null;
+  error: unknown;
+  isRefreshing: boolean;
+  lastUpdatedAt: number;
+  onRefresh: () => void;
+}) {
+  const staleData = Boolean(error && detail);
+  const phaseLabel = getPhaseLabel(detail);
+  const runDetails = detail?.running;
+  const tokenDetails = runDetails?.tokens;
+  const lastEventLabel = getLastEventLabel(detail);
+
+  return (
+    <main className="min-h-screen bg-bg-default text-text-primary">
+      <header className="border-b border-border-default bg-[#161618]">
+        <div className="mx-auto flex w-full max-w-[1440px] items-center justify-between gap-4 px-6 py-3 sm:px-8">
+          <div className="flex items-center gap-4 overflow-hidden">
+            <a
+              className="text-sm font-medium text-interactive no-underline transition hover:text-blue-300"
+              href="/"
+            >
+              ← Overview
+            </a>
+            <div className="h-5 w-px bg-border-subtle" />
+            <span className="truncate font-mono text-[13px] text-text-muted">
+              {detail?.issue_identifier ?? "Issue detail"}
+            </span>
+          </div>
+          <Button
+            disabled={isRefreshing}
+            size="sm"
+            variant="ghost"
+            onClick={onRefresh}
+          >
+            {isRefreshing ? "Refreshing..." : "Refresh"}
+          </Button>
+        </div>
+      </header>
+
+      <div className="mx-auto flex w-full max-w-[1440px] flex-col gap-6 px-6 py-6 sm:px-8">
+        {staleData ? (
+          <div
+            aria-live="polite"
+            className="rounded-lg border border-status-retry-text/30 bg-status-retry-bg/40 px-4 py-3 text-sm text-status-retry-text"
+          >
+            Showing stale data due to a network error. Last updated:{" "}
+            {formatDateTime(lastUpdatedAt)}
+          </div>
+        ) : null}
+
+        {detail ? (
+          <>
+            <section className="space-y-3">
+              <h1 className="font-mono text-3xl font-medium tracking-[-0.03em] text-text-primary">
+                {detail.issue_identifier}
+              </h1>
+              <div className="flex flex-wrap items-center gap-2">
+                <Badge variant={mapStatusVariant(detail.status)} />
+                {phaseLabel ? <PhaseBadge label={phaseLabel} /> : null}
+                <span className="text-[13px] text-text-muted">
+                  {formatAttemptSummary(detail)}
+                </span>
+              </div>
+            </section>
+
+            <div className="grid gap-6 xl:grid-cols-[minmax(0,820px)_minmax(0,1fr)]">
+              <div className="space-y-3">
+                <DetailCard title="Run Details">
+                  <DetailRow label="Session ID" value={runDetails?.session_id} />
+                  <DetailRow
+                    label="Started"
+                    value={
+                      runDetails?.started_at ? (
+                        <Tooltip content={runDetails.started_at}>
+                          <time
+                            className="font-mono text-[13px] text-text-primary"
+                            dateTime={runDetails.started_at}
+                          >
+                            {formatDateTime(runDetails.started_at)}
+                          </time>
+                        </Tooltip>
+                      ) : undefined
+                    }
+                  />
+                  <DetailRow
+                    label="Turn count"
+                    value={formatNumericValue(runDetails?.turn_count)}
+                  />
+                  <DetailRow
+                    label="Workspace path"
+                    value={detail.workspace.path}
+                    multiline
+                  />
+                  <DetailRow label="Last event" value={lastEventLabel} />
+                </DetailCard>
+
+                <DetailCard title="Token Usage">
+                  <DetailRow
+                    label="Input tokens"
+                    value={formatNumericValue(tokenDetails?.input_tokens)}
+                  />
+                  <DetailRow
+                    label="Output tokens"
+                    value={formatNumericValue(tokenDetails?.output_tokens)}
+                  />
+                  <DetailRow
+                    label="Total tokens"
+                    value={formatNumericValue(tokenDetails?.total_tokens)}
+                  />
+                  <DetailRow
+                    label="Cumulative total"
+                    value={formatCumulativeTotal(detail)}
+                  />
+                </DetailCard>
+              </div>
+
+              <DetailCard title="Recent Events" className="self-start">
+                <RecentEvents events={detail.recent_events} />
+              </DetailCard>
+            </div>
+          </>
+        ) : (
+          <IssueUnavailableView />
+        )}
+      </div>
+    </main>
+  );
+}
+
+function IssueNotFoundView({ identifier }: { identifier: string }) {
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-bg-default px-6 text-text-primary">
+      <div className="w-full max-w-xl rounded-2xl border border-border-default bg-bg-surface p-8 text-center">
+        <p className="mb-3 font-mono text-sm text-text-muted">{identifier}</p>
+        <h1 className="text-2xl font-semibold">Issue not found</h1>
+        <p className="mt-3 text-sm text-text-secondary">
+          The requested issue detail could not be loaded.
+        </p>
+        <a
+          className="mt-6 inline-flex text-sm font-medium text-interactive no-underline hover:text-blue-300"
+          href="/"
+        >
+          ← Overview
+        </a>
+      </div>
+    </main>
+  );
+}
+
+function IssueUnavailableView() {
+  return (
+    <div className="rounded-2xl border border-border-default bg-bg-surface p-8">
+      <h2 className="text-lg font-semibold text-text-primary">
+        Issue detail unavailable
+      </h2>
+      <p className="mt-2 text-sm text-text-secondary">
+        Waiting for the first successful response from `/api/v1/:identifier`.
+      </p>
+    </div>
+  );
+}
+
+function DetailCard({
+  title,
+  className,
+  children,
+}: {
+  title: string;
+  className?: string;
+  children: ReactNode;
+}) {
+  return (
+    <section
+      className={[
+        "overflow-hidden rounded-xl border border-border-default bg-bg-surface",
+        className,
+      ]
+        .filter(Boolean)
+        .join(" ")}
+    >
+      <div className="border-b border-border-default bg-bg-muted px-4 py-3 text-[13px] font-semibold text-text-primary">
+        {title}
+      </div>
+      {children}
+    </section>
+  );
+}
+
+function DetailRow({
+  label,
+  value,
+  multiline = false,
+}: {
+  label: string;
+  value?: ReactNode;
+  multiline?: boolean;
+}) {
+  return (
+    <div className="grid gap-2 border-b border-border-default px-4 py-3 last:border-b-0 sm:grid-cols-[180px_minmax(0,1fr)] sm:gap-4">
+      <dt className="text-[13px] text-text-muted">{label}</dt>
+      <dd
+        className={[
+          "m-0 font-mono text-[13px] text-text-primary",
+          multiline ? "break-all" : "truncate",
+        ]
+          .filter(Boolean)
+          .join(" ")}
+      >
+        {value ?? "—"}
+      </dd>
+    </div>
+  );
+}
+
+function PhaseBadge({ label }: { label: string }) {
+  return (
+    <span className="inline-flex rounded-full border border-border-subtle bg-bg-muted px-2 py-[3px] font-mono text-[12px] leading-4 text-text-secondary">
+      {label}
+    </span>
+  );
+}
+
+function RecentEvents({ events }: { events: IssueStatusEvent[] }) {
+  if (events.length === 0) {
+    return (
+      <div className="px-4 py-6 text-sm text-text-secondary">
+        No recent events recorded.
+      </div>
+    );
+  }
+
+  return (
+    <ul className="m-0 max-h-[480px] list-none overflow-y-auto p-0">
+      {events
+        .slice()
+        .reverse()
+        .map((event, index) => {
+          const tone = classifyEventTone(event);
+
+          return (
+            <li
+              className="grid grid-cols-[84px_minmax(0,1fr)] gap-4 border-b border-border-default px-4 py-3 last:border-b-0"
+              key={`${event.at}-${event.event}-${index}`}
+            >
+              <time
+                className="font-mono text-[11px] text-text-muted"
+                dateTime={event.at}
+              >
+                {formatEventTime(event.at)}
+              </time>
+              <span className={`text-[13px] ${EVENT_STYLES[tone]}`}>
+                {event.message ?? event.event}
+              </span>
+            </li>
+          );
+        })}
+    </ul>
+  );
+}
+
+function getStatusCode(error: unknown) {
+  if (isAxiosError(error)) {
+    return error.response?.status ?? null;
+  }
+
+  return null;
+}
+
+function getPhaseLabel(detail: IssueStatusSnapshot | null) {
+  const tracked = detail?.tracked ?? {};
+  const executionPhase = tracked.execution_phase;
+  const runPhase = tracked.run_phase;
+
+  if (typeof executionPhase === "string" && executionPhase.length > 0) {
+    return executionPhase;
+  }
+
+  if (typeof runPhase === "string" && runPhase.length > 0) {
+    return runPhase;
+  }
+
+  return null;
+}
+
+export function mapStatusVariant(status: string): BadgeVariant {
+  switch (status.toLowerCase()) {
+    case "running":
+    case "active":
+      return "running";
+    case "retry":
+    case "retrying":
+      return "retry";
+    case "failed":
+    case "error":
+      return "failed";
+    case "completed":
+    case "done":
+      return "completed";
+    case "degraded":
+      return "degraded";
+    default:
+      return "idle";
+  }
+}
+
+export function formatAttemptSummary(detail: IssueStatusSnapshot) {
+  const attempt = Math.max(detail.attempts.current_retry_attempt, 1);
+  const restarts = Math.max(detail.attempts.restart_count, 0);
+  const restartLabel = restarts === 1 ? "restart" : "restarts";
+
+  return `Attempt ${attempt} · ${restarts} ${restartLabel}`;
+}
+
+function getLastEventLabel(detail: IssueStatusSnapshot | null) {
+  const lastEventAt = detail?.running?.last_event_at;
+  if (!lastEventAt) {
+    return detail?.running?.last_event ?? detail?.last_error ?? null;
+  }
+
+  return formatRelativeTime(lastEventAt);
+}
+
+function formatCumulativeTotal(detail: IssueStatusSnapshot) {
+  const total = detail.running?.tokens?.cumulative_total_tokens;
+  if (typeof total !== "number") {
+    return "—";
+  }
+
+  const runs = detail.attempts.restart_count + 1;
+  return `${formatNumber(total)} (across ${runs} runs)`;
+}
+
+function formatNumericValue(value: number | null | undefined) {
+  if (typeof value !== "number") {
+    return "—";
+  }
+
+  return formatNumber(value);
+}
+
+function formatNumber(value: number) {
+  return new Intl.NumberFormat("en-US").format(value);
+}
+
+function formatDateTime(value: string | number) {
+  const date = typeof value === "number" ? new Date(value) : new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return "—";
+  }
+
+  return new Intl.DateTimeFormat("en-US", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+    timeZone: "UTC",
+  })
+    .format(date)
+    .replace(",", "")
+    .concat(" UTC");
+}
+
+function formatEventTime(value: string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return "--:--:--";
+  }
+
+  return new Intl.DateTimeFormat("en-US", {
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+    timeZone: "UTC",
+  }).format(date);
+}
+
+function formatRelativeTime(value: string) {
+  const eventTime = new Date(value).getTime();
+  if (Number.isNaN(eventTime)) {
+    return "—";
+  }
+
+  const deltaSeconds = Math.max(0, Math.round((Date.now() - eventTime) / 1000));
+  if (deltaSeconds < 60) {
+    return `${deltaSeconds}s ago`;
+  }
+
+  const deltaMinutes = Math.floor(deltaSeconds / 60);
+  if (deltaMinutes < 60) {
+    return `${deltaMinutes}m ago`;
+  }
+
+  const deltaHours = Math.floor(deltaMinutes / 60);
+  if (deltaHours < 24) {
+    return `${deltaHours}h ago`;
+  }
+
+  const deltaDays = Math.floor(deltaHours / 24);
+  return `${deltaDays}d ago`;
+}
+
+export function classifyEventTone(event: IssueStatusEvent): EventTone {
+  const timestamp = Date.parse(event.at);
+  if (!Number.isNaN(timestamp) && Date.now() - timestamp > 5 * 60 * 1000) {
+    return "muted";
+  }
+
+  const text = `${event.event} ${event.message ?? ""}`.toLowerCase();
+  if (text.includes("worker started")) {
+    return "success";
+  }
+
+  if (text.includes("convergence")) {
+    return "warning";
+  }
+
+  return "default";
+}


### PR DESCRIPTION
## Issues

- Fixes #188

## Summary

- Control Plane 클라이언트에 TanStack Router/Query 기반의 이슈 상세 화면을 연결했습니다.
- `/issues/:identifier`에서 status, phase, attempt, token usage, recent events, 오류 상태를 실시간으로 확인할 수 있습니다.

## Changes

- `useIssueDetail`/`useRefresh` 훅과 Axios/QueryClient wiring을 추가해 10초 자동 갱신과 수동 refresh를 연결했습니다.
- `/issues/$identifier` 페이지를 구현해 Figma 요구사항에 맞춘 헤더, 상세 카드, 최근 이벤트 목록, 404/네트워크 오류 UI를 렌더링했습니다.
- `main.tsx`를 RouterProvider + QueryClientProvider 기반으로 전환하고, 이슈 상세 렌더링/분류 헬퍼를 검증하는 테스트를 추가했습니다.

## Evidence

- `pnpm -r build`
- `pnpm lint && pnpm test && pnpm typecheck && pnpm build`
- Manual check: Figma node `20:2` 스크린샷과 구현 UI 구성을 대조해 navigation, header badges, 2-column card layout, stale/404 states를 확인

## Human Validation

- [ ] `/issues/:identifier`에서 status, phase, attempt 요약이 기대한 값으로 보이는지 확인
- [ ] Refresh 버튼과 10초 자동 갱신 후 recent events / token usage가 갱신되는지 확인
- [ ] 404 및 네트워크 오류 시 fallback/stale UI가 요구사항과 일치하는지 확인

## Risks

- `/` overview 화면은 별도 이슈 범위라 현재는 기존 foundations 화면으로 남아 있습니다.
