### PR TITLE
feat(cli): paginate GitHub Project discovery in init/project add

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ The interactive wizard will:
 | `.gh-symphony/reference-workflow.md` | Reference workflow documentation |
 | `.codex/skills/` (or `.claude/skills/`) | Agent skill definitions |
 
+Project discovery is pagination-aware for larger GitHub accounts, so personal projects, organization pages, and organization-owned projects are fetched across multiple API pages before selection. If the CLI hits a discovery safety cap, it keeps the partial list and prints a warning before you choose a board.
+
 `gh-symphony workflow init --dry-run` resolves the same generated outputs, shows whether each path would be created, updated, or left unchanged, and prints the detected environment inputs that shaped the preview.
 
 Token-only interactive setup is supported:
@@ -137,6 +139,8 @@ The interactive wizard will:
 3. Optionally limit processing to issues assigned to the authenticated user
 4. Optionally customize advanced settings for repository filtering and workspace root directory
 5. Write project configuration to `~/.gh-symphony/`
+
+Project discovery is pagination-aware here as well, so large personal and organization-backed GitHub accounts can browse across multiple project pages. If discovery stops at a safety limit, the wizard warns that the visible list may be incomplete.
 
 Token-only project registration is supported too:
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -71,6 +71,8 @@ The interactive wizard will:
 3. Map project status columns to workflow phases (active / wait / terminal)
 4. Generate `WORKFLOW.md` and supporting files in the repository
 
+Project discovery is pagination-aware for larger GitHub accounts, so viewer projects plus organization-owned projects are collected across multiple API pages before the selection prompt. If a discovery safety cap is hit, the wizard keeps the partial list and prints a warning.
+
 Token-only interactive setup is supported:
 
 ```bash
@@ -138,6 +140,8 @@ The interactive wizard will:
 3. Optionally limit processing to issues assigned to the authenticated user
 4. Optionally customize advanced settings for repository filtering and workspace root directory
 5. Write project configuration to `~/.gh-symphony/`
+
+This wizard uses the same pagination-aware discovery path as `workflow init`, so it can enumerate large personal and organization-backed GitHub accounts more reliably. If the CLI stops at a safety limit, it warns that the visible project list may be incomplete.
 
 Token-only non-interactive setup:
 

--- a/packages/cli/src/commands/init.test.ts
+++ b/packages/cli/src/commands/init.test.ts
@@ -82,7 +82,12 @@ describe("init interactive auth", () => {
     });
     const ensureSpy = vi.spyOn(ghAuth, "ensureGhAuth");
     vi.spyOn(githubClient, "createClient").mockReturnValue({} as never);
-    vi.spyOn(githubClient, "listUserProjects").mockResolvedValue([]);
+    vi.spyOn(githubClient, "discoverUserProjects").mockResolvedValue({
+      projects: [],
+      partial: false,
+      reason: null,
+      requests: 1,
+    });
 
     await initCommand([], {
       configDir,
@@ -100,6 +105,34 @@ describe("init interactive auth", () => {
     );
     expect(p.log.error).toHaveBeenCalledWith(
       "No GitHub Projects found. Create a project at https://github.com/orgs/YOUR_ORG/projects and re-run."
+    );
+  });
+
+  it("warns when project discovery hits a safety limit", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "cli-init-partial-projects-"));
+    vi.spyOn(ghAuth, "resolveGitHubAuth").mockResolvedValue({
+      source: "env",
+      login: "env-user",
+      token: "env-token",
+      scopes: ["repo", "read:org", "project"],
+    });
+    vi.spyOn(githubClient, "createClient").mockReturnValue({} as never);
+    vi.spyOn(githubClient, "discoverUserProjects").mockResolvedValue({
+      projects: [],
+      partial: true,
+      reason: "request_limit",
+      requests: 40,
+    });
+
+    await initCommand([], {
+      configDir,
+      verbose: false,
+      json: false,
+      noColor: true,
+    });
+
+    expect(p.log.warn).toHaveBeenCalledWith(
+      "Project discovery may be incomplete: the GitHub API request budget reached the safety cap. Showing 0 discovered projects after 40 requests."
     );
   });
 });

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -7,10 +7,12 @@ import {
   createClient,
   validateToken,
   checkRequiredScopes,
+  discoverUserProjects,
   listUserProjects,
   getProjectDetail,
   GitHubScopeError,
   type GitHubClient,
+  type ProjectDiscoveryResult,
   type ProjectSummary,
   type ProjectDetail,
   type ProjectStatusField,
@@ -65,6 +67,23 @@ function displayScopeError(
   p.note(
     `gh auth refresh --scopes ${scopeArg}\n\nThen re-run: ${retryCommand}`,
     "Fix missing scope"
+  );
+}
+
+export function warnIfProjectDiscoveryPartial(
+  result: Pick<ProjectDiscoveryResult, "partial" | "reason" | "projects" | "requests">
+): void {
+  if (!result.partial) {
+    return;
+  }
+
+  const limitDetail =
+    result.reason === "result_limit"
+      ? "the discovered project count reached the safety cap"
+      : "the GitHub API request budget reached the safety cap";
+
+  p.log.warn(
+    `Project discovery may be incomplete: ${limitDetail}. Showing ${result.projects.length} discovered project${result.projects.length === 1 ? "" : "s"} after ${result.requests} request${result.requests === 1 ? "" : "s"}.`
   );
 }
 
@@ -821,10 +840,12 @@ async function runInteractiveStandalone(
   s2.start("Loading projects...");
   let projects: ProjectSummary[];
   try {
-    projects = await listUserProjects(client);
+    const discovery = await discoverUserProjects(client);
+    projects = discovery.projects;
     s2.stop(
       `Found ${projects.length} project${projects.length === 1 ? "" : "s"}`
     );
+    warnIfProjectDiscoveryPartial(discovery);
   } catch (error) {
     s2.stop("Failed to load projects.");
     if (error instanceof GitHubScopeError) {

--- a/packages/cli/src/commands/project.test.ts
+++ b/packages/cli/src/commands/project.test.ts
@@ -395,9 +395,12 @@ describe("project add interactive", () => {
       scopes: ["repo", "read:org", "project"],
     });
     vi.spyOn(githubClient, "createClient").mockReturnValue({} as never);
-    vi.spyOn(githubClient, "listUserProjects").mockResolvedValue([
-      MOCK_PROJECT_SUMMARY,
-    ]);
+    vi.spyOn(githubClient, "discoverUserProjects").mockResolvedValue({
+      projects: [MOCK_PROJECT_SUMMARY],
+      partial: false,
+      reason: null,
+      requests: 1,
+    });
     vi.spyOn(githubClient, "getProjectDetail").mockResolvedValue(
       MOCK_PROJECT_DETAIL
     );
@@ -469,6 +472,32 @@ describe("project add interactive", () => {
         "Repos:      acme/repo-a, acme/repo-b, acme/repo-c  (all 3 linked)"
       ),
       "Configuration Summary"
+    );
+  });
+
+  it("warns when project discovery returns partial results", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "project-add-partial-"));
+    vi.mocked(p.select).mockResolvedValue(MOCK_PROJECT_SUMMARY.id as never);
+    vi.mocked(p.confirm)
+      .mockResolvedValueOnce(false as never)
+      .mockResolvedValueOnce(false as never)
+      .mockResolvedValueOnce(true as never);
+    vi.spyOn(githubClient, "discoverUserProjects").mockResolvedValue({
+      projects: [MOCK_PROJECT_SUMMARY],
+      partial: true,
+      reason: "result_limit",
+      requests: 12,
+    });
+
+    await projectCommand(["add"], {
+      configDir,
+      verbose: false,
+      json: false,
+      noColor: true,
+    });
+
+    expect(p.log.warn).toHaveBeenCalledWith(
+      "Project discovery may be incomplete: the discovered project count reached the safety cap. Showing 1 discovered project after 12 requests."
     );
   });
 

--- a/packages/cli/src/commands/project.ts
+++ b/packages/cli/src/commands/project.ts
@@ -10,6 +10,7 @@ import {
   createClient,
   validateToken,
   checkRequiredScopes,
+  discoverUserProjects,
   listUserProjects,
   getProjectDetail,
   GitHubScopeError,
@@ -30,7 +31,12 @@ import {
   type CliGlobalConfig,
   type CliProjectConfig,
 } from "../config.js";
-import { writeConfig, generateProjectId, abortIfCancelled } from "./init.js";
+import {
+  writeConfig,
+  generateProjectId,
+  abortIfCancelled,
+  warnIfProjectDiscoveryPartial,
+} from "./init.js";
 import startCommand from "./start.js";
 import statusCommand from "./status.js";
 import stopCommand from "./stop.js";
@@ -611,10 +617,12 @@ async function projectAddInteractive(
   s2.start("Loading GitHub Project boards...");
   let projects: ProjectSummary[];
   try {
-    projects = await listUserProjects(client);
+    const discovery = await discoverUserProjects(client);
+    projects = discovery.projects;
     s2.stop(
       `Found ${projects.length} project${projects.length === 1 ? "" : "s"}`
     );
+    warnIfProjectDiscoveryPartial(discovery);
   } catch (error) {
     s2.stop("Failed to load projects.");
     if (error instanceof GitHubScopeError) {

--- a/packages/cli/src/github/client.test.ts
+++ b/packages/cli/src/github/client.test.ts
@@ -1,0 +1,285 @@
+import { describe, expect, it, vi } from "vitest";
+import { createClient, discoverUserProjects } from "./client.js";
+
+function graphqlResponse(data: unknown): Response {
+  return new Response(JSON.stringify({ data }), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("discoverUserProjects", () => {
+  it("paginates viewer projects", async () => {
+    const fetchImpl = vi.fn(async (_url: string, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body)) as {
+        query: string;
+        variables?: { cursor?: string | null };
+      };
+
+      if (body.query.includes("ViewerProjectsPage")) {
+        if (!body.variables?.cursor) {
+          return graphqlResponse({
+            viewer: {
+              login: "moncher-dev",
+              projectsV2: {
+                nodes: [
+                  {
+                    id: "PVT_user_1",
+                    title: "Viewer One",
+                    shortDescription: null,
+                    url: "https://github.com/users/moncher-dev/projects/1",
+                    items: { totalCount: 3 },
+                  },
+                ],
+                pageInfo: { endCursor: "viewer-page-1", hasNextPage: true },
+              },
+            },
+          });
+        }
+
+        return graphqlResponse({
+          viewer: {
+            login: "moncher-dev",
+            projectsV2: {
+              nodes: [
+                {
+                  id: "PVT_user_2",
+                  title: "Viewer Two",
+                  shortDescription: "second",
+                  url: "https://github.com/users/moncher-dev/projects/2",
+                  items: { totalCount: 5 },
+                },
+              ],
+              pageInfo: { endCursor: null, hasNextPage: false },
+            },
+          },
+        });
+      }
+
+      if (body.query.includes("ViewerOrganizationsPage")) {
+        return graphqlResponse({
+          viewer: {
+            organizations: {
+              nodes: [],
+              pageInfo: { endCursor: null, hasNextPage: false },
+            },
+          },
+        });
+      }
+
+      throw new Error(`Unexpected query: ${body.query}`);
+    });
+
+    const result = await discoverUserProjects(
+      createClient("token", { fetchImpl: fetchImpl as typeof fetch })
+    );
+
+    expect(result).toMatchObject({
+      partial: false,
+      reason: null,
+      requests: 3,
+    });
+    expect(result.projects.map((project) => project.id)).toEqual([
+      "PVT_user_1",
+      "PVT_user_2",
+    ]);
+    expect(result.projects.map((project) => project.owner)).toEqual([
+      { login: "moncher-dev", type: "User" },
+      { login: "moncher-dev", type: "User" },
+    ]);
+  });
+
+  it("paginates organization pages and organization projects", async () => {
+    const fetchImpl = vi.fn(async (_url: string, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body)) as {
+        query: string;
+        variables?: { cursor?: string | null; login?: string };
+      };
+
+      if (body.query.includes("ViewerProjectsPage")) {
+        return graphqlResponse({
+          viewer: {
+            login: "moncher-dev",
+            projectsV2: {
+              nodes: [],
+              pageInfo: { endCursor: null, hasNextPage: false },
+            },
+          },
+        });
+      }
+
+      if (body.query.includes("ViewerOrganizationsPage")) {
+        if (!body.variables?.cursor) {
+          return graphqlResponse({
+            viewer: {
+              organizations: {
+                nodes: [{ login: "acme" }],
+                pageInfo: { endCursor: "org-page-1", hasNextPage: true },
+              },
+            },
+          });
+        }
+
+        return graphqlResponse({
+          viewer: {
+            organizations: {
+              nodes: [{ login: "beta" }],
+              pageInfo: { endCursor: null, hasNextPage: false },
+            },
+          },
+        });
+      }
+
+      if (body.query.includes("OrganizationProjectsPage")) {
+        if (body.variables?.login === "acme" && !body.variables?.cursor) {
+          return graphqlResponse({
+            organization: {
+              projectsV2: {
+                nodes: [
+                  {
+                    id: "PVT_acme_1",
+                    title: "Acme One",
+                    shortDescription: null,
+                    url: "https://github.com/orgs/acme/projects/1",
+                    items: { totalCount: 2 },
+                  },
+                ],
+                pageInfo: { endCursor: "acme-page-1", hasNextPage: true },
+              },
+            },
+          });
+        }
+
+        if (body.variables?.login === "acme") {
+          return graphqlResponse({
+            organization: {
+              projectsV2: {
+                nodes: [
+                  {
+                    id: "PVT_acme_2",
+                    title: "Acme Two",
+                    shortDescription: "extra",
+                    url: "https://github.com/orgs/acme/projects/2",
+                    items: { totalCount: 4 },
+                  },
+                ],
+                pageInfo: { endCursor: null, hasNextPage: false },
+              },
+            },
+          });
+        }
+
+        return graphqlResponse({
+          organization: {
+            projectsV2: {
+              nodes: [
+                {
+                  id: "PVT_beta_1",
+                  title: "Beta One",
+                  shortDescription: null,
+                  url: "https://github.com/orgs/beta/projects/1",
+                  items: { totalCount: 1 },
+                },
+              ],
+              pageInfo: { endCursor: null, hasNextPage: false },
+            },
+          },
+        });
+      }
+
+      throw new Error(`Unexpected query: ${body.query}`);
+    });
+
+    const result = await discoverUserProjects(
+      createClient("token", { fetchImpl: fetchImpl as typeof fetch })
+    );
+
+    expect(result).toMatchObject({
+      partial: false,
+      reason: null,
+      requests: 6,
+    });
+    expect(result.projects.map((project) => `${project.owner.login}:${project.title}`))
+      .toEqual(["acme:Acme One", "acme:Acme Two", "beta:Beta One"]);
+  });
+
+  it("returns partial results when the request budget is exhausted", async () => {
+    const orgLogins = Array.from({ length: 40 }, (_, index) => `org-${index + 1}`);
+    const fetchImpl = vi.fn(async (_url: string, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body)) as {
+        query: string;
+        variables?: { cursor?: string | null; login?: string };
+      };
+
+      if (body.query.includes("ViewerProjectsPage")) {
+        return graphqlResponse({
+          viewer: {
+            login: "moncher-dev",
+            projectsV2: {
+              nodes: [],
+              pageInfo: { endCursor: null, hasNextPage: false },
+            },
+          },
+        });
+      }
+
+      if (body.query.includes("ViewerOrganizationsPage")) {
+        if (!body.variables?.cursor) {
+          return graphqlResponse({
+            viewer: {
+              organizations: {
+                nodes: orgLogins.slice(0, 20).map((login) => ({ login })),
+                pageInfo: { endCursor: "org-page-1", hasNextPage: true },
+              },
+            },
+          });
+        }
+
+        return graphqlResponse({
+          viewer: {
+            organizations: {
+              nodes: orgLogins.slice(20).map((login) => ({ login })),
+              pageInfo: { endCursor: null, hasNextPage: false },
+            },
+          },
+        });
+      }
+
+      if (body.query.includes("OrganizationProjectsPage")) {
+        return graphqlResponse({
+          organization: {
+            projectsV2: {
+              nodes: [
+                {
+                  id: `PVT_${body.variables?.login}`,
+                  title: `Project ${body.variables?.login}`,
+                  shortDescription: null,
+                  url: `https://github.com/orgs/${body.variables?.login}/projects/1`,
+                  items: { totalCount: 1 },
+                },
+              ],
+              pageInfo: { endCursor: null, hasNextPage: false },
+            },
+          },
+        });
+      }
+
+      throw new Error(`Unexpected query: ${body.query}`);
+    });
+
+    const result = await discoverUserProjects(
+      createClient("token", { fetchImpl: fetchImpl as typeof fetch })
+    );
+
+    expect(result).toMatchObject({
+      partial: true,
+      reason: "request_limit",
+      requests: 40,
+    });
+    expect(result.projects).toHaveLength(37);
+    expect(result.projects[0]?.owner).toEqual({
+      login: "org-1",
+      type: "Organization",
+    });
+  });
+});

--- a/packages/cli/src/github/client.ts
+++ b/packages/cli/src/github/client.ts
@@ -25,6 +25,13 @@ export type ProjectSummary = {
   };
 };
 
+export type ProjectDiscoveryResult = {
+  projects: ProjectSummary[];
+  partial: boolean;
+  reason: "request_limit" | "result_limit" | null;
+  requests: number;
+};
+
 export type StatusFieldOption = {
   id: string;
   name: string;
@@ -273,39 +280,162 @@ export function checkRequiredScopes(scopes: string[]): {
 
 // ── 2.2: Projects v2 list ────────────────────────────────────────────────────
 
-export async function listUserProjects(
-  client: GitHubClient
-): Promise<ProjectSummary[]> {
-  const data = await graphql<ViewerProjectsResponse>(
-    client,
-    VIEWER_PROJECTS_QUERY
-  );
-  const projects: ProjectSummary[] = [];
+const PROJECT_PAGE_SIZE = 50;
+const ORGANIZATION_PAGE_SIZE = 20;
+const MAX_PROJECT_DISCOVERY_REQUESTS = 40;
+const MAX_DISCOVERED_PROJECTS = 1000;
 
-  for (const node of data.viewer.projectsV2?.nodes ?? []) {
-    if (!node) continue;
-    projects.push(
-      normalizeProjectSummary(node, {
-        login: data.viewer.login,
-        type: "User",
-      })
+export async function discoverUserProjects(
+  client: GitHubClient
+): Promise<ProjectDiscoveryResult> {
+  const projects: ProjectSummary[] = [];
+  const seenProjectIds = new Set<string>();
+  const orgLogins: string[] = [];
+  let requestCount = 0;
+  let partial = false;
+  let reason: ProjectDiscoveryResult["reason"] = null;
+
+  const tryStartRequest = (): boolean => {
+    if (requestCount >= MAX_PROJECT_DISCOVERY_REQUESTS) {
+      partial = true;
+      reason ??= "request_limit";
+      return false;
+    }
+    requestCount += 1;
+    return true;
+  };
+
+  const collectProject = (
+    node: GraphQLProjectNode,
+    owner: { login: string; type: "User" | "Organization" }
+  ): boolean => {
+    if (seenProjectIds.has(node.id)) {
+      return true;
+    }
+    if (projects.length >= MAX_DISCOVERED_PROJECTS) {
+      partial = true;
+      reason ??= "result_limit";
+      return false;
+    }
+
+    seenProjectIds.add(node.id);
+    projects.push(normalizeProjectSummary(node, owner));
+    return true;
+  };
+
+  let viewerProjectsCursor: string | null = null;
+  let hasMoreViewerProjects = true;
+  let viewerLogin = "";
+
+  while (hasMoreViewerProjects) {
+    if (!tryStartRequest()) {
+      break;
+    }
+
+    const data: ViewerProjectsPageResponse = await graphql<ViewerProjectsPageResponse>(
+      client,
+      VIEWER_PROJECTS_PAGE_QUERY,
+      { cursor: viewerProjectsCursor }
     );
+
+    viewerLogin = data.viewer.login;
+    const projectPage: ViewerProjectsPageResponse["viewer"]["projectsV2"] =
+      data.viewer.projectsV2;
+    for (const node of projectPage?.nodes ?? []) {
+      if (!node) continue;
+      if (!collectProject(node, { login: viewerLogin, type: "User" })) {
+        hasMoreViewerProjects = false;
+        break;
+      }
+    }
+
+    if (partial) {
+      break;
+    }
+
+    hasMoreViewerProjects = projectPage?.pageInfo?.hasNextPage ?? false;
+    viewerProjectsCursor = projectPage?.pageInfo?.endCursor ?? null;
   }
 
-  for (const orgNode of data.viewer.organizations?.nodes ?? []) {
-    if (!orgNode) continue;
-    for (const projNode of orgNode.projectsV2?.nodes ?? []) {
-      if (!projNode) continue;
-      projects.push(
-        normalizeProjectSummary(projNode, {
-          login: orgNode.login,
-          type: "Organization",
-        })
+  let organizationsCursor: string | null = null;
+  let hasMoreOrganizations = true;
+
+  while (!partial && hasMoreOrganizations) {
+    if (!tryStartRequest()) {
+      break;
+    }
+
+    const data: ViewerOrganizationsPageResponse =
+      await graphql<ViewerOrganizationsPageResponse>(
+      client,
+      VIEWER_ORGANIZATIONS_PAGE_QUERY,
+      { cursor: organizationsCursor }
+    );
+
+    for (const orgNode of data.viewer.organizations?.nodes ?? []) {
+      if (!orgNode) continue;
+      orgLogins.push(orgNode.login);
+    }
+
+    hasMoreOrganizations =
+      data.viewer.organizations?.pageInfo?.hasNextPage ?? false;
+    organizationsCursor = data.viewer.organizations?.pageInfo?.endCursor ?? null;
+  }
+
+  for (const orgLogin of orgLogins) {
+    let orgProjectsCursor: string | null = null;
+    let hasMoreOrgProjects = true;
+
+    while (!partial && hasMoreOrgProjects) {
+      if (!tryStartRequest()) {
+        break;
+      }
+
+      const data: OrganizationProjectsPageResponse =
+        await graphql<OrganizationProjectsPageResponse>(
+        client,
+        ORGANIZATION_PROJECTS_PAGE_QUERY,
+        { login: orgLogin, cursor: orgProjectsCursor }
       );
+
+      const projectPage: NonNullable<
+        OrganizationProjectsPageResponse["organization"]
+      >["projectsV2"] =
+        data.organization?.projectsV2 ?? null;
+      for (const node of projectPage?.nodes ?? []) {
+        if (!node) continue;
+        if (
+          !collectProject(node, {
+            login: orgLogin,
+            type: "Organization",
+          })
+        ) {
+          hasMoreOrgProjects = false;
+          break;
+        }
+      }
+
+      if (partial) {
+        break;
+      }
+
+      hasMoreOrgProjects = projectPage?.pageInfo?.hasNextPage ?? false;
+      orgProjectsCursor = projectPage?.pageInfo?.endCursor ?? null;
     }
   }
 
-  return projects;
+  return {
+    projects,
+    partial,
+    reason,
+    requests: requestCount,
+  };
+}
+
+export async function listUserProjects(
+  client: GitHubClient
+): Promise<ProjectSummary[]> {
+  return (await discoverUserProjects(client)).projects;
 }
 
 function normalizeProjectSummary(
@@ -508,17 +638,41 @@ type GraphQLProjectNode = {
   items: { totalCount: number } | null;
 };
 
-type ViewerProjectsResponse = {
+type ProjectPageInfo = {
+  endCursor: string | null;
+  hasNextPage: boolean;
+};
+
+type ViewerProjectsPageResponse = {
   viewer: {
     login: string;
-    projectsV2: { nodes: Array<GraphQLProjectNode | null> | null } | null;
+    projectsV2: {
+      nodes: Array<GraphQLProjectNode | null> | null;
+      pageInfo: ProjectPageInfo | null;
+    } | null;
     organizations: {
-      nodes: Array<{
-        login: string;
-        projectsV2: { nodes: Array<GraphQLProjectNode | null> | null } | null;
-      } | null> | null;
+      nodes: Array<{ login: string } | null> | null;
+      pageInfo: ProjectPageInfo | null;
     } | null;
   };
+};
+
+type ViewerOrganizationsPageResponse = {
+  viewer: {
+    organizations: {
+      nodes: Array<{ login: string } | null> | null;
+      pageInfo: ProjectPageInfo | null;
+    } | null;
+  };
+};
+
+type OrganizationProjectsPageResponse = {
+  organization: {
+    projectsV2: {
+      nodes: Array<GraphQLProjectNode | null> | null;
+      pageInfo: ProjectPageInfo | null;
+    } | null;
+  } | null;
 };
 
 type ProjectDetailResponse = {
@@ -583,11 +737,11 @@ type ProjectItemsPageResponse = {
 
 // ── GraphQL queries ──────────────────────────────────────────────────────────
 
-const VIEWER_PROJECTS_QUERY = `
-  query ViewerProjects {
+const VIEWER_PROJECTS_PAGE_QUERY = `
+  query ViewerProjectsPage($cursor: String) {
     viewer {
       login
-      projectsV2(first: 50) {
+      projectsV2(first: ${PROJECT_PAGE_SIZE}, after: $cursor) {
         nodes {
           id
           title
@@ -595,19 +749,45 @@ const VIEWER_PROJECTS_QUERY = `
           url
           items { totalCount }
         }
+        pageInfo {
+          endCursor
+          hasNextPage
+        }
       }
-      organizations(first: 20) {
+    }
+  }
+`;
+
+const VIEWER_ORGANIZATIONS_PAGE_QUERY = `
+  query ViewerOrganizationsPage($cursor: String) {
+    viewer {
+      organizations(first: ${ORGANIZATION_PAGE_SIZE}, after: $cursor) {
         nodes {
           login
-          projectsV2(first: 50) {
-            nodes {
-              id
-              title
-              shortDescription
-              url
-              items { totalCount }
-            }
-          }
+        }
+        pageInfo {
+          endCursor
+          hasNextPage
+        }
+      }
+    }
+  }
+`;
+
+const ORGANIZATION_PROJECTS_PAGE_QUERY = `
+  query OrganizationProjectsPage($login: String!, $cursor: String) {
+    organization(login: $login) {
+      projectsV2(first: ${PROJECT_PAGE_SIZE}, after: $cursor) {
+        nodes {
+          id
+          title
+          shortDescription
+          url
+          items { totalCount }
+        }
+        pageInfo {
+          endCursor
+          hasNextPage
         }
       }
     }


### PR DESCRIPTION
## Issues

- Fixes #181

## Summary

- paginate GitHub Project discovery across viewer projects, organization pages, and organization-owned project pages
- keep interactive `workflow init` and `project add` aligned on partial-result warnings when discovery stops at a safety cap

## Changes

- add `discoverUserProjects()` in the CLI GitHub client with cursor-based pagination, deduplication, and request/result safety caps while preserving `listUserProjects()` as the array-only compatibility wrapper
- switch interactive `workflow init` and `project add` to the shared discovery helper so both flows surface the same partial-result warning before project selection
- add regression coverage for viewer pagination, organization pagination, request-budget truncation, and interactive warning paths; document pagination-aware discovery in the root and CLI READMEs

## Evidence

- `pnpm --filter @gh-symphony/cli test -- src/github/client.test.ts src/commands/init.test.ts src/commands/project.test.ts`
- `pnpm lint && pnpm test && pnpm typecheck && pnpm build`
- Manual check: re-read issue #181 against the final diff and confirmed the implementation covers viewer pagination, organization pagination, partial-result warnings in both interactive wizards, regression tests, and documentation updates

## Human Validation

- [ ] Confirm `gh-symphony workflow init` lists expected projects for an account with more than 50 personal projects or many organizations
- [ ] Confirm `gh-symphony project add` shows the same project discovery behavior and partial-result warning semantics
- [ ] Confirm reviewer-visible docs match the updated large-account discovery behavior

## Risks

- discovery now prefers completeness over the previous single query, so reviewer attention should stay on whether the current request cap is generous enough for unusually large GitHub accounts without causing slow setup flows
