### PR TITLE
feat(cli): reflect detected repo commands in generated workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ The interactive wizard will:
 
 `gh-symphony workflow init --dry-run` resolves the same generated outputs, shows whether each path would be created, updated, or left unchanged, and prints the detected environment inputs that shaped the preview.
 
+Those detected inputs are also threaded into the generated artifacts themselves: `WORKFLOW.md`, `.gh-symphony/reference-workflow.md`, and the runtime skill templates all include repository-aware validation guidance based on the detected package manager, monorepo shape, and `test` / `lint` / `build` scripts when present.
+
 Token-only interactive setup is supported:
 
 ```bash
@@ -361,6 +363,8 @@ gh-symphony workflow preview
 `--dry-run` resolves the same generated `WORKFLOW.md`, `.gh-symphony/context.yaml`,
 `.gh-symphony/reference-workflow.md`, and runtime skill files, then prints whether
 each path would be created, updated, or left unchanged without writing anything.
+
+When `gh-symphony workflow init` detects repository scripts, it bakes that information back into the generated policy files so the out-of-the-box workflow already tells agents which test/lint/build commands to prefer and whether workspace-aware validation is expected.
 
 Without a project (standalone):
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -83,6 +83,8 @@ whether `WORKFLOW.md`, `.gh-symphony/context.yaml`,
 `.gh-symphony/reference-workflow.md`, and runtime skill files would be created,
 updated, or left unchanged, and then exits without modifying the repository.
 
+The same detected environment data is applied to the generated artifacts, so `WORKFLOW.md`, `.gh-symphony/reference-workflow.md`, and the runtime skill templates already include repository-aware validation guidance for the detected package manager, monorepo layout, and `test` / `lint` / `build` scripts when they exist.
+
 ### Customizing Agent Behavior
 
 `gh-symphony workflow init` generates skill files under `.codex/skills/` (or `.claude/skills/` for Claude Code). These skills define how the AI agent handles commits, pushes, pulls, and project status transitions.

--- a/packages/cli/src/commands/init.test.ts
+++ b/packages/cli/src/commands/init.test.ts
@@ -385,10 +385,14 @@ describe("init ecosystem generation", () => {
     );
 
     expect(referenceWorkflow).toContain("Detected repository validation commands:");
-    expect(referenceWorkflow).toContain("`pnpm --filter fixture test`");
+    expect(referenceWorkflow).toContain("`pnpm test`");
+    expect(referenceWorkflow).toContain(
+      "(script: `pnpm --filter fixture test`)"
+    );
     expect(referenceWorkflow).toContain("This repository appears to be a monorepo");
     expect(skill).toContain("Detected repository validation commands:");
-    expect(skill).toContain("`pnpm --filter fixture lint`");
+    expect(skill).toContain("`pnpm lint`");
+    expect(skill).toContain("(script: `pnpm --filter fixture lint`)");
     expect(skill).toContain("Use `pnpm` conventions");
   });
 

--- a/packages/cli/src/commands/init.test.ts
+++ b/packages/cli/src/commands/init.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile } from "node:fs/promises";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -38,6 +38,7 @@ import initCommand from "./init.js";
 import {
   buildDryRunJsonResult,
   generateProjectId,
+  planWorkflowArtifacts,
   planEcosystem,
   renderDryRunPreview,
   writeConfig,
@@ -342,6 +343,94 @@ describe("init ecosystem generation", () => {
       "utf8"
     );
     expect(refWorkflow).toContain("# Reference WORKFLOW.md");
+  });
+
+  it("reflects detected repository commands across generated artifacts", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "cli-eco-guidance-"));
+    await writeFile(
+      join(cwd, "package.json"),
+      JSON.stringify(
+        {
+          name: "fixture",
+          private: true,
+          scripts: {
+            test: "pnpm --filter fixture test",
+            lint: "pnpm --filter fixture lint",
+            build: "pnpm --filter fixture build",
+          },
+        },
+        null,
+        2
+      )
+    );
+    await writeFile(join(cwd, "pnpm-lock.yaml"), "lockfileVersion: '9.0'\n");
+    await writeFile(join(cwd, "pnpm-workspace.yaml"), "packages:\n  - .\n");
+
+    await writeEcosystem({
+      cwd,
+      projectDetail: MOCK_PROJECT_DETAIL,
+      statusField: MOCK_STATUS_FIELD,
+      runtime: "codex",
+      skipSkills: false,
+      skipContext: false,
+    });
+
+    const referenceWorkflow = await readFile(
+      join(cwd, ".gh-symphony", "reference-workflow.md"),
+      "utf8"
+    );
+    const skill = await readFile(
+      join(cwd, ".codex", "skills", "gh-symphony", "SKILL.md"),
+      "utf8"
+    );
+
+    expect(referenceWorkflow).toContain("Detected repository validation commands:");
+    expect(referenceWorkflow).toContain("`pnpm --filter fixture test`");
+    expect(referenceWorkflow).toContain("This repository appears to be a monorepo");
+    expect(skill).toContain("Detected repository validation commands:");
+    expect(skill).toContain("`pnpm --filter fixture lint`");
+    expect(skill).toContain("Use `pnpm` conventions");
+  });
+
+  it("threads detected repository commands into generated WORKFLOW.md", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "cli-workflow-guidance-"));
+    await writeFile(
+      join(cwd, "package.json"),
+      JSON.stringify(
+        {
+          name: "fixture",
+          private: true,
+          scripts: {
+            test: "npm test",
+            lint: "npm run lint",
+          },
+        },
+        null,
+        2
+      )
+    );
+    await writeFile(join(cwd, "package-lock.json"), "{}\n");
+
+    const plan = await planWorkflowArtifacts({
+      cwd,
+      outputPath: join(cwd, "WORKFLOW.md"),
+      projectDetail: MOCK_PROJECT_DETAIL,
+      statusField: MOCK_STATUS_FIELD,
+      mappings: {
+        Todo: { role: "active" },
+        "In Progress": { role: "active" },
+        Done: { role: "terminal" },
+      },
+      runtime: "codex",
+      skipSkills: true,
+      skipContext: true,
+    });
+
+    expect(plan.workflowMd).toContain("### Repository Validation Guidance");
+    expect(plan.workflowMd).toContain("Detected repository validation commands:");
+    expect(plan.workflowMd).toContain("`npm test`");
+    expect(plan.workflowMd).toContain("`npm run lint`");
+    expect(plan.workflowMd).toContain("Use `npm` conventions");
   });
 
   it("generates codex skills when runtime is the codex agent command", async () => {

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -36,6 +36,7 @@ import {
 } from "../github/gh-auth.js";
 import { resolveGitHubAuth } from "../github/gh-auth.js";
 import { detectEnvironment } from "../detection/environment-detector.js";
+import type { DetectedEnvironment } from "../detection/environment-detector.js";
 import {
   buildContextYaml,
   generateContextYamlString,
@@ -157,6 +158,7 @@ type EcosystemOptions = {
   runtime: string;
   skipSkills: boolean;
   skipContext: boolean;
+  environment?: DetectedEnvironment;
 };
 
 export type EcosystemResult = {
@@ -214,6 +216,7 @@ export type WorkflowArtifactsOptions = {
   runtime: string;
   skipSkills: boolean;
   skipContext: boolean;
+  environment?: DetectedEnvironment;
 };
 
 export type WorkflowArtifactsPlan = {
@@ -331,12 +334,14 @@ export async function promptStateMappings(
 export async function planWorkflowArtifacts(
   opts: WorkflowArtifactsOptions
 ): Promise<WorkflowArtifactsPlan> {
+  const environment = opts.environment ?? (await detectEnvironment(opts.cwd));
   const workflowMd = generateWorkflowMarkdown({
     projectId: opts.projectDetail.id,
     stateFieldName: opts.statusField.name,
     mappings: opts.mappings,
     lifecycle: toWorkflowLifecycleConfig(opts.statusField.name, opts.mappings),
     runtime: opts.runtime,
+    detectedEnvironment: environment,
   });
 
   const workflowPlan = await planFileChange({
@@ -352,6 +357,7 @@ export async function planWorkflowArtifacts(
     runtime: opts.runtime,
     skipSkills: opts.skipSkills,
     skipContext: opts.skipContext,
+    environment,
   });
 
   return {
@@ -386,7 +392,7 @@ export async function planEcosystem(
   const { cwd, projectDetail, statusField, runtime, skipSkills, skipContext } =
     opts;
   const ghSymphonyDir = join(cwd, ".gh-symphony");
-  const environment = await detectEnvironment(cwd);
+  const environment = opts.environment ?? (await detectEnvironment(cwd));
   const files: PlannedFileChange[] = [];
 
   if (!skipContext) {
@@ -421,6 +427,7 @@ export async function planEcosystem(
       role: null as "active" | "wait" | "terminal" | null,
     })),
     projectId: projectDetail.id,
+    detectedEnvironment: environment,
   });
   files.push(
     await planFileChange({
@@ -453,6 +460,7 @@ export async function planEcosystem(
         statusFieldId: statusField.id,
         contextYamlPath: ".gh-symphony/context.yaml",
         referenceWorkflowPath: ".gh-symphony/reference-workflow.md",
+        detectedEnvironment: environment,
       }
     );
 

--- a/packages/cli/src/skills/skill-writer.test.ts
+++ b/packages/cli/src/skills/skill-writer.test.ts
@@ -9,6 +9,14 @@ import {
 } from "./skill-writer.js";
 import type { SkillTemplate, SkillTemplateContext } from "./types.js";
 
+const detectedEnvironment = {
+  packageManager: "pnpm" as const,
+  testCommand: "pnpm test",
+  lintCommand: "pnpm lint",
+  buildCommand: "pnpm build",
+  monorepo: false,
+};
+
 describe("skill-writer", () => {
   describe("resolveSkillsDir", () => {
     it("resolves claude-code runtime to .claude/skills", () => {
@@ -60,6 +68,7 @@ describe("skill-writer", () => {
         statusFieldId: "field-123",
         contextYamlPath: "context.yaml",
         referenceWorkflowPath: "WORKFLOW.md",
+        detectedEnvironment,
       };
 
       const result = await writeSkillFile(skillsDir, template, context);
@@ -90,6 +99,7 @@ describe("skill-writer", () => {
         statusFieldId: "field-123",
         contextYamlPath: "context.yaml",
         referenceWorkflowPath: "WORKFLOW.md",
+        detectedEnvironment,
       };
 
       const firstResult = await writeSkillFile(skillsDir, template, context);
@@ -124,6 +134,7 @@ describe("skill-writer", () => {
         statusFieldId: "field-123",
         contextYamlPath: "context.yaml",
         referenceWorkflowPath: "WORKFLOW.md",
+        detectedEnvironment,
       };
 
       const firstResult = await writeSkillFile(skillsDir, template, context);
@@ -165,6 +176,7 @@ describe("skill-writer", () => {
         statusFieldId: "field-123",
         contextYamlPath: "context.yaml",
         referenceWorkflowPath: "WORKFLOW.md",
+        detectedEnvironment,
       };
 
       const result = await writeAllSkills(
@@ -200,6 +212,7 @@ describe("skill-writer", () => {
         statusFieldId: "field-123",
         contextYamlPath: "context.yaml",
         referenceWorkflowPath: "WORKFLOW.md",
+        detectedEnvironment,
       };
 
       const result = await writeAllSkills(tempDir, "codex", templates, context);
@@ -228,6 +241,7 @@ describe("skill-writer", () => {
         statusFieldId: "field-123",
         contextYamlPath: "context.yaml",
         referenceWorkflowPath: "WORKFLOW.md",
+        detectedEnvironment,
       };
 
       const result = await writeAllSkills(
@@ -266,6 +280,7 @@ describe("skill-writer", () => {
         statusFieldId: "field-123",
         contextYamlPath: "context.yaml",
         referenceWorkflowPath: "WORKFLOW.md",
+        detectedEnvironment,
       };
 
       const firstResult = await writeAllSkills(
@@ -312,6 +327,7 @@ describe("skill-writer", () => {
           statusFieldId: "field-123",
           contextYamlPath: "context.yaml",
           referenceWorkflowPath: "WORKFLOW.md",
+          detectedEnvironment,
         }
       );
 

--- a/packages/cli/src/skills/templates/commit.test.ts
+++ b/packages/cli/src/skills/templates/commit.test.ts
@@ -11,6 +11,13 @@ const mockCtx: SkillTemplateContext = {
   statusFieldId: "PVTF_field",
   contextYamlPath: ".gh-symphony/context.yaml",
   referenceWorkflowPath: ".gh-symphony/reference-workflow.md",
+  detectedEnvironment: {
+    packageManager: "pnpm",
+    testCommand: "pnpm test",
+    lintCommand: "pnpm lint",
+    buildCommand: "pnpm build",
+    monorepo: false,
+  },
 };
 
 describe("generateCommitSkill", () => {

--- a/packages/cli/src/skills/templates/gh-project.test.ts
+++ b/packages/cli/src/skills/templates/gh-project.test.ts
@@ -15,6 +15,13 @@ const mockCtx: SkillTemplateContext = {
   statusFieldId: "PVTF_field123",
   contextYamlPath: ".gh-symphony/context.yaml",
   referenceWorkflowPath: ".gh-symphony/reference-workflow.md",
+  detectedEnvironment: {
+    packageManager: "pnpm",
+    testCommand: "pnpm test",
+    lintCommand: "pnpm lint",
+    buildCommand: "pnpm build",
+    monorepo: false,
+  },
 };
 
 describe("generateGhProjectSkill", () => {

--- a/packages/cli/src/skills/templates/gh-symphony.test.ts
+++ b/packages/cli/src/skills/templates/gh-symphony.test.ts
@@ -15,6 +15,13 @@ const mockCtx: SkillTemplateContext = {
   statusFieldId: "PVTF_field123",
   contextYamlPath: ".gh-symphony/context.yaml",
   referenceWorkflowPath: ".gh-symphony/reference-workflow.md",
+  detectedEnvironment: {
+    packageManager: "pnpm",
+    testCommand: "pnpm test",
+    lintCommand: "pnpm lint",
+    buildCommand: "pnpm build",
+    monorepo: false,
+  },
 };
 
 describe("generateGhSymphonySkill", () => {
@@ -53,6 +60,14 @@ describe("generateGhSymphonySkill", () => {
     expect(result).toContain("gh-project");
     expect(result).toContain("commit");
     expect(result).toContain("land");
+  });
+
+  it("includes detected repository validation guidance", () => {
+    const result = generateGhSymphonySkill(mockCtx);
+    expect(result).toContain("Repository Validation Guidance");
+    expect(result).toContain("Detected repository validation commands:");
+    expect(result).toContain("`pnpm test`");
+    expect(result).toContain("Use `pnpm` conventions");
   });
 
   it("does not contain raw double-brace template variables", () => {

--- a/packages/cli/src/skills/templates/gh-symphony.test.ts
+++ b/packages/cli/src/skills/templates/gh-symphony.test.ts
@@ -67,6 +67,7 @@ describe("generateGhSymphonySkill", () => {
     expect(result).toContain("Repository Validation Guidance");
     expect(result).toContain("Detected repository validation commands:");
     expect(result).toContain("`pnpm test`");
+    expect(result).not.toContain("(script:");
     expect(result).toContain("Use `pnpm` conventions");
   });
 

--- a/packages/cli/src/skills/templates/gh-symphony.ts
+++ b/packages/cli/src/skills/templates/gh-symphony.ts
@@ -1,5 +1,6 @@
 import type { SkillTemplateContext } from "../types.js";
 import { renderSkillDocument } from "./document.js";
+import { buildRepositoryValidationGuidance } from "../../workflow/repository-guidance.js";
 
 export function generateGhSymphonySkill(ctx: SkillTemplateContext): string {
   const lines: string[] = [];
@@ -22,6 +23,17 @@ export function generateGhSymphonySkill(ctx: SkillTemplateContext): string {
     `- \`${ctx.referenceWorkflowPath}\` must exist (annotated reference template)`
   );
   lines.push("- `gh` CLI must be authenticated");
+  lines.push("");
+  lines.push("## Repository Validation Guidance");
+  lines.push("");
+  lines.push(
+    "Carry the detected repository validation posture into any new or refined `WORKFLOW.md` instead of falling back to generic instructions."
+  );
+  for (const line of buildRepositoryValidationGuidance(
+    ctx.detectedEnvironment
+  )) {
+    lines.push(`- ${line}`);
+  }
   lines.push("");
   lines.push("## Mode Detection");
   lines.push("");

--- a/packages/cli/src/skills/templates/land.test.ts
+++ b/packages/cli/src/skills/templates/land.test.ts
@@ -11,6 +11,13 @@ const mockCtx: SkillTemplateContext = {
   statusFieldId: "PVTF_field",
   contextYamlPath: ".gh-symphony/context.yaml",
   referenceWorkflowPath: ".gh-symphony/reference-workflow.md",
+  detectedEnvironment: {
+    packageManager: "pnpm",
+    testCommand: "pnpm test",
+    lintCommand: "pnpm lint",
+    buildCommand: "pnpm build",
+    monorepo: false,
+  },
 };
 
 describe("generateLandSkill", () => {

--- a/packages/cli/src/skills/templates/pull.test.ts
+++ b/packages/cli/src/skills/templates/pull.test.ts
@@ -11,6 +11,13 @@ const mockCtx: SkillTemplateContext = {
   statusFieldId: "PVTF_field",
   contextYamlPath: ".gh-symphony/context.yaml",
   referenceWorkflowPath: ".gh-symphony/reference-workflow.md",
+  detectedEnvironment: {
+    packageManager: "pnpm",
+    testCommand: "pnpm test",
+    lintCommand: "pnpm lint",
+    buildCommand: "pnpm build",
+    monorepo: false,
+  },
 };
 
 describe("generatePullSkill", () => {

--- a/packages/cli/src/skills/templates/push.test.ts
+++ b/packages/cli/src/skills/templates/push.test.ts
@@ -11,6 +11,13 @@ const mockCtx: SkillTemplateContext = {
   statusFieldId: "PVTF_field",
   contextYamlPath: ".gh-symphony/context.yaml",
   referenceWorkflowPath: ".gh-symphony/reference-workflow.md",
+  detectedEnvironment: {
+    packageManager: "pnpm",
+    testCommand: "pnpm test",
+    lintCommand: "pnpm lint",
+    buildCommand: "pnpm build",
+    monorepo: false,
+  },
 };
 
 describe("generatePushSkill", () => {

--- a/packages/cli/src/skills/types.ts
+++ b/packages/cli/src/skills/types.ts
@@ -1,3 +1,5 @@
+import type { DetectedEnvironment } from "../detection/environment-detector.js";
+
 export type SkillRuntime = "claude-code" | "codex";
 
 export type SkillTemplateContext = {
@@ -13,6 +15,10 @@ export type SkillTemplateContext = {
   statusFieldId: string; // field ID (needed for gh project item-edit --field-id)
   contextYamlPath: string; // relative path
   referenceWorkflowPath: string; // relative path
+  detectedEnvironment: Pick<
+    DetectedEnvironment,
+    "packageManager" | "testCommand" | "lintCommand" | "buildCommand" | "monorepo"
+  >;
 };
 
 export type SkillTemplate = {

--- a/packages/cli/src/workflow/generate-reference-workflow.test.ts
+++ b/packages/cli/src/workflow/generate-reference-workflow.test.ts
@@ -196,7 +196,8 @@ describe("generateReferenceWorkflow", () => {
     const output = generateReferenceWorkflow(defaultInput);
 
     expect(output).toContain("Detected repository validation commands:");
-    expect(output).toContain("`pnpm --filter @gh-symphony/cli test`");
+    expect(output).toContain("`pnpm test`");
+    expect(output).toContain("(script: `pnpm --filter @gh-symphony/cli test`)");
     expect(output).toContain("Use `pnpm` conventions");
     expect(output).toContain("This repository appears to be a monorepo");
   });

--- a/packages/cli/src/workflow/generate-reference-workflow.test.ts
+++ b/packages/cli/src/workflow/generate-reference-workflow.test.ts
@@ -13,6 +13,13 @@ const defaultInput: ReferenceWorkflowInput = {
     { name: "Done", role: "terminal" },
   ],
   projectId: "PVT_abc123",
+  detectedEnvironment: {
+    packageManager: "pnpm",
+    testCommand: "pnpm --filter @gh-symphony/cli test",
+    lintCommand: "pnpm lint",
+    buildCommand: "pnpm build",
+    monorepo: true,
+  },
 };
 
 describe("generateReferenceWorkflow", () => {
@@ -47,6 +54,7 @@ describe("generateReferenceWorkflow", () => {
     expect(output).toContain("# ═══ FRONT MATTER FIELD REFERENCE ═══");
     expect(output).toContain("# ═══ PROMPT BODY REFERENCE ═══");
     expect(output).toContain("## Status Map");
+    expect(output).toContain("## Repository Validation Guidance");
     expect(output).toContain("## Default Posture");
     expect(output).toContain("## Related Skills");
     expect(output).toContain("## Step 0: Determine current state and route");
@@ -182,5 +190,14 @@ describe("generateReferenceWorkflow", () => {
     expect(output).toContain("after_run: null");
     expect(output).toContain("before_remove: null");
     expect(output).toContain("timeout_ms: 60000");
+  });
+
+  it("includes detected repository guidance", () => {
+    const output = generateReferenceWorkflow(defaultInput);
+
+    expect(output).toContain("Detected repository validation commands:");
+    expect(output).toContain("`pnpm --filter @gh-symphony/cli test`");
+    expect(output).toContain("Use `pnpm` conventions");
+    expect(output).toContain("This repository appears to be a monorepo");
   });
 });

--- a/packages/cli/src/workflow/generate-reference-workflow.ts
+++ b/packages/cli/src/workflow/generate-reference-workflow.ts
@@ -1,3 +1,6 @@
+import type { DetectedEnvironment } from "../detection/environment-detector.js";
+import { buildRepositoryValidationGuidance } from "./repository-guidance.js";
+
 export type ReferenceWorkflowInput = {
   runtime: "codex" | "claude-code" | string;
   statusColumns: Array<{
@@ -5,6 +8,10 @@ export type ReferenceWorkflowInput = {
     role: "active" | "wait" | "terminal" | null;
   }>;
   projectId: string;
+  detectedEnvironment: Pick<
+    DetectedEnvironment,
+    "packageManager" | "testCommand" | "lintCommand" | "buildCommand" | "monorepo"
+  >;
 };
 
 export function generateReferenceWorkflow(
@@ -130,6 +137,14 @@ export function generateReferenceWorkflow(
     }
   }
 
+  lines.push("");
+  lines.push("## Repository Validation Guidance");
+  lines.push("");
+  for (const line of buildRepositoryValidationGuidance(
+    input.detectedEnvironment
+  )) {
+    lines.push(`- ${line}`);
+  }
   lines.push("");
 
   lines.push("## Default Posture");

--- a/packages/cli/src/workflow/generate-workflow-md.test.ts
+++ b/packages/cli/src/workflow/generate-workflow-md.test.ts
@@ -19,6 +19,13 @@ describe("generateWorkflowMarkdown", () => {
       blockerCheckStates: ["Queued"],
     },
     runtime: "codex",
+    detectedEnvironment: {
+      packageManager: "pnpm" as const,
+      testCommand: "pnpm test",
+      lintCommand: "pnpm lint",
+      buildCommand: "pnpm build",
+      monorepo: true,
+    },
   };
 
   it("generates valid WORKFLOW.md that round-trips through parseWorkflowMarkdown", () => {
@@ -105,6 +112,36 @@ describe("generateWorkflowMarkdown", () => {
     expect(markdown).toContain("### Default Posture");
     expect(markdown).toContain("unattended orchestration session");
     expect(markdown).toContain("genuine blocker");
+  });
+
+  it("includes repository-specific validation guidance when commands are detected", () => {
+    const markdown = generateWorkflowMarkdown(defaultInput);
+
+    expect(markdown).toContain("### Repository Validation Guidance");
+    expect(markdown).toContain("Detected repository validation commands:");
+    expect(markdown).toContain("`pnpm test`");
+    expect(markdown).toContain("`pnpm lint`");
+    expect(markdown).toContain("`pnpm build`");
+    expect(markdown).toContain("Use `pnpm` conventions");
+    expect(markdown).toContain("This repository appears to be a monorepo");
+  });
+
+  it("keeps generic validation fallback when no scripts are detected", () => {
+    const markdown = generateWorkflowMarkdown({
+      ...defaultInput,
+      detectedEnvironment: {
+        packageManager: null,
+        testCommand: null,
+        lintCommand: null,
+        buildCommand: null,
+        monorepo: false,
+      },
+    });
+
+    expect(markdown).toContain(
+      "No repository-specific test/lint/build scripts were detected"
+    );
+    expect(markdown).not.toContain("Detected repository validation commands:");
   });
 
   it("includes Guardrails section", () => {

--- a/packages/cli/src/workflow/generate-workflow-md.ts
+++ b/packages/cli/src/workflow/generate-workflow-md.ts
@@ -1,5 +1,7 @@
 import type { WorkflowLifecycleConfig } from "@gh-symphony/core";
 import type { StateMapping } from "../config.js";
+import type { DetectedEnvironment } from "../detection/environment-detector.js";
+import { buildRepositoryValidationGuidance } from "./repository-guidance.js";
 
 export type GenerateWorkflowInput = {
   projectId: string;
@@ -9,11 +11,15 @@ export type GenerateWorkflowInput = {
   runtime: string;
   pollIntervalMs?: number;
   concurrency?: number;
+  detectedEnvironment: Pick<
+    DetectedEnvironment,
+    "packageManager" | "testCommand" | "lintCommand" | "buildCommand" | "monorepo"
+  >;
 };
 
 export function generateWorkflowMarkdown(input: GenerateWorkflowInput): string {
   const frontMatter = buildFrontMatter(input);
-  const promptBody = buildPromptBody(input.mappings);
+  const promptBody = buildPromptBody(input);
   return `---\n${frontMatter}---\n${promptBody}\n`;
 }
 
@@ -80,8 +86,11 @@ function resolveAgentCommand(runtime: string): string {
   }
 }
 
-function buildPromptBody(mappings: Record<string, StateMapping>): string {
-  const statusMap = generateStatusMapWithDescriptions(mappings);
+function buildPromptBody(input: GenerateWorkflowInput): string {
+  const statusMap = generateStatusMapWithDescriptions(input.mappings);
+  const validationGuidance = buildRepositoryValidationGuidance(
+    input.detectedEnvironment
+  );
   const template = `${statusMap}
 
 ## Agent Instructions
@@ -100,6 +109,10 @@ You are an AI coding agent working on issue {{issue.identifier}}: "{{issue.title
 1. This is an unattended orchestration session. Do not ask humans for follow-up actions.
 2. Only abort early if there is a genuine blocker (missing required credentials or secrets).
 3. In your final message, report only what was completed and any blockers. Do not include "next steps".
+
+### Repository Validation Guidance
+
+${validationGuidance.map((line, index) => `${index + 1}. ${line}`).join("\n")}
 
 ### Workflow
 

--- a/packages/cli/src/workflow/repository-guidance.test.ts
+++ b/packages/cli/src/workflow/repository-guidance.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { buildRepositoryValidationGuidance } from "./repository-guidance.js";
+
+describe("buildRepositoryValidationGuidance", () => {
+  it("prefers runnable package-manager commands and retains the raw script as context", () => {
+    const guidance = buildRepositoryValidationGuidance({
+      packageManager: "pnpm",
+      testCommand: "vitest run",
+      lintCommand: "eslint src",
+      buildCommand: "tsc -b",
+      monorepo: false,
+    });
+
+    expect(guidance[0]).toContain("test: `pnpm test` (script: `vitest run`)");
+    expect(guidance[0]).toContain("lint: `pnpm lint` (script: `eslint src`)");
+    expect(guidance[0]).toContain("build: `pnpm build` (script: `tsc -b`)");
+  });
+
+  it("normalizes whitespace and renders inline code safely for special characters", () => {
+    const guidance = buildRepositoryValidationGuidance({
+      packageManager: null,
+      testCommand: "node -e \"console.log(`one`)\nconsole.log('two')\"",
+      lintCommand: null,
+      buildCommand: null,
+      monorepo: false,
+    });
+
+    expect(guidance[0]).toContain(
+      "test: ``node -e \"console.log(`one`) console.log('two')\"``"
+    );
+    expect(guidance[0]).not.toContain("\nconsole.log");
+  });
+});

--- a/packages/cli/src/workflow/repository-guidance.ts
+++ b/packages/cli/src/workflow/repository-guidance.ts
@@ -1,0 +1,47 @@
+import type { DetectedEnvironment } from "../detection/environment-detector.js";
+
+export type RepositoryGuidanceInput = Pick<
+  DetectedEnvironment,
+  "packageManager" | "testCommand" | "lintCommand" | "buildCommand" | "monorepo"
+>;
+
+export function buildRepositoryValidationGuidance(
+  input: RepositoryGuidanceInput
+): string[] {
+  const lines: string[] = [];
+  const commands = [
+    input.testCommand ? `test: \`${input.testCommand}\`` : null,
+    input.lintCommand ? `lint: \`${input.lintCommand}\`` : null,
+    input.buildCommand ? `build: \`${input.buildCommand}\`` : null,
+  ].filter((value): value is string => value !== null);
+
+  if (commands.length > 0) {
+    lines.push(
+      `Detected repository validation commands: ${commands.join(" ; ")}.`
+    );
+    lines.push(
+      "Prefer these repository-defined commands over generic guesses when validating changes."
+    );
+    lines.push(
+      "Use the smallest relevant command during iteration, then run the full available validation sequence before handoff in this order when applicable: test, lint, build."
+    );
+  } else {
+    lines.push(
+      "No repository-specific test/lint/build scripts were detected. Keep the generic fallback posture: infer the smallest meaningful validation command from the files you changed, and explicitly report when no automated validation is available."
+    );
+  }
+
+  if (input.packageManager) {
+    lines.push(
+      `Use \`${input.packageManager}\` conventions for ad hoc install/run commands unless the repository clearly requires something else.`
+    );
+  }
+
+  if (input.monorepo) {
+    lines.push(
+      "This repository appears to be a monorepo. Infer the affected package or workspace first, prefer workspace-scoped validation when available, and avoid unnecessary full-repo runs unless cross-package changes require them."
+    );
+  }
+
+  return lines;
+}

--- a/packages/cli/src/workflow/repository-guidance.ts
+++ b/packages/cli/src/workflow/repository-guidance.ts
@@ -5,14 +5,76 @@ export type RepositoryGuidanceInput = Pick<
   "packageManager" | "testCommand" | "lintCommand" | "buildCommand" | "monorepo"
 >;
 
+function normalizeCommand(command: string): string {
+  return command.replace(/\s+/g, " ").trim();
+}
+
+function renderInlineCode(command: string): string {
+  const normalized = normalizeCommand(command);
+  const longestBacktickRun = Math.max(
+    0,
+    ...Array.from(normalized.matchAll(/`+/g), (match) => match[0].length)
+  );
+  const fence = "`".repeat(longestBacktickRun + 1);
+  const padded =
+    normalized.startsWith("`") || normalized.endsWith("`")
+      ? ` ${normalized} `
+      : normalized;
+
+  return `${fence}${padded}${fence}`;
+}
+
+function buildRunnableScriptCommand(
+  packageManager: RepositoryGuidanceInput["packageManager"],
+  scriptName: "test" | "lint" | "build"
+): string | null {
+  switch (packageManager) {
+    case "pnpm":
+      return scriptName === "test" ? "pnpm test" : `pnpm ${scriptName}`;
+    case "npm":
+      return scriptName === "test" ? "npm test" : `npm run ${scriptName}`;
+    case "yarn":
+      return `yarn ${scriptName}`;
+    case "bun":
+      return `bun run ${scriptName}`;
+    default:
+      return null;
+  }
+}
+
+function formatDetectedCommand(
+  label: "test" | "lint" | "build",
+  rawCommand: string | null,
+  packageManager: RepositoryGuidanceInput["packageManager"]
+): string | null {
+  if (!rawCommand) {
+    return null;
+  }
+
+  const runnableCommand = buildRunnableScriptCommand(packageManager, label);
+  const normalizedRawCommand = normalizeCommand(rawCommand);
+
+  if (!runnableCommand) {
+    return `${label}: ${renderInlineCode(normalizedRawCommand)}`;
+  }
+
+  if (normalizeCommand(runnableCommand) === normalizedRawCommand) {
+    return `${label}: ${renderInlineCode(runnableCommand)}`;
+  }
+
+  return `${label}: ${renderInlineCode(runnableCommand)} (script: ${renderInlineCode(
+    normalizedRawCommand
+  )})`;
+}
+
 export function buildRepositoryValidationGuidance(
   input: RepositoryGuidanceInput
 ): string[] {
   const lines: string[] = [];
   const commands = [
-    input.testCommand ? `test: \`${input.testCommand}\`` : null,
-    input.lintCommand ? `lint: \`${input.lintCommand}\`` : null,
-    input.buildCommand ? `build: \`${input.buildCommand}\`` : null,
+    formatDetectedCommand("test", input.testCommand, input.packageManager),
+    formatDetectedCommand("lint", input.lintCommand, input.packageManager),
+    formatDetectedCommand("build", input.buildCommand, input.packageManager),
   ].filter((value): value is string => value !== null);
 
   if (commands.length > 0) {


### PR DESCRIPTION
## Issues

- Fixes #170

## Summary

- `gh-symphony init`가 감지한 repository validation guidance를 generated artifact에 반영하는 기존 변경 위에, PR 리뷰에서 지적된 명령 실행 가능성과 Markdown 안전성 문제를 보강했습니다.
- 생성되는 `WORKFLOW.md`, `.gh-symphony/reference-workflow.md`, `gh-symphony` skill 템플릿이 이제 package-manager runner 명령을 우선 안내하고, 필요하면 원래 script body를 보조 설명으로 함께 남깁니다.
- backtick/newline이 포함된 script 값도 safe inline-code 렌더링으로 처리되도록 helper 테스트를 추가했습니다.

## Changes

- `packages/cli/src/workflow/repository-guidance.ts`에서 detected `test` / `lint` / `build` script를 package-manager별 runnable command (`pnpm test`, `npm run lint` 등)로 우선 변환하도록 바꿨습니다.
- raw script body는 runnable wrapper와 다를 때만 `(script: ...)`로 보조 표기하고, inline code는 whitespace 정규화와 가변 backtick fence로 Markdown-safe 하게 렌더링하도록 정리했습니다.
- `packages/cli/src/workflow/repository-guidance.test.ts`를 추가하고 `init` / reference workflow / `gh-symphony` skill 테스트 기대값을 새 guidance 포맷에 맞춰 갱신했습니다.

## Evidence

- `pnpm --filter @gh-symphony/cli test -- src/workflow/repository-guidance.test.ts src/workflow/generate-workflow-md.test.ts src/workflow/generate-reference-workflow.test.ts src/skills/templates/gh-symphony.test.ts src/commands/init.test.ts`
- `pnpm --filter @gh-symphony/cli typecheck`
- `pnpm lint`
- `pnpm test`
- `pnpm typecheck`
- `pnpm build`
- `node packages/cli/dist/index.js init --non-interactive --project PVT_kwDOBB0_W84BS45_ --dry-run --json`
- Test case: `vitest run` 같은 local binary 기반 script body는 generated guidance에서 `pnpm test` 같은 runnable package-manager command를 우선 표시하고, backtick/newline이 포함된 command 문자열은 Markdown-safe inline code로 렌더링됨을 `repository-guidance.test.ts`에서 검증했습니다.

## Human Validation

- [ ] `gh-symphony workflow init` 직후 생성된 `WORKFLOW.md`가 저장소의 실제 `test` / `lint` / `build` 명령을 package-manager runner 기준으로 우선 안내하는지 확인
- [ ] `.gh-symphony/reference-workflow.md`와 `.codex/skills/gh-symphony/SKILL.md`가 같은 repository-aware validation guidance와 `(script: ...)` 보조 표기를 유지하는지 확인
- [ ] backtick/newline이 섞인 script 값이 있는 fixture 또는 샘플 저장소에서도 generated Markdown formatting이 깨지지 않는지 확인

## Risks

- 현재 `init --dry-run --json`의 비-TTY interactive selection UX 문제는 그대로이며, 이번 재작업 범위는 detected-command guidance의 실행 가능성/서식 안전성 보강에 한정됩니다.