### PR TITLE
feat(cli): let workflow preview load a live GitHub Project issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,12 +61,12 @@ The one-command setup flow will:
 4. Configure managed-project settings for the orchestrator
 5. Generate the following files:
 
-| File | Description |
-| --- | --- |
-| `WORKFLOW.md` | Workflow policy — the agent prompt template with lifecycle config |
-| `.gh-symphony/context.yaml` | Project metadata and environment context |
-| `.gh-symphony/reference-workflow.md` | Reference workflow documentation |
-| `.codex/skills/` (or `.claude/skills/`) | Agent skill definitions |
+| File                                    | Description                                                       |
+| --------------------------------------- | ----------------------------------------------------------------- |
+| `WORKFLOW.md`                           | Workflow policy — the agent prompt template with lifecycle config |
+| `.gh-symphony/context.yaml`             | Project metadata and environment context                          |
+| `.gh-symphony/reference-workflow.md`    | Reference workflow documentation                                  |
+| `.codex/skills/` (or `.claude/skills/`) | Agent skill definitions                                           |
 
 Before writing anything, the interactive wizard shows a final summary that combines the workflow file preview and the managed-project configuration that will be saved under `~/.gh-symphony/`.
 
@@ -90,7 +90,7 @@ Preview the generated files without writing anything:
 ```bash
 gh-symphony workflow init --dry-run
 gh-symphony workflow validate
-gh-symphony workflow preview
+gh-symphony workflow preview --issue owner/repo#123
 ```
 
 The interactive wizard will:
@@ -100,12 +100,12 @@ The interactive wizard will:
 3. Map project status columns to workflow phases (active / wait / terminal)
 4. Generate the following files:
 
-| File | Description |
-| --- | --- |
-| `WORKFLOW.md` | Workflow policy — the agent prompt template with lifecycle config |
-| `.gh-symphony/context.yaml` | Project metadata and environment context |
-| `.gh-symphony/reference-workflow.md` | Reference workflow documentation |
-| `.codex/skills/` (or `.claude/skills/`) | Agent skill definitions |
+| File                                    | Description                                                       |
+| --------------------------------------- | ----------------------------------------------------------------- |
+| `WORKFLOW.md`                           | Workflow policy — the agent prompt template with lifecycle config |
+| `.gh-symphony/context.yaml`             | Project metadata and environment context                          |
+| `.gh-symphony/reference-workflow.md`    | Reference workflow documentation                                  |
+| `.codex/skills/` (or `.claude/skills/`) | Agent skill definitions                                           |
 
 `gh-symphony workflow init --dry-run` resolves the same generated outputs, shows whether each path would be created, updated, or left unchanged, and prints the detected environment inputs that shaped the preview.
 
@@ -355,7 +355,7 @@ cd my-repo
 gh-symphony workflow init        # generates ./WORKFLOW.md from active project config
 gh-symphony workflow init --dry-run
 gh-symphony workflow validate
-gh-symphony workflow preview
+gh-symphony workflow preview --issue owner/repo#123
 ```
 
 `--dry-run` resolves the same generated `WORKFLOW.md`, `.gh-symphony/context.yaml`,
@@ -371,7 +371,7 @@ gh-symphony workflow init --non-interactive --project PVT_xxx --dry-run
 
 `gh-symphony workflow validate` parses the target file, strictly renders the prompt body and continuation guidance with canonical sample variables, and prints a compact runtime/lifecycle summary.
 
-`gh-symphony workflow preview` renders the exact worker prompt that will be sent for either the built-in sample issue or a custom `--sample <path-to-json>` payload. Use `--attempt <n>` to inspect retry prompts before changing policy files.
+`gh-symphony workflow preview --issue owner/repo#123` is the fastest validation step after `workflow init`: it resolves the active managed project (or `--project-id`) and renders the exact worker prompt from the live GitHub Project issue. Keep `--sample <path-to-json>` for fixture-based debugging, and use `--attempt <n>` to inspect retry prompts before changing policy files.
 
 ### Resolution order
 
@@ -408,11 +408,11 @@ API_SECRET_KEY=sk-secret-xxx
 
 Environment variables are merged from three sources (later overrides earlier):
 
-| Priority | Source | Description |
-| --- | --- | --- |
-| 1 (lowest) | Project `.env` | `~/.gh-symphony/projects/<project-id>/.env` |
-| 2 | System environment | Orchestrator process's `process.env` |
-| 3 (highest) | Symphony context | Auto-injected `SYMPHONY_*` variables |
+| Priority    | Source             | Description                                 |
+| ----------- | ------------------ | ------------------------------------------- |
+| 1 (lowest)  | Project `.env`     | `~/.gh-symphony/projects/<project-id>/.env` |
+| 2           | System environment | Orchestrator process's `process.env`        |
+| 3 (highest) | Symphony context   | Auto-injected `SYMPHONY_*` variables        |
 
 In CI, regular process env can override the project `.env` without changing `WORKFLOW.md`.
 
@@ -420,16 +420,16 @@ In CI, regular process env can override the project `.env` without changing `WOR
 
 All hooks (`after_create`, `before_run`, `after_run`, `before_remove`) automatically receive the following variables in addition to the merged environment above:
 
-| Variable | Description |
-| --- | --- |
-| `SYMPHONY_PROJECT_ID` | Orchestrator project ID |
-| `SYMPHONY_ISSUE_WORKSPACE_KEY` | Workspace key for the issue |
-| `SYMPHONY_ISSUE_SUBJECT_ID` | Issue subject ID (tracker-specific) |
-| `SYMPHONY_ISSUE_IDENTIFIER` | e.g. `acme/platform#42` |
-| `SYMPHONY_WORKSPACE_PATH` | Absolute path to the issue workspace |
-| `SYMPHONY_REPOSITORY_PATH` | Absolute path to the cloned repository |
-| `SYMPHONY_RUN_ID` | Current run ID (absent in `after_create`) |
-| `SYMPHONY_ISSUE_STATE` | Current tracker state (absent in `after_create`) |
+| Variable                       | Description                                      |
+| ------------------------------ | ------------------------------------------------ |
+| `SYMPHONY_PROJECT_ID`          | Orchestrator project ID                          |
+| `SYMPHONY_ISSUE_WORKSPACE_KEY` | Workspace key for the issue                      |
+| `SYMPHONY_ISSUE_SUBJECT_ID`    | Issue subject ID (tracker-specific)              |
+| `SYMPHONY_ISSUE_IDENTIFIER`    | e.g. `acme/platform#42`                          |
+| `SYMPHONY_WORKSPACE_PATH`      | Absolute path to the issue workspace             |
+| `SYMPHONY_REPOSITORY_PATH`     | Absolute path to the cloned repository           |
+| `SYMPHONY_RUN_ID`              | Current run ID (absent in `after_create`)        |
+| `SYMPHONY_ISSUE_STATE`         | Current tracker state (absent in `after_create`) |
 
 #### Example: Inline Hook
 
@@ -497,14 +497,14 @@ pnpm --filter @gh-symphony/orchestrator start -- status
 
 Runtime state lives under `.runtime/orchestrator/`:
 
-| Path                           | Contents                                       |
-| ------------------------------ | ---------------------------------------------- |
-| `projects/<id>/config.json`    | Project metadata                               |
-| `projects/<id>/WORKFLOW.md`    | Project-level workflow policy (repo fallback)  |
-| `projects/<id>/leases.json`    | Active or released issue-phase leases          |
-| `projects/<id>/status.json`    | Latest project status snapshot                 |
-| `runs/<run-id>/run.json`       | Run snapshot, retry state, worker assignment   |
-| `runs/<run-id>/events.ndjson`  | Structured orchestration events                |
+| Path                          | Contents                                      |
+| ----------------------------- | --------------------------------------------- |
+| `projects/<id>/config.json`   | Project metadata                              |
+| `projects/<id>/WORKFLOW.md`   | Project-level workflow policy (repo fallback) |
+| `projects/<id>/leases.json`   | Active or released issue-phase leases         |
+| `projects/<id>/status.json`   | Latest project status snapshot                |
+| `runs/<run-id>/run.json`      | Run snapshot, retry state, worker assignment  |
+| `runs/<run-id>/events.ndjson` | Structured orchestration events               |
 
 Read orchestration state via the status API (`/api/v1/projects/<id>/status`) rather than reading status files directly.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -61,7 +61,7 @@ Navigate to the repository you want to orchestrate, then run:
 gh-symphony workflow init
 gh-symphony workflow init --dry-run
 gh-symphony workflow validate
-gh-symphony workflow preview
+gh-symphony workflow preview --issue owner/repo#123
 ```
 
 The interactive wizard will:
@@ -263,7 +263,7 @@ JSON output includes the resolved auth source as `env` or `gh`.
 Setup:
   workflow init       Interactive repository setup wizard
   workflow validate   Parse and strictly validate WORKFLOW.md
-  workflow preview    Render the final worker prompt from a sample issue
+  workflow preview    Render the final worker prompt from a sample or live issue
   doctor              Run diagnostics and optional first-run remediation
   config show         Show current configuration
   config set          Set a configuration value

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -542,62 +542,13 @@ const handler = async (
         }
       },
     });
-    const httpServer =
-      parsed.webPort !== undefined
-        ? await startControlPlaneServer({
-            host: HTTP_HOST,
-            port: parsed.webPort,
-            runtimeRoot,
-            projectId,
-            onRefreshRequest: () => service.requestReconcile(),
-          })
-        : parsed.httpPort !== undefined
-        ? await startHttpServer({
-            runtimeRoot,
-            projectId,
-            initialPort: parsed.httpPort,
-            service,
-          })
-        : null;
-    if (httpServer) {
-      try {
-        await writeHttpBindingState(options.configDir, projectId, {
-          host: HTTP_HOST,
-          port: httpServer.port,
-          endpoint: httpServer.url,
-        });
-      } catch (error) {
-        logLine(
-          yellow("\u26A0"),
-          yellow(
-            `Failed to persist HTTP binding state (http.json): ${
-              error instanceof Error ? error.message : "Unknown error"
-            }`
-          )
-        );
-      }
-    }
-
-    logLine(
-      green("\u25B2"),
-      `Starting orchestrator for project: ${bold(projectId)}`
-    );
-    if (httpServer) {
-      logLine(
-        cyan("\u25A1"),
-        parsed.webPort !== undefined
-          ? `Web dashboard listening on ${httpServer.url}`
-          : `HTTP dashboard listening on ${httpServer.url}`
-      );
-    }
-    logLine(
-      dim("\u00B7"),
-      dim(parsed.once ? "Running one orchestration tick" : "Press Ctrl+C to stop")
-    );
-
     let shuttingDown = false;
     let shutdownPromise: Promise<never> | null = null;
     let keepHttpAliveResolve: (() => void) | null = null;
+    let httpServer:
+      | Awaited<ReturnType<typeof startControlPlaneServer>>
+      | Awaited<ReturnType<typeof startHttpServer>>
+      | null = null;
     const shutdown = async () => {
       if (shuttingDown) {
         return shutdownPromise;
@@ -626,9 +577,67 @@ const handler = async (
     process.on("SIGTERM", handleSigterm);
 
     try {
+      httpServer =
+        parsed.webPort !== undefined
+          ? await startControlPlaneServer({
+              host: HTTP_HOST,
+              port: parsed.webPort,
+              runtimeRoot,
+              projectId,
+              onRefreshRequest: () => service.requestReconcile(),
+            })
+          : parsed.httpPort !== undefined
+          ? await startHttpServer({
+              runtimeRoot,
+              projectId,
+              initialPort: parsed.httpPort,
+              service,
+            })
+          : null;
+      if (httpServer) {
+        try {
+          await writeHttpBindingState(options.configDir, projectId, {
+            host: HTTP_HOST,
+            port: httpServer.port,
+            endpoint: httpServer.url,
+          });
+        } catch (error) {
+          logLine(
+            yellow("\u26A0"),
+            yellow(
+              `Failed to persist HTTP binding state (http.json): ${
+                error instanceof Error ? error.message : "Unknown error"
+              }`
+            )
+          );
+        }
+      }
+
+      logLine(
+        green("\u25B2"),
+        `Starting orchestrator for project: ${bold(projectId)}`
+      );
+      if (httpServer) {
+        logLine(
+          cyan("\u25A1"),
+          parsed.webPort !== undefined
+            ? `Web dashboard listening on ${httpServer.url}`
+            : `HTTP dashboard listening on ${httpServer.url}`
+        );
+      }
+      logLine(
+        dim("\u00B7"),
+        dim(
+          parsed.once ? "Running one orchestration tick" : "Press Ctrl+C to stop"
+        )
+      );
+
       while (!shuttingDown) {
         try {
           await service.run({ once: parsed.once });
+          if (shuttingDown) {
+            break;
+          }
           if (parsed.once) {
             if (httpServer) {
               logLine(
@@ -637,6 +646,9 @@ const handler = async (
                   ? "One-shot tick completed; web dashboard remains available until Ctrl+C"
                   : "One-shot tick completed; HTTP dashboard remains available until Ctrl+C"
               );
+              if (shuttingDown) {
+                break;
+              }
               await new Promise<void>((resolve) => {
                 keepHttpAliveResolve = resolve;
               });

--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -2,7 +2,10 @@ import { mkdtemp, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import workflowCommand from "./workflow.js";
+import workflowCommand, {
+  resetWorkflowCommandDependenciesForTest,
+  setWorkflowCommandDependenciesForTest,
+} from "./workflow.js";
 
 function captureWrites(stream: NodeJS.WriteStream): {
   output: () => string;
@@ -46,6 +49,7 @@ Labels={% for label in issue.labels %}{{ label }} {% endfor %}
 
 afterEach(() => {
   vi.restoreAllMocks();
+  resetWorkflowCommandDependenciesForTest();
   process.exitCode = undefined;
 });
 
@@ -154,6 +158,319 @@ describe("workflow command handler", () => {
     expect(stdout.output()).toContain(`Sample: ${samplePath}`);
     expect(stdout.output()).toContain("acme/api#9: Fix preview rendering");
     expect(stdout.output()).toContain("Attempt=3");
+  });
+
+  it("loads a live GitHub Project issue for preview rendering", async () => {
+    const root = await mkdtemp(join(tmpdir(), "workflow-preview-live-"));
+    const workflowPath = join(root, "WORKFLOW.md");
+    const stdout = captureWrites(process.stdout);
+
+    await writeFile(workflowPath, SAMPLE_WORKFLOW, "utf8");
+
+    setWorkflowCommandDependenciesForTest({
+      getGitHubTokenWithSource: () => ({
+        token: "token-123",
+        source: "gh",
+      }),
+      validateGitHubToken: vi.fn().mockResolvedValue({
+        token: "token-123",
+        source: "gh",
+        login: "octocat",
+        scopes: ["repo", "read:org", "project"],
+      }),
+      createGitHubClient: vi.fn().mockReturnValue({
+        token: "token-123",
+        apiUrl: "https://api.github.com/graphql",
+        fetchImpl: fetch,
+      }),
+      resolveManagedProjectSelection: vi.fn().mockResolvedValue({
+        kind: "resolved",
+        projectId: "tenant-a",
+        projectConfig: {
+          projectId: "tenant-a",
+          slug: "tenant-a",
+          workspaceDir: "/tmp/tenant-a",
+          repositories: [],
+          tracker: {
+            adapter: "github-project",
+            bindingId: "PVT_project_123",
+            settings: {
+              projectId: "PVT_project_123",
+            },
+          },
+        },
+      }),
+      getGitHubProjectDetail: vi.fn().mockResolvedValue({
+        id: "PVT_project_123",
+        title: "Acme Roadmap",
+        url: "https://github.com/users/acme/projects/1",
+        statusFields: [],
+        textFields: [],
+        linkedRepositories: [
+          {
+            owner: "acme",
+            name: "api",
+            url: "https://github.com/acme/api",
+            cloneUrl: "https://github.com/acme/api.git",
+          },
+        ],
+      }),
+      fetchLiveIssue: vi.fn().mockResolvedValue({
+        id: "issue-9",
+        identifier: "acme/api#9",
+        number: 9,
+        title: "Fix preview rendering",
+        description: "Preview should use live issue payloads.",
+        priority: 1,
+        state: "Ready",
+        branchName: null,
+        url: "https://github.com/acme/api/issues/9",
+        labels: ["bug"],
+        blockedBy: [],
+        createdAt: "2026-04-01T00:00:00Z",
+        updatedAt: "2026-04-02T00:00:00Z",
+        repository: {
+          owner: "acme",
+          name: "api",
+          url: "https://github.com/acme/api",
+          cloneUrl: "https://github.com/acme/api.git",
+        },
+        tracker: {
+          adapter: "github-project",
+          bindingId: "PVT_project_123",
+          itemId: "PVTI_issue_9",
+        },
+        metadata: {},
+      }),
+    });
+
+    try {
+      await workflowCommand(
+        [
+          "preview",
+          "--file",
+          workflowPath,
+          "--issue",
+          "acme/api#9",
+          "--attempt",
+          "2",
+        ],
+        {
+          configDir: root,
+          verbose: false,
+          json: false,
+          noColor: false,
+        }
+      );
+    } finally {
+      stdout.restore();
+    }
+
+    expect(stdout.output()).toContain("Sample: live:acme/api#9");
+    expect(stdout.output()).toContain("acme/api#9: Fix preview rendering");
+    expect(stdout.output()).toContain("Attempt=2");
+  });
+
+  it("fails live preview when the repository is not linked to the bound GitHub Project", async () => {
+    const root = await mkdtemp(
+      join(tmpdir(), "workflow-preview-live-missing-repo-")
+    );
+    const workflowPath = join(root, "WORKFLOW.md");
+    const stderr = captureWrites(process.stderr);
+
+    await writeFile(workflowPath, SAMPLE_WORKFLOW, "utf8");
+
+    setWorkflowCommandDependenciesForTest({
+      getGitHubTokenWithSource: () => ({
+        token: "token-123",
+        source: "gh",
+      }),
+      validateGitHubToken: vi.fn().mockResolvedValue({
+        token: "token-123",
+        source: "gh",
+        login: "octocat",
+        scopes: ["repo", "read:org", "project"],
+      }),
+      createGitHubClient: vi.fn().mockReturnValue({
+        token: "token-123",
+        apiUrl: "https://api.github.com/graphql",
+        fetchImpl: fetch,
+      }),
+      resolveManagedProjectSelection: vi.fn().mockResolvedValue({
+        kind: "resolved",
+        projectId: "tenant-a",
+        projectConfig: {
+          projectId: "tenant-a",
+          slug: "tenant-a",
+          workspaceDir: "/tmp/tenant-a",
+          repositories: [],
+          tracker: {
+            adapter: "github-project",
+            bindingId: "PVT_project_123",
+          },
+        },
+      }),
+      getGitHubProjectDetail: vi.fn().mockResolvedValue({
+        id: "PVT_project_123",
+        title: "Acme Roadmap",
+        url: "https://github.com/users/acme/projects/1",
+        statusFields: [],
+        textFields: [],
+        linkedRepositories: [],
+      }),
+    });
+
+    try {
+      await workflowCommand(
+        ["preview", "--file", workflowPath, "--issue", "acme/api#9"],
+        {
+          configDir: root,
+          verbose: false,
+          json: false,
+          noColor: false,
+        }
+      );
+    } finally {
+      stderr.restore();
+    }
+
+    expect(stderr.output()).toContain(
+      'Repository acme/api is not linked to the configured GitHub Project "Acme Roadmap".'
+    );
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("fails live preview when the issue is not in the configured GitHub Project", async () => {
+    const root = await mkdtemp(
+      join(tmpdir(), "workflow-preview-live-missing-issue-")
+    );
+    const workflowPath = join(root, "WORKFLOW.md");
+    const stderr = captureWrites(process.stderr);
+
+    await writeFile(workflowPath, SAMPLE_WORKFLOW, "utf8");
+
+    setWorkflowCommandDependenciesForTest({
+      getGitHubTokenWithSource: () => ({
+        token: "token-123",
+        source: "gh",
+      }),
+      validateGitHubToken: vi.fn().mockResolvedValue({
+        token: "token-123",
+        source: "gh",
+        login: "octocat",
+        scopes: ["repo", "read:org", "project"],
+      }),
+      createGitHubClient: vi.fn().mockReturnValue({
+        token: "token-123",
+        apiUrl: "https://api.github.com/graphql",
+        fetchImpl: fetch,
+      }),
+      resolveManagedProjectSelection: vi.fn().mockResolvedValue({
+        kind: "resolved",
+        projectId: "tenant-a",
+        projectConfig: {
+          projectId: "tenant-a",
+          slug: "tenant-a",
+          workspaceDir: "/tmp/tenant-a",
+          repositories: [],
+          tracker: {
+            adapter: "github-project",
+            bindingId: "PVT_project_123",
+          },
+        },
+      }),
+      getGitHubProjectDetail: vi.fn().mockResolvedValue({
+        id: "PVT_project_123",
+        title: "Acme Roadmap",
+        url: "https://github.com/users/acme/projects/1",
+        statusFields: [],
+        textFields: [],
+        linkedRepositories: [
+          {
+            owner: "acme",
+            name: "api",
+            url: "https://github.com/acme/api",
+            cloneUrl: "https://github.com/acme/api.git",
+          },
+        ],
+      }),
+      fetchLiveIssue: vi.fn().mockResolvedValue(null),
+    });
+
+    try {
+      await workflowCommand(
+        ["preview", "--file", workflowPath, "--issue", "acme/api#9"],
+        {
+          configDir: root,
+          verbose: false,
+          json: false,
+          noColor: false,
+        }
+      );
+    } finally {
+      stderr.restore();
+    }
+
+    expect(stderr.output()).toContain(
+      'Issue acme/api#9 is not in the configured GitHub Project "Acme Roadmap".'
+    );
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("fails live preview with actionable auth guidance when scopes are missing", async () => {
+    const root = await mkdtemp(join(tmpdir(), "workflow-preview-live-auth-"));
+    const workflowPath = join(root, "WORKFLOW.md");
+    const stderr = captureWrites(process.stderr);
+
+    await writeFile(workflowPath, SAMPLE_WORKFLOW, "utf8");
+
+    setWorkflowCommandDependenciesForTest({
+      getGitHubTokenWithSource: () => ({
+        token: "token-123",
+        source: "gh",
+      }),
+      resolveManagedProjectSelection: vi.fn().mockResolvedValue({
+        kind: "resolved",
+        projectId: "tenant-a",
+        projectConfig: {
+          projectId: "tenant-a",
+          slug: "tenant-a",
+          workspaceDir: "/tmp/tenant-a",
+          repositories: [],
+          tracker: {
+            adapter: "github-project",
+            bindingId: "PVT_project_123",
+          },
+        },
+      }),
+      validateGitHubToken: vi
+        .fn()
+        .mockRejectedValue(
+          new Error(
+            "Run 'gh auth refresh --scopes repo,read:org,project'. Missing scopes: project"
+          )
+        ),
+    });
+
+    try {
+      await workflowCommand(
+        ["preview", "--file", workflowPath, "--issue", "acme/api#9"],
+        {
+          configDir: root,
+          verbose: false,
+          json: false,
+          noColor: false,
+        }
+      );
+    } finally {
+      stderr.restore();
+    }
+
+    expect(stderr.output()).toContain(
+      "GitHub authentication is required for live issue preview."
+    );
+    expect(stderr.output()).toContain("Missing scopes: project");
+    expect(process.exitCode).toBe(1);
   });
 
   it("rejects unsupported continuation guidance Liquid syntax during validation", async () => {

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -6,7 +6,21 @@ import {
   renderPrompt,
   type TrackedIssue,
 } from "@gh-symphony/core";
+import { fetchGithubProjectIssueByRepositoryAndNumber } from "@gh-symphony/tracker-github";
+import type { CliProjectConfig } from "../config.js";
+import {
+  createClient,
+  findLinkedRepository,
+  getProjectDetail,
+  GitHubApiError,
+} from "../github/client.js";
+import {
+  getGhTokenWithSource,
+  type GhAuthError,
+  validateGitHubToken,
+} from "../github/gh-auth.js";
 import type { GlobalOptions } from "../index.js";
+import { inspectManagedProjectSelection } from "../project-selection.js";
 import initCommand from "./init.js";
 
 type WorkflowSubcommand = "init" | "validate" | "preview";
@@ -24,7 +38,25 @@ type ValidateFlags = {
 type PreviewFlags = {
   attempt: number | null;
   file?: string;
+  issue?: string;
+  projectId?: string;
   sample?: string;
+};
+
+type PreviewIssueReference = {
+  owner: string;
+  name: string;
+  number: number;
+  identifier: string;
+};
+
+type WorkflowCommandDependencies = {
+  createGitHubClient: typeof createClient;
+  fetchLiveIssue: typeof fetchGithubProjectIssueByRepositoryAndNumber;
+  getGitHubProjectDetail: typeof getProjectDetail;
+  getGitHubTokenWithSource: typeof getGhTokenWithSource;
+  resolveManagedProjectSelection: typeof inspectManagedProjectSelection;
+  validateGitHubToken: typeof validateGitHubToken;
 };
 
 type WorkflowValidationReport = {
@@ -109,6 +141,32 @@ const SAMPLE_CONTINUATION_VARIABLES = {
   cumulativeTurnCount: 3,
 };
 
+const workflowCommandDependencies: WorkflowCommandDependencies = {
+  createGitHubClient: createClient,
+  fetchLiveIssue: fetchGithubProjectIssueByRepositoryAndNumber,
+  getGitHubProjectDetail: getProjectDetail,
+  getGitHubTokenWithSource: getGhTokenWithSource,
+  resolveManagedProjectSelection: inspectManagedProjectSelection,
+  validateGitHubToken,
+};
+
+export function setWorkflowCommandDependenciesForTest(
+  overrides: Partial<WorkflowCommandDependencies>
+): void {
+  Object.assign(workflowCommandDependencies, overrides);
+}
+
+export function resetWorkflowCommandDependenciesForTest(): void {
+  workflowCommandDependencies.createGitHubClient = createClient;
+  workflowCommandDependencies.fetchLiveIssue =
+    fetchGithubProjectIssueByRepositoryAndNumber;
+  workflowCommandDependencies.getGitHubProjectDetail = getProjectDetail;
+  workflowCommandDependencies.getGitHubTokenWithSource = getGhTokenWithSource;
+  workflowCommandDependencies.resolveManagedProjectSelection =
+    inspectManagedProjectSelection;
+  workflowCommandDependencies.validateGitHubToken = validateGitHubToken;
+}
+
 function parseWorkflowArgs(args: string[]): ParsedWorkflowArgs {
   const [subcommand, ...rest] = args;
 
@@ -182,6 +240,21 @@ function parsePreviewFlags(args: string[]): PreviewFlags {
         flags.sample = value;
         i += 1;
         break;
+      case "--issue":
+        if (!value || value.startsWith("-")) {
+          throw new Error("Option '--issue' argument missing");
+        }
+        flags.issue = value;
+        i += 1;
+        break;
+      case "--project-id":
+      case "--project":
+        if (!value || value.startsWith("-")) {
+          throw new Error(`Option '${arg}' argument missing`);
+        }
+        flags.projectId = value;
+        i += 1;
+        break;
       case "--attempt":
         if (!value || value.startsWith("-")) {
           throw new Error("Option '--attempt' argument missing");
@@ -216,12 +289,12 @@ function printWorkflowUsage(): void {
 Commands:
   init       Generate WORKFLOW.md and workflow support files
   validate   Parse and strictly validate a WORKFLOW.md file
-  preview    Render the final worker prompt from a sample issue
+  preview    Render the final worker prompt from a sample or live issue
 
 Options:
   workflow init [--non-interactive] [--project <id>] [--output <path>] [--skip-skills] [--skip-context] [--dry-run]
   workflow validate [--file <path>]
-  workflow preview [--file <path>] [--sample <json>] [--attempt <n>]
+  workflow preview [--file <path>] [--issue <owner/repo#number>] [--project-id <projectId>] [--sample <json>] [--attempt <n>]
 `);
 }
 
@@ -252,7 +325,10 @@ function normalizeIssue(value: unknown): TrackedIssue {
     repositoryRecord.name,
     "repository.name"
   );
-  const repositoryUrl = readOptionalString(repositoryRecord.url, "repository.url");
+  const repositoryUrl = readOptionalString(
+    repositoryRecord.url,
+    "repository.url"
+  );
 
   return {
     id: readRequiredString(record.id, "id"),
@@ -342,8 +418,13 @@ function readStringArray(value: unknown, field: string): string[] {
   if (value === undefined) {
     return [];
   }
-  if (!Array.isArray(value) || value.some((entry) => typeof entry !== "string")) {
-    throw new Error(`Sample JSON field '${field}' must be an array of strings.`);
+  if (
+    !Array.isArray(value) ||
+    value.some((entry) => typeof entry !== "string")
+  ) {
+    throw new Error(
+      `Sample JSON field '${field}' must be an array of strings.`
+    );
   }
 
   return value as string[];
@@ -354,7 +435,9 @@ function readBlockers(value: unknown): TrackedIssue["blockedBy"] {
     return [];
   }
   if (!Array.isArray(value)) {
-    throw new Error("Sample JSON field 'blockedBy/blocked_by' must be an array.");
+    throw new Error(
+      "Sample JSON field 'blockedBy/blocked_by' must be an array."
+    );
   }
 
   return value.map((entry, index) => {
@@ -427,6 +510,149 @@ async function loadSampleIssue(samplePath?: string): Promise<{
   return {
     issue: normalizeIssue(JSON.parse(raw) as unknown),
     sampleSource: resolvedPath,
+  };
+}
+
+function parseIssueReference(value: string): PreviewIssueReference {
+  const match =
+    /^(?<owner>[A-Za-z0-9_.-]+)\/(?<name>[A-Za-z0-9_.-]+)#(?<number>\d+)$/.exec(
+      value.trim()
+    );
+
+  if (!match?.groups) {
+    throw new Error(
+      "Option '--issue' must be in the format 'owner/repo#number'."
+    );
+  }
+
+  return {
+    owner: match.groups.owner,
+    name: match.groups.name,
+    number: Number.parseInt(match.groups.number, 10),
+    identifier: `${match.groups.owner}/${match.groups.name}#${match.groups.number}`,
+  };
+}
+
+function readGitHubProjectBinding(
+  projectConfig: CliProjectConfig
+): string | null {
+  const bindingId = projectConfig.tracker.bindingId?.trim();
+  if (bindingId) {
+    return bindingId;
+  }
+
+  const settingsProjectId = projectConfig.tracker.settings?.projectId;
+  return typeof settingsProjectId === "string" &&
+    settingsProjectId.trim().length > 0
+    ? settingsProjectId.trim()
+    : null;
+}
+
+function formatAuthError(error: GhAuthError | Error): string {
+  return `GitHub authentication is required for live issue preview. ${error.message}`;
+}
+
+async function loadLiveIssue(
+  issueReference: string,
+  projectId: string | undefined,
+  options: GlobalOptions
+): Promise<{
+  issue: TrackedIssue;
+  sampleSource: string;
+}> {
+  const issue = parseIssueReference(issueReference);
+  const selection =
+    await workflowCommandDependencies.resolveManagedProjectSelection({
+      configDir: options.configDir,
+      requestedProjectId: projectId,
+    });
+
+  if (selection.kind !== "resolved") {
+    throw new Error(selection.message);
+  }
+
+  const githubProjectId = readGitHubProjectBinding(selection.projectConfig);
+  if (!githubProjectId) {
+    throw new Error(
+      `Managed project "${selection.projectId}" is not bound to a GitHub Project. Re-run 'gh-symphony project add' and select a valid GitHub Project binding.`
+    );
+  }
+
+  let auth: Awaited<ReturnType<typeof validateGitHubToken>>;
+  try {
+    const tokenResult = workflowCommandDependencies.getGitHubTokenWithSource();
+    auth = await workflowCommandDependencies.validateGitHubToken(
+      tokenResult.token,
+      tokenResult.source
+    );
+  } catch (error) {
+    if (error instanceof Error) {
+      throw new Error(formatAuthError(error));
+    }
+    throw error;
+  }
+
+  const client = workflowCommandDependencies.createGitHubClient(auth.token, {
+    apiUrl: selection.projectConfig.tracker.apiUrl,
+  });
+
+  let detail: Awaited<ReturnType<typeof getProjectDetail>>;
+  try {
+    detail = await workflowCommandDependencies.getGitHubProjectDetail(
+      client,
+      githubProjectId
+    );
+  } catch (error) {
+    const message =
+      error instanceof GitHubApiError
+        ? error.message
+        : error instanceof Error
+          ? error.message
+          : "Unknown GitHub API error.";
+    throw new Error(
+      `Failed to resolve the configured GitHub Project binding '${githubProjectId}': ${message}`
+    );
+  }
+
+  if (!findLinkedRepository(detail, issue.owner, issue.name)) {
+    throw new Error(
+      `Repository ${issue.owner}/${issue.name} is not linked to the configured GitHub Project "${detail.title}". Run 'gh-symphony repo add ${issue.owner}/${issue.name}' or re-run 'gh-symphony project add' with the correct project binding.`
+    );
+  }
+
+  const trackedIssue = await workflowCommandDependencies.fetchLiveIssue(
+    {
+      projectId: githubProjectId,
+      token: auth.token,
+      apiUrl: selection.projectConfig.tracker.apiUrl,
+      assignedOnly:
+        selection.projectConfig.tracker.settings?.assignedOnly === true,
+      priorityFieldName:
+        typeof selection.projectConfig.tracker.settings?.priorityFieldName ===
+        "string"
+          ? selection.projectConfig.tracker.settings.priorityFieldName
+          : undefined,
+      timeoutMs:
+        typeof selection.projectConfig.tracker.settings?.timeoutMs === "number"
+          ? selection.projectConfig.tracker.settings.timeoutMs
+          : undefined,
+    },
+    {
+      owner: issue.owner,
+      name: issue.name,
+    },
+    issue.number
+  );
+
+  if (!trackedIssue) {
+    throw new Error(
+      `Issue ${issue.identifier} is not in the configured GitHub Project "${detail.title}". Add the issue to the project and re-run the preview.`
+    );
+  }
+
+  return {
+    issue: trackedIssue,
+    sampleSource: `live:${trackedIssue.identifier}`,
   };
 }
 
@@ -534,7 +760,10 @@ Hooks
 `);
 }
 
-async function runValidate(args: string[], options: GlobalOptions): Promise<void> {
+async function runValidate(
+  args: string[],
+  options: GlobalOptions
+): Promise<void> {
   const flags = parseValidateFlags(args);
   const { workflowPath, markdown } = await loadWorkflowMarkdown(flags.file);
   const report = validateWorkflow(workflowPath, markdown);
@@ -547,11 +776,26 @@ async function runValidate(args: string[], options: GlobalOptions): Promise<void
   printValidationReport(report);
 }
 
-async function runPreview(args: string[], options: GlobalOptions): Promise<void> {
+async function runPreview(
+  args: string[],
+  options: GlobalOptions
+): Promise<void> {
   const flags = parsePreviewFlags(args);
+  if (flags.sample && flags.issue) {
+    throw new Error(
+      "Options '--sample' and '--issue' cannot be used together."
+    );
+  }
   const { workflowPath, markdown } = await loadWorkflowMarkdown(flags.file);
   const workflow = parseWorkflowMarkdown(markdown);
-  const { issue, sampleSource } = await loadSampleIssue(flags.sample);
+  if (flags.issue && workflow.tracker.kind !== "github-project") {
+    throw new Error(
+      "Live issue preview requires 'tracker.kind: github-project' in WORKFLOW.md."
+    );
+  }
+  const { issue, sampleSource } = flags.issue
+    ? await loadLiveIssue(flags.issue, flags.projectId, options)
+    : await loadSampleIssue(flags.sample);
   const variables = buildPromptVariables(issue, {
     attempt: flags.attempt,
   });

--- a/packages/cli/src/github/client.ts
+++ b/packages/cli/src/github/client.ts
@@ -64,6 +64,23 @@ export type ProjectDetail = {
   linkedRepositories: LinkedRepository[];
 };
 
+export function findLinkedRepository(
+  project: ProjectDetail,
+  owner: string,
+  name: string
+): LinkedRepository | null {
+  const normalizedOwner = owner.trim().toLowerCase();
+  const normalizedName = name.trim().toLowerCase();
+
+  return (
+    project.linkedRepositories.find(
+      (repository) =>
+        repository.owner.trim().toLowerCase() === normalizedOwner &&
+        repository.name.trim().toLowerCase() === normalizedName
+    ) ?? null
+  );
+}
+
 export class GitHubApiError extends Error {
   constructor(
     message: string,
@@ -144,9 +161,9 @@ export async function getRepositoryMetadata(
   }
 
   if (!response.ok) {
-    const payload = (await response.json().catch(() => null)) as
-      | { message?: string }
-      | null;
+    const payload = (await response.json().catch(() => null)) as {
+      message?: string;
+    } | null;
     const message = payload?.message?.trim() || response.statusText;
 
     if (

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -267,8 +267,11 @@ function createProgram(): { program: Command; wasInvoked: () => boolean } {
   addGlobalOptions(
     workflow
       .command("preview")
-      .description("Render the final worker prompt from a sample issue")
+      .description("Render the final worker prompt from a sample or live issue")
       .option("--file <path>", "Read a custom WORKFLOW.md path")
+      .option("--issue <owner/repo#number>", "Load a live GitHub Project issue")
+      .option("--project-id <projectId>", "Managed project identifier")
+      .addOption(new Option("--project <projectId>").hideHelp())
       .option("--sample <json>", "Read sample issue JSON from a file")
       .option("--attempt <n>", "Render as retry attempt n")
       .allowExcessArguments(false)
@@ -277,6 +280,8 @@ function createProgram(): { program: Command; wasInvoked: () => boolean } {
     const values = this.optsWithGlobals<CliOptionValues>();
     const args: string[] = ["preview"];
     pushOption(args, "--file", values.file);
+    pushOption(args, "--issue", values.issue);
+    pushOption(args, "--project-id", resolveProjectId(values));
     pushOption(args, "--sample", values.sample);
     pushOption(args, "--attempt", values.attempt);
     await invokeHandler("workflow", args, values);
@@ -313,7 +318,10 @@ function createProgram(): { program: Command; wasInvoked: () => boolean } {
       .command("doctor")
       .description("Run diagnostics and optional first-run remediation")
       .option("--project-id <projectId>", "Project identifier")
-      .option("--fix", "Apply safe remediation steps and print manual follow-ups")
+      .option(
+        "--fix",
+        "Apply safe remediation steps and print manual follow-ups"
+      )
       .addOption(new Option("--project <projectId>").hideHelp())
       .allowExcessArguments(false)
   ).action(async function (this: Command) {
@@ -341,7 +349,10 @@ function createProgram(): { program: Command; wasInvoked: () => boolean } {
       .description("Start the orchestrator")
       .option("-d, --daemon", "Start in daemon mode")
       .option("--once", "Run a single orchestration tick and exit")
-      .option("--http [port]", "Expose dashboard and refresh endpoints over HTTP")
+      .option(
+        "--http [port]",
+        "Expose dashboard and refresh endpoints over HTTP"
+      )
       .option(
         "--web [port]",
         "Expose the control plane web dashboard and API over HTTP"
@@ -515,7 +526,10 @@ function createProgram(): { program: Command; wasInvoked: () => boolean } {
       .description("Start a specific project")
       .option("-d, --daemon", "Start in daemon mode")
       .option("--once", "Run a single orchestration tick and exit")
-      .option("--http [port]", "Expose dashboard and refresh endpoints over HTTP")
+      .option(
+        "--http [port]",
+        "Expose dashboard and refresh endpoints over HTTP"
+      )
       .option(
         "--web [port]",
         "Expose the control plane web dashboard and API over HTTP"

--- a/packages/tracker-github/src/adapter.ts
+++ b/packages/tracker-github/src/adapter.ts
@@ -1293,7 +1293,7 @@ const REPOSITORY_ISSUE_QUERY = `
             login
           }
         }
-        blockedBy(first: 20) {
+        blockedBy(first: 100) {
           nodes {
             id
             number

--- a/packages/tracker-github/src/adapter.ts
+++ b/packages/tracker-github/src/adapter.ts
@@ -56,12 +56,10 @@ type GraphQLProjectFieldConfiguration =
   | {
       __typename: "ProjectV2SingleSelectField";
       name: string | null;
-      options:
-        | Array<{
-            id: string;
-            name: string;
-          } | null>
-        | null;
+      options: Array<{
+        id: string;
+        name: string;
+      } | null> | null;
     }
   | {
       __typename: string;
@@ -164,6 +162,16 @@ type GraphQLIssueProjectItemsByIdResponse = {
   node?: GraphQLIssueStateLookupNode | null;
 };
 
+type GraphQLRepositoryIssueLookupNode = GraphQLIssueNode & {
+  projectItems: GraphQLIssueProjectItemsConnection | null;
+};
+
+type GraphQLRepositoryIssueLookupResponse = {
+  repository?: {
+    issue?: GraphQLRepositoryIssueLookupNode | null;
+  } | null;
+};
+
 type GraphQLResponse<TData> = {
   data?: TData;
   errors?: Array<{ message: string }>;
@@ -214,22 +222,19 @@ export function normalizeProjectItem(
     return null;
   }
 
-  const fieldValues = extractFieldValues(
-    item.fieldValues?.nodes ?? []
-  );
+  const fieldValues = extractFieldValues(item.fieldValues?.nodes ?? []);
   const state = fieldValues[lifecycle.stateFieldName] ?? "Unknown";
   const repository = item.content.repository;
-  const blockedBy = (item.content.blockedBy?.nodes ?? []).flatMap(
-    (node) =>
-      node
-        ? [
-            {
-              id: node.id,
-              identifier: `${node.repository.owner.login}/${node.repository.name}#${node.number}`,
-              state: normalizeBlockerState(node.state, lifecycle),
-            },
-          ]
-        : []
+  const blockedBy = (item.content.blockedBy?.nodes ?? []).flatMap((node) =>
+    node
+      ? [
+          {
+            id: node.id,
+            identifier: `${node.repository.owner.login}/${node.repository.name}#${node.number}`,
+            state: normalizeBlockerState(node.state, lifecycle),
+          },
+        ]
+      : []
   );
   const issueUpdatedAtMs = parseTimestampMs(item.content.updatedAt);
   const itemUpdatedAtMs = parseTimestampMs(item.updatedAt);
@@ -237,7 +242,7 @@ export function normalizeProjectItem(
     itemUpdatedAtMs !== null &&
     (issueUpdatedAtMs === null || itemUpdatedAtMs > issueUpdatedAtMs)
       ? item.updatedAt
-      : item.content.updatedAt ?? item.updatedAt;
+      : (item.content.updatedAt ?? item.updatedAt);
 
   return {
     id: item.content.id,
@@ -296,36 +301,32 @@ export async function fetchProjectIssues(
     const pageResult = await fetchProjectItemsPage(config, cursor, fetchImpl);
     const page = pageResult.page;
     latestRateLimits = pageResult.rateLimits ?? latestRateLimits;
-    const pageIssues = (page.nodes ?? [])
-      .flatMap((item) => {
-        if (!item) {
-          return [];
-        }
+    const pageIssues = (page.nodes ?? []).flatMap((item) => {
+      if (!item) {
+        return [];
+      }
 
-        const normalized = normalizeProjectItem(
-          config.projectId,
-          item,
-          config.lifecycle,
-          {
-            fieldName: config.priorityFieldName,
-            optionIds: priorityOptionIds,
-          },
-          latestRateLimits
-        );
-        if (!normalized) {
-          return [];
-        }
+      const normalized = normalizeProjectItem(
+        config.projectId,
+        item,
+        config.lifecycle,
+        {
+          fieldName: config.priorityFieldName,
+          optionIds: priorityOptionIds,
+        },
+        latestRateLimits
+      );
+      if (!normalized) {
+        return [];
+      }
 
-        if (
-          currentUserLogin &&
-          !isIssueAssignedToLogin(item, currentUserLogin)
-        ) {
-          excludedCount += 1;
-          return [];
-        }
+      if (currentUserLogin && !isIssueAssignedToLogin(item, currentUserLogin)) {
+        excludedCount += 1;
+        return [];
+      }
 
-        return [normalized];
-      });
+      return [normalized];
+    });
 
     issues.push(...pageIssues);
     cursor = page.pageInfo.hasNextPage ? page.pageInfo.endCursor : null;
@@ -377,13 +378,13 @@ export async function fetchIssueStatesByIds(
   for (const issueIdBatch of chunkValues([...new Set(issueIds)], 100)) {
     const result =
       await executeGraphQLQueryWithMetadata<GraphQLIssueStatesByIdsResponse>(
-      config,
-      ISSUE_STATES_BY_IDS_QUERY,
-      {
-        issueIds: issueIdBatch,
-      },
-      fetchImpl
-    );
+        config,
+        ISSUE_STATES_BY_IDS_QUERY,
+        {
+          issueIds: issueIdBatch,
+        },
+        fetchImpl
+      );
     const data = result.data;
     const rateLimits = result.rateLimits;
 
@@ -409,6 +410,62 @@ export async function fetchIssueStatesByIds(
   return issues;
 }
 
+export async function fetchProjectIssueByRepositoryAndNumber(
+  config: GitHubTrackerConfig,
+  repository: {
+    owner: string;
+    name: string;
+  },
+  issueNumber: number,
+  fetchImpl: FetchLike = fetch
+): Promise<GitHubTrackedIssue | null> {
+  const priorityOptionIds = config.priorityFieldName
+    ? await fetchPriorityOptionOrder(
+        config,
+        config.priorityFieldName,
+        fetchImpl
+      )
+    : undefined;
+  const result =
+    await executeGraphQLQueryWithMetadata<GraphQLRepositoryIssueLookupResponse>(
+      config,
+      REPOSITORY_ISSUE_QUERY,
+      {
+        owner: repository.owner,
+        name: repository.name,
+        issueNumber,
+      },
+      fetchImpl
+    );
+  const issue = result.data.repository?.issue ?? null;
+
+  if (!issue) {
+    return null;
+  }
+
+  const projectItem = await resolveIssueProjectItemForStateLookup(
+    config,
+    issue,
+    fetchImpl
+  );
+
+  if (!projectItem) {
+    return null;
+  }
+
+  return normalizeRepositoryIssueLookup(
+    config.projectId,
+    issue,
+    projectItem,
+    config.lifecycle,
+    {
+      fieldName: config.priorityFieldName,
+      optionIds: priorityOptionIds,
+    },
+    result.rateLimits
+  );
+}
+
 async function fetchProjectItemsPage(
   config: GitHubTrackerConfig,
   cursor: string | null,
@@ -417,16 +474,17 @@ async function fetchProjectItemsPage(
   page: GraphQLProjectItemsPage;
   rateLimits: Record<string, unknown> | null;
 }> {
-  const result = await executeGraphQLQueryWithMetadata<GraphQLProjectItemsResponse>(
-    config,
-    PROJECT_ITEMS_QUERY,
-    {
-      projectId: config.projectId,
-      cursor,
-      pageSize: config.pageSize ?? DEFAULT_PAGE_SIZE,
-    },
-    fetchImpl
-  );
+  const result =
+    await executeGraphQLQueryWithMetadata<GraphQLProjectItemsResponse>(
+      config,
+      PROJECT_ITEMS_QUERY,
+      {
+        projectId: config.projectId,
+        cursor,
+        pageSize: config.pageSize ?? DEFAULT_PAGE_SIZE,
+      },
+      fetchImpl
+    );
   const data = result.data;
   const items = data.node?.items;
 
@@ -445,6 +503,8 @@ async function fetchProjectItemsPage(
 export const normalizeGithubProjectItem = normalizeProjectItem;
 export const fetchGithubProjectIssues = fetchProjectIssues;
 export const fetchGithubIssueStatesByIds = fetchIssueStatesByIds;
+export const fetchGithubProjectIssueByRepositoryAndNumber =
+  fetchProjectIssueByRepositoryAndNumber;
 
 async function fetchCurrentUserLogin(
   config: GitHubTrackerConfig,
@@ -583,6 +643,35 @@ function normalizeIssueStateLookupNode(
   };
 }
 
+function normalizeRepositoryIssueLookup(
+  projectId: string,
+  issue: GraphQLRepositoryIssueLookupNode | null,
+  projectItem: GraphQLIssueProjectItemNode | null,
+  lifecycle: WorkflowLifecycleConfig = DEFAULT_WORKFLOW_LIFECYCLE,
+  priority: {
+    fieldName?: string;
+    optionIds?: PriorityMap;
+  } = {},
+  rateLimits: Record<string, unknown> | null = null
+): GitHubTrackedIssue | null {
+  if (!issue || !projectItem) {
+    return null;
+  }
+
+  return normalizeProjectItem(
+    projectId,
+    {
+      id: projectItem.id,
+      updatedAt: projectItem.updatedAt,
+      fieldValues: projectItem.fieldValues,
+      content: issue,
+    },
+    lifecycle,
+    priority,
+    rateLimits
+  );
+}
+
 async function resolveIssueProjectItemForStateLookup(
   config: GitHubTrackerConfig,
   issue: GraphQLIssueStateLookupNode | null,
@@ -625,14 +714,14 @@ async function fetchIssueProjectItemsPage(
 ): Promise<GraphQLIssueProjectItemsConnection> {
   const result =
     await executeGraphQLQueryWithMetadata<GraphQLIssueProjectItemsByIdResponse>(
-    config,
-    ISSUE_PROJECT_ITEMS_PAGE_QUERY,
-    {
-      issueId,
-      cursor,
-    },
-    fetchImpl
-  );
+      config,
+      ISSUE_PROJECT_ITEMS_PAGE_QUERY,
+      {
+        issueId,
+        cursor,
+      },
+      fetchImpl
+    );
   const data = result.data;
   const issue = data.node;
 
@@ -783,11 +872,7 @@ function buildRequestSignal(timeoutMs?: number): AbortSignal {
 }
 
 function resolveNetworkTimeoutMs(timeoutMs?: number): number {
-  if (
-    timeoutMs !== undefined &&
-    Number.isInteger(timeoutMs) &&
-    timeoutMs > 0
-  ) {
+  if (timeoutMs !== undefined && Number.isInteger(timeoutMs) && timeoutMs > 0) {
     return timeoutMs;
   }
 
@@ -1136,6 +1221,92 @@ const ISSUE_PROJECT_ITEMS_PAGE_QUERY = `
           }
         }
         projectItems(first: 100, after: $cursor, includeArchived: false) {
+          nodes {
+            id
+            updatedAt
+            project {
+              id
+            }
+            fieldValues(first: 20) {
+              nodes {
+                __typename
+                ... on ProjectV2ItemFieldSingleSelectValue {
+                  name
+                  optionId
+                  field {
+                    ... on ProjectV2SingleSelectField {
+                      name
+                    }
+                  }
+                }
+                ... on ProjectV2ItemFieldTextValue {
+                  text
+                  field {
+                    ... on ProjectV2FieldCommon {
+                      name
+                    }
+                  }
+                }
+              }
+            }
+          }
+          pageInfo {
+            endCursor
+            hasNextPage
+          }
+        }
+      }
+    }
+  }
+`;
+
+const REPOSITORY_ISSUE_QUERY = `
+  query RepositoryIssue(
+    $owner: String!
+    $name: String!
+    $issueNumber: Int!
+  ) {
+    repository(owner: $owner, name: $name) {
+      issue(number: $issueNumber) {
+        __typename
+        id
+        number
+        title
+        body
+        url
+        createdAt
+        updatedAt
+        labels(first: 20) {
+          nodes {
+            name
+          }
+        }
+        assignees(first: 20) {
+          nodes {
+            login
+          }
+        }
+        repository {
+          name
+          url
+          owner {
+            login
+          }
+        }
+        blockedBy(first: 20) {
+          nodes {
+            id
+            number
+            state
+            repository {
+              name
+              owner {
+                login
+              }
+            }
+          }
+        }
+        projectItems(first: 20, includeArchived: false) {
           nodes {
             id
             updatedAt


### PR DESCRIPTION
## Issues

- Fixes #191

## Summary

- add `workflow preview --issue owner/repo#number` so prompt previews can load a live GitHub Project issue
- harden the CLI foreground start/shutdown flow so the existing PR no longer flakes in `CI / Test`

## Changes

- extended the CLI preview command and help text with `--issue` / `--project-id`, plus managed-project selection, GitHub auth validation, linked-repository checks, and actionable project mismatch errors
- added a tracker helper that fetches one GitHub Project issue by repository and number and normalizes it through the existing GitHub tracker adapter logic
- aligned the live repository issue query to `blockedBy(first: 100)` so live preview and orchestration use the same blocker limit
- moved foreground signal registration ahead of async server startup and guarded the one-shot HTTP keep-alive path against shutdown races in `packages/cli/src/commands/start.ts`
- added regression coverage for live preview success, missing repository linkage, missing project membership, and auth guidance, and updated README examples to prefer live preview after `workflow init`

## Evidence

- `pnpm --filter @gh-symphony/cli test -- --run src/commands/workflow.test.ts`
- `pnpm --filter @gh-symphony/cli test -- --run src/commands/start.test.ts`
- `pnpm --filter @gh-symphony/cli test`
- `pnpm lint && pnpm test && pnpm typecheck && pnpm build`
- Manual blackbox: `printf "[]\\n" > e2e/fixtures/issues.json`, `docker compose -f docker-compose.e2e.yml -f docker-compose.e2e.events.yml up -d`, `curl http://localhost:4680/healthz`, `cp e2e/fixtures/happy-path.json e2e/fixtures/issues.json`, `curl -X POST http://localhost:4680/api/v1/refresh`, inspect `/api/v1/state` and `docker logs symphony-e2e`, then `printf "[]\\n" > e2e/fixtures/issues.json` and `docker compose -f docker-compose.e2e.yml -f docker-compose.e2e.events.yml down`

## Human Validation

- [ ] Confirm `gh-symphony workflow preview --issue owner/repo#number` renders a live prompt against a configured GitHub Project
- [ ] Confirm missing linked repositories and missing project membership return the new actionable error messages
- [ ] Confirm fixture-based preview with `--sample` still behaves the same

## Risks

- `getProjectDetail()` still infers linked repositories from project items, so the repository-link pre-check remains intentionally conservative until the shared project-detail query is widened
- missing/inaccessible repository issues still rely on GitHub GraphQL resolution errors versus project-membership lookup, so reviewer focus should stay on the distinction between not-found and not-in-project messaging
- the Docker blackbox run confirmed dispatch, `completed` worker stderr event, and `lastError: null`, but the stub-worker fixture continues into retry-oriented lifecycle behavior if the fixture is left in place