### PR TITLE
feat(cli): scaffold a safe default after_create hook during workflow init

### DIFF
--- a/packages/cli/src/commands/init.test.ts
+++ b/packages/cli/src/commands/init.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, stat, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -34,6 +34,11 @@ import * as p from "@clack/prompts";
 import type { CliProjectConfig } from "../config.js";
 import * as ghAuth from "../github/gh-auth.js";
 import * as githubClient from "../github/client.js";
+import {
+  DEFAULT_AFTER_CREATE_HOOK_CONTENT,
+  DEFAULT_AFTER_CREATE_HOOK_LABEL,
+  DEFAULT_AFTER_CREATE_HOOK_PATH,
+} from "../workflow/default-hooks.js";
 import initCommand from "./init.js";
 import {
   buildDryRunJsonResult,
@@ -310,6 +315,7 @@ describe("init ecosystem generation", () => {
     );
     expect(preview).toContain("Init dry-run preview");
     expect(preview).toContain("create");
+    expect(preview).toContain(DEFAULT_AFTER_CREATE_HOOK_PATH);
     expect(preview).toContain(".gh-symphony/context.yaml");
     expect(preview).toContain("Detected environment inputs");
     expect(preview).toContain("Dry run only. No files were written.");
@@ -347,6 +353,9 @@ describe("init ecosystem generation", () => {
       mode: "overwrite",
     });
     expect(
+      result.files.some((file) => file.path.endsWith(DEFAULT_AFTER_CREATE_HOOK_PATH))
+    ).toBe(true);
+    expect(
       result.files.some((file) => file.path.endsWith(".gh-symphony/context.yaml"))
     ).toBe(true);
     expect(result.environment.packageManager).toBeDefined();
@@ -355,7 +364,7 @@ describe("init ecosystem generation", () => {
   it("generates context.yaml and reference-workflow.md", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "cli-eco-"));
 
-    await writeEcosystem({
+    const result = await writeEcosystem({
       cwd,
       projectDetail: MOCK_PROJECT_DETAIL,
       statusField: MOCK_STATUS_FIELD,
@@ -363,6 +372,8 @@ describe("init ecosystem generation", () => {
       skipSkills: false,
       skipContext: false,
     });
+
+    expect(result.afterCreateHookWritten).toBe(true);
 
     const contextYaml = await readFile(
       join(cwd, ".gh-symphony", "context.yaml"),
@@ -376,6 +387,12 @@ describe("init ecosystem generation", () => {
       "utf8"
     );
     expect(refWorkflow).toContain("# Reference WORKFLOW.md");
+
+    const hookPath = join(cwd, DEFAULT_AFTER_CREATE_HOOK_PATH);
+    const hook = await readFile(hookPath, "utf8");
+    const hookStats = await stat(hookPath);
+    expect(hook).toBe(DEFAULT_AFTER_CREATE_HOOK_CONTENT);
+    expect(hookStats.mode & 0o111).not.toBe(0);
   });
 
   it("reflects detected repository commands across generated artifacts", async () => {
@@ -625,6 +642,11 @@ describe("init ecosystem generation", () => {
       file.path.endsWith(".gh-symphony/reference-workflow.md")
     );
     expect(referenceWorkflow?.status).toBe("unchanged");
+
+    const hookScaffold = plan.files.find(
+      (file) => file.label === DEFAULT_AFTER_CREATE_HOOK_LABEL
+    );
+    expect(hookScaffold?.status).toBe("unchanged");
 
     const contextYaml = plan.files.find((file) =>
       file.path.endsWith(".gh-symphony/context.yaml")

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,6 +1,6 @@
 import * as p from "@clack/prompts";
 import { createHash } from "node:crypto";
-import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { chmod, mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { basename, dirname, join, relative, resolve } from "node:path";
 import type { GlobalOptions } from "../index.js";
 import {
@@ -43,6 +43,11 @@ import {
   buildContextYaml,
   generateContextYamlString,
 } from "../context/generate-context-yaml.js";
+import {
+  DEFAULT_AFTER_CREATE_HOOK_CONTENT,
+  DEFAULT_AFTER_CREATE_HOOK_LABEL,
+  DEFAULT_AFTER_CREATE_HOOK_PATH,
+} from "../workflow/default-hooks.js";
 import { generateReferenceWorkflow } from "../workflow/generate-reference-workflow.js";
 import { buildSkillFilePlans, resolveSkillsDir } from "../skills/skill-writer.js";
 import { ALL_SKILL_TEMPLATES } from "../skills/templates/index.js";
@@ -185,6 +190,7 @@ export type EcosystemResult = {
   githubProjectTitle: string;
   runtime: string;
   skillsDir: string | null;
+  afterCreateHookWritten: boolean;
   contextYamlWritten: boolean;
   referenceWorkflowWritten: boolean;
   skillsWritten: string[];
@@ -200,6 +206,7 @@ export type PlannedFileChange = {
   content: string;
   mode: PlannedWriteMode;
   status: PlannedChangeStatus;
+  executable?: boolean;
 };
 
 export type EcosystemPlan = {
@@ -270,6 +277,7 @@ async function planFileChange(input: {
   label: string;
   content: string;
   mode: PlannedWriteMode;
+  executable?: boolean;
 }): Promise<PlannedFileChange> {
   return {
     ...input,
@@ -286,6 +294,9 @@ async function writePlannedFile(file: PlannedFileChange): Promise<boolean> {
   const temporaryPath = `${file.path}.tmp`;
   await writeFile(temporaryPath, file.content, "utf8");
   await rename(temporaryPath, file.path);
+  if (file.executable) {
+    await chmod(file.path, 0o755);
+  }
   return true;
 }
 
@@ -414,6 +425,16 @@ export async function planEcosystem(
   const environment = opts.environment ?? (await detectEnvironment(cwd));
   const files: PlannedFileChange[] = [];
 
+  files.push(
+    await planFileChange({
+      path: join(cwd, DEFAULT_AFTER_CREATE_HOOK_PATH),
+      label: DEFAULT_AFTER_CREATE_HOOK_LABEL,
+      content: DEFAULT_AFTER_CREATE_HOOK_CONTENT,
+      mode: "create-only",
+      executable: true,
+    })
+  );
+
   if (!skipContext) {
     const contextYaml = buildContextYaml({
       projectDetail,
@@ -510,6 +531,7 @@ export async function writeEcosystem(
 ): Promise<EcosystemResult> {
   const plan = await planEcosystem(opts);
   await mkdir(join(opts.cwd, ".gh-symphony"), { recursive: true });
+  const afterCreateHookPath = join(opts.cwd, DEFAULT_AFTER_CREATE_HOOK_PATH);
   const contextYamlPath = join(opts.cwd, ".gh-symphony", "context.yaml");
   const referenceWorkflowPath = join(
     opts.cwd,
@@ -517,6 +539,7 @@ export async function writeEcosystem(
     "reference-workflow.md"
   );
 
+  let afterCreateHookWritten = false;
   let contextYamlWritten = false;
   let referenceWorkflowWritten = false;
   const skillsWritten: string[] = [];
@@ -524,6 +547,10 @@ export async function writeEcosystem(
 
   for (const file of plan.files) {
     const written = await writePlannedFile(file);
+    if (file.path === afterCreateHookPath) {
+      afterCreateHookWritten = written;
+      continue;
+    }
     if (file.path === contextYamlPath) {
       contextYamlWritten = written;
       continue;
@@ -547,6 +574,7 @@ export async function writeEcosystem(
     githubProjectTitle: plan.githubProjectTitle,
     runtime: plan.runtime,
     skillsDir: plan.skillsDir,
+    afterCreateHookWritten,
     contextYamlWritten,
     referenceWorkflowWritten,
     skillsWritten: skillsWritten.sort(),
@@ -570,6 +598,11 @@ function printEcosystemSummary(
   lines.push("");
   lines.push("Generated files");
   lines.push(`  ✓ WORKFLOW.md                          ${relWorkflow}`);
+  if (result.afterCreateHookWritten) {
+    lines.push(
+      `  ✓ ${DEFAULT_AFTER_CREATE_HOOK_LABEL.padEnd(36)} ${DEFAULT_AFTER_CREATE_HOOK_PATH}`
+    );
+  }
   if (result.contextYamlWritten) {
     lines.push(
       "  ✓ Context metadata                     .gh-symphony/context.yaml"

--- a/packages/cli/src/workflow/default-hooks.ts
+++ b/packages/cli/src/workflow/default-hooks.ts
@@ -1,0 +1,12 @@
+export const DEFAULT_AFTER_CREATE_HOOK_PATH = "hooks/after_create.sh";
+export const DEFAULT_AFTER_CREATE_HOOK_LABEL = "Workspace hook scaffold";
+export const DEFAULT_AFTER_CREATE_HOOK_COMMENT =
+  "scaffolded by workflow init; customize this script for repository setup";
+
+export const DEFAULT_AFTER_CREATE_HOOK_CONTENT = `#!/usr/bin/env bash
+set -euo pipefail
+
+# Customize this hook to prepare a freshly created workspace.
+# This scaffold is intentionally a no-op so generated workflows run cleanly.
+exit 0
+`;

--- a/packages/cli/src/workflow/generate-reference-workflow.test.ts
+++ b/packages/cli/src/workflow/generate-reference-workflow.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
+  DEFAULT_AFTER_CREATE_HOOK_COMMENT,
+  DEFAULT_AFTER_CREATE_HOOK_PATH,
+} from "./default-hooks.js";
+import {
   generateReferenceWorkflow,
   type ReferenceWorkflowInput,
 } from "./generate-reference-workflow.js";
@@ -185,7 +189,8 @@ describe("generateReferenceWorkflow", () => {
 
   it("includes hooks section with after_create", () => {
     const output = generateReferenceWorkflow(defaultInput);
-    expect(output).toContain("after_create: hooks/after_create.sh");
+    expect(output).toContain(`after_create: ${DEFAULT_AFTER_CREATE_HOOK_PATH}`);
+    expect(output).toContain(DEFAULT_AFTER_CREATE_HOOK_COMMENT);
     expect(output).toContain("before_run: null");
     expect(output).toContain("after_run: null");
     expect(output).toContain("before_remove: null");

--- a/packages/cli/src/workflow/generate-reference-workflow.ts
+++ b/packages/cli/src/workflow/generate-reference-workflow.ts
@@ -1,4 +1,8 @@
 import type { DetectedEnvironment } from "../detection/environment-detector.js";
+import {
+  DEFAULT_AFTER_CREATE_HOOK_COMMENT,
+  DEFAULT_AFTER_CREATE_HOOK_PATH,
+} from "./default-hooks.js";
 import { buildRepositoryValidationGuidance } from "./repository-guidance.js";
 
 export type ReferenceWorkflowInput = {
@@ -76,7 +80,6 @@ export function generateReferenceWorkflow(
   lines.push("");
 
   const agentCommand = resolveAgentCommand(input.runtime);
-  const hookComment = resolveHookComment(input.runtime);
   lines.push("polling:");
   lines.push("  interval_ms: 30000");
   lines.push("");
@@ -86,7 +89,9 @@ export function generateReferenceWorkflow(
   lines.push("");
 
   lines.push("hooks:");
-  lines.push(`  after_create: hooks/after_create.sh  # ${hookComment}`);
+  lines.push(
+    `  after_create: ${DEFAULT_AFTER_CREATE_HOOK_PATH}  # ${DEFAULT_AFTER_CREATE_HOOK_COMMENT}`
+  );
   lines.push("  before_run: null");
   lines.push("  after_run: null");
   lines.push("  before_remove: null");
@@ -372,17 +377,6 @@ function resolveAgentCommand(runtime: string): string {
       return "claude-code";
     default:
       return runtime;
-  }
-}
-
-function resolveHookComment(runtime: string): string {
-  switch (runtime) {
-    case "codex":
-      return "npm/yarn/pnpm install script";
-    case "claude-code":
-      return "npm/yarn/pnpm install script";
-    default:
-      return "package-manager-specific script";
   }
 }
 

--- a/packages/cli/src/workflow/generate-workflow-md.test.ts
+++ b/packages/cli/src/workflow/generate-workflow-md.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { parseWorkflowMarkdown, renderPrompt } from "@gh-symphony/core";
+import { DEFAULT_AFTER_CREATE_HOOK_PATH } from "./default-hooks.js";
 import { generateWorkflowMarkdown } from "./generate-workflow-md.js";
 
 describe("generateWorkflowMarkdown", () => {
@@ -92,6 +93,12 @@ describe("generateWorkflowMarkdown", () => {
     });
 
     expect(markdown).toContain("command: node worker.js");
+  });
+
+  it("points after_create at the scaffolded default hook path", () => {
+    const markdown = generateWorkflowMarkdown(defaultInput);
+
+    expect(markdown).toContain(`after_create: ${DEFAULT_AFTER_CREATE_HOOK_PATH}`);
   });
 
   it("includes template variables that resolve without errors", () => {

--- a/packages/cli/src/workflow/generate-workflow-md.ts
+++ b/packages/cli/src/workflow/generate-workflow-md.ts
@@ -1,6 +1,7 @@
 import type { WorkflowLifecycleConfig } from "@gh-symphony/core";
 import type { StateMapping } from "../config.js";
 import type { DetectedEnvironment } from "../detection/environment-detector.js";
+import { DEFAULT_AFTER_CREATE_HOOK_PATH } from "./default-hooks.js";
 import { buildRepositoryValidationGuidance } from "./repository-guidance.js";
 
 export type GenerateWorkflowInput = {
@@ -60,7 +61,7 @@ function buildFrontMatter(input: GenerateWorkflowInput): string {
   lines.push("  root: .runtime/symphony-workspaces");
 
   lines.push("hooks:");
-  lines.push("  after_create: hooks/after_create.sh");
+  lines.push(`  after_create: ${DEFAULT_AFTER_CREATE_HOOK_PATH}`);
 
   lines.push("agent:");
   lines.push("  max_concurrent_agents: 10");


### PR DESCRIPTION
## Issues

- Fixes #208

## Summary

- scaffold a safe default `hooks/after_create.sh` during `gh-symphony workflow init`
- keep generated `WORKFLOW.md` and `.gh-symphony/reference-workflow.md` aligned with the scaffolded hook path and customization guidance
- cover the scaffold in dry-run planning, write-flow assertions, and reference/workflow regression tests

## Changes

- added a shared default hook module so init planning, generated workflow front matter, and reference workflow docs all point to the same `after_create` scaffold path/content
- taught `planEcosystem()` / `writeEcosystem()` to plan and write `hooks/after_create.sh` as a create-only executable scaffold, and surface it in dry-run and setup output
- extended CLI workflow-init tests to verify the scaffold appears in dry-run/json plans, is written with executable permissions, and remains unchanged on rerun

## Evidence

- `pnpm --filter @gh-symphony/cli test -- --run src/commands/init.test.ts src/workflow/generate-workflow-md.test.ts src/workflow/generate-reference-workflow.test.ts`
- `pnpm --filter @gh-symphony/cli typecheck`
- `pnpm lint`
- `pnpm test`
- `pnpm typecheck`
- `pnpm build`
- Manual check: confirmed `writeEcosystem()` now writes `hooks/after_create.sh` with executable bits and the expected no-op scaffold content in the CLI regression test
- Note: `pnpm install` was required in this workspace before running the checks because `node_modules` was initially absent

## Human Validation

- [ ] Confirm `gh-symphony workflow init --dry-run` shows `hooks/after_create.sh` in the planned output
- [ ] Confirm `gh-symphony workflow init` creates an executable `hooks/after_create.sh` scaffold beside `WORKFLOW.md`
- [ ] Confirm a first workspace run no longer records an `after_create` hook failure when the generated defaults are accepted unchanged

## Risks

- The scaffold is intentionally `create-only`, so existing customized `hooks/after_create.sh` files are preserved on rerun; reviewer attention should stay on whether that non-clobbering behavior matches the desired onboarding UX
