### PR TITLE
feat(release): publish official container image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,3 +49,54 @@ jobs:
         if: always()
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  container-smoke:
+    name: Container Smoke
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build container image from local package bundle
+        run: |
+          docker build \
+            --build-arg GH_SYMPHONY_INSTALL_SOURCE=local \
+            --tag gh-symphony:test .
+
+      - name: Smoke test container image
+        run: |
+          TMPDIR="$(mktemp -d)"
+          mkdir -p "${TMPDIR}/config/projects/smoke"
+
+          cat > "${TMPDIR}/config/config.json" <<'EOF'
+          {
+            "activeProject": "smoke",
+            "projects": ["smoke"]
+          }
+          EOF
+
+          cat > "${TMPDIR}/config/projects/smoke/project.json" <<'EOF'
+          {
+            "projectId": "smoke",
+            "slug": "smoke",
+            "workspaceDir": "/var/lib/gh-symphony/workspaces/smoke",
+            "repositories": [],
+            "tracker": {
+              "adapter": "file",
+              "bindingId": "smoke-file",
+              "settings": {
+                "issuesPath": "/var/lib/gh-symphony/issues.json"
+              }
+            }
+          }
+          EOF
+
+          echo "[]" > "${TMPDIR}/config/issues.json"
+
+          docker run --rm gh-symphony:test gh-symphony --version
+          docker run --rm \
+            -v "${TMPDIR}/config:/var/lib/gh-symphony" \
+            gh-symphony:test \
+            gh-symphony start --once --project-id smoke

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ jobs:
     environment: release
     permissions:
       contents: write
+      packages: write
       pull-requests: write
       id-token: write
     steps:
@@ -55,12 +56,108 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      - name: Capture published version
+        if: steps.changesets.outputs.published == 'true'
+        id: version
+        run: echo "value=$(jq -r '.version' packages/cli/package.json)" >> "$GITHUB_OUTPUT"
+
+      - name: Login to GHCR
+        if: steps.changesets.outputs.published == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Wait for npm package availability
+        if: steps.changesets.outputs.published == 'true'
+        run: |
+          for attempt in $(seq 1 15); do
+            if npm view "@gh-symphony/cli@${{ steps.version.outputs.value }}" version >/dev/null 2>&1; then
+              exit 0
+            fi
+
+            echo "Package @gh-symphony/cli@${{ steps.version.outputs.value }} is not visible on npm yet (attempt ${attempt}/15)."
+            sleep 20
+          done
+
+          echo "Timed out waiting for @gh-symphony/cli@${{ steps.version.outputs.value }} to become available on npm."
+          exit 1
+
+      - name: Compute image metadata
+        if: steps.changesets.outputs.published == 'true'
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=raw,value=latest
+            type=raw,value=${{ steps.version.outputs.value }}
+            type=sha,format=short,prefix=sha-
+          labels: |
+            org.opencontainers.image.title=GitHub Symphony
+            org.opencontainers.image.description=Official GitHub Symphony headless orchestration image
+            org.opencontainers.image.version=${{ steps.version.outputs.value }}
+
+      - name: Build and publish OCI image
+        if: steps.changesets.outputs.published == 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          build-args: |
+            GH_SYMPHONY_VERSION=${{ steps.version.outputs.value }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Smoke test published image
+        if: steps.changesets.outputs.published == 'true'
+        env:
+          IMAGE_REF: ghcr.io/${{ github.repository }}:${{ steps.version.outputs.value }}
+        run: |
+          docker pull "${IMAGE_REF}"
+
+          TMPDIR="$(mktemp -d)"
+          mkdir -p "${TMPDIR}/config/projects/smoke"
+
+          cat > "${TMPDIR}/config/config.json" <<'EOF'
+          {
+            "activeProject": "smoke",
+            "projects": ["smoke"]
+          }
+          EOF
+
+          cat > "${TMPDIR}/config/projects/smoke/project.json" <<'EOF'
+          {
+            "projectId": "smoke",
+            "slug": "smoke",
+            "workspaceDir": "/var/lib/gh-symphony/workspaces/smoke",
+            "repositories": [],
+            "tracker": {
+              "adapter": "file",
+              "bindingId": "smoke-file",
+              "settings": {
+                "issuesPath": "/var/lib/gh-symphony/issues.json"
+              }
+            }
+          }
+          EOF
+
+          echo "[]" > "${TMPDIR}/config/issues.json"
+
+          docker run --rm "${IMAGE_REF}" gh-symphony --version
+          docker run --rm \
+            -v "${TMPDIR}/config:/var/lib/gh-symphony" \
+            "${IMAGE_REF}" \
+            gh-symphony start --once --project-id smoke
+
       - name: Tag and create GitHub Release
         if: steps.changesets.outputs.published == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          VERSION=$(jq -r '.version' packages/cli/package.json)
+          VERSION="${{ steps.version.outputs.value }}"
           git tag "v$VERSION"
           git push origin "v$VERSION"
           gh release create "v$VERSION" --generate-notes --title "v$VERSION"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,47 @@
+ARG NODE_IMAGE=node:24-bookworm-slim
+ARG PNPM_VERSION=9.15.9
+
+FROM ${NODE_IMAGE} AS pack
+
+ARG PNPM_VERSION
+
+WORKDIR /src
+
+COPY . .
+
+RUN corepack enable && corepack prepare pnpm@${PNPM_VERSION} --activate
+RUN pnpm install --frozen-lockfile
+RUN pnpm build
+RUN mkdir -p /tmp/gh-symphony-dist
+RUN cd packages/cli && npm pack --pack-destination /tmp/gh-symphony-dist
+
+FROM ${NODE_IMAGE}
+
+ARG GH_SYMPHONY_INSTALL_SOURCE=registry
+ARG GH_SYMPHONY_VERSION=latest
+
+ENV NODE_ENV=production
+ENV GH_SYMPHONY_CONFIG_DIR=/var/lib/gh-symphony
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates git openssh-client tini && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY --from=pack /tmp/gh-symphony-dist /tmp/gh-symphony-dist
+
+RUN set -eux; \
+    if [ "${GH_SYMPHONY_INSTALL_SOURCE}" = "local" ]; then \
+      pkg="$(find /tmp/gh-symphony-dist -maxdepth 1 -name '*.tgz' -print -quit)"; \
+      test -n "${pkg}"; \
+      npm install -g "${pkg}"; \
+    else \
+      npm install -g "@gh-symphony/cli@${GH_SYMPHONY_VERSION}"; \
+    fi; \
+    npm cache clean --force; \
+    rm -rf /tmp/gh-symphony-dist
+
+WORKDIR /workspace
+VOLUME ["/var/lib/gh-symphony"]
+
+ENTRYPOINT ["/usr/bin/tini", "--"]
+CMD ["gh-symphony", "start"]

--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ GitHub Symphony is a multi-tenant AI coding agent orchestration platform built o
 npm install -g @gh-symphony/cli
 ```
 
+Or use the official container image:
+
+```bash
+docker pull ghcr.io/hojinzs/github-symphony:latest
+docker run --rm ghcr.io/hojinzs/github-symphony:latest gh-symphony --version
+```
+
 Verify the installation:
 
 ```bash
@@ -42,6 +49,70 @@ Token-only validation works without `gh`:
 
 ```bash
 GITHUB_GRAPHQL_TOKEN=ghp_your_classic_token gh-symphony doctor --json
+```
+
+### Official Container Deployment
+
+The official image is designed for headless orchestration and defaults to:
+
+- image: `ghcr.io/hojinzs/github-symphony:<tag>`
+- config/state volume: `/var/lib/gh-symphony`
+- default command: `gh-symphony start`
+
+Supported container environment variables:
+
+- `GITHUB_GRAPHQL_TOKEN`: recommended auth source inside containers; requires `repo`, `read:org`, `project`
+- `GH_SYMPHONY_CONFIG_DIR`: optional override for the runtime config directory; defaults to `/var/lib/gh-symphony`
+
+Supported volume mounts:
+
+- `/var/lib/gh-symphony`: persists `config.json`, `projects/<project-id>/project.json`, project `.env`, logs, and orchestrator workspaces across restarts
+
+Seed the managed-project config into the mounted volume once:
+
+```bash
+docker run --rm -it \
+  -e GITHUB_GRAPHQL_TOKEN=ghp_your_classic_token \
+  -v gh-symphony-data:/var/lib/gh-symphony \
+  ghcr.io/hojinzs/github-symphony:latest \
+  gh-symphony project add --non-interactive --project PVT_xxx --workspace-dir /var/lib/gh-symphony/workspaces
+```
+
+Then start the long-running orchestrator:
+
+```bash
+docker run -d \
+  --name gh-symphony \
+  --restart unless-stopped \
+  -e GITHUB_GRAPHQL_TOKEN=ghp_your_classic_token \
+  -v gh-symphony-data:/var/lib/gh-symphony \
+  ghcr.io/hojinzs/github-symphony:latest
+```
+
+Example `docker compose` deployment:
+
+```yaml
+services:
+  gh-symphony:
+    image: ghcr.io/hojinzs/github-symphony:latest
+    restart: unless-stopped
+    environment:
+      GITHUB_GRAPHQL_TOKEN: ${GITHUB_GRAPHQL_TOKEN}
+    volumes:
+      - gh-symphony-data:/var/lib/gh-symphony
+
+volumes:
+  gh-symphony-data:
+```
+
+For a first-run smoke check against an existing mounted config directory:
+
+```bash
+docker run --rm \
+  -e GITHUB_GRAPHQL_TOKEN=ghp_your_classic_token \
+  -v gh-symphony-data:/var/lib/gh-symphony \
+  ghcr.io/hojinzs/github-symphony:latest \
+  gh-symphony start --once --project-id your-project-id
 ```
 
 ### 2. Run Setup

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,13 +41,13 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
-    "@gh-symphony/control-plane": "workspace:*",
     "@clack/prompts": "^0.9.1",
     "commander": "^14.0.1",
     "liquidjs": "^10.25.0"
   },
   "devDependencies": {
     "@gh-symphony/core": "workspace:*",
+    "@gh-symphony/control-plane": "workspace:*",
     "@gh-symphony/dashboard": "workspace:*",
     "@gh-symphony/orchestrator": "workspace:*",
     "@gh-symphony/tracker-github": "workspace:*",

--- a/packages/control-plane/package.json
+++ b/packages/control-plane/package.json
@@ -42,7 +42,7 @@
     "dev:server": "tsup src/index.ts --watch --format esm",
     "lint": "eslint src client/src client/.storybook client/vite.config.ts client/tailwind.config.ts --ext .ts,.tsx",
     "storybook": "storybook dev -p 6006 -c client/.storybook",
-    "typecheck": "tsc -p tsconfig.typecheck.json && tsc -p client/tsconfig.json --noEmit",
+    "typecheck": "pnpm build:client >/dev/null && tsc -p tsconfig.typecheck.json && tsc -p client/tsconfig.json --noEmit",
     "test": "vitest run --passWithNoTests"
   },
   "dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,9 +47,6 @@ importers:
       '@clack/prompts':
         specifier: ^0.9.1
         version: 0.9.1
-      '@gh-symphony/control-plane':
-        specifier: workspace:*
-        version: link:../control-plane
       commander:
         specifier: ^14.0.1
         version: 14.0.3
@@ -57,6 +54,9 @@ importers:
         specifier: ^10.25.0
         version: 10.25.0
     devDependencies:
+      '@gh-symphony/control-plane':
+        specifier: workspace:*
+        version: link:../control-plane
       '@gh-symphony/core':
         specifier: workspace:*
         version: link:../core


### PR DESCRIPTION
## Issues

- Fixes #167

## Summary

- publish an official `ghcr.io/hojinzs/github-symphony` container image for headless orchestration
- add CI and release smoke checks that validate image startup against a mounted config directory

## Changes

- add a production `Dockerfile` with a registry-install default path for releases and a local-pack path for CI validation
- extend `.github/workflows/release.yml` to wait for npm availability, publish versioned GHCR tags, and smoke test the published image
- extend `.github/workflows/ci.yml` to build the image from the local package bundle and run `gh-symphony --version` plus `start --once` against a mounted config volume
- document supported container environment variables, persistent volume mounts, and `docker run` / `docker compose` deployment flows in `README.md`
- remove the CLI's bundled control-plane workspace dependency from runtime install requirements and make control-plane typecheck generate the TanStack route tree before checking

## Evidence

- `docker build --build-arg GH_SYMPHONY_INSTALL_SOURCE=local -t gh-symphony:test .`
- `docker run --rm gh-symphony:test gh-symphony --version`
- `docker run --rm -v "$TMPDIR/config:/var/lib/gh-symphony" gh-symphony:test gh-symphony start --once --project-id smoke`
- `pnpm lint && pnpm test && pnpm typecheck && pnpm build`
- Manual check: verified the local container smoke config uses a mounted `GH_SYMPHONY_CONFIG_DIR` with a file-tracker project and exits cleanly after one orchestration tick

## Human Validation

- [ ] Confirm the documented `docker run` bootstrap flow works with a real GitHub Project binding
- [ ] Confirm the published GHCR tags include both `latest` and the release version
- [ ] Confirm the image can orchestrate a long-running project with persistent `/var/lib/gh-symphony` state

## Risks

- The release image build depends on npm propagation timing; the workflow now retries package visibility before building, but registry delays remain the main external dependency
