### PR TITLE
feat(cli): auto-configure tracker priority field during workflow init

### DIFF
--- a/packages/cli/src/commands/init.test.ts
+++ b/packages/cli/src/commands/init.test.ts
@@ -234,6 +234,143 @@ describe("init command config output", () => {
   });
 });
 
+describe("init priority field detection", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.mocked(p.intro).mockImplementation(() => undefined);
+    vi.mocked(p.outro).mockImplementation(() => undefined);
+    vi.mocked(p.cancel).mockImplementation(() => undefined);
+    vi.mocked(p.note).mockImplementation(() => undefined);
+    vi.mocked(p.spinner).mockImplementation(mockSpinner);
+    vi.mocked(p.log.error).mockImplementation(() => undefined);
+    vi.mocked(p.log.warn).mockImplementation(() => undefined);
+    vi.mocked(p.log.info).mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    process.exitCode = undefined;
+  });
+
+  it("adds tracker.priority_field during non-interactive dry-run when Priority exists", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "cli-init-priority-nonint-"));
+    const stdout = vi
+      .spyOn(process.stdout, "write")
+      .mockReturnValue(true as never);
+    vi.spyOn(ghAuth, "getGhTokenWithSource").mockReturnValue({
+      token: "test-token",
+      source: "gh",
+    });
+    vi.spyOn(githubClient, "createClient").mockReturnValue({} as never);
+    vi.spyOn(githubClient, "validateToken").mockResolvedValue({
+      login: "tester",
+      name: "Tester",
+      scopes: ["repo", "read:org", "project"],
+    });
+    vi.spyOn(githubClient, "listUserProjects").mockResolvedValue([
+      {
+        id: "project-1",
+        title: "Roadmap",
+        shortDescription: "",
+        url: "https://github.com/users/tester/projects/1",
+        openItemCount: 3,
+        owner: { login: "tester", type: "User" },
+      },
+    ]);
+    vi.spyOn(githubClient, "getProjectDetail").mockResolvedValue({
+      ...MOCK_PROJECT_DETAIL,
+      id: "project-1",
+      statusFields: [MOCK_STATUS_FIELD, MOCK_PRIORITY_FIELD],
+    });
+
+    await initCommand(
+      ["--non-interactive", "--dry-run", "--output", join(configDir, "WORKFLOW.md")],
+      {
+        configDir,
+        verbose: false,
+        json: true,
+        noColor: true,
+      }
+    );
+
+    const payload = JSON.parse(
+      stdout.mock.calls.map(([chunk]) => String(chunk)).join("")
+    ) as { priorityFieldName: string | null };
+    expect(payload.priorityFieldName).toBe("Priority");
+  });
+
+  it("prompts for a priority field when multiple priority-like fields are present", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "cli-init-priority-int-"));
+    const stdout = vi
+      .spyOn(process.stdout, "write")
+      .mockReturnValue(true as never);
+    vi.spyOn(ghAuth, "resolveGitHubAuth").mockResolvedValue({
+      source: "env",
+      login: "env-user",
+      token: "env-token",
+      scopes: ["repo", "read:org", "project"],
+    });
+    vi.spyOn(githubClient, "createClient").mockReturnValue({} as never);
+    vi.spyOn(githubClient, "discoverUserProjects").mockResolvedValue({
+      projects: [
+        {
+          id: "project-1",
+          title: "Roadmap",
+          shortDescription: "",
+          url: "https://github.com/users/tester/projects/1",
+          openItemCount: 3,
+          owner: { login: "tester", type: "User" },
+        },
+      ],
+      partial: false,
+      reason: null,
+      requests: 1,
+    });
+    vi.spyOn(githubClient, "getProjectDetail").mockResolvedValue({
+      ...MOCK_PROJECT_DETAIL,
+      id: "project-1",
+      statusFields: [
+        MOCK_STATUS_FIELD,
+        {
+          ...MOCK_PRIORITY_FIELD,
+          id: "priority-team",
+          name: "Priority (Team)",
+        },
+        {
+          ...MOCK_PRIORITY_FIELD,
+          id: "priority-severity",
+          name: "Priority (Severity)",
+        },
+      ],
+    });
+    vi.mocked(p.select)
+      .mockResolvedValueOnce("project-1" as never)
+      .mockResolvedValueOnce("active" as never)
+      .mockResolvedValueOnce("active" as never)
+      .mockResolvedValueOnce("terminal" as never)
+      .mockResolvedValueOnce("priority-severity" as never);
+
+    await initCommand(["--dry-run", "--output", join(configDir, "WORKFLOW.md")], {
+      configDir,
+      verbose: false,
+      json: false,
+      noColor: true,
+    });
+
+    const rendered = stdout.mock.calls.map(([chunk]) => String(chunk)).join("");
+    expect(rendered).toContain("Priority field   Priority (Severity)");
+    expect(vi.mocked(p.select).mock.calls).toEqual(
+      expect.arrayContaining([
+        [
+          expect.objectContaining({
+            message:
+              "Step 3/3 — Multiple GitHub Project priority fields look plausible. Select the one Symphony should use:",
+          }),
+        ],
+      ])
+    );
+  });
+});
+
 const MOCK_PROJECT_DETAIL = {
   id: "PVT_eco1",
   title: "Ecosystem Test",
@@ -284,6 +421,25 @@ const MOCK_STATUS_FIELD = {
   ],
 };
 
+const MOCK_PRIORITY_FIELD = {
+  id: "PVTSSF_priority",
+  name: "Priority",
+  options: [
+    {
+      id: "opt_p0",
+      name: "P0",
+      description: null,
+      color: "RED" as string | null,
+    },
+    {
+      id: "opt_p1",
+      name: "P1",
+      description: null,
+      color: "ORANGE" as string | null,
+    },
+  ],
+};
+
 describe("init ecosystem generation", () => {
   it("plans dry-run output without writing files", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "cli-eco-plan-"));
@@ -292,6 +448,7 @@ describe("init ecosystem generation", () => {
       cwd,
       projectDetail: MOCK_PROJECT_DETAIL,
       statusField: MOCK_STATUS_FIELD,
+      priorityField: MOCK_PRIORITY_FIELD,
       runtime: "codex",
       skipSkills: false,
       skipContext: false,
@@ -317,6 +474,7 @@ describe("init ecosystem generation", () => {
     expect(preview).toContain("create");
     expect(preview).toContain(DEFAULT_AFTER_CREATE_HOOK_PATH);
     expect(preview).toContain(".gh-symphony/context.yaml");
+    expect(preview).toContain("Priority field   Priority");
     expect(preview).toContain("Detected environment inputs");
     expect(preview).toContain("Dry run only. No files were written.");
   });
@@ -328,6 +486,7 @@ describe("init ecosystem generation", () => {
       cwd,
       projectDetail: MOCK_PROJECT_DETAIL,
       statusField: MOCK_STATUS_FIELD,
+      priorityField: MOCK_PRIORITY_FIELD,
       runtime: "codex",
       skipSkills: false,
       skipContext: false,
@@ -347,6 +506,7 @@ describe("init ecosystem generation", () => {
 
     expect(result.dryRun).toBe(true);
     expect(result.output).toBe(join(cwd, "WORKFLOW.md"));
+    expect(result.priorityFieldName).toBe("Priority");
     expect(result.files[0]).toMatchObject({
       label: "WORKFLOW.md",
       status: "create",
@@ -368,6 +528,7 @@ describe("init ecosystem generation", () => {
       cwd,
       projectDetail: MOCK_PROJECT_DETAIL,
       statusField: MOCK_STATUS_FIELD,
+      priorityField: MOCK_PRIORITY_FIELD,
       runtime: "codex",
       skipSkills: false,
       skipContext: false,
@@ -420,6 +581,7 @@ describe("init ecosystem generation", () => {
       cwd,
       projectDetail: MOCK_PROJECT_DETAIL,
       statusField: MOCK_STATUS_FIELD,
+      priorityField: MOCK_PRIORITY_FIELD,
       runtime: "codex",
       skipSkills: false,
       skipContext: false,
@@ -470,6 +632,7 @@ describe("init ecosystem generation", () => {
       outputPath: join(cwd, "WORKFLOW.md"),
       projectDetail: MOCK_PROJECT_DETAIL,
       statusField: MOCK_STATUS_FIELD,
+      priorityField: MOCK_PRIORITY_FIELD,
       mappings: {
         Todo: { role: "active" },
         "In Progress": { role: "active" },
@@ -481,6 +644,7 @@ describe("init ecosystem generation", () => {
     });
 
     expect(plan.workflowMd).toContain("### Repository Validation Guidance");
+    expect(plan.workflowMd).toContain("priority_field: Priority");
     expect(plan.workflowMd).toContain("Detected repository validation commands:");
     expect(plan.workflowMd).toContain("`npm test`");
     expect(plan.workflowMd).toContain("`npm run lint`");
@@ -494,6 +658,7 @@ describe("init ecosystem generation", () => {
       cwd,
       projectDetail: MOCK_PROJECT_DETAIL,
       statusField: MOCK_STATUS_FIELD,
+      priorityField: null,
       runtime: "bash -lc codex app-server",
       skipSkills: false,
       skipContext: false,
@@ -516,6 +681,7 @@ describe("init ecosystem generation", () => {
       cwd,
       projectDetail: MOCK_PROJECT_DETAIL,
       statusField: MOCK_STATUS_FIELD,
+      priorityField: null,
       runtime: "codex",
       skipSkills: false,
       skipContext: false,
@@ -549,6 +715,7 @@ describe("init ecosystem generation", () => {
       cwd,
       projectDetail: MOCK_PROJECT_DETAIL,
       statusField: MOCK_STATUS_FIELD,
+      priorityField: null,
       runtime: "codex",
       skipSkills: true,
       skipContext: false,
@@ -573,6 +740,7 @@ describe("init ecosystem generation", () => {
       cwd,
       projectDetail: MOCK_PROJECT_DETAIL,
       statusField: MOCK_STATUS_FIELD,
+      priorityField: null,
       runtime: "codex",
       skipSkills: true,
       skipContext: true,
@@ -603,6 +771,7 @@ describe("init ecosystem generation", () => {
           { id: "opt_def", name: "Done", description: null, color: null },
         ],
       },
+      priorityField: null,
       runtime: "codex",
       skipSkills: true,
       skipContext: false,
@@ -624,6 +793,7 @@ describe("init ecosystem generation", () => {
       cwd,
       projectDetail: MOCK_PROJECT_DETAIL,
       statusField: MOCK_STATUS_FIELD,
+      priorityField: null,
       runtime: "codex",
       skipSkills: false,
       skipContext: false,
@@ -633,6 +803,7 @@ describe("init ecosystem generation", () => {
       cwd,
       projectDetail: MOCK_PROJECT_DETAIL,
       statusField: MOCK_STATUS_FIELD,
+      priorityField: null,
       runtime: "codex",
       skipSkills: false,
       skipContext: false,
@@ -667,6 +838,7 @@ describe("init ecosystem generation", () => {
       cwd,
       projectDetail: MOCK_PROJECT_DETAIL,
       statusField: MOCK_STATUS_FIELD,
+      priorityField: null,
       runtime: "codex",
       skipSkills: true,
       skipContext: true,
@@ -676,6 +848,7 @@ describe("init ecosystem generation", () => {
       cwd,
       projectDetail: MOCK_PROJECT_DETAIL,
       statusField: MOCK_STATUS_FIELD,
+      priorityField: null,
       runtime: "codex",
       skipSkills: true,
       skipContext: true,

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -179,6 +179,7 @@ type EcosystemOptions = {
   cwd: string;
   projectDetail: ProjectDetail;
   statusField: ProjectStatusField;
+  priorityField: ProjectStatusField | null;
   runtime: string;
   skipSkills: boolean;
   skipContext: boolean;
@@ -189,6 +190,7 @@ export type EcosystemResult = {
   projectId: string;
   githubProjectTitle: string;
   runtime: string;
+  priorityFieldName: string | null;
   skillsDir: string | null;
   afterCreateHookWritten: boolean;
   contextYamlWritten: boolean;
@@ -213,6 +215,7 @@ export type EcosystemPlan = {
   projectId: string;
   githubProjectTitle: string;
   runtime: string;
+  priorityFieldName: string | null;
   skillsDir: string | null;
   environment: Awaited<ReturnType<typeof detectEnvironment>>;
   files: PlannedFileChange[];
@@ -224,6 +227,7 @@ export type DryRunJsonResult = {
   projectId: string;
   githubProjectTitle: string;
   runtime: string;
+  priorityFieldName: string | null;
   files: Array<{
     path: string;
     label: string;
@@ -238,6 +242,7 @@ export type WorkflowArtifactsOptions = {
   outputPath: string;
   projectDetail: ProjectDetail;
   statusField: ProjectStatusField;
+  priorityField: ProjectStatusField | null;
   mappings: Record<string, StateMapping>;
   runtime: string;
   skipSkills: boolean;
@@ -322,6 +327,81 @@ export function buildAutomaticStateMappings(
   return mappings;
 }
 
+function isPriorityFieldCandidateName(fieldName: string): boolean {
+  return /\bpriority\b/i.test(fieldName.trim());
+}
+
+export function resolvePriorityField(
+  projectDetail: ProjectDetail,
+  statusField: ProjectStatusField
+): {
+  field: ProjectStatusField | null;
+  ambiguous: ProjectStatusField[];
+} {
+  const singleSelectFields = projectDetail.statusFields.filter(
+    (field) => field.id !== statusField.id
+  );
+
+  const exactMatches = singleSelectFields.filter(
+    (field) => field.name.trim().toLowerCase() === "priority"
+  );
+  if (exactMatches.length === 1) {
+    return { field: exactMatches[0]!, ambiguous: [] };
+  }
+  if (exactMatches.length > 1) {
+    return { field: null, ambiguous: exactMatches };
+  }
+
+  const likelyMatches = singleSelectFields.filter((field) =>
+    isPriorityFieldCandidateName(field.name)
+  );
+  if (likelyMatches.length === 1) {
+    return { field: likelyMatches[0]!, ambiguous: [] };
+  }
+  if (likelyMatches.length > 1) {
+    return { field: null, ambiguous: likelyMatches };
+  }
+
+  return { field: null, ambiguous: [] };
+}
+
+async function promptPriorityField(
+  priorityCandidates: ProjectStatusField[],
+  options?: {
+    stepLabel?: string;
+  }
+): Promise<ProjectStatusField | null> {
+  if (priorityCandidates.length === 0) {
+    return null;
+  }
+
+  const selectedFieldId = await abortIfCancelled(
+    p.select({
+      message: `${options?.stepLabel ?? "Priority field"} — Multiple GitHub Project priority fields look plausible. Select the one Symphony should use:`,
+      options: [
+        ...priorityCandidates.map((field) => ({
+          value: field.id,
+          label: field.name,
+          hint: `${field.options.length} option${field.options.length === 1 ? "" : "s"}`,
+        })),
+        {
+          value: "__skip_priority_field__",
+          label: "Skip priority-aware dispatch",
+          hint: "Leave tracker.priority_field unset",
+        },
+      ],
+    })
+  );
+
+  if (selectedFieldId === "__skip_priority_field__") {
+    return null;
+  }
+
+  return (
+    priorityCandidates.find((field) => field.id === selectedFieldId) ?? null
+  );
+}
+
 export async function promptStateMappings(
   statusField: ProjectStatusField,
   options?: {
@@ -368,6 +448,7 @@ export async function planWorkflowArtifacts(
   const workflowMd = generateWorkflowMarkdown({
     projectId: opts.projectDetail.id,
     stateFieldName: opts.statusField.name,
+    priorityFieldName: opts.priorityField?.name ?? null,
     mappings: opts.mappings,
     lifecycle: toWorkflowLifecycleConfig(opts.statusField.name, opts.mappings),
     runtime: opts.runtime,
@@ -384,6 +465,7 @@ export async function planWorkflowArtifacts(
     cwd: opts.cwd,
     projectDetail: opts.projectDetail,
     statusField: opts.statusField,
+    priorityField: opts.priorityField,
     runtime: opts.runtime,
     skipSkills: opts.skipSkills,
     skipContext: opts.skipContext,
@@ -419,8 +501,15 @@ function summarizeEnvironment(
 export async function planEcosystem(
   opts: EcosystemOptions
 ): Promise<EcosystemPlan> {
-  const { cwd, projectDetail, statusField, runtime, skipSkills, skipContext } =
-    opts;
+  const {
+    cwd,
+    projectDetail,
+    statusField,
+    priorityField,
+    runtime,
+    skipSkills,
+    skipContext,
+  } = opts;
   const ghSymphonyDir = join(cwd, ".gh-symphony");
   const environment = opts.environment ?? (await detectEnvironment(cwd));
   const files: PlannedFileChange[] = [];
@@ -467,6 +556,7 @@ export async function planEcosystem(
       role: null as "active" | "wait" | "terminal" | null,
     })),
     projectId: projectDetail.id,
+    priorityFieldName: priorityField?.name ?? null,
     detectedEnvironment: environment,
   });
   files.push(
@@ -520,6 +610,7 @@ export async function planEcosystem(
     projectId: projectDetail.id,
     githubProjectTitle: projectDetail.title,
     runtime,
+    priorityFieldName: priorityField?.name ?? null,
     skillsDir,
     environment,
     files,
@@ -573,6 +664,7 @@ export async function writeEcosystem(
     projectId: plan.projectId,
     githubProjectTitle: plan.githubProjectTitle,
     runtime: plan.runtime,
+    priorityFieldName: plan.priorityFieldName,
     skillsDir: plan.skillsDir,
     afterCreateHookWritten,
     contextYamlWritten,
@@ -595,6 +687,9 @@ function printEcosystemSummary(
   const lines: string[] = [];
   lines.push(`GitHub Project   ${result.githubProjectTitle}  (${result.projectId})`);
   lines.push(`Runtime   ${result.runtime}`);
+  if (result.priorityFieldName) {
+    lines.push(`Priority field   ${result.priorityFieldName}`);
+  }
   lines.push("");
   lines.push("Generated files");
   lines.push(`  ✓ WORKFLOW.md                          ${relWorkflow}`);
@@ -656,6 +751,9 @@ export function renderDryRunPreview(
     `GitHub Project   ${ecosystemPlan.githubProjectTitle}  (${ecosystemPlan.projectId})`
   );
   lines.push(`Runtime   ${ecosystemPlan.runtime}`);
+  if (ecosystemPlan.priorityFieldName) {
+    lines.push(`Priority field   ${ecosystemPlan.priorityFieldName}`);
+  }
   lines.push("");
   lines.push("Planned file changes");
   lines.push(
@@ -689,6 +787,7 @@ export function buildDryRunJsonResult(
     projectId: ecosystemPlan.projectId,
     githubProjectTitle: ecosystemPlan.githubProjectTitle,
     runtime: ecosystemPlan.runtime,
+    priorityFieldName: ecosystemPlan.priorityFieldName,
     files: [workflowPlan, ...ecosystemPlan.files].map((file) => ({
       path: file.path,
       label: file.label,
@@ -780,6 +879,13 @@ async function runNonInteractive(
   }
 
   const mappings = buildAutomaticStateMappings(statusField);
+  const { field: autoPriorityField, ambiguous: ambiguousPriorityFields } =
+    resolvePriorityField(githubProject, statusField);
+  if (ambiguousPriorityFields.length > 0) {
+    process.stderr.write(
+      `Warning: Multiple priority-like single-select fields found (${ambiguousPriorityFields.map((field) => `"${field.name}"`).join(", ")}). Skipping tracker.priority_field in non-interactive mode.\n`
+    );
+  }
 
   const validation = validateStateMapping(mappings);
   if (!validation.valid) {
@@ -796,6 +902,7 @@ async function runNonInteractive(
     outputPath,
     projectDetail: githubProject,
     statusField,
+    priorityField: autoPriorityField,
     mappings,
     runtime: "codex",
     skipSkills: flags.skipSkills,
@@ -821,6 +928,7 @@ async function runNonInteractive(
     cwd: process.cwd(),
     projectDetail: githubProject,
     statusField,
+    priorityField: autoPriorityField,
     runtime: "codex",
     skipSkills: flags.skipSkills,
     skipContext: flags.skipContext,
@@ -942,7 +1050,17 @@ async function runInteractiveStandalone(
     return;
   }
 
-  const mappings = await promptStateMappings(statusField);
+  const priorityResolution = resolvePriorityField(projectDetail, statusField);
+  const mappings = await promptStateMappings(statusField, {
+    stepLabel:
+      priorityResolution.ambiguous.length > 0 ? "Step 2/3" : "Step 2/2",
+  });
+  let priorityField = priorityResolution.field;
+  if (priorityResolution.ambiguous.length > 0) {
+    priorityField = await promptPriorityField(priorityResolution.ambiguous, {
+      stepLabel: "Step 3/3",
+    });
+  }
 
   const validation = validateStateMapping(mappings);
   if (!validation.valid) {
@@ -963,6 +1081,7 @@ async function runInteractiveStandalone(
     outputPath,
     projectDetail,
     statusField,
+    priorityField,
     mappings,
     runtime: "codex",
     skipSkills: flags.skipSkills,
@@ -980,6 +1099,7 @@ async function runInteractiveStandalone(
     cwd: process.cwd(),
     projectDetail,
     statusField,
+    priorityField,
     runtime: "codex",
     skipSkills: flags.skipSkills,
     skipContext: flags.skipContext,

--- a/packages/cli/src/commands/setup.test.ts
+++ b/packages/cli/src/commands/setup.test.ts
@@ -93,6 +93,27 @@ const MOCK_PROJECT_DETAIL = {
   ],
 };
 
+const MOCK_PROJECT_DETAIL_WITH_AMBIGUOUS_PRIORITY = {
+  ...MOCK_PROJECT_DETAIL,
+  statusFields: [
+    ...MOCK_PROJECT_DETAIL.statusFields,
+    {
+      id: "priority-team",
+      name: "Priority (Team)",
+      options: [
+        { id: "p1", name: "P1", description: null, color: "RED" as string | null },
+      ],
+    },
+    {
+      id: "priority-severity",
+      name: "Priority (Severity)",
+      options: [
+        { id: "high", name: "High", description: null, color: "ORANGE" as string | null },
+      ],
+    },
+  ],
+};
+
 describe("setup command", () => {
   const originalCwd = process.cwd();
 
@@ -217,6 +238,38 @@ describe("setup command", () => {
       expect.stringContaining("Repos:      acme/repo-b  (1 of 2 linked)"),
       "Final summary"
     );
+  });
+
+  it("warns and skips tracker.priority_field in non-interactive mode when priority fields are ambiguous", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "setup-non-interactive-priority-cwd-"));
+    const configDir = await mkdtemp(
+      join(tmpdir(), "setup-non-interactive-priority-config-")
+    );
+    process.chdir(cwd);
+
+    vi.spyOn(githubClient, "getProjectDetail").mockResolvedValue(
+      MOCK_PROJECT_DETAIL_WITH_AMBIGUOUS_PRIORITY
+    );
+    const stderrWrite = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+
+    await setupCommand(
+      ["--non-interactive", "--project", MOCK_PROJECT_SUMMARY.id],
+      {
+        configDir,
+        verbose: false,
+        json: false,
+        noColor: true,
+      }
+    );
+
+    const workflow = await readFile(join(cwd, "WORKFLOW.md"), "utf8");
+
+    expect(stderrWrite).toHaveBeenCalledWith(
+      'Warning: Multiple priority-like single-select fields found ("Priority (Team)", "Priority (Severity)"). Skipping tracker.priority_field in non-interactive mode.\n'
+    );
+    expect(workflow).not.toContain("priority_field:");
   });
 
   it("uses --assigned-only as the interactive prompt default and preserves the setting", async () => {

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -18,6 +18,7 @@ import {
   buildAutomaticStateMappings,
   generateProjectId,
   planWorkflowArtifacts,
+  resolvePriorityField,
   renderDryRunPreview,
   resolveStatusField,
   writeConfig,
@@ -258,6 +259,7 @@ async function runNonInteractive(
   }
 
   const mappings = buildAutomaticStateMappings(statusField);
+  const { field: priorityField } = resolvePriorityField(projectDetail, statusField);
   const workflowValidation = validateStateMapping(mappings);
   if (!workflowValidation.valid) {
     process.stderr.write(
@@ -273,6 +275,7 @@ async function runNonInteractive(
     outputPath: workflowPath,
     projectDetail,
     statusField,
+    priorityField,
     mappings,
     runtime: "codex",
     skipSkills: flags.skipSkills,
@@ -284,6 +287,7 @@ async function runNonInteractive(
     cwd: process.cwd(),
     projectDetail,
     statusField,
+    priorityField,
     runtime: "codex",
     skipSkills: flags.skipSkills,
     skipContext: flags.skipContext,
@@ -406,8 +410,9 @@ async function runInteractive(
     return;
   }
 
+  const priorityResolution = resolvePriorityField(projectDetail, statusField);
   const mappings = await promptStateMappings(statusField, {
-    stepLabel: "Step 2/3",
+    stepLabel: priorityResolution.ambiguous.length > 0 ? "Step 2/4" : "Step 2/3",
   });
   const workflowValidation = validateStateMapping(mappings);
   if (!workflowValidation.valid) {
@@ -422,6 +427,37 @@ async function runInteractive(
     p.log.warn(`  ⚠ ${warning}`);
   }
 
+  const priorityField =
+    priorityResolution.ambiguous.length > 0
+      ? await (async () => {
+          const selectedId = await abortIfCancelled(
+            p.select({
+              message:
+                "Step 3/4 — Multiple GitHub Project priority fields look plausible. Select the one Symphony should use:",
+              options: [
+                ...priorityResolution.ambiguous.map((field) => ({
+                  value: field.id,
+                  label: field.name,
+                  hint: `${field.options.length} option${field.options.length === 1 ? "" : "s"}`,
+                })),
+                {
+                  value: "__skip_priority_field__",
+                  label: "Skip priority-aware dispatch",
+                  hint: "Leave tracker.priority_field unset",
+                },
+              ],
+            })
+          );
+          if (selectedId === "__skip_priority_field__") {
+            return null;
+          }
+          return (
+            priorityResolution.ambiguous.find((field) => field.id === selectedId) ??
+            null
+          );
+        })()
+      : priorityResolution.field;
+
   const {
     assignedOnly: promptAssignedOnly,
     selectedRepos,
@@ -431,7 +467,9 @@ async function runInteractive(
       projectDetail,
       defaultWorkspaceDir: flags.workspaceDir ?? join(options.configDir, "workspaces"),
       assignedOnlyMessage:
-        "Step 3/3 — Only process issues assigned to the authenticated GitHub user?",
+        `${
+          priorityResolution.ambiguous.length > 0 ? "Step 4/4" : "Step 3/3"
+        } — Only process issues assigned to the authenticated GitHub user?`,
       assignedOnlyInitialValue: flags.assignedOnly,
     });
   const assignedOnly = flags.assignedOnly || promptAssignedOnly;
@@ -442,6 +480,7 @@ async function runInteractive(
     outputPath: workflowPath,
     projectDetail,
     statusField,
+    priorityField,
     mappings,
     runtime: "codex",
     skipSkills: flags.skipSkills,
@@ -483,6 +522,7 @@ async function runInteractive(
       cwd: process.cwd(),
       projectDetail,
       statusField,
+      priorityField,
       runtime: "codex",
       skipSkills: flags.skipSkills,
       skipContext: flags.skipContext,

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -259,7 +259,13 @@ async function runNonInteractive(
   }
 
   const mappings = buildAutomaticStateMappings(statusField);
-  const { field: priorityField } = resolvePriorityField(projectDetail, statusField);
+  const { field: priorityField, ambiguous: ambiguousPriorityFields } =
+    resolvePriorityField(projectDetail, statusField);
+  if (ambiguousPriorityFields.length > 0) {
+    process.stderr.write(
+      `Warning: Multiple priority-like single-select fields found (${ambiguousPriorityFields.map((field) => `"${field.name}"`).join(", ")}). Skipping tracker.priority_field in non-interactive mode.\n`
+    );
+  }
   const workflowValidation = validateStateMapping(mappings);
   if (!workflowValidation.valid) {
     process.stderr.write(

--- a/packages/cli/src/workflow/generate-reference-workflow.test.ts
+++ b/packages/cli/src/workflow/generate-reference-workflow.test.ts
@@ -17,6 +17,7 @@ const defaultInput: ReferenceWorkflowInput = {
     { name: "Done", role: "terminal" },
   ],
   projectId: "PVT_abc123",
+  priorityFieldName: "Priority",
   detectedEnvironment: {
     packageManager: "pnpm",
     testCommand: "pnpm --filter @gh-symphony/cli test",
@@ -137,6 +138,19 @@ describe("generateReferenceWorkflow", () => {
   it("includes projectId in front matter", () => {
     const output = generateReferenceWorkflow(defaultInput);
     expect(output).toContain("project_id: PVT_abc123");
+  });
+
+  it("includes priority_field in front matter when configured", () => {
+    const output = generateReferenceWorkflow(defaultInput);
+    expect(output).toContain("priority_field: Priority");
+  });
+
+  it("shows priority_field as an optional reference when not configured", () => {
+    const output = generateReferenceWorkflow({
+      ...defaultInput,
+      priorityFieldName: null,
+    });
+    expect(output).toContain("# priority_field: Priority");
   });
 
   it("does not include allowed_repositories in front matter", () => {

--- a/packages/cli/src/workflow/generate-reference-workflow.ts
+++ b/packages/cli/src/workflow/generate-reference-workflow.ts
@@ -12,6 +12,7 @@ export type ReferenceWorkflowInput = {
     role: "active" | "wait" | "terminal" | null;
   }>;
   projectId: string;
+  priorityFieldName: string | null;
   detectedEnvironment: Pick<
     DetectedEnvironment,
     "packageManager" | "testCommand" | "lintCommand" | "buildCommand" | "monorepo"
@@ -43,6 +44,11 @@ export function generateReferenceWorkflow(
   lines.push("  kind: github-project");
   lines.push(`  project_id: ${input.projectId}`);
   lines.push("  state_field: Status");
+  if (input.priorityFieldName) {
+    lines.push(`  priority_field: ${input.priorityFieldName}`);
+  } else {
+    lines.push("  # priority_field: Priority");
+  }
   lines.push("");
 
   const activeColumns = input.statusColumns.filter((c) => c.role === "active");

--- a/packages/cli/src/workflow/generate-workflow-md.test.ts
+++ b/packages/cli/src/workflow/generate-workflow-md.test.ts
@@ -7,6 +7,7 @@ describe("generateWorkflowMarkdown", () => {
   const defaultInput = {
     projectId: "PVT_abc123",
     stateFieldName: "Stage",
+    priorityFieldName: "Priority",
     mappings: {
       Queued: { role: "active" as const, goal: "Triage and plan the issue" },
       Doing: { role: "active" as const, goal: "Implement the solution" },
@@ -45,6 +46,25 @@ describe("generateWorkflowMarkdown", () => {
     expect(parsed.lifecycle.activeStates).toEqual(["Queued", "Doing"]);
     expect(parsed.lifecycle.terminalStates).toEqual(["Done"]);
     expect(parsed.lifecycle.blockerCheckStates).toEqual(["Queued"]);
+  });
+
+  it("emits tracker.priority_field when configured", () => {
+    const markdown = generateWorkflowMarkdown(defaultInput);
+    const parsed = parseWorkflowMarkdown(markdown, {});
+
+    expect(markdown).toContain("priority_field: Priority");
+    expect(parsed.tracker.priorityFieldName).toBe("Priority");
+  });
+
+  it("omits tracker.priority_field when not configured", () => {
+    const markdown = generateWorkflowMarkdown({
+      ...defaultInput,
+      priorityFieldName: null,
+    });
+    const parsed = parseWorkflowMarkdown(markdown, {});
+
+    expect(markdown).not.toContain("priority_field:");
+    expect(parsed.tracker.priorityFieldName).toBeNull();
   });
 
   it("includes a Status Map section in the prompt body", () => {

--- a/packages/cli/src/workflow/generate-workflow-md.ts
+++ b/packages/cli/src/workflow/generate-workflow-md.ts
@@ -7,6 +7,7 @@ import { buildRepositoryValidationGuidance } from "./repository-guidance.js";
 export type GenerateWorkflowInput = {
   projectId: string;
   stateFieldName: string;
+  priorityFieldName: string | null;
   mappings: Record<string, StateMapping>;
   lifecycle: WorkflowLifecycleConfig;
   runtime: string;
@@ -31,6 +32,9 @@ function buildFrontMatter(input: GenerateWorkflowInput): string {
   lines.push("  kind: github-project");
   lines.push(`  project_id: ${input.projectId}`);
   lines.push(`  state_field: ${input.stateFieldName}`);
+  if (input.priorityFieldName) {
+    lines.push(`  priority_field: ${input.priorityFieldName}`);
+  }
 
   if (input.lifecycle.activeStates.length > 0) {
     lines.push("  active_states:");


### PR DESCRIPTION
## Issues

- Fixes #207

## Summary

- auto-detect a GitHub Project priority field during `workflow init`
- carry the detected field into generated workflow/reference artifacts and setup/setup-init summaries
- warn in non-interactive `setup` when priority-like fields are ambiguous and `tracker.priority_field` is skipped

## Changes

- added priority-field resolution in `packages/cli/src/commands/init.ts`, preferring an exact `Priority` field and prompting only when multiple priority-like fields are plausible
- threaded `priority_field` through `generate-workflow-md` and `generate-reference-workflow`, and surfaced it in dry-run/setup summaries
- aligned `packages/cli/src/commands/setup.ts` with the same non-interactive ambiguous-priority warning behavior used by `init.ts`
- added regression coverage for interactive/non-interactive init flows, workflow/reference generation, and the ambiguous non-interactive setup path

## Evidence

- `pnpm --filter @gh-symphony/cli test -- --run src/commands/setup.test.ts`
- `pnpm --filter @gh-symphony/cli typecheck`
- `pnpm lint`
- `pnpm test`
- `pnpm typecheck`
- `pnpm build`
- Manual check: verified `gh-symphony setup --non-interactive` now warns and omits `tracker.priority_field` when multiple priority-like single-select fields exist

## Human Validation

- [ ] Confirm `gh-symphony workflow init --non-interactive --dry-run` includes the detected priority field for a project with a `Priority` single-select field
- [ ] Confirm interactive `workflow init` prompts for a priority field only when multiple priority-like fields exist
- [ ] Confirm `gh-symphony setup --non-interactive` warns when multiple priority-like fields are present and leaves `tracker.priority_field` unset
- [ ] Confirm generated `WORKFLOW.md` and `.gh-symphony/reference-workflow.md` include the expected `tracker.priority_field`

## Risks

- Priority detection still relies on single-select field names; unusual or non-English naming conventions may still require explicit interactive choice or manual editing