### PR TITLE
chore(docker): run official image as non-root user

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,7 @@ jobs:
           EOF
 
           echo "[]" > "${TMPDIR}/config/issues.json"
+          sudo chown -R 1000:1000 "${TMPDIR}/config"
 
           docker run --rm gh-symphony:test gh-symphony --version
           docker run --rm \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,6 +145,7 @@ jobs:
           EOF
 
           echo "[]" > "${TMPDIR}/config/issues.json"
+          sudo chown -R 1000:1000 "${TMPDIR}/config"
 
           docker run --rm "${IMAGE_REF}" gh-symphony --version
           docker run --rm \

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,12 +19,22 @@ FROM ${NODE_IMAGE}
 
 ARG GH_SYMPHONY_INSTALL_SOURCE=registry
 ARG GH_SYMPHONY_VERSION=latest
+ARG GH_SYMPHONY_UID=1000
+ARG GH_SYMPHONY_GID=1000
 
 ENV NODE_ENV=production
 ENV GH_SYMPHONY_CONFIG_DIR=/var/lib/gh-symphony
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends ca-certificates git openssh-client tini && \
+    existing_group="$(getent group "${GH_SYMPHONY_GID}" | cut -d: -f1 || true)" && \
+    if [ -n "${existing_group}" ] && [ "${existing_group}" != "symphony" ]; then groupmod --new-name symphony "${existing_group}"; \
+    elif [ -z "${existing_group}" ]; then groupadd --gid "${GH_SYMPHONY_GID}" symphony; fi && \
+    existing_user="$(getent passwd "${GH_SYMPHONY_UID}" | cut -d: -f1 || true)" && \
+    if [ -n "${existing_user}" ] && [ "${existing_user}" != "symphony" ]; then usermod --login symphony --home /home/symphony --move-home --gid "${GH_SYMPHONY_GID}" --shell /bin/bash "${existing_user}"; \
+    elif [ -z "${existing_user}" ]; then useradd --uid "${GH_SYMPHONY_UID}" --gid "${GH_SYMPHONY_GID}" --create-home --shell /bin/bash symphony; fi && \
+    mkdir -p /var/lib/gh-symphony /workspace && \
+    chown -R symphony:symphony /var/lib/gh-symphony /workspace && \
     rm -rf /var/lib/apt/lists/*
 
 COPY --from=pack /tmp/gh-symphony-dist /tmp/gh-symphony-dist
@@ -42,6 +52,7 @@ RUN set -eux; \
 
 WORKDIR /workspace
 VOLUME ["/var/lib/gh-symphony"]
+USER symphony
 
 ENTRYPOINT ["/usr/bin/tini", "--"]
 CMD ["gh-symphony", "start"]

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ The official image is designed for headless orchestration and defaults to:
 - image: `ghcr.io/hojinzs/github-symphony:<tag>`
 - config/state volume: `/var/lib/gh-symphony`
 - default command: `gh-symphony start`
+- runtime user: `symphony` (`UID:GID 1000:1000`)
 
 Supported container environment variables:
 
@@ -67,6 +68,26 @@ Supported container environment variables:
 Supported volume mounts:
 
 - `/var/lib/gh-symphony`: persists `config.json`, `projects/<project-id>/project.json`, project `.env`, logs, and orchestrator workspaces across restarts
+
+Named Docker volumes work as-is. If you use a host bind mount such as `-v ./data:/var/lib/gh-symphony`, the host directory must be writable by `UID:GID 1000:1000` or the container will fail to persist state.
+
+Prepare a bind-mounted host directory:
+
+```bash
+mkdir -p ./data
+sudo chown -R 1000:1000 ./data
+```
+
+If you need to run the container with your host user instead, pass `--user "$(id -u):$(id -g)"` and make sure the mounted directory is writable by that same UID/GID:
+
+```bash
+docker run --rm -it \
+  --user "$(id -u):$(id -g)" \
+  -e GITHUB_GRAPHQL_TOKEN=ghp_your_classic_token \
+  -v "$(pwd)/data:/var/lib/gh-symphony" \
+  ghcr.io/hojinzs/github-symphony:latest \
+  gh-symphony start --once
+```
 
 Seed the managed-project config into the mounted volume once:
 
@@ -104,6 +125,21 @@ services:
 volumes:
   gh-symphony-data:
 ```
+
+If you prefer a host bind mount in `docker compose`, align the container user with the host directory owner:
+
+```yaml
+services:
+  gh-symphony:
+    image: ghcr.io/hojinzs/github-symphony:latest
+    user: "${UID:-1000}:${GID:-1000}"
+    environment:
+      GITHUB_GRAPHQL_TOKEN: ${GITHUB_GRAPHQL_TOKEN}
+    volumes:
+      - ./data:/var/lib/gh-symphony
+```
+
+Create `./data` ahead of time and ensure it is writable by the UID/GID that you pass through `user`.
 
 For a first-run smoke check against an existing mounted config directory:
 


### PR DESCRIPTION
## Issues

- Fixes #228

## Summary

- 공식 Docker 이미지가 root 대신 전용 `symphony` 사용자로 실행되도록 유지했습니다
- bind mount 기반 CI/release smoke job도 `UID:GID 1000:1000` 권한을 정렬해 non-root 전환 회귀를 제거했습니다

## Changes

- `Dockerfile`에서 런타임 UID/GID `1000:1000`을 `symphony` 사용자/그룹으로 보장하고 `USER symphony`로 전환했습니다
- 이미지 빌드 시 `/var/lib/gh-symphony`, `/workspace`를 생성하고 `symphony:symphony` 소유권을 부여했습니다
- `README.md`에 named volume 기본 동작, bind mount `chown`, `--user`, `docker compose` `user:` 예시를 추가했습니다
- `.github/workflows/ci.yml`, `.github/workflows/release.yml`에서 smoke bind mount 디렉터리를 `1000:1000`으로 맞춘 뒤 컨테이너를 실행하도록 보강했습니다

## Evidence

- `docker build --build-arg GH_SYMPHONY_INSTALL_SOURCE=local -t gh-symphony-issue228 .`
- `docker run --rm -v "$TMPDIR/config:/target" alpine:3.22 sh -lc 'chown -R 1000:1000 /target'`
- `docker run --rm gh-symphony-issue228 gh-symphony --version`
- `docker run --rm -v "$TMPDIR/config:/var/lib/gh-symphony" gh-symphony-issue228 gh-symphony start --once --project-id smoke`
- `pnpm lint`
- `pnpm test`
- `pnpm typecheck`
- `pnpm build`

## Human Validation

- [ ] Bind mount 사용 시 README 예시대로 `./data` 권한을 맞추면 실제 운영 환경에서도 쓰기가 되는지 확인
- [ ] 기존 named volume 배포에서 회귀 없이 `gh-symphony start`가 기동되는지 확인
- [ ] 리뷰어 관점에서 Docker/docker compose 가이드와 CI smoke 보강이 이슈 요구사항과 일치하는지 확인

## Risks

- 호스트 bind mount는 여전히 호스트 파일 시스템 소유권 정책에 의존하므로, 운영 환경마다 `UID:GID` 정렬 여부를 확인해야 합니다