### PR TITLE
feat(core): introduce AgentRuntimeAdapter interface

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,5 +13,6 @@ export * from "./workflow/loader.js";
 export * from "./workflow/render.js";
 export * from "./workflow/exit-classification.js";
 export * from "./orchestration/index.js";
+export * from "./runtime/index.js";
 export * from "./workspace/index.js";
 export * from "./observability/index.js";

--- a/packages/core/src/runtime/adapter.test.ts
+++ b/packages/core/src/runtime/adapter.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, expectTypeOf, it } from "vitest";
+import type {
+  AgentRuntimeAdapter,
+  AgentRuntimeCredentialBrokerResponse,
+  AgentRuntimeEvent,
+} from "./adapter.js";
+
+type SpawnLoopEventName =
+  | "agent.turnStarted"
+  | "agent.messageDelta"
+  | "agent.turnCompleted";
+
+type SpawnLoopEvent = AgentRuntimeEvent & {
+  name: SpawnLoopEventName;
+  payload: {
+    runtime: "codex" | "claude-print";
+    turnId: string;
+  };
+};
+
+type PrepareContext = {
+  sessionId: string;
+};
+
+type TurnInput = {
+  turnId: string;
+  prompt: string;
+};
+
+type TurnResult = {
+  exitCode: number;
+};
+
+type BrokerResponse = AgentRuntimeCredentialBrokerResponse & {
+  provider: "openai" | "anthropic";
+};
+
+type RuntimeAdapter = AgentRuntimeAdapter<
+  PrepareContext,
+  TurnInput,
+  TurnResult,
+  SpawnLoopEvent,
+  BrokerResponse
+>;
+
+async function executeSpawnLoop(
+  adapter: RuntimeAdapter,
+  context: PrepareContext,
+  input: TurnInput
+): Promise<{
+  events: SpawnLoopEventName[];
+  result: TurnResult;
+}> {
+  const events: SpawnLoopEventName[] = [];
+  await adapter.prepare(context);
+  const unsubscribe = adapter.onEvent((event) => {
+    events.push(event.name);
+  });
+  const result = await adapter.spawnTurn(input);
+  unsubscribe();
+  await adapter.shutdown();
+  return { events, result };
+}
+
+class CodexRuntimeAdapterStub implements RuntimeAdapter {
+  private readonly handlers = new Set<(event: SpawnLoopEvent) => void>();
+
+  async prepare(_context: PrepareContext): Promise<void> {}
+
+  async spawnTurn(input: TurnInput): Promise<TurnResult> {
+    this.emit("agent.turnStarted", input.turnId);
+    this.emit("agent.messageDelta", input.turnId);
+    this.emit("agent.turnCompleted", input.turnId);
+    return { exitCode: 0 };
+  }
+
+  onEvent(
+    handler: (event: SpawnLoopEvent) => void
+  ): () => void {
+    this.handlers.add(handler);
+    return () => {
+      this.handlers.delete(handler);
+    };
+  }
+
+  resolveCredentials(brokerResponse: BrokerResponse): Record<string, string> {
+    return brokerResponse.provider === "openai"
+      ? { OPENAI_API_KEY: brokerResponse.env.OPENAI_API_KEY ?? "" }
+      : {};
+  }
+
+  async shutdown(): Promise<void> {}
+
+  async cancel(_reason?: string): Promise<void> {}
+
+  private emit(name: SpawnLoopEventName, turnId: string): void {
+    for (const handler of this.handlers) {
+      handler({
+        name,
+        payload: {
+          runtime: "codex",
+          turnId,
+        },
+      });
+    }
+  }
+}
+
+class ClaudePrintRuntimeAdapterStub implements RuntimeAdapter {
+  private readonly handlers = new Set<(event: SpawnLoopEvent) => void>();
+
+  async prepare(_context: PrepareContext): Promise<void> {}
+
+  async spawnTurn(input: TurnInput): Promise<TurnResult> {
+    this.emit("agent.turnStarted", input.turnId);
+    this.emit("agent.messageDelta", input.turnId);
+    this.emit("agent.turnCompleted", input.turnId);
+    return { exitCode: 0 };
+  }
+
+  onEvent(
+    handler: (event: SpawnLoopEvent) => void
+  ): () => void {
+    this.handlers.add(handler);
+    return () => {
+      this.handlers.delete(handler);
+    };
+  }
+
+  resolveCredentials(brokerResponse: BrokerResponse): Record<string, string> {
+    return brokerResponse.provider === "anthropic"
+      ? { ANTHROPIC_API_KEY: brokerResponse.env.ANTHROPIC_API_KEY ?? "" }
+      : {};
+  }
+
+  async shutdown(): Promise<void> {}
+
+  async cancel(_reason?: string): Promise<void> {}
+
+  private emit(name: SpawnLoopEventName, turnId: string): void {
+    for (const handler of this.handlers) {
+      handler({
+        name,
+        payload: {
+          runtime: "claude-print",
+          turnId,
+        },
+      });
+    }
+  }
+}
+
+describe("AgentRuntimeAdapter", () => {
+  it("supports a shared spawn-loop contract for daemon and one-shot runtimes", async () => {
+    const codex = new CodexRuntimeAdapterStub();
+    const claude = new ClaudePrintRuntimeAdapterStub();
+
+    expectTypeOf(codex).toMatchTypeOf<RuntimeAdapter>();
+    expectTypeOf(claude).toMatchTypeOf<RuntimeAdapter>();
+
+    await expect(
+      executeSpawnLoop(codex, { sessionId: "session-1" }, {
+        turnId: "turn-1",
+        prompt: "implement the change",
+      })
+    ).resolves.toEqual({
+      events: [
+        "agent.turnStarted",
+        "agent.messageDelta",
+        "agent.turnCompleted",
+      ],
+      result: { exitCode: 0 },
+    });
+
+    await expect(
+      executeSpawnLoop(claude, { sessionId: "session-2" }, {
+        turnId: "turn-2",
+        prompt: "implement the change",
+      })
+    ).resolves.toEqual({
+      events: [
+        "agent.turnStarted",
+        "agent.messageDelta",
+        "agent.turnCompleted",
+      ],
+      result: { exitCode: 0 },
+    });
+  });
+
+  it("lets each runtime resolve provider-specific credentials from the broker payload", () => {
+    const codex = new CodexRuntimeAdapterStub();
+    const claude = new ClaudePrintRuntimeAdapterStub();
+
+    expect(
+      codex.resolveCredentials({
+        provider: "openai",
+        env: { OPENAI_API_KEY: "sk-openai" },
+        expires_at: "2026-04-21T00:00:00.000Z",
+      })
+    ).toEqual({ OPENAI_API_KEY: "sk-openai" });
+
+    expect(
+      claude.resolveCredentials({
+        provider: "anthropic",
+        env: { ANTHROPIC_API_KEY: "sk-anthropic" },
+        expires_at: "2026-04-21T00:00:00.000Z",
+      })
+    ).toEqual({ ANTHROPIC_API_KEY: "sk-anthropic" });
+  });
+});

--- a/packages/core/src/runtime/adapter.ts
+++ b/packages/core/src/runtime/adapter.ts
@@ -1,0 +1,73 @@
+export type AgentRuntimeEnv = Record<string, string>;
+
+export type AgentRuntimeCredentialBrokerResponse = {
+  env: AgentRuntimeEnv;
+  expires_at?: string;
+};
+
+export type AgentRuntimeEvent = {
+  name: string;
+  payload?: unknown;
+};
+
+export type AgentRuntimeEventHandler<
+  RuntimeEvent extends AgentRuntimeEvent = AgentRuntimeEvent,
+> = (event: RuntimeEvent) => void;
+
+export type AgentRuntimeEventSubscription = () => void;
+
+/**
+ * Spawn-loop contract for agent runtimes.
+ *
+ * A worker prepares the runtime once, subscribes to the neutral event stream,
+ * calls {@link spawnTurn} for each turn in the run, and finally calls
+ * {@link shutdown} or {@link cancel}. This lets a long-running daemon such as
+ * Codex app-server map one turn to an in-process RPC, while a one-shot runtime
+ * such as `claude -p` can map one turn to a brand-new process invocation.
+ */
+export interface AgentRuntimeAdapter<
+  PrepareContext = unknown,
+  TurnInput = unknown,
+  TurnResult = unknown,
+  RuntimeEvent extends AgentRuntimeEvent = AgentRuntimeEvent,
+  BrokerResponse extends AgentRuntimeCredentialBrokerResponse = AgentRuntimeCredentialBrokerResponse,
+  ResolvedCredentials extends AgentRuntimeEnv = AgentRuntimeEnv,
+> {
+  /**
+   * Perform pre-spawn setup for the run, such as MCP composition, credential
+   * resolution, or runtime session selection.
+   */
+  prepare(context: PrepareContext): Promise<void> | void;
+
+  /**
+   * Execute one logical Symphony turn.
+   *
+   * Implementations may translate this to a daemon turn on a long-lived
+   * process, or to a fresh process spawn for one-shot runtimes.
+   */
+  spawnTurn(input: TurnInput): Promise<TurnResult> | TurnResult;
+
+  /**
+   * Subscribe to runtime events that have already been normalized away from the
+   * runtime wire protocol.
+   */
+  onEvent(
+    handler: AgentRuntimeEventHandler<RuntimeEvent>
+  ): AgentRuntimeEventSubscription;
+
+  /**
+   * Extract runtime-specific environment variables from a credential broker
+   * response without coupling the worker to a specific provider.
+   */
+  resolveCredentials(brokerResponse: BrokerResponse): ResolvedCredentials;
+
+  /**
+   * Release runtime resources once the spawn loop is complete.
+   */
+  shutdown(): Promise<void> | void;
+
+  /**
+   * Abort in-flight work when the worker terminates the run early.
+   */
+  cancel(reason?: string): Promise<void> | void;
+}

--- a/packages/core/src/runtime/index.ts
+++ b/packages/core/src/runtime/index.ts
@@ -1,0 +1,1 @@
+export * from "./adapter.js";


### PR DESCRIPTION
## Issues

- Fixes #214

## Summary

- add a core-level `AgentRuntimeAdapter` interface for runtime-agnostic worker integration
- document the spawn-loop lifecycle so daemon and one-shot runtimes fit the same contract

## Changes

- add `packages/core/src/runtime/adapter.ts` with generic adapter, event, subscription, env, and broker response types
- add runtime barrel exports and re-export them from `packages/core/src/index.ts`
- add `packages/core/src/runtime/adapter.test.ts` covering shared spawn-loop usage for Codex-style and `claude -p`-style adapters plus provider-specific credential extraction

## Evidence

- `pnpm install`
- `pnpm --filter @gh-symphony/core lint`
- `pnpm --filter @gh-symphony/core test`
- `pnpm --filter @gh-symphony/core typecheck`
- `pnpm --filter @gh-symphony/core build`
- `pnpm lint`
- `pnpm test`
- `pnpm typecheck`
- `pnpm build`
- Manual check: verified the new JSDoc in `packages/core/src/runtime/adapter.ts` explicitly describes how Codex app-server and `claude -p` map onto the same spawn-loop contract without changing other packages

## Human Validation

- [ ] Confirm the runtime adapter contract matches the intended worker integration surface
- [ ] Confirm the documented spawn-loop wording is sufficient for follow-up runtime-codex and worker migration issues
- [ ] Confirm there is no reviewer-visible regression outside `packages/core`

## Risks

- The event payload schema remains intentionally loose until the follow-up worker event neutralization issue freezes the neutral event set
