### PR TITLE
feat(core): extend credential broker response with expires_at and runtime env split

### DIFF
--- a/packages/core/src/runtime/credentials.test.ts
+++ b/packages/core/src/runtime/credentials.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  AgentRuntimeCredentialError,
+  extractEnvForClaude,
+  extractEnvForCodex,
+  readAgentCredentialCache,
+  shouldReuseAgentCredentialCache,
+  TOKEN_REUSE_WINDOW_MS,
+  writeAgentCredentialCache,
+} from "./credentials.js";
+
+describe("extractEnvForCodex", () => {
+  it("keeps the existing OpenAI runtime keys only", () => {
+    expect(
+      extractEnvForCodex({
+        OPENAI_API_KEY: "sk-openai",
+        OPENAI_BASE_URL: "https://openai.example.test/v1",
+        OPENAI_PROJECT: "project-123",
+        ANTHROPIC_API_KEY: "sk-anthropic",
+      })
+    ).toEqual({
+      OPENAI_API_KEY: "sk-openai",
+      OPENAI_BASE_URL: "https://openai.example.test/v1",
+      OPENAI_PROJECT: "project-123",
+    });
+  });
+});
+
+describe("extractEnvForClaude", () => {
+  it("returns the Anthropic API key", () => {
+    expect(
+      extractEnvForClaude({
+        ANTHROPIC_API_KEY: "sk-anthropic",
+        OPENAI_API_KEY: "sk-openai",
+      })
+    ).toEqual({
+      ANTHROPIC_API_KEY: "sk-anthropic",
+    });
+  });
+
+  it("fails with a clear missing-key error", () => {
+    expect(() => extractEnvForClaude({})).toThrowError(
+      new AgentRuntimeCredentialError(
+        "ANTHROPIC_API_KEY is required in the credential broker response."
+      )
+    );
+  });
+});
+
+describe("agent credential cache reuse", () => {
+  it("reuses a cache entry when expires_at remains outside the reuse window", () => {
+    expect(
+      shouldReuseAgentCredentialCache(
+        {
+          env: { OPENAI_API_KEY: "sk-openai" },
+          expires_at: "2026-04-22T10:10:00.000Z",
+          cachedAt: "2026-04-22T10:00:00.000Z",
+        },
+        new Date("2026-04-22T10:00:00.000Z")
+      )
+    ).toBe(true);
+  });
+
+  it("does not reuse a cache entry when expires_at falls inside the reuse window", () => {
+    expect(
+      shouldReuseAgentCredentialCache(
+        {
+          env: { OPENAI_API_KEY: "sk-openai" },
+          expires_at: new Date(
+            Date.parse("2026-04-22T10:00:00.000Z") + TOKEN_REUSE_WINDOW_MS
+          ).toISOString(),
+          cachedAt: "2026-04-22T09:59:00.000Z",
+        },
+        new Date("2026-04-22T10:00:00.000Z")
+      )
+    ).toBe(false);
+  });
+
+  it("does not reuse an invalid or expired cache entry", () => {
+    expect(
+      shouldReuseAgentCredentialCache(
+        {
+          env: { OPENAI_API_KEY: "sk-openai" },
+          expires_at: "not-a-date",
+          cachedAt: "2026-04-22T10:00:00.000Z",
+        },
+        new Date("2026-04-22T10:00:00.000Z")
+      )
+    ).toBe(false);
+    expect(
+      shouldReuseAgentCredentialCache(
+        {
+          env: { OPENAI_API_KEY: "sk-openai" },
+          expires_at: "2026-04-22T09:59:00.000Z",
+          cachedAt: "2026-04-22T09:58:00.000Z",
+        },
+        new Date("2026-04-22T10:00:00.000Z")
+      )
+    ).toBe(false);
+  });
+
+  it("reuses a legacy cache entry that has no expires_at", () => {
+    expect(
+      shouldReuseAgentCredentialCache(
+        {
+          env: { OPENAI_API_KEY: "sk-openai" },
+          cachedAt: "2026-04-22T10:00:00.000Z",
+        },
+        new Date("2026-04-22T11:00:00.000Z")
+      )
+    ).toBe(true);
+  });
+});
+
+describe("agent credential cache io", () => {
+  it("reads legacy cache files without expires_at", async () => {
+    const entry = await readAgentCredentialCache(
+      "/tmp/agent-cache.json",
+      vi
+        .fn()
+        .mockResolvedValue(JSON.stringify({ env: { OPENAI_API_KEY: "sk-openai" } })) as never
+    );
+
+    expect(entry).toEqual({
+      env: { OPENAI_API_KEY: "sk-openai" },
+      expires_at: undefined,
+      cachedAt: new Date(0).toISOString(),
+    });
+  });
+
+  it("writes expires_at alongside cachedAt", async () => {
+    const writeFileImpl = vi.fn().mockResolvedValue(undefined);
+
+    await writeAgentCredentialCache(
+      "/tmp/agent-cache.json",
+      {
+        env: { OPENAI_API_KEY: "sk-openai" },
+        expires_at: "2026-04-22T10:10:00.000Z",
+      },
+      writeFileImpl as never,
+      new Date("2026-04-22T10:00:00.000Z")
+    );
+
+    expect(writeFileImpl).toHaveBeenCalledWith(
+      "/tmp/agent-cache.json",
+      JSON.stringify({
+        env: { OPENAI_API_KEY: "sk-openai" },
+        expires_at: "2026-04-22T10:10:00.000Z",
+        cachedAt: "2026-04-22T10:00:00.000Z",
+      }),
+      "utf8"
+    );
+  });
+});

--- a/packages/core/src/runtime/credentials.ts
+++ b/packages/core/src/runtime/credentials.ts
@@ -1,0 +1,152 @@
+import { readFile, writeFile } from "node:fs/promises";
+import type {
+  AgentRuntimeCredentialBrokerResponse,
+  AgentRuntimeEnv,
+} from "./adapter.js";
+
+export const TOKEN_REUSE_WINDOW_MS = 60 * 1000;
+
+const CODEX_ENV_KEYS = [
+  "OPENAI_API_KEY",
+  "OPENAI_BASE_URL",
+  "OPENAI_ORG_ID",
+  "OPENAI_PROJECT",
+] as const;
+
+export type AgentRuntimeCredentialCacheEntry =
+  AgentRuntimeCredentialBrokerResponse & {
+    cachedAt: string;
+  };
+
+export class AgentRuntimeCredentialError extends Error {}
+
+type AgentRuntimeEnvSource = Record<string, string | undefined>;
+
+export function extractEnvForCodex(
+  env: AgentRuntimeEnvSource
+): AgentRuntimeEnv {
+  return pickRuntimeEnv(env, CODEX_ENV_KEYS);
+}
+
+export function extractEnvForClaude(
+  env: AgentRuntimeEnvSource
+): AgentRuntimeEnv {
+  const apiKey = env.ANTHROPIC_API_KEY;
+
+  if (!apiKey) {
+    throw new AgentRuntimeCredentialError(
+      "ANTHROPIC_API_KEY is required in the credential broker response."
+    );
+  }
+
+  return {
+    ANTHROPIC_API_KEY: apiKey,
+  };
+}
+
+export function toAgentCredentialCacheEntry(
+  brokerResponse: AgentRuntimeCredentialBrokerResponse,
+  now: Date = new Date()
+): AgentRuntimeCredentialCacheEntry {
+  return {
+    env: brokerResponse.env,
+    expires_at: brokerResponse.expires_at,
+    cachedAt: now.toISOString(),
+  };
+}
+
+export function shouldReuseAgentCredentialCache(
+  entry: AgentRuntimeCredentialCacheEntry,
+  now: Date = new Date()
+): boolean {
+  if (Object.keys(entry.env).length === 0) {
+    return false;
+  }
+
+  if (!entry.expires_at) {
+    return true;
+  }
+
+  const expiresAt = Date.parse(entry.expires_at);
+  if (Number.isNaN(expiresAt)) {
+    return false;
+  }
+
+  return expiresAt - now.getTime() > TOKEN_REUSE_WINDOW_MS;
+}
+
+export async function readAgentCredentialCache(
+  path: string,
+  readFileImpl: typeof readFile = readFile
+): Promise<AgentRuntimeCredentialCacheEntry | null> {
+  try {
+    return normalizeAgentCredentialCacheEntry(
+      JSON.parse(await readFileImpl(path, "utf8")) as unknown
+    );
+  } catch {
+    return null;
+  }
+}
+
+export async function writeAgentCredentialCache(
+  path: string,
+  brokerResponse: AgentRuntimeCredentialBrokerResponse,
+  writeFileImpl: typeof writeFile = writeFile,
+  now: Date = new Date()
+): Promise<AgentRuntimeCredentialCacheEntry> {
+  const entry = toAgentCredentialCacheEntry(brokerResponse, now);
+  await writeFileImpl(path, JSON.stringify(entry), "utf8");
+  return entry;
+}
+
+function pickRuntimeEnv(
+  env: AgentRuntimeEnvSource,
+  keys: ReadonlyArray<string>
+): AgentRuntimeEnv {
+  const resolved: AgentRuntimeEnv = {};
+
+  for (const key of keys) {
+    const value = env[key];
+    if (value) {
+      resolved[key] = value;
+    }
+  }
+
+  return resolved;
+}
+
+function normalizeAgentCredentialCacheEntry(
+  payload: unknown
+): AgentRuntimeCredentialCacheEntry | null {
+  if (!isRecord(payload)) {
+    return null;
+  }
+
+  if (!isRecord(payload.env)) {
+    return null;
+  }
+
+  const env = Object.fromEntries(
+    Object.entries(payload.env).filter(
+      (entry): entry is [string, string] => typeof entry[1] === "string"
+    )
+  );
+
+  if (Object.keys(env).length === 0) {
+    return null;
+  }
+
+  return {
+    env,
+    expires_at:
+      typeof payload.expires_at === "string" ? payload.expires_at : undefined,
+    cachedAt:
+      typeof payload.cachedAt === "string"
+        ? payload.cachedAt
+        : new Date(0).toISOString(),
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object";
+}

--- a/packages/core/src/runtime/index.ts
+++ b/packages/core/src/runtime/index.ts
@@ -1,1 +1,2 @@
 export * from "./adapter.js";
+export * from "./credentials.js";

--- a/packages/runtime-claude/package.json
+++ b/packages/runtime-claude/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@gh-symphony/runtime-claude",
+  "version": "0.0.14",
+  "private": true,
+  "license": "MIT",
+  "author": "hojinzs",
+  "description": "Claude runtime credential adapter helpers for Symphony workers",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/hojinzs/github-symphony.git",
+    "directory": "packages/runtime-claude"
+  },
+  "homepage": "https://github.com/hojinzs/github-symphony#readme",
+  "bugs": {
+    "url": "https://github.com/hojinzs/github-symphony/issues"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "lint": "eslint src --ext .ts",
+    "test": "vitest run --passWithNoTests",
+    "typecheck": "tsc -p tsconfig.typecheck.json"
+  },
+  "dependencies": {
+    "@gh-symphony/core": "workspace:*"
+  }
+}

--- a/packages/runtime-claude/src/adapter.test.ts
+++ b/packages/runtime-claude/src/adapter.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { resolveClaudeCredentials } from "./adapter.js";
+
+describe("resolveClaudeCredentials", () => {
+  it("extracts only the Anthropic runtime credential", () => {
+    expect(
+      resolveClaudeCredentials({
+        env: {
+          ANTHROPIC_API_KEY: "sk-anthropic",
+          OPENAI_API_KEY: "sk-openai",
+        },
+        expires_at: "2026-04-22T10:10:00.000Z",
+      })
+    ).toEqual({
+      ANTHROPIC_API_KEY: "sk-anthropic",
+    });
+  });
+
+  it("fails with a clear ANTHROPIC_API_KEY error when missing", () => {
+    expect(() =>
+      resolveClaudeCredentials({
+        env: {},
+      })
+    ).toThrowError("ANTHROPIC_API_KEY");
+  });
+});

--- a/packages/runtime-claude/src/adapter.ts
+++ b/packages/runtime-claude/src/adapter.ts
@@ -1,0 +1,11 @@
+import {
+  extractEnvForClaude,
+  type AgentRuntimeCredentialBrokerResponse,
+  type AgentRuntimeEnv,
+} from "@gh-symphony/core";
+
+export function resolveClaudeCredentials(
+  brokerResponse: AgentRuntimeCredentialBrokerResponse
+): AgentRuntimeEnv {
+  return extractEnvForClaude(brokerResponse.env);
+}

--- a/packages/runtime-claude/src/index.ts
+++ b/packages/runtime-claude/src/index.ts
@@ -1,0 +1,6 @@
+export const RUNTIME_CLAUDE_BOUNDARY = {
+  package: "@gh-symphony/runtime-claude",
+  responsibilities: ["claude credential resolution"],
+} as const;
+
+export * from "./adapter.js";

--- a/packages/runtime-claude/tsconfig.json
+++ b/packages/runtime-claude/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "noEmit": false,
+    "declaration": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/runtime-claude/tsconfig.typecheck.json
+++ b/packages/runtime-claude/tsconfig.typecheck.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "..",
+    "baseUrl": ".",
+    "paths": {
+      "@gh-symphony/core": ["../core/src/index.ts"]
+    }
+  }
+}

--- a/packages/runtime-claude/vitest.config.ts
+++ b/packages/runtime-claude/vitest.config.ts
@@ -1,0 +1,16 @@
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+const packageRoot = dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@gh-symphony/core": resolve(packageRoot, "../core/src/index.ts"),
+    },
+  },
+  test: {
+    environment: "node",
+  },
+});

--- a/packages/runtime-codex/src/launcher.ts
+++ b/packages/runtime-codex/src/launcher.ts
@@ -1,6 +1,6 @@
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { readEnvFile } from "@gh-symphony/core";
+import { extractEnvForCodex, readEnvFile } from "@gh-symphony/core";
 import {
   launchCodexAppServer,
   prepareCodexRuntimePlan,
@@ -78,21 +78,7 @@ export function loadLauncherEnvironment(
 function readDirectAgentEnvironment(
   env: NodeJS.ProcessEnv
 ): Record<string, string> | undefined {
-  const agentEnv: Record<string, string> = {};
-
-  for (const key of [
-    "OPENAI_API_KEY",
-    "OPENAI_BASE_URL",
-    "OPENAI_ORG_ID",
-    "OPENAI_PROJECT",
-  ]) {
-    const value = env[key];
-
-    if (value) {
-      agentEnv[key] = value;
-    }
-  }
-
+  const agentEnv = extractEnvForCodex(env);
   return Object.keys(agentEnv).length ? agentEnv : undefined;
 }
 

--- a/packages/runtime-codex/src/runtime.test.ts
+++ b/packages/runtime-codex/src/runtime.test.ts
@@ -122,7 +122,9 @@ describe("resolveAgentRuntimeEnvironment", () => {
         JSON.stringify({
           env: {
             OPENAI_API_KEY: "sk-brokered-agent",
+            ANTHROPIC_API_KEY: "sk-anthropic",
           },
+          expires_at: "2026-04-22T10:10:00.000Z",
         }),
         { status: 200 }
       )
@@ -139,13 +141,135 @@ describe("resolveAgentRuntimeEnvironment", () => {
       {
         fetchImpl: fetchImpl as typeof fetch,
         writeFileImpl,
+        now: new Date("2026-04-22T10:00:00.000Z"),
       }
     );
 
     expect(env).toEqual({
       OPENAI_API_KEY: "sk-brokered-agent",
     });
-    expect(writeFileImpl).toHaveBeenCalledTimes(1);
+    expect(writeFileImpl).toHaveBeenCalledWith(
+      "/workspace-runtime/.agent-runtime-auth.json",
+      JSON.stringify({
+        env: {
+          OPENAI_API_KEY: "sk-brokered-agent",
+          ANTHROPIC_API_KEY: "sk-anthropic",
+        },
+        expires_at: "2026-04-22T10:10:00.000Z",
+        cachedAt: "2026-04-22T10:00:00.000Z",
+      }),
+      "utf8"
+    );
+  });
+
+  it("reuses a cached broker response when expires_at is still fresh", async () => {
+    const fetchImpl = vi.fn();
+
+    const env = await resolveAgentRuntimeEnvironment(
+      {
+        agentCredentialBrokerUrl:
+          "http://host.docker.internal:3000/api/workspaces/workspace-123/agent-credentials",
+        agentCredentialBrokerSecret: "runtime-secret",
+        agentCredentialCachePath: "/workspace-runtime/.agent-runtime-auth.json",
+      },
+      {
+        fetchImpl: fetchImpl as typeof fetch,
+        readFileImpl: vi
+          .fn()
+          .mockResolvedValue(
+            JSON.stringify({
+              env: {
+                OPENAI_API_KEY: "sk-cached-agent",
+                OPENAI_BASE_URL: "https://openai.example.test/v1",
+              },
+              expires_at: "2026-04-22T10:10:00.000Z",
+              cachedAt: "2026-04-22T10:00:00.000Z",
+            })
+          ) as never,
+        now: new Date("2026-04-22T10:00:00.000Z"),
+      }
+    );
+
+    expect(env).toEqual({
+      OPENAI_API_KEY: "sk-cached-agent",
+      OPENAI_BASE_URL: "https://openai.example.test/v1",
+    });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("refreshes when the cached broker response is inside the reuse window", async () => {
+    const writeFileImpl = vi.fn().mockResolvedValue(undefined);
+
+    const env = await resolveAgentRuntimeEnvironment(
+      {
+        agentCredentialBrokerUrl:
+          "http://host.docker.internal:3000/api/workspaces/workspace-123/agent-credentials",
+        agentCredentialBrokerSecret: "runtime-secret",
+        agentCredentialCachePath: "/workspace-runtime/.agent-runtime-auth.json",
+      },
+      {
+        fetchImpl: vi.fn().mockResolvedValue(
+          new Response(
+            JSON.stringify({
+              env: {
+                OPENAI_API_KEY: "sk-refreshed-agent",
+              },
+              expires_at: "2026-04-22T10:15:00.000Z",
+            }),
+            { status: 200 }
+          )
+        ) as never,
+        readFileImpl: vi
+          .fn()
+          .mockResolvedValue(
+            JSON.stringify({
+              env: {
+                OPENAI_API_KEY: "sk-stale-agent",
+              },
+              expires_at: "2026-04-22T10:00:30.000Z",
+              cachedAt: "2026-04-22T09:50:00.000Z",
+            })
+          ) as never,
+        writeFileImpl,
+        now: new Date("2026-04-22T10:00:00.000Z"),
+      }
+    );
+
+    expect(env).toEqual({
+      OPENAI_API_KEY: "sk-refreshed-agent",
+    });
+    expect(writeFileImpl).toHaveBeenCalledOnce();
+  });
+
+  it("reuses a legacy cache entry without expires_at", async () => {
+    const fetchImpl = vi.fn();
+
+    const env = await resolveAgentRuntimeEnvironment(
+      {
+        agentCredentialBrokerUrl:
+          "http://host.docker.internal:3000/api/workspaces/workspace-123/agent-credentials",
+        agentCredentialBrokerSecret: "runtime-secret",
+        agentCredentialCachePath: "/workspace-runtime/.agent-runtime-auth.json",
+      },
+      {
+        fetchImpl: fetchImpl as typeof fetch,
+        readFileImpl: vi
+          .fn()
+          .mockResolvedValue(
+            JSON.stringify({
+              env: {
+                OPENAI_API_KEY: "sk-legacy-agent",
+              },
+            })
+          ) as never,
+        now: new Date("2026-04-22T11:00:00.000Z"),
+      }
+    );
+
+    expect(env).toEqual({
+      OPENAI_API_KEY: "sk-legacy-agent",
+    });
+    expect(fetchImpl).not.toHaveBeenCalled();
   });
 
   it("fails cleanly when the broker cannot resolve the credential", async () => {
@@ -194,6 +318,7 @@ describe("prepareCodexRuntimePlan", () => {
               env: {
                 OPENAI_API_KEY: "sk-plan-agent",
               },
+              expires_at: "2026-04-22T10:10:00.000Z",
             }),
             { status: 200 }
           )

--- a/packages/runtime-codex/src/runtime.ts
+++ b/packages/runtime-codex/src/runtime.ts
@@ -1,9 +1,16 @@
 import { spawn } from "node:child_process";
 import type { ChildProcess, SpawnOptions } from "node:child_process";
-import { copyFile, mkdir, writeFile } from "node:fs/promises";
+import { copyFile, mkdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { homedir } from "node:os";
 import { fileURLToPath } from "node:url";
+import {
+  extractEnvForCodex,
+  readAgentCredentialCache,
+  shouldReuseAgentCredentialCache,
+  writeAgentCredentialCache,
+  type AgentRuntimeCredentialBrokerResponse,
+} from "@gh-symphony/core";
 import { resolveGitHubGraphQLMcpServerEntryPoint } from "@gh-symphony/tool-github-graphql";
 
 const DEFAULT_GITHUB_GRAPHQL_API_URL = "https://api.github.com/graphql";
@@ -266,15 +273,27 @@ export async function resolveAgentRuntimeEnvironment(
   >,
   dependencies: {
     fetchImpl?: typeof fetch;
+    readFileImpl?: typeof readFile;
     writeFileImpl?: typeof writeFile;
+    now?: Date;
   } = {}
 ): Promise<Record<string, string>> {
   if (config.agentEnv) {
-    return config.agentEnv;
+    return extractEnvForCodex(config.agentEnv);
   }
 
   if (!config.agentCredentialBrokerUrl || !config.agentCredentialBrokerSecret) {
     return {};
+  }
+
+  const now = dependencies.now ?? new Date();
+  const readFileImpl = dependencies.readFileImpl ?? readFile;
+  const cachedCredentials = config.agentCredentialCachePath
+    ? await readAgentCredentialCache(config.agentCredentialCachePath, readFileImpl)
+    : null;
+
+  if (cachedCredentials && shouldReuseAgentCredentialCache(cachedCredentials, now)) {
+    return extractEnvForCodex(cachedCredentials.env);
   }
 
   const fetchImpl = dependencies.fetchImpl ?? fetch;
@@ -285,8 +304,7 @@ export async function resolveAgentRuntimeEnvironment(
       authorization: `Bearer ${config.agentCredentialBrokerSecret}`,
     },
   });
-  const payload = (await response.json()) as {
-    env?: Record<string, string>;
+  const payload = (await response.json()) as AgentRuntimeCredentialBrokerResponse & {
     error?: string;
   };
 
@@ -299,12 +317,13 @@ export async function resolveAgentRuntimeEnvironment(
 
   if (config.agentCredentialCachePath) {
     const writeFileImpl = dependencies.writeFileImpl ?? writeFile;
-    await writeFileImpl(
+    await writeAgentCredentialCache(
       config.agentCredentialCachePath,
-      JSON.stringify(payload),
-      "utf8"
+      payload,
+      writeFileImpl,
+      now
     );
   }
 
-  return payload.env;
+  return extractEnvForCodex(payload.env);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -170,6 +170,12 @@ importers:
         specifier: workspace:*
         version: link:../tracker-github
 
+  packages/runtime-claude:
+    dependencies:
+      '@gh-symphony/core':
+        specifier: workspace:*
+        version: link:../core
+
   packages/runtime-codex:
     dependencies:
       '@gh-symphony/core':


### PR DESCRIPTION
## Issues

- Fixes #218

## Summary

- Extend brokered runtime credential handling to persist and reuse `expires_at`
- Split runtime env extraction so Codex keeps OpenAI keys and Claude requires `ANTHROPIC_API_KEY`

## Changes

- Added core runtime credential helpers for cache parsing/writing, reuse-window checks, and Codex/Claude env extraction
- Updated `@gh-symphony/runtime-codex` to reuse cached broker credentials until `expires_at - TOKEN_REUSE_WINDOW_MS`, then refresh and rewrite cache with `cachedAt`
- Added a minimal `@gh-symphony/runtime-claude` adapter scaffold that resolves only `ANTHROPIC_API_KEY` and fails clearly when it is missing
- Added unit coverage for cache hit / miss / expired / legacy fallback scenarios and runtime-specific env extraction

## Evidence

- `pnpm install`
- `pnpm lint`
- `pnpm test`
- `pnpm typecheck`
- `pnpm build`
- Manual TC: `resolveAgentRuntimeEnvironment` unit tests verify fresh-cache reuse, expired refresh, legacy cache fallback, and broker payload cache writes with `expires_at`
- Manual TC: `resolveClaudeCredentials` unit tests verify Anthropic-only extraction and missing `ANTHROPIC_API_KEY` error text
- Docker E2E not run: current stub-worker blackbox harness does not exercise `runtime-codex` broker credential resolution paths, so unit coverage is the highest-signal validation for this diff

## Human Validation

- [ ] Confirm brokered Codex runs keep using cached OpenAI credentials until the reuse window is reached
- [ ] Confirm Claude credential preflight surfaces `ANTHROPIC_API_KEY` clearly when the broker payload omits it
- [ ] Confirm legacy cache files without `expires_at` still allow existing deployments to launch without broker regressions

## Risks

- `@gh-symphony/runtime-claude` is a minimal credential-resolution scaffold only; full Claude process integration remains separate work
