### PR TITLE
refactor(runtime-codex): port to AgentRuntimeAdapter interface

### DIFF
--- a/packages/runtime-codex/src/convergence-detection.test.ts
+++ b/packages/runtime-codex/src/convergence-detection.test.ts
@@ -1,0 +1,117 @@
+import { execSync } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  captureTurnWorkspaceSnapshot,
+  evaluateTurnProgress,
+  resolveMaxNonProductiveTurns,
+} from "./convergence-detection.js";
+
+describe("convergence detection helpers", () => {
+  const tempRoots: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      tempRoots.map(async (path) => rm(path, { recursive: true, force: true }))
+    );
+    tempRoots.length = 0;
+  });
+
+  it("defaults max non-productive turns to 3", () => {
+    expect(resolveMaxNonProductiveTurns({})).toBe(3);
+    expect(
+      resolveMaxNonProductiveTurns({
+        SYMPHONY_MAX_NONPRODUCTIVE_TURNS: "0",
+      })
+    ).toBe(3);
+  });
+
+  it("parses configured max non-productive turns", () => {
+    expect(
+      resolveMaxNonProductiveTurns({
+        SYMPHONY_MAX_NONPRODUCTIVE_TURNS: "5",
+      })
+    ).toBe(5);
+  });
+
+  it("captures the git workspace fingerprint from file changes", async () => {
+    const repoRoot = await mkdtemp(join(tmpdir(), "runtime-codex-convergence-"));
+    tempRoots.push(repoRoot);
+
+    execSync("git init", {
+      cwd: repoRoot,
+      stdio: "ignore",
+    });
+    await writeFile(join(repoRoot, "notes.txt"), "hello\n", "utf8");
+
+    const snapshot = captureTurnWorkspaceSnapshot(repoRoot);
+
+    expect(snapshot.fingerprint).toContain("notes.txt");
+    expect(snapshot.changedFiles).toEqual(["?? notes.txt"]);
+  });
+
+  it("marks unchanged workspace snapshots as non-productive", () => {
+    expect(
+      evaluateTurnProgress(
+        {
+          fingerprint: "M src/index.ts",
+          changedFiles: ["M src/index.ts"],
+          lastError: null,
+        },
+        {
+          fingerprint: "M src/index.ts",
+          changedFiles: ["M src/index.ts"],
+          lastError: null,
+        }
+      )
+    ).toEqual({
+      nonProductive: true,
+      repeatedPattern: true,
+      reason: "workspace diff unchanged (1 tracked change)",
+    });
+  });
+
+  it("marks repeated errors as non-productive even without git state", () => {
+    expect(
+      evaluateTurnProgress(
+        {
+          fingerprint: null,
+          changedFiles: [],
+          lastError: "turn_failed: tool execution failed",
+        },
+        {
+          fingerprint: null,
+          changedFiles: [],
+          lastError: "turn_failed: tool execution failed",
+        }
+      )
+    ).toEqual({
+      nonProductive: true,
+      repeatedPattern: true,
+      reason: "repeated error: turn_failed: tool execution failed",
+    });
+  });
+
+  it("treats changed workspace fingerprints as productive", () => {
+    expect(
+      evaluateTurnProgress(
+        {
+          fingerprint: "",
+          changedFiles: [],
+          lastError: null,
+        },
+        {
+          fingerprint: "M src/index.ts",
+          changedFiles: ["M src/index.ts"],
+          lastError: null,
+        }
+      )
+    ).toEqual({
+      nonProductive: false,
+      repeatedPattern: false,
+      reason: null,
+    });
+  });
+});

--- a/packages/runtime-codex/src/convergence-detection.ts
+++ b/packages/runtime-codex/src/convergence-detection.ts
@@ -1,0 +1,110 @@
+import { spawnSync } from "node:child_process";
+
+const DEFAULT_MAX_NONPRODUCTIVE_TURNS = 3;
+
+export type TurnWorkspaceSnapshot = {
+  fingerprint: string | null;
+  changedFiles: string[];
+};
+
+export type TurnProgressSnapshot = TurnWorkspaceSnapshot & {
+  lastError: string | null;
+};
+
+export type TurnProgressEvaluation = {
+  nonProductive: boolean;
+  repeatedPattern: boolean;
+  reason: string | null;
+};
+
+export function resolveMaxNonProductiveTurns(
+  env: NodeJS.ProcessEnv
+): number {
+  const rawValue = env.SYMPHONY_MAX_NONPRODUCTIVE_TURNS;
+  const parsed = Number(rawValue);
+  return Number.isInteger(parsed) && parsed > 0
+    ? parsed
+    : DEFAULT_MAX_NONPRODUCTIVE_TURNS;
+}
+
+export function captureTurnWorkspaceSnapshot(
+  cwd: string
+): TurnWorkspaceSnapshot {
+  const result = spawnSync(
+    "git",
+    ["status", "--porcelain=v1", "--untracked-files=all"],
+    {
+      cwd,
+      encoding: "utf8",
+    }
+  );
+
+  if (result.status !== 0) {
+    return {
+      fingerprint: null,
+      changedFiles: [],
+    };
+  }
+
+  const changedFiles = result.stdout
+    .split(/\r?\n/)
+    .map((line) => line.trimEnd())
+    .filter(Boolean)
+    .sort();
+
+  return {
+    fingerprint: changedFiles.join("\n"),
+    changedFiles,
+  };
+}
+
+export function evaluateTurnProgress(
+  previous: TurnProgressSnapshot,
+  current: TurnProgressSnapshot
+): TurnProgressEvaluation {
+  const normalizedPreviousError = normalizeError(previous.lastError);
+  const normalizedCurrentError = normalizeError(current.lastError);
+  const repeatedError =
+    normalizedPreviousError !== null &&
+    normalizedCurrentError !== null &&
+    normalizedPreviousError === normalizedCurrentError;
+
+  if (repeatedError) {
+    return {
+      nonProductive: true,
+      repeatedPattern: true,
+      reason: `repeated error: ${normalizedCurrentError}`,
+    };
+  }
+
+  const unchangedWorkspace =
+    previous.fingerprint !== null &&
+    current.fingerprint !== null &&
+    previous.fingerprint === current.fingerprint;
+
+  if (unchangedWorkspace) {
+    return {
+      nonProductive: true,
+      repeatedPattern: true,
+      reason:
+        current.changedFiles.length > 0
+          ? `workspace diff unchanged (${current.changedFiles.length} tracked change${current.changedFiles.length === 1 ? "" : "s"})`
+          : "workspace unchanged",
+    };
+  }
+
+  return {
+    nonProductive: false,
+    repeatedPattern: false,
+    reason: null,
+  };
+}
+
+function normalizeError(value: string | null): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const normalized = value.trim();
+  return normalized.length > 0 ? normalized : null;
+}

--- a/packages/runtime-codex/src/index.ts
+++ b/packages/runtime-codex/src/index.ts
@@ -11,3 +11,6 @@ export * from "./runtime.js";
 export * from "./launcher.js";
 export * from "./git-credential-helper.js";
 export * from "./session.js";
+export * from "./thread-resume.js";
+export * from "./turn-limits.js";
+export * from "./convergence-detection.js";

--- a/packages/runtime-codex/src/runtime.test.ts
+++ b/packages/runtime-codex/src/runtime.test.ts
@@ -2,11 +2,14 @@ import { describe, expect, it, vi } from "vitest";
 import {
   AgentRuntimeResolutionError,
   buildCodexRuntimePlan,
+  createCodexRuntimeAdapter,
   createGitCredentialHelperEnvironment,
   createGitHubGraphQLToolDefinition,
   prepareCodexRuntimePlan,
+  resolvePreparedAgentEnvironment,
   resolveAgentRuntimeEnvironment,
   launchCodexAppServer,
+  resolveStagedCodexHome,
 } from "./runtime.js";
 
 describe("createGitHubGraphQLToolDefinition", () => {
@@ -64,6 +67,23 @@ describe("buildCodexRuntimePlan", () => {
     expect(plan.env.GIT_CONFIG_VALUE_0).toContain("git-credential-helper.js");
     expect(plan.env.WORKER_PROFILE).toBe("test");
     expect(plan.env.OPENAI_API_KEY).toBe("sk-ready-runtime");
+    expect(plan.env.CODEX_HOME).toBe("/tmp/workspace-123/.codex-agent");
+  });
+});
+
+describe("resolvePreparedAgentEnvironment", () => {
+  it("filters direct agent env keys and stages CODEX_HOME", () => {
+    expect(
+      resolvePreparedAgentEnvironment("/tmp/workspace-123", {
+        OPENAI_API_KEY: "sk-openai",
+        OPENAI_BASE_URL: "https://example.test/v1",
+        UNRELATED: "ignored",
+      })
+    ).toEqual({
+      OPENAI_API_KEY: "sk-openai",
+      OPENAI_BASE_URL: "https://example.test/v1",
+      CODEX_HOME: "/tmp/workspace-123/.codex-agent",
+    });
   });
 });
 
@@ -131,6 +151,7 @@ describe("resolveAgentRuntimeEnvironment", () => {
 
     const env = await resolveAgentRuntimeEnvironment(
       {
+        workingDirectory: "/tmp/workspace-123",
         agentCredentialBrokerUrl:
           "http://host.docker.internal:3000/api/workspaces/workspace-123/agent-credentials",
         agentCredentialBrokerSecret: "runtime-secret",
@@ -144,6 +165,7 @@ describe("resolveAgentRuntimeEnvironment", () => {
 
     expect(env).toEqual({
       OPENAI_API_KEY: "sk-brokered-agent",
+      CODEX_HOME: "/tmp/workspace-123/.codex-agent",
     });
     expect(writeFileImpl).toHaveBeenCalledTimes(1);
   });
@@ -162,6 +184,7 @@ describe("resolveAgentRuntimeEnvironment", () => {
     await expect(
       resolveAgentRuntimeEnvironment(
         {
+          workingDirectory: "/tmp/workspace-123",
           agentCredentialBrokerUrl:
             "http://host.docker.internal:3000/api/workspaces/workspace-123/agent-credentials",
           agentCredentialBrokerSecret: "runtime-secret",
@@ -202,5 +225,42 @@ describe("prepareCodexRuntimePlan", () => {
     );
 
     expect(plan.env.OPENAI_API_KEY).toBe("sk-plan-agent");
+    expect(plan.env.CODEX_HOME).toBe("/tmp/workspace-123/.codex-agent");
+  });
+});
+
+describe("createCodexRuntimeAdapter", () => {
+  it("implements the adapter prepare -> spawnTurn -> shutdown flow", async () => {
+    const spawnImpl = vi.fn().mockReturnValue({
+      pid: 42,
+      exitCode: null,
+      signalCode: null,
+      kill: vi.fn(),
+    });
+    const adapter = createCodexRuntimeAdapter(
+      {
+        projectId: "workspace-123",
+        workingDirectory: "/tmp/workspace-123",
+        agentEnv: {
+          OPENAI_API_KEY: "sk-direct-runtime",
+        },
+      },
+      {
+        mkdirImpl: vi.fn().mockResolvedValue(undefined),
+        writeFileImpl: vi.fn().mockResolvedValue(undefined),
+        copyFileImpl: vi.fn().mockResolvedValue(undefined),
+        spawnImpl,
+      }
+    );
+
+    await adapter.prepare();
+    const result = await adapter.spawnTurn();
+
+    expect(result.plan.env.OPENAI_API_KEY).toBe("sk-direct-runtime");
+    expect(result.plan.env.CODEX_HOME).toBe(resolveStagedCodexHome("/tmp/workspace-123"));
+    expect(spawnImpl).toHaveBeenCalledOnce();
+
+    await adapter.shutdown();
+    expect(result.child.kill).toHaveBeenCalledWith("SIGTERM");
   });
 });

--- a/packages/runtime-codex/src/runtime.test.ts
+++ b/packages/runtime-codex/src/runtime.test.ts
@@ -170,6 +170,31 @@ describe("resolveAgentRuntimeEnvironment", () => {
     expect(writeFileImpl).toHaveBeenCalledTimes(1);
   });
 
+  it("fails when the broker returns an empty credential env", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          env: {},
+        }),
+        { status: 200 }
+      )
+    );
+
+    await expect(
+      resolveAgentRuntimeEnvironment(
+        {
+          workingDirectory: "/tmp/workspace-123",
+          agentCredentialBrokerUrl:
+            "http://host.docker.internal:3000/api/workspaces/workspace-123/agent-credentials",
+          agentCredentialBrokerSecret: "runtime-secret",
+        },
+        {
+          fetchImpl: fetchImpl as typeof fetch,
+        }
+      )
+    ).rejects.toThrow(AgentRuntimeResolutionError);
+  });
+
   it("fails cleanly when the broker cannot resolve the credential", async () => {
     const fetchImpl = vi.fn().mockResolvedValue(
       new Response(
@@ -262,5 +287,38 @@ describe("createCodexRuntimeAdapter", () => {
 
     await adapter.shutdown();
     expect(result.child.kill).toHaveBeenCalledWith("SIGTERM");
+  });
+
+  it("terminates the running child when cancel() is invoked", async () => {
+    const kill = vi.fn();
+    const spawnImpl = vi.fn().mockReturnValue({
+      pid: 99,
+      exitCode: null,
+      signalCode: null,
+      kill,
+    });
+    const adapter = createCodexRuntimeAdapter(
+      {
+        projectId: "workspace-cancel",
+        workingDirectory: "/tmp/workspace-cancel",
+        agentEnv: {
+          OPENAI_API_KEY: "sk-cancel",
+        },
+      },
+      {
+        mkdirImpl: vi.fn().mockResolvedValue(undefined),
+        writeFileImpl: vi.fn().mockResolvedValue(undefined),
+        copyFileImpl: vi.fn().mockResolvedValue(undefined),
+        spawnImpl,
+      }
+    );
+
+    await adapter.prepare();
+    await adapter.spawnTurn();
+    await adapter.cancel("operator-requested");
+    await adapter.cancel("already-stopped");
+
+    expect(kill).toHaveBeenCalledOnce();
+    expect(kill).toHaveBeenCalledWith("SIGTERM");
   });
 });

--- a/packages/runtime-codex/src/runtime.ts
+++ b/packages/runtime-codex/src/runtime.ts
@@ -4,11 +4,23 @@ import { copyFile, mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { homedir } from "node:os";
 import { fileURLToPath } from "node:url";
+import type {
+  AgentRuntimeAdapter,
+  AgentRuntimeCredentialBrokerResponse,
+  AgentRuntimeEvent,
+} from "@gh-symphony/core";
 import { resolveGitHubGraphQLMcpServerEntryPoint } from "@gh-symphony/tool-github-graphql";
 
 const DEFAULT_GITHUB_GRAPHQL_API_URL = "https://api.github.com/graphql";
 const DEFAULT_GITHUB_GIT_HOST = "github.com";
 const DEFAULT_GITHUB_GIT_USERNAME = "x-access-token";
+const STAGED_CODEX_HOME_DIRNAME = ".codex-agent";
+const DIRECT_AGENT_ENV_KEYS = [
+  "OPENAI_API_KEY",
+  "OPENAI_BASE_URL",
+  "OPENAI_ORG_ID",
+  "OPENAI_PROJECT",
+] as const;
 
 export type RuntimeToolDefinition = {
   name: "github_graphql";
@@ -51,6 +63,28 @@ export type CodexRuntimePlan = {
 };
 
 export class AgentRuntimeResolutionError extends Error {}
+
+export type CodexRuntimePrepareContext = void;
+
+export type CodexRuntimeTurnInput = void;
+
+export type CodexRuntimeTurnResult = {
+  plan: CodexRuntimePlan;
+  child: ChildProcess;
+};
+
+export type CodexRuntimeCredentialBrokerResponse =
+  AgentRuntimeCredentialBrokerResponse;
+
+export type CodexRuntimeEvent = AgentRuntimeEvent;
+
+export type CodexRuntimeDependencies = {
+  fetchImpl?: typeof fetch;
+  writeFileImpl?: typeof writeFile;
+  mkdirImpl?: typeof mkdir;
+  copyFileImpl?: typeof copyFile;
+  spawnImpl?: SpawnLike;
+};
 
 type SpawnLike = (
   command: string,
@@ -126,6 +160,27 @@ export function createGitHubGraphQLToolDefinition(
   };
 }
 
+export function resolveStagedCodexHome(workingDirectory: string): string {
+  return join(workingDirectory, STAGED_CODEX_HOME_DIRNAME);
+}
+
+export function resolvePreparedAgentEnvironment(
+  workingDirectory: string,
+  env?: Record<string, string | undefined>
+): Record<string, string> {
+  const preparedEnv = Object.fromEntries(
+    DIRECT_AGENT_ENV_KEYS.flatMap((key) => {
+      const value = env?.[key];
+      return typeof value === "string" && value.length > 0 ? [[key, value]] : [];
+    })
+  );
+
+  return {
+    ...preparedEnv,
+    CODEX_HOME: resolveStagedCodexHome(workingDirectory),
+  };
+}
+
 export function buildCodexRuntimePlan(
   config: CodexRuntimeConfig
 ): CodexRuntimePlan {
@@ -136,6 +191,10 @@ export function buildCodexRuntimePlan(
     const cmd = config.agentCommand ?? "codex app-server";
     return cmd.startsWith("bash -lc ") ? cmd.slice("bash -lc ".length) : cmd;
   })();
+  const agentEnv = resolvePreparedAgentEnvironment(
+    config.workingDirectory,
+    config.agentEnv
+  );
 
   return {
     cwd: config.workingDirectory,
@@ -152,7 +211,7 @@ export function buildCodexRuntimePlan(
       // Point codex to an isolated config dir so personal MCPs (playwright,
       // chrome-devtools, context7, etc.) from the operator's ~/.codex/config.toml
       // are not loaded and do not confuse the implementation agent.
-      CODEX_HOME: join(config.workingDirectory, ".codex-agent"),
+      ...agentEnv,
       ...gitCredentialHelper,
       ...tool.env,
     },
@@ -171,48 +230,121 @@ export function launchCodexAppServer(
   });
 }
 
-export async function prepareCodexRuntimePlan(
-  config: CodexRuntimeConfig,
-  dependencies: {
-    fetchImpl?: typeof fetch;
-    writeFileImpl?: typeof writeFile;
-    mkdirImpl?: typeof mkdir;
-    copyFileImpl?: typeof copyFile;
-  } = {}
-): Promise<CodexRuntimePlan> {
-  const agentEnv = await resolveAgentRuntimeEnvironment(config, dependencies);
+export class CodexRuntimeAdapter
+  implements
+    AgentRuntimeAdapter<
+      CodexRuntimePrepareContext,
+      CodexRuntimeTurnInput,
+      CodexRuntimeTurnResult,
+      CodexRuntimeEvent,
+      CodexRuntimeCredentialBrokerResponse
+    >
+{
+  private readonly handlers = new Set<(event: CodexRuntimeEvent) => void>();
 
-  // Create an isolated CODEX_HOME directory with a minimal config.toml so the agent
-  // does not inherit personal MCP servers from the operator's ~/.codex/config.toml.
-  // We still copy auth.json so codex can authenticate without requiring OPENAI_API_KEY.
-  const codexHomeDir = join(config.workingDirectory, ".codex-agent");
-  const mkdirImpl = dependencies.mkdirImpl ?? mkdir;
-  await mkdirImpl(codexHomeDir, { recursive: true });
-  const writeFileImpl = dependencies.writeFileImpl ?? writeFile;
-  // Write a minimal config.toml with no mcp_servers block so codex only uses
-  // the dynamic tool definitions passed via thread/start config.
-  await writeFileImpl(
-    join(codexHomeDir, "config.toml"),
-    "# Isolated agent config \u2014 no personal MCP servers\n",
-    "utf8"
-  );
-  // Copy auth.json from the real CODEX_HOME so codex can use ChatGPT OAuth tokens.
-  // This is safe: auth is per-user and needed for the agent to call OpenAI APIs.
-  const realCodexHome = process.env.CODEX_HOME ?? join(homedir(), ".codex");
-  const copyFileImpl = dependencies.copyFileImpl ?? copyFile;
-  try {
-    await copyFileImpl(
-      join(realCodexHome, "auth.json"),
-      join(codexHomeDir, "auth.json")
+  private plan: CodexRuntimePlan | null = null;
+
+  private child: ChildProcess | null = null;
+
+  constructor(
+    private readonly config: CodexRuntimeConfig,
+    private readonly dependencies: CodexRuntimeDependencies = {}
+  ) {}
+
+  async prepare(_context?: CodexRuntimePrepareContext): Promise<void> {
+    if (this.plan) {
+      return;
+    }
+
+    const agentEnv = await resolveAgentRuntimeEnvironment(
+      this.config,
+      this.dependencies,
+      this
     );
-  } catch {
-    // auth.json may not exist (e.g. when OPENAI_API_KEY is used instead)
+    await stageCodexHome(this.config, this.dependencies);
+    this.plan = buildCodexRuntimePlan({
+      ...this.config,
+      agentEnv,
+    });
   }
 
-  return buildCodexRuntimePlan({
-    ...config,
-    agentEnv,
-  });
+  async spawnTurn(_input?: CodexRuntimeTurnInput): Promise<CodexRuntimeTurnResult> {
+    if (!this.plan) {
+      await this.prepare();
+    }
+
+    if (!this.plan) {
+      throw new AgentRuntimeResolutionError(
+        "Codex runtime plan was not prepared before spawnTurn."
+      );
+    }
+
+    if (!hasRunningChild(this.child)) {
+      this.child = launchCodexAppServer(
+        this.plan,
+        this.dependencies.spawnImpl ?? spawn
+      );
+    }
+
+    return {
+      plan: this.plan,
+      child: this.child,
+    };
+  }
+
+  onEvent(handler: (event: CodexRuntimeEvent) => void): () => void {
+    this.handlers.add(handler);
+    return () => {
+      this.handlers.delete(handler);
+    };
+  }
+
+  resolveCredentials(
+    brokerResponse: CodexRuntimeCredentialBrokerResponse
+  ): Record<string, string> {
+    return resolvePreparedAgentEnvironment(
+      this.config.workingDirectory,
+      brokerResponse.env
+    );
+  }
+
+  async shutdown(): Promise<void> {
+    terminateChildProcess(this.child);
+    this.child = null;
+  }
+
+  async cancel(_reason?: string): Promise<void> {
+    terminateChildProcess(this.child);
+    this.child = null;
+  }
+
+  getPreparedPlan(): CodexRuntimePlan | null {
+    return this.plan;
+  }
+}
+
+export function createCodexRuntimeAdapter(
+  config: CodexRuntimeConfig,
+  dependencies: CodexRuntimeDependencies = {}
+): CodexRuntimeAdapter {
+  return new CodexRuntimeAdapter(config, dependencies);
+}
+
+export async function prepareCodexRuntimePlan(
+  config: CodexRuntimeConfig,
+  dependencies: CodexRuntimeDependencies = {}
+): Promise<CodexRuntimePlan> {
+  const adapter = createCodexRuntimeAdapter(config, dependencies);
+  await adapter.prepare();
+  const plan = adapter.getPreparedPlan();
+
+  if (!plan) {
+    throw new AgentRuntimeResolutionError(
+      "Codex runtime plan was not prepared."
+    );
+  }
+
+  return plan;
 }
 
 export function createGitCredentialHelperEnvironment(
@@ -259,22 +391,27 @@ export function createGitCredentialHelperEnvironment(
 export async function resolveAgentRuntimeEnvironment(
   config: Pick<
     CodexRuntimeConfig,
+    | "workingDirectory"
     | "agentEnv"
     | "agentCredentialBrokerUrl"
     | "agentCredentialBrokerSecret"
     | "agentCredentialCachePath"
   >,
-  dependencies: {
-    fetchImpl?: typeof fetch;
-    writeFileImpl?: typeof writeFile;
-  } = {}
+  dependencies: Pick<
+    CodexRuntimeDependencies,
+    "fetchImpl" | "writeFileImpl"
+  > = {},
+  adapter?: Pick<CodexRuntimeAdapter, "resolveCredentials">
 ): Promise<Record<string, string>> {
   if (config.agentEnv) {
-    return config.agentEnv;
+    return resolvePreparedAgentEnvironment(
+      config.workingDirectory,
+      config.agentEnv
+    );
   }
 
   if (!config.agentCredentialBrokerUrl || !config.agentCredentialBrokerSecret) {
-    return {};
+    return resolvePreparedAgentEnvironment(config.workingDirectory);
   }
 
   const fetchImpl = dependencies.fetchImpl ?? fetch;
@@ -288,9 +425,23 @@ export async function resolveAgentRuntimeEnvironment(
   const payload = (await response.json()) as {
     env?: Record<string, string>;
     error?: string;
+    expires_at?: string;
   };
+  const resolvedEnv =
+    payload.env && response.ok
+      ? (
+          adapter ??
+          createCodexRuntimeAdapter({
+            projectId: "runtime-codex",
+            workingDirectory: config.workingDirectory,
+          })
+        ).resolveCredentials({
+          env: payload.env,
+          expires_at: payload.expires_at,
+        })
+      : null;
 
-  if (!response.ok || !payload.env || Object.keys(payload.env).length === 0) {
+  if (!response.ok || !resolvedEnv || Object.keys(resolvedEnv).length === 0) {
     throw new AgentRuntimeResolutionError(
       payload.error ??
         `Agent credential broker request failed with status ${response.status}.`
@@ -306,5 +457,50 @@ export async function resolveAgentRuntimeEnvironment(
     );
   }
 
-  return payload.env;
+  return resolvedEnv;
+}
+
+async function stageCodexHome(
+  config: Pick<CodexRuntimeConfig, "workingDirectory">,
+  dependencies: Pick<
+    CodexRuntimeDependencies,
+    "mkdirImpl" | "writeFileImpl" | "copyFileImpl"
+  > = {}
+): Promise<void> {
+  const codexHomeDir = resolveStagedCodexHome(config.workingDirectory);
+  const mkdirImpl = dependencies.mkdirImpl ?? mkdir;
+  await mkdirImpl(codexHomeDir, { recursive: true });
+  const writeFileImpl = dependencies.writeFileImpl ?? writeFile;
+  await writeFileImpl(
+    join(codexHomeDir, "config.toml"),
+    "# Isolated agent config \u2014 no personal MCP servers\n",
+    "utf8"
+  );
+
+  const realCodexHome = process.env.CODEX_HOME ?? join(homedir(), ".codex");
+  const copyFileImpl = dependencies.copyFileImpl ?? copyFile;
+  try {
+    await copyFileImpl(
+      join(realCodexHome, "auth.json"),
+      join(codexHomeDir, "auth.json")
+    );
+  } catch {
+    // auth.json may not exist (e.g. when OPENAI_API_KEY is used instead)
+  }
+}
+
+function hasRunningChild(child: ChildProcess | null): child is ChildProcess {
+  return child !== null && child.exitCode === null && child.signalCode === null;
+}
+
+function terminateChildProcess(child: ChildProcess | null): void {
+  if (!hasRunningChild(child) || !child.pid) {
+    return;
+  }
+
+  try {
+    child.kill("SIGTERM");
+  } catch {
+    // Ignore shutdown races.
+  }
 }

--- a/packages/runtime-codex/src/runtime.ts
+++ b/packages/runtime-codex/src/runtime.ts
@@ -168,6 +168,9 @@ export function resolvePreparedAgentEnvironment(
   workingDirectory: string,
   env?: Record<string, string | undefined>
 ): Record<string, string> {
+  // Point codex to an isolated config dir so personal MCPs (playwright,
+  // chrome-devtools, context7, etc.) from the operator's ~/.codex/config.toml
+  // are not loaded and do not confuse the implementation agent.
   const preparedEnv = Object.fromEntries(
     DIRECT_AGENT_ENV_KEYS.flatMap((key) => {
       const value = env?.[key];
@@ -181,6 +184,10 @@ export function resolvePreparedAgentEnvironment(
   };
 }
 
+/**
+ * Build the `codex app-server` launch plan after `stageCodexHome()` has prepared
+ * the staged `CODEX_HOME` directory for the target working directory.
+ */
 export function buildCodexRuntimePlan(
   config: CodexRuntimeConfig
 ): CodexRuntimePlan {
@@ -208,9 +215,6 @@ export function buildCodexRuntimePlan(
       GITHUB_PROJECT_ID: config.githubProjectId ?? "",
       GITHUB_GRAPHQL_TOOL_NAME: tool.name,
       GITHUB_GRAPHQL_TOOL_COMMAND: [tool.command, ...tool.args].join(" "),
-      // Point codex to an isolated config dir so personal MCPs (playwright,
-      // chrome-devtools, context7, etc.) from the operator's ~/.codex/config.toml
-      // are not loaded and do not confuse the implementation agent.
       ...agentEnv,
       ...gitCredentialHelper,
       ...tool.env,
@@ -240,6 +244,8 @@ export class CodexRuntimeAdapter
       CodexRuntimeCredentialBrokerResponse
     >
 {
+  // Event emission is intentionally deferred until the worker-owned loop is
+  // neutralized in #4. Until then, keep handler registration compatible.
   private readonly handlers = new Set<(event: CodexRuntimeEvent) => void>();
 
   private plan: CodexRuntimePlan | null = null;
@@ -311,11 +317,13 @@ export class CodexRuntimeAdapter
   async shutdown(): Promise<void> {
     terminateChildProcess(this.child);
     this.child = null;
+    this.handlers.clear();
   }
 
   async cancel(_reason?: string): Promise<void> {
     terminateChildProcess(this.child);
     this.child = null;
+    this.handlers.clear();
   }
 
   getPreparedPlan(): CodexRuntimePlan | null {
@@ -429,19 +437,20 @@ export async function resolveAgentRuntimeEnvironment(
   };
   const resolvedEnv =
     payload.env && response.ok
-      ? (
-          adapter ??
-          createCodexRuntimeAdapter({
-            projectId: "runtime-codex",
-            workingDirectory: config.workingDirectory,
+      ? adapter
+        ? adapter.resolveCredentials({
+            env: payload.env,
+            expires_at: payload.expires_at,
           })
-        ).resolveCredentials({
-          env: payload.env,
-          expires_at: payload.expires_at,
-        })
+        : resolvePreparedAgentEnvironment(config.workingDirectory, payload.env)
       : null;
 
-  if (!response.ok || !resolvedEnv || Object.keys(resolvedEnv).length === 0) {
+  if (
+    !response.ok ||
+    !payload.env ||
+    Object.keys(payload.env).length === 0 ||
+    !resolvedEnv
+  ) {
     throw new AgentRuntimeResolutionError(
       payload.error ??
         `Agent credential broker request failed with status ${response.status}.`

--- a/packages/runtime-codex/src/thread-resume.test.ts
+++ b/packages/runtime-codex/src/thread-resume.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildContinuationTurnInput,
+  DEFAULT_CONTINUATION_GUIDANCE,
+  parseNonNegativeInteger,
+} from "./thread-resume.js";
+
+describe("parseNonNegativeInteger", () => {
+  it("returns zero for missing or invalid values", () => {
+    expect(parseNonNegativeInteger(undefined)).toBe(0);
+    expect(parseNonNegativeInteger(null)).toBe(0);
+    expect(parseNonNegativeInteger("")).toBe(0);
+    expect(parseNonNegativeInteger("-4")).toBe(0);
+    expect(parseNonNegativeInteger("abc")).toBe(0);
+  });
+
+  it("normalizes positive values", () => {
+    expect(parseNonNegativeInteger("7")).toBe(7);
+    expect(parseNonNegativeInteger(3.8)).toBe(3);
+  });
+});
+
+describe("buildContinuationTurnInput", () => {
+  it("falls back to the default continuation guidance", () => {
+    expect(buildContinuationTurnInput({})).toBe(
+      DEFAULT_CONTINUATION_GUIDANCE
+    );
+  });
+
+  it("renders continuation template variables for resume-aware prompts", () => {
+    expect(
+      buildContinuationTurnInput({
+        continuationGuidance:
+          "Continue after {{cumulativeTurnCount}} turns. Summary: {{lastTurnSummary}}",
+        cumulativeTurnCount: 6,
+        lastTurnSummary: "worker resumed the same issue thread",
+      })
+    ).toBe(
+      "Continue after 6 turns. Summary: worker resumed the same issue thread"
+    );
+  });
+
+  it("rejects unsupported Liquid syntax in continuation guidance", () => {
+    expect(() =>
+      buildContinuationTurnInput({
+        continuationGuidance: "{% if cumulativeTurnCount %}resume{% endif %}",
+        cumulativeTurnCount: 6,
+        lastTurnSummary: "worker resumed the same issue thread",
+      })
+    ).toThrow("continuation guidance does not support Liquid tags");
+  });
+});

--- a/packages/runtime-codex/src/thread-resume.ts
+++ b/packages/runtime-codex/src/thread-resume.ts
@@ -1,0 +1,88 @@
+export const DEFAULT_CONTINUATION_GUIDANCE =
+  "Continue working on the issue. Review your progress and complete any remaining tasks.";
+
+type BuildContinuationTurnInputParams = {
+  continuationGuidance?: string | null;
+  lastTurnSummary?: string | null;
+  cumulativeTurnCount?: number;
+};
+
+export function parseNonNegativeInteger(
+  value: string | number | null | undefined
+): number {
+  const parsed =
+    typeof value === "number" ? value : Number.parseInt(value ?? "", 10);
+
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return 0;
+  }
+
+  return Math.floor(parsed);
+}
+
+export function buildContinuationTurnInput({
+  continuationGuidance,
+  lastTurnSummary,
+  cumulativeTurnCount = 0,
+}: BuildContinuationTurnInputParams): string {
+  const template =
+    continuationGuidance?.trim() || DEFAULT_CONTINUATION_GUIDANCE;
+
+  return renderContinuationGuidance(template, {
+    lastTurnSummary:
+      normalizeContinuationVariable(lastTurnSummary) ??
+      "No previous turn summary was captured.",
+    cumulativeTurnCount: String(
+      Math.max(0, parseNonNegativeInteger(cumulativeTurnCount))
+    ),
+  });
+}
+
+function normalizeContinuationVariable(
+  value: string | null | undefined
+): string | null {
+  const normalized = value?.trim();
+  return normalized ? normalized : null;
+}
+
+function renderContinuationGuidance(
+  template: string,
+  variables: Record<string, string>
+): string {
+  if (template.includes("{%") || template.includes("%}")) {
+    throw new Error(
+      "template_parse_error: continuation guidance does not support Liquid tags."
+    );
+  }
+
+  let rendered = "";
+  let lastIndex = 0;
+  const pattern = /\{\{\s*([a-zA-Z_][a-zA-Z0-9_.]*)\s*\}\}/g;
+
+  for (const match of template.matchAll(pattern)) {
+    const matchedText = match[0];
+    const expression = match[1];
+    const index = match.index ?? 0;
+    rendered += template.slice(lastIndex, index);
+
+    if (!(expression in variables)) {
+      throw new Error(
+        `template_render_error: unsupported continuation guidance variable '${expression}'.`
+      );
+    }
+
+    rendered += variables[expression] ?? "";
+    lastIndex = index + matchedText.length;
+  }
+
+  rendered += template.slice(lastIndex);
+
+  const strayLiquidExpression = rendered.match(/\{\{[^}]*\}\}/);
+  if (strayLiquidExpression) {
+    throw new Error(
+      `template_parse_error: invalid continuation guidance expression '${strayLiquidExpression[0]}'.`
+    );
+  }
+
+  return rendered;
+}

--- a/packages/runtime-codex/src/turn-limits.test.ts
+++ b/packages/runtime-codex/src/turn-limits.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_SESSION_MAX_TURNS,
+  resolveMaxTurns,
+} from "./turn-limits.js";
+
+describe("resolveMaxTurns", () => {
+  it("falls back to the default when max_turns is missing or invalid", () => {
+    expect(resolveMaxTurns(undefined)).toEqual({
+      maxTurns: DEFAULT_SESSION_MAX_TURNS,
+      exhaustedBeforeStart: false,
+    });
+    expect(resolveMaxTurns("not-a-number")).toEqual({
+      maxTurns: DEFAULT_SESSION_MAX_TURNS,
+      exhaustedBeforeStart: false,
+    });
+  });
+
+  it("accepts positive integer-like max_turns values", () => {
+    expect(resolveMaxTurns("3")).toEqual({
+      maxTurns: 3,
+      exhaustedBeforeStart: false,
+    });
+    expect(resolveMaxTurns(4.9)).toEqual({
+      maxTurns: 4,
+      exhaustedBeforeStart: false,
+    });
+  });
+
+  it("treats zero or negative max_turns as exhausted before the first turn", () => {
+    expect(resolveMaxTurns("0")).toEqual({
+      maxTurns: 0,
+      exhaustedBeforeStart: true,
+    });
+    expect(resolveMaxTurns("-2")).toEqual({
+      maxTurns: 0,
+      exhaustedBeforeStart: true,
+    });
+  });
+});

--- a/packages/runtime-codex/src/turn-limits.ts
+++ b/packages/runtime-codex/src/turn-limits.ts
@@ -1,0 +1,32 @@
+export const DEFAULT_SESSION_MAX_TURNS = 20;
+
+export type MaxTurnsResolution = {
+  maxTurns: number;
+  exhaustedBeforeStart: boolean;
+};
+
+export function resolveMaxTurns(
+  value: string | number | null | undefined
+): MaxTurnsResolution {
+  const parsed = typeof value === "number" ? value : Number(value);
+
+  if (!Number.isFinite(parsed)) {
+    return {
+      maxTurns: DEFAULT_SESSION_MAX_TURNS,
+      exhaustedBeforeStart: false,
+    };
+  }
+
+  const normalized = Math.trunc(parsed);
+  if (normalized <= 0) {
+    return {
+      maxTurns: 0,
+      exhaustedBeforeStart: true,
+    };
+  }
+
+  return {
+    maxTurns: normalized,
+    exhaustedBeforeStart: false,
+  };
+}


### PR DESCRIPTION
## Issues

- Fixes #215

## Summary

- keep `@gh-symphony/runtime-codex` behind the `AgentRuntimeAdapter` contract while reconciling the branch with the latest `main`
- preserve the existing Codex worker experience and credential-resolution behavior after the conflict merge

## Changes

- merged `origin/main` into `refactor/215-runtime-codex-adapter` and reconciled `packages/runtime-codex/src/runtime.ts` so the adapter-based prepare/spawnTurn/shutdown flow now coexists with the new core credential cache helpers
- kept `resolveCredentials()` and staged `CODEX_HOME` handling inside `runtime-codex`, including the empty broker-env guard and direct fallback path without the old throwaway adapter pattern
- refreshed `runtime-codex` tests so cached/brokered credential paths still stage `CODEX_HOME`, and revalidated the existing Docker Codex happy path after conflict resolution

## Evidence

- `pnpm --filter @gh-symphony/runtime-codex test`
- `pnpm lint`
- `pnpm test`
- `pnpm typecheck`
- `pnpm install --frozen-lockfile`
- `pnpm build`
- `./e2e/run-e2e.sh happy 40`
- Manual check: Docker happy-path showed `idle -> running -> retrying -> idle`, worker logs emitted `codex_update` start/running/completed events, and the run completed with the existing continuation flow after the conflict merge

## Human Validation

- [ ] Confirm the existing Codex worker flow still launches `thread/start -> turn/* -> shutdown` without behavior changes
- [ ] Confirm brokered OpenAI credentials and staged `CODEX_HOME` behave the same as before in a real worker run
- [ ] Confirm no worker-facing API change leaked out of `@gh-symphony/runtime-codex`

## Risks

- worker internals still own the Codex wire protocol loop, so the neutral event renaming tracked by #4 remains intentionally out of scope for this PR