### PR TITLE
chore(docker): skip pack stage when installing from registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Build container image from local package bundle
         run: |
           docker build \
-            --build-arg GH_SYMPHONY_INSTALL_SOURCE=local \
+            --build-arg INSTALLER_STAGE=installer-local \
             --tag gh-symphony:test .
 
       - name: Smoke test container image

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,6 +107,7 @@ jobs:
           file: ./Dockerfile
           push: true
           build-args: |
+            INSTALLER_STAGE=installer-registry
             GH_SYMPHONY_VERSION=${{ steps.version.outputs.value }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,6 @@ RUN set -eux; \
     npm cache clean --force; \
     rm -rf /tmp/gh-symphony-dist
 
-ARG INSTALLER_STAGE
 FROM ${INSTALLER_STAGE} AS final
 
 WORKDIR /workspace

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 ARG NODE_IMAGE=node:24-bookworm-slim
 ARG PNPM_VERSION=9.15.9
+ARG INSTALLER_STAGE=installer-registry
 
 FROM ${NODE_IMAGE} AS pack
 
@@ -15,10 +16,8 @@ RUN pnpm build
 RUN mkdir -p /tmp/gh-symphony-dist
 RUN cd packages/cli && npm pack --pack-destination /tmp/gh-symphony-dist
 
-FROM ${NODE_IMAGE}
+FROM ${NODE_IMAGE} AS runtime-base
 
-ARG GH_SYMPHONY_INSTALL_SOURCE=registry
-ARG GH_SYMPHONY_VERSION=latest
 ARG GH_SYMPHONY_UID=1000
 ARG GH_SYMPHONY_GID=1000
 
@@ -37,18 +36,26 @@ RUN apt-get update && \
     chown -R symphony:symphony /var/lib/gh-symphony /workspace && \
     rm -rf /var/lib/apt/lists/*
 
+FROM runtime-base AS installer-registry
+
+ARG GH_SYMPHONY_VERSION=latest
+
+RUN npm install -g "@gh-symphony/cli@${GH_SYMPHONY_VERSION}" && \
+    npm cache clean --force
+
+FROM runtime-base AS installer-local
+
 COPY --from=pack /tmp/gh-symphony-dist /tmp/gh-symphony-dist
 
 RUN set -eux; \
-    if [ "${GH_SYMPHONY_INSTALL_SOURCE}" = "local" ]; then \
-      pkg="$(find /tmp/gh-symphony-dist -maxdepth 1 -name '*.tgz' -print -quit)"; \
-      test -n "${pkg}"; \
-      npm install -g "${pkg}"; \
-    else \
-      npm install -g "@gh-symphony/cli@${GH_SYMPHONY_VERSION}"; \
-    fi; \
+    pkg="$(find /tmp/gh-symphony-dist -maxdepth 1 -name '*.tgz' -print -quit)"; \
+    test -n "${pkg}"; \
+    npm install -g "${pkg}"; \
     npm cache clean --force; \
     rm -rf /tmp/gh-symphony-dist
+
+ARG INSTALLER_STAGE
+FROM ${INSTALLER_STAGE} AS final
 
 WORKDIR /workspace
 VOLUME ["/var/lib/gh-symphony"]


### PR DESCRIPTION
## Issues

- Fixes #227

## Summary

- registry 설치 경로가 `pack` stage를 참조하지 않도록 Docker build graph를 분리했습니다.
- 후속 리뷰 반영으로 final stage 선택이 파일 상단 전역 `INSTALLER_STAGE`만 참조하도록 정리했습니다.
- local package smoke 경로는 별도 installer stage로 유지해 기존 tgz 설치 검증을 계속 수행합니다.

## Changes

- `Dockerfile`을 `runtime-base`, `installer-registry`, `installer-local`, `final` 구조로 재구성하고 최종 stage를 `FROM ${INSTALLER_STAGE}`로 선택하도록 유지했습니다.
- registry installer는 npm registry에서 바로 `@gh-symphony/cli`를 설치하고, local installer만 `pack` stage 산출물을 `npm install -g <tgz>`로 사용하도록 분리했습니다.
- 후속 리뷰에서 지적된 불필요한 `ARG INSTALLER_STAGE` 재선언을 제거해 final stage가 전역 ARG만 참조하도록 가독성을 정리했습니다.
- CI는 `INSTALLER_STAGE=installer-local`로 local-pack smoke 경로를 명시하고, release workflow는 `INSTALLER_STAGE=installer-registry`를 명시해 registry 경로를 그대로 사용하도록 정리했습니다.

## Evidence

- `DOCKER_BUILDKIT=1 docker build --progress=plain --build-arg INSTALLER_STAGE=installer-registry --build-arg GH_SYMPHONY_VERSION=latest -t gh-symphony:registry-check .` (`pack` stage 미실행 확인)
- `DOCKER_BUILDKIT=1 docker build --progress=plain --build-arg INSTALLER_STAGE=installer-local -t gh-symphony:local-check .`
- `docker run --rm gh-symphony:local-check gh-symphony --version`
- `docker run --rm -v "$TMPDIR/config:/var/lib/gh-symphony" gh-symphony:local-check gh-symphony start --once --project-id smoke`
- `pnpm lint && pnpm test && pnpm typecheck && pnpm build`
- Manual check: registry 빌드 로그에서 `installer-registry`만 실행되고 `pack` stage가 계산되지 않는 것을 확인했습니다.
- Manual check: 후속 커밋 `c5cbd95` 이후에도 local smoke와 전체 저장소 검증이 동일하게 유지되는 것을 확인했습니다.

## Human Validation

- [ ] release workflow가 registry 경로로 이미지를 빌드할 때 `pack` stage 없이 완료되는지 확인
- [ ] PR CI의 container smoke가 local installer 경로로 계속 통과하는지 확인
- [ ] reviewer-visible Dockerfile stage 구성이 이슈의 단일 Dockerfile 접근과 일치하는지 확인

## Risks

- 외부에서 기존 `GH_SYMPHONY_INSTALL_SOURCE=local` 인자를 직접 사용하던 비공식 빌드 스크립트는 `INSTALLER_STAGE=installer-local`로 맞춰야 합니다.