### PR TITLE
feat(cli): detect non-Node repo validation commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,17 @@ Project discovery is pagination-aware for larger GitHub accounts, so personal pr
 
 `gh-symphony workflow init --dry-run` resolves the same generated outputs, shows whether each path would be created, updated, or left unchanged, and prints the detected environment inputs that shaped the preview.
 
-Those detected inputs are also threaded into the generated artifacts themselves: `WORKFLOW.md`, `.gh-symphony/reference-workflow.md`, and the runtime skill templates all include repository-aware validation guidance based on the detected package manager, monorepo shape, and `test` / `lint` / `build` scripts when present.
+Those detected inputs are also threaded into the generated artifacts themselves: `WORKFLOW.md`, `.gh-symphony/reference-workflow.md`, and the runtime skill templates all include repository-aware validation guidance based on the detected package manager, monorepo shape, and explicit validation entry points when present.
+
+`workflow init` is not limited to Node repositories. The detector now recognizes conservative validation signals for:
+
+- JavaScript / TypeScript lockfiles and `package.json` scripts
+- Python repositories with `uv.lock`, `poetry.lock`, `pyproject.toml`, `pytest.ini`, and `requirements*.txt`
+- Go repositories with `go.mod`
+- Rust repositories with `Cargo.toml`
+- Top-level command runners such as `Makefile` and `justfile`
+
+When the repository exposes an unambiguous entry point, the generated guidance will prefer commands such as `make test`, `just lint`, `uv run pytest`, `go test ./...`, or `cargo test`. When signals conflict at the same confidence level, the generator intentionally falls back to generic validation guidance instead of guessing.
 
 Token-only interactive setup is supported:
 
@@ -475,7 +485,7 @@ gh-symphony workflow preview --issue owner/repo#123
 `.gh-symphony/reference-workflow.md`, and runtime skill files, then prints whether
 each path would be created, updated, or left unchanged without writing anything.
 
-When `gh-symphony workflow init` detects repository scripts, it bakes that information back into the generated policy files so the out-of-the-box workflow already tells agents which test/lint/build commands to prefer and whether workspace-aware validation is expected.
+When `gh-symphony workflow init` detects repository validation entry points, it bakes that information back into the generated policy files so the out-of-the-box workflow already tells agents which test/lint/build commands to prefer and whether workspace-aware validation is expected. That includes non-Node repositories when the detector can prove a conservative command from `Makefile`, `justfile`, Python tooling, `go.mod`, or `Cargo.toml`.
 
 Without a project (standalone):
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -85,7 +85,17 @@ whether `WORKFLOW.md`, `.gh-symphony/context.yaml`,
 `.gh-symphony/reference-workflow.md`, and runtime skill files would be created,
 updated, or left unchanged, and then exits without modifying the repository.
 
-The same detected environment data is applied to the generated artifacts, so `WORKFLOW.md`, `.gh-symphony/reference-workflow.md`, and the runtime skill templates already include repository-aware validation guidance for the detected package manager, monorepo layout, and `test` / `lint` / `build` scripts when they exist.
+The same detected environment data is applied to the generated artifacts, so `WORKFLOW.md`, `.gh-symphony/reference-workflow.md`, and the runtime skill templates already include repository-aware validation guidance for the detected package manager, monorepo layout, and explicit validation commands when they exist.
+
+The detector is language-agnostic by default:
+
+- Node repositories: JS lockfiles plus `package.json` `test` / `lint` / `build` scripts
+- Python repositories: `uv.lock`, `poetry.lock`, `pyproject.toml`, `pytest.ini`, `requirements*.txt`
+- Go repositories: `go.mod`
+- Rust repositories: `Cargo.toml`
+- Generic runners: `Makefile`, `justfile`
+
+Examples of generated validation guidance include `make test`, `just build`, `uv run pytest`, `poetry run pytest`, `go test ./...`, and `cargo test` when those commands are the clearest repository entry points. If the repository exposes conflicting signals, the CLI keeps the generic fallback instead of guessing.
 
 ### Customizing Agent Behavior
 

--- a/packages/cli/src/commands/init.test.ts
+++ b/packages/cli/src/commands/init.test.ts
@@ -651,6 +651,41 @@ describe("init ecosystem generation", () => {
     expect(plan.workflowMd).toContain("Use `npm` conventions");
   });
 
+  it("threads non-Node repository commands into generated workflow artifacts", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "cli-non-node-guidance-"));
+    await writeFile(join(cwd, "pyproject.toml"), "[project]\nname = 'fixture'\n");
+    await writeFile(join(cwd, "uv.lock"), "version = 1\n");
+    await writeFile(join(cwd, "pytest.ini"), "[pytest]\n");
+    await writeFile(
+      join(cwd, "Makefile"),
+      ["test:", "\tuv run pytest", "lint:", "\truff check ."].join("\n")
+    );
+
+    const plan = await planWorkflowArtifacts({
+      cwd,
+      outputPath: join(cwd, "WORKFLOW.md"),
+      projectDetail: MOCK_PROJECT_DETAIL,
+      statusField: MOCK_STATUS_FIELD,
+      priorityField: MOCK_PRIORITY_FIELD,
+      mappings: {
+        Todo: { role: "active" },
+        "In Progress": { role: "active" },
+        Done: { role: "terminal" },
+      },
+      runtime: "codex",
+      skipSkills: false,
+      skipContext: false,
+    });
+
+    expect(plan.workflowMd).toContain("Detected repository validation commands:");
+    expect(plan.workflowMd).toContain("`make test`");
+    expect(plan.workflowMd).toContain("`make lint`");
+    expect(plan.workflowMd).toContain("Use `uv` conventions");
+    expect(plan.ecosystemPlan.files.some((file) => file.path.endsWith("reference-workflow.md"))).toBe(
+      true
+    );
+  });
+
   it("generates codex skills when runtime is the codex agent command", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "cli-eco-codex-cmd-"));
 

--- a/packages/cli/src/detection/environment-detector.test.ts
+++ b/packages/cli/src/detection/environment-detector.test.ts
@@ -221,6 +221,23 @@ describe("detectEnvironment", () => {
     expect(result.testCommand).toBeNull();
   });
 
+  it("ignores justfile variable assignments that are not recipes", async () => {
+    await writeFile(
+      join(tempDir, "justfile"),
+      [
+        'test := "cargo test"',
+        'lint := "cargo clippy"',
+        'build := "cargo build"',
+      ].join("\n")
+    );
+
+    const result = await detectEnvironment(tempDir);
+
+    expect(result.testCommand).toBeNull();
+    expect(result.lintCommand).toBeNull();
+    expect(result.buildCommand).toBeNull();
+  });
+
   it("detects monorepo with lerna.json", async () => {
     await writeFile(
       join(tempDir, "package-lock.json"),

--- a/packages/cli/src/detection/environment-detector.test.ts
+++ b/packages/cli/src/detection/environment-detector.test.ts
@@ -122,6 +122,41 @@ describe("detectEnvironment", () => {
     expect(result.lockfile).toBe("bun.lockb");
   });
 
+  it("detects uv-managed python repositories with pytest guidance", async () => {
+    await writeFile(
+      join(tempDir, "pyproject.toml"),
+      [
+        "[project]",
+        'name = "python-fixture"',
+        "",
+        "[tool.pytest.ini_options]",
+        'addopts = "-q"',
+        "",
+      ].join("\n")
+    );
+    await writeFile(join(tempDir, "uv.lock"), "version = 1\n");
+
+    const result = await detectEnvironment(tempDir);
+
+    expect(result.packageManager).toBe("uv");
+    expect(result.lockfile).toBe("uv.lock");
+    expect(result.testCommand).toBe("uv run pytest");
+    expect(result.lintCommand).toBeNull();
+    expect(result.buildCommand).toBeNull();
+  });
+
+  it("detects poetry-managed python repositories with pytest guidance", async () => {
+    await writeFile(join(tempDir, "pyproject.toml"), "[project]\nname = 'poetry-fixture'\n");
+    await writeFile(join(tempDir, "poetry.lock"), "package = []\n");
+    await writeFile(join(tempDir, "pytest.ini"), "[pytest]\n");
+
+    const result = await detectEnvironment(tempDir);
+
+    expect(result.packageManager).toBe("poetry");
+    expect(result.lockfile).toBe("poetry.lock");
+    expect(result.testCommand).toBe("poetry run pytest");
+  });
+
   it("returns null for package manager when no lockfile exists", async () => {
     await writeFile(
       join(tempDir, "package.json"),
@@ -134,6 +169,56 @@ describe("detectEnvironment", () => {
 
     expect(result.packageManager).toBeNull();
     expect(result.lockfile).toBeNull();
+  });
+
+  it("detects go repositories conservatively", async () => {
+    await writeFile(join(tempDir, "go.mod"), "module example.com/fixture\n");
+
+    const result = await detectEnvironment(tempDir);
+
+    expect(result.packageManager).toBeNull();
+    expect(result.testCommand).toBe("go test ./...");
+    expect(result.lintCommand).toBeNull();
+    expect(result.buildCommand).toBeNull();
+  });
+
+  it("detects rust repositories conservatively", async () => {
+    await writeFile(
+      join(tempDir, "Cargo.toml"),
+      '[package]\nname = "fixture"\nversion = "0.1.0"\n'
+    );
+
+    const result = await detectEnvironment(tempDir);
+
+    expect(result.packageManager).toBeNull();
+    expect(result.testCommand).toBe("cargo test");
+    expect(result.lintCommand).toBeNull();
+    expect(result.buildCommand).toBeNull();
+  });
+
+  it("prefers explicit make targets over inferred language commands", async () => {
+    await writeFile(join(tempDir, "go.mod"), "module example.com/fixture\n");
+    await writeFile(
+      join(tempDir, "Makefile"),
+      ["test:", "\tgo test ./pkg/...", "lint:", "\tgolangci-lint run"].join(
+        "\n"
+      )
+    );
+
+    const result = await detectEnvironment(tempDir);
+
+    expect(result.testCommand).toBe("make test");
+    expect(result.lintCommand).toBe("make lint");
+    expect(result.buildCommand).toBeNull();
+  });
+
+  it("falls back when equally explicit command runners conflict", async () => {
+    await writeFile(join(tempDir, "Makefile"), "test:\n\tnpm test\n");
+    await writeFile(join(tempDir, "justfile"), "test:\n    cargo test\n");
+
+    const result = await detectEnvironment(tempDir);
+
+    expect(result.testCommand).toBeNull();
   });
 
   it("detects monorepo with lerna.json", async () => {
@@ -192,6 +277,22 @@ describe("detectEnvironment", () => {
         },
       })
     );
+
+    const result = await detectEnvironment(tempDir);
+
+    expect(result.monorepo).toBe(true);
+  });
+
+  it("detects Cargo workspace monorepos", async () => {
+    await writeFile(join(tempDir, "Cargo.toml"), "[workspace]\nmembers = [\"crates/*\"]\n");
+
+    const result = await detectEnvironment(tempDir);
+
+    expect(result.monorepo).toBe(true);
+  });
+
+  it("detects Go workspace monorepos", async () => {
+    await writeFile(join(tempDir, "go.work"), "go 1.22\nuse ./services/api\n");
 
     const result = await detectEnvironment(tempDir);
 

--- a/packages/cli/src/detection/environment-detector.ts
+++ b/packages/cli/src/detection/environment-detector.ts
@@ -189,7 +189,7 @@ async function detectJustCommands(cwd: string): Promise<DetectedCommands> {
   }
 
   const hasRecipe = (name: string): boolean =>
-    new RegExp(`^${name}\\s*:`, "m").test(justfile);
+    new RegExp(`^${name}\\s*:(?!=)`, "m").test(justfile);
 
   return {
     testCommand: hasRecipe("test") ? "just test" : null,

--- a/packages/cli/src/detection/environment-detector.ts
+++ b/packages/cli/src/detection/environment-detector.ts
@@ -1,8 +1,16 @@
-import { access, readFile } from "node:fs/promises";
+import { access, readFile, readdir } from "node:fs/promises";
 import { join } from "node:path";
 
+type DetectedPackageManager =
+  | "pnpm"
+  | "npm"
+  | "yarn"
+  | "bun"
+  | "uv"
+  | "poetry";
+
 export type DetectedEnvironment = {
-  packageManager: "pnpm" | "npm" | "yarn" | "bun" | null;
+  packageManager: DetectedPackageManager | null;
   lockfile: string | null;
   testCommand: string | null;
   buildCommand: string | null;
@@ -48,8 +56,19 @@ async function readJsonFile<T>(path: string): Promise<T | null> {
   }
 }
 
+async function readTextFile(path: string): Promise<string | null> {
+  try {
+    return await readFile(path, "utf8");
+  } catch (error) {
+    if (isFileMissing(error)) {
+      return null;
+    }
+    throw error;
+  }
+}
+
 async function detectPackageManager(cwd: string): Promise<{
-  packageManager: "pnpm" | "npm" | "yarn" | "bun" | null;
+  packageManager: DetectedPackageManager | null;
   lockfile: string | null;
 }> {
   const lockfiles = [
@@ -58,6 +77,8 @@ async function detectPackageManager(cwd: string): Promise<{
     { name: "bun.lockb", manager: "bun" as const },
     { name: "yarn.lock", manager: "yarn" as const },
     { name: "package-lock.json", manager: "npm" as const },
+    { name: "uv.lock", manager: "uv" as const },
+    { name: "poetry.lock", manager: "poetry" as const },
   ];
 
   for (const { name, manager } of lockfiles) {
@@ -70,11 +91,62 @@ async function detectPackageManager(cwd: string): Promise<{
   return { packageManager: null, lockfile: null };
 }
 
-async function detectScripts(cwd: string): Promise<{
+type DetectedCommands = {
   testCommand: string | null;
   buildCommand: string | null;
   lintCommand: string | null;
-}> {
+};
+
+type CommandLabel = keyof DetectedCommands;
+type CommandCandidate = {
+  command: string;
+  priority: number;
+};
+
+function normalizeCommand(command: string): string {
+  return command.replace(/\s+/g, " ").trim();
+}
+
+function addCandidate(
+  candidates: Record<CommandLabel, CommandCandidate[]>,
+  label: CommandLabel,
+  command: string | null,
+  priority: number
+): void {
+  if (!command) {
+    return;
+  }
+
+  candidates[label].push({
+    command: normalizeCommand(command),
+    priority,
+  });
+}
+
+function resolveCommand(
+  candidates: Record<CommandLabel, CommandCandidate[]>,
+  label: CommandLabel
+): string | null {
+  const entries = candidates[label];
+  if (entries.length === 0) {
+    return null;
+  }
+
+  const highestPriority = Math.max(...entries.map((entry) => entry.priority));
+  const highestPriorityCommands = [
+    ...new Set(
+      entries
+        .filter((entry) => entry.priority === highestPriority)
+        .map((entry) => entry.command)
+    ),
+  ];
+
+  return highestPriorityCommands.length === 1
+    ? highestPriorityCommands[0]
+    : null;
+}
+
+async function detectNodeScripts(cwd: string): Promise<DetectedCommands> {
   const packageJson = await readJsonFile<{
     scripts?: Record<string, string>;
   }>(join(cwd, "package.json"));
@@ -87,6 +159,156 @@ async function detectScripts(cwd: string): Promise<{
     testCommand: packageJson.scripts.test ?? null,
     buildCommand: packageJson.scripts.build ?? null,
     lintCommand: packageJson.scripts.lint ?? null,
+  };
+}
+
+async function detectMakeCommands(cwd: string): Promise<DetectedCommands> {
+  const makefile =
+    (await readTextFile(join(cwd, "Makefile"))) ??
+    (await readTextFile(join(cwd, "makefile")));
+  if (!makefile) {
+    return { testCommand: null, buildCommand: null, lintCommand: null };
+  }
+
+  const hasTarget = (target: string): boolean =>
+    new RegExp(`^${target}\\s*::?(?:\\s|$)`, "m").test(makefile);
+
+  return {
+    testCommand: hasTarget("test") ? "make test" : null,
+    lintCommand: hasTarget("lint") ? "make lint" : null,
+    buildCommand: hasTarget("build") ? "make build" : null,
+  };
+}
+
+async function detectJustCommands(cwd: string): Promise<DetectedCommands> {
+  const justfile =
+    (await readTextFile(join(cwd, "justfile"))) ??
+    (await readTextFile(join(cwd, ".justfile")));
+  if (!justfile) {
+    return { testCommand: null, buildCommand: null, lintCommand: null };
+  }
+
+  const hasRecipe = (name: string): boolean =>
+    new RegExp(`^${name}\\s*:`, "m").test(justfile);
+
+  return {
+    testCommand: hasRecipe("test") ? "just test" : null,
+    lintCommand: hasRecipe("lint") ? "just lint" : null,
+    buildCommand: hasRecipe("build") ? "just build" : null,
+  };
+}
+
+async function hasRequirementsFile(cwd: string): Promise<boolean> {
+  try {
+    const entries = await readdir(cwd);
+    return entries.some((entry) => /^requirements[^/]*\.txt$/i.test(entry));
+  } catch (error) {
+    if (isFileMissing(error)) {
+      return false;
+    }
+    throw error;
+  }
+}
+
+async function detectPythonCommands(cwd: string): Promise<DetectedCommands> {
+  const [
+    pyproject,
+    hasUvLock,
+    hasPoetryLock,
+    hasPytestIni,
+    hasToxIni,
+    hasRequirements,
+  ] = await Promise.all([
+    readTextFile(join(cwd, "pyproject.toml")),
+    fileExists(join(cwd, "uv.lock")),
+    fileExists(join(cwd, "poetry.lock")),
+    fileExists(join(cwd, "pytest.ini")),
+    fileExists(join(cwd, "tox.ini")),
+    hasRequirementsFile(cwd),
+  ]);
+
+  const hasPythonSignals =
+    pyproject !== null ||
+    hasUvLock ||
+    hasPoetryLock ||
+    hasPytestIni ||
+    hasToxIni ||
+    hasRequirements;
+  if (!hasPythonSignals) {
+    return { testCommand: null, buildCommand: null, lintCommand: null };
+  }
+
+  const hasPytestConfig =
+    hasPytestIni ||
+    /\[tool\.pytest(?:\.ini_options)?\]/.test(pyproject ?? "");
+  if (!hasPytestConfig) {
+    return { testCommand: null, buildCommand: null, lintCommand: null };
+  }
+
+  const testCommand = hasUvLock
+    ? "uv run pytest"
+    : hasPoetryLock
+      ? "poetry run pytest"
+      : "pytest";
+
+  return { testCommand, buildCommand: null, lintCommand: null };
+}
+
+async function detectGoCommands(cwd: string): Promise<DetectedCommands> {
+  const hasGoMod = await fileExists(join(cwd, "go.mod"));
+  return {
+    testCommand: hasGoMod ? "go test ./..." : null,
+    buildCommand: null,
+    lintCommand: null,
+  };
+}
+
+async function detectRustCommands(cwd: string): Promise<DetectedCommands> {
+  const hasCargoToml = await fileExists(join(cwd, "Cargo.toml"));
+  return {
+    testCommand: hasCargoToml ? "cargo test" : null,
+    buildCommand: null,
+    lintCommand: null,
+  };
+}
+
+async function detectValidationCommands(cwd: string): Promise<DetectedCommands> {
+  const [makeCommands, justCommands, nodeCommands, pythonCommands, goCommands, rustCommands] =
+    await Promise.all([
+      detectMakeCommands(cwd),
+      detectJustCommands(cwd),
+      detectNodeScripts(cwd),
+      detectPythonCommands(cwd),
+      detectGoCommands(cwd),
+      detectRustCommands(cwd),
+    ]);
+
+  const candidates: Record<CommandLabel, CommandCandidate[]> = {
+    testCommand: [],
+    lintCommand: [],
+    buildCommand: [],
+  };
+
+  for (const commandSet of [makeCommands, justCommands]) {
+    addCandidate(candidates, "testCommand", commandSet.testCommand, 3);
+    addCandidate(candidates, "lintCommand", commandSet.lintCommand, 3);
+    addCandidate(candidates, "buildCommand", commandSet.buildCommand, 3);
+  }
+
+  addCandidate(candidates, "testCommand", nodeCommands.testCommand, 2);
+  addCandidate(candidates, "lintCommand", nodeCommands.lintCommand, 2);
+  addCandidate(candidates, "buildCommand", nodeCommands.buildCommand, 2);
+
+  for (const commandSet of [pythonCommands, goCommands, rustCommands]) {
+    addCandidate(candidates, "testCommand", commandSet.testCommand, 1);
+    addCandidate(candidates, "lintCommand", commandSet.lintCommand, 1);
+    addCandidate(candidates, "buildCommand", commandSet.buildCommand, 1);
+  }
+
+  return {
+    testCommand: resolveCommand(candidates, "testCommand"),
+    lintCommand: resolveCommand(candidates, "lintCommand"),
+    buildCommand: resolveCommand(candidates, "buildCommand"),
   };
 }
 
@@ -109,12 +331,22 @@ async function detectMonorepo(cwd: string): Promise<boolean> {
     return true;
   }
 
+  const hasGoWorkspace = await fileExists(join(cwd, "go.work"));
+  if (hasGoWorkspace) {
+    return true;
+  }
+
   // Check for workspaces field in package.json
   const packageJson = await readJsonFile<{
     workspaces?: string[] | { packages?: string[] };
   }>(join(cwd, "package.json"));
 
   if (packageJson?.workspaces) {
+    return true;
+  }
+
+  const cargoToml = await readTextFile(join(cwd, "Cargo.toml"));
+  if (cargoToml?.includes("[workspace]")) {
     return true;
   }
 
@@ -170,7 +402,7 @@ export async function detectEnvironment(
     existingSkills,
   ] = await Promise.all([
     detectPackageManager(cwd),
-    detectScripts(cwd),
+    detectValidationCommands(cwd),
     detectCiPlatform(cwd),
     detectMonorepo(cwd),
     detectExistingSkills(cwd),

--- a/packages/cli/src/workflow/repository-guidance.test.ts
+++ b/packages/cli/src/workflow/repository-guidance.test.ts
@@ -30,4 +30,19 @@ describe("buildRepositoryValidationGuidance", () => {
     );
     expect(guidance[0]).not.toContain("\nconsole.log");
   });
+
+  it("renders explicit non-Node commands without inventing package-script wrappers", () => {
+    const guidance = buildRepositoryValidationGuidance({
+      packageManager: "uv",
+      testCommand: "uv run pytest",
+      lintCommand: "make lint",
+      buildCommand: null,
+      monorepo: false,
+    });
+
+    expect(guidance[0]).toContain("test: `uv run pytest`");
+    expect(guidance[0]).toContain("lint: `make lint`");
+    expect(guidance[0]).not.toContain("(script:");
+    expect(guidance[3]).toContain("Use `uv` conventions");
+  });
 });


### PR DESCRIPTION
## Issues

- Fixes #235

## Summary

- extend CLI repository detection beyond Node-specific `package.json` scripts and lockfiles
- generate conservative validation guidance for Python, Go, Rust, Make, and Just based repositories during `workflow init`
- tighten justfile detection so variable assignments do not masquerade as runnable recipes

## Changes

- add non-Node detector support for `uv.lock`, `poetry.lock`, `pyproject.toml`, `pytest.ini`, `requirements*.txt`, `go.mod`, `Cargo.toml`, `Makefile`, and `justfile`
- resolve validation commands by confidence so explicit `make`/`just` entry points win over package scripts, and same-priority conflicts fall back to generic guidance
- distinguish just recipe declarations from `:=` assignments and add regression coverage for variable-only justfiles
- detect `go.work` and Cargo workspaces as additional monorepo signals
- add fixture coverage for Python, Go, Rust, Make, monorepo, conflicting command-runner cases, and the justfile assignment edge case
- update the root and CLI READMEs to describe language-agnostic validation command detection in `workflow init`

## Evidence

- `pnpm --filter @gh-symphony/cli test -- src/detection/environment-detector.test.ts`
- `pnpm lint`
- `pnpm test`
- `pnpm typecheck`
- `pnpm build`
- Manual check: re-read issue #235 against the final diff and confirmed the implementation plus follow-up review fix cover non-Node signal detection, conservative command derivation, threaded workflow guidance, fixture coverage, README updates, and the justfile assignment regression

## Human Validation

- [ ] Confirm `gh-symphony workflow init --dry-run` surfaces non-Node validation guidance for representative Python, Go, Rust, and Make repositories
- [ ] Confirm generated `WORKFLOW.md`, `.gh-symphony/reference-workflow.md`, and skill files stay aligned with the detected repository commands
- [ ] Confirm mixed or conflicting repository signals still fall back to generic validation guidance instead of guessing
- [ ] Confirm justfiles that only define `test := ...` style variables do not emit `just test` guidance

## Risks

- Python command derivation intentionally stays conservative and currently only emits `pytest`-based guidance when pytest configuration is detectable, so repositories that rely on other Python runners still fall back to generic guidance