### PR TITLE
refactor(worker): normalize agent events to runtime-neutral names

### DIFF
--- a/packages/core/src/runtime/adapter.ts
+++ b/packages/core/src/runtime/adapter.ts
@@ -7,6 +7,7 @@ export type AgentRuntimeCredentialBrokerResponse = {
   expires_at?: string;
 };
 
+// Loose runtime event shape used by adapters before narrowing to AgentEvent.
 export type AgentRuntimeEvent = {
   name: AgentEventName;
   payload?: unknown;

--- a/packages/core/src/runtime/adapter.ts
+++ b/packages/core/src/runtime/adapter.ts
@@ -1,3 +1,5 @@
+import type { AgentEventName } from "./events.js";
+
 export type AgentRuntimeEnv = Record<string, string>;
 
 export type AgentRuntimeCredentialBrokerResponse = {
@@ -6,7 +8,7 @@ export type AgentRuntimeCredentialBrokerResponse = {
 };
 
 export type AgentRuntimeEvent = {
-  name: string;
+  name: AgentEventName;
   payload?: unknown;
 };
 

--- a/packages/core/src/runtime/events.ts
+++ b/packages/core/src/runtime/events.ts
@@ -12,8 +12,22 @@ export type AgentEventName =
 
 type AgentEventPayloadBase = {
   observabilityEvent?: string;
-  shouldEmitUpdate?: boolean;
+  suppressUpdate?: true;
 };
+
+export const DEFAULT_AGENT_INPUT_REQUIRED_REASON =
+  "turn_input_required: agent requires user input";
+
+export function buildAgentInputRequiredReason(prompt: unknown): string {
+  if (typeof prompt === "string") {
+    const trimmedPrompt = prompt.trim();
+    if (trimmedPrompt) {
+      return `turn_input_required: ${trimmedPrompt}`;
+    }
+  }
+
+  return DEFAULT_AGENT_INPUT_REQUIRED_REASON;
+}
 
 export type AgentTurnStartedEvent = {
   name: "agent.turnStarted";
@@ -67,6 +81,8 @@ export type AgentInputRequiredEvent = {
 export type AgentRateLimitEvent = {
   name: "agent.rateLimit";
   payload: AgentEventPayloadBase & {
+    // Rate-limit data stays in params so runtimes can preserve provider-specific
+    // shapes while worker-side extraction remains centralized.
     params: Record<string, unknown>;
   };
 };

--- a/packages/core/src/runtime/events.ts
+++ b/packages/core/src/runtime/events.ts
@@ -1,0 +1,108 @@
+export type AgentEventName =
+  | "agent.turnStarted"
+  | "agent.turnCompleted"
+  | "agent.turnFailed"
+  | "agent.turnCancelled"
+  | "agent.toolCallRequested"
+  | "agent.inputRequired"
+  | "agent.rateLimit"
+  | "agent.messageDelta"
+  | "agent.tokenUsageUpdated"
+  | "agent.error";
+
+type AgentEventPayloadBase = {
+  observabilityEvent?: string;
+  shouldEmitUpdate?: boolean;
+};
+
+export type AgentTurnStartedEvent = {
+  name: "agent.turnStarted";
+  payload: AgentEventPayloadBase & {
+    params: Record<string, unknown>;
+  };
+};
+
+export type AgentTurnCompletedEvent = {
+  name: "agent.turnCompleted";
+  payload: AgentEventPayloadBase & {
+    params: Record<string, unknown>;
+    inputRequired: boolean;
+  };
+};
+
+export type AgentTurnFailedEvent = {
+  name: "agent.turnFailed";
+  payload: AgentEventPayloadBase & {
+    params: Record<string, unknown>;
+  };
+};
+
+export type AgentTurnCancelledEvent = {
+  name: "agent.turnCancelled";
+  payload: AgentEventPayloadBase & {
+    params: Record<string, unknown>;
+  };
+};
+
+export type AgentToolCallRequestedEvent = {
+  name: "agent.toolCallRequested";
+  payload: AgentEventPayloadBase & {
+    params: Record<string, unknown>;
+    callId: string;
+    toolName: string;
+    threadId: string;
+    turnId: string;
+    arguments: unknown;
+  };
+};
+
+export type AgentInputRequiredEvent = {
+  name: "agent.inputRequired";
+  payload: AgentEventPayloadBase & {
+    params: Record<string, unknown>;
+    reason: string;
+  };
+};
+
+export type AgentRateLimitEvent = {
+  name: "agent.rateLimit";
+  payload: AgentEventPayloadBase & {
+    params: Record<string, unknown>;
+  };
+};
+
+export type AgentMessageDeltaEvent = {
+  name: "agent.messageDelta";
+  payload: AgentEventPayloadBase & {
+    params: Record<string, unknown>;
+    delta: string;
+    itemId: string;
+  };
+};
+
+export type AgentTokenUsageUpdatedEvent = {
+  name: "agent.tokenUsageUpdated";
+  payload: AgentEventPayloadBase & {
+    params: Record<string, unknown>;
+  };
+};
+
+export type AgentErrorEvent = {
+  name: "agent.error";
+  payload: AgentEventPayloadBase & {
+    params: Record<string, unknown>;
+    error: string;
+  };
+};
+
+export type AgentEvent =
+  | AgentTurnStartedEvent
+  | AgentTurnCompletedEvent
+  | AgentTurnFailedEvent
+  | AgentTurnCancelledEvent
+  | AgentToolCallRequestedEvent
+  | AgentInputRequiredEvent
+  | AgentRateLimitEvent
+  | AgentMessageDeltaEvent
+  | AgentTokenUsageUpdatedEvent
+  | AgentErrorEvent;

--- a/packages/core/src/runtime/index.ts
+++ b/packages/core/src/runtime/index.ts
@@ -1,2 +1,3 @@
 export * from "./adapter.js";
 export * from "./credentials.js";
+export * from "./events.js";

--- a/packages/runtime-codex/src/runtime.test.ts
+++ b/packages/runtime-codex/src/runtime.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   AgentRuntimeResolutionError,
+  CODEX_PROTOCOL_EVENT_NAMES,
   buildCodexRuntimePlan,
   createCodexRuntimeAdapter,
   createGitCredentialHelperEnvironment,
   createGitHubGraphQLToolDefinition,
+  getCodexObservabilityEventName,
+  normalizeCodexRuntimeEvents,
   prepareCodexRuntimePlan,
   resolvePreparedAgentEnvironment,
   resolveAgentRuntimeEnvironment,
@@ -349,6 +352,90 @@ describe("resolveAgentRuntimeEnvironment", () => {
         }
       )
     ).rejects.toThrow(AgentRuntimeResolutionError);
+  });
+});
+
+describe("normalizeCodexRuntimeEvents", () => {
+  it("maps a completion payload to neutral events", () => {
+    const events = normalizeCodexRuntimeEvents({
+      method: CODEX_PROTOCOL_EVENT_NAMES.turnCompleted,
+      params: {
+        inputRequired: false,
+        usage: {
+          input_tokens: 12,
+          output_tokens: 8,
+          total_tokens: 20,
+        },
+        rate_limits: {
+          remaining: 10,
+        },
+      },
+    });
+
+    expect(events.map((event) => event.name)).toEqual([
+      "agent.tokenUsageUpdated",
+      "agent.rateLimit",
+      "agent.turnCompleted",
+    ]);
+    expect(getCodexObservabilityEventName(events[2]!)).toBe(
+      CODEX_PROTOCOL_EVENT_NAMES.turnCompleted
+    );
+    expect(events[2]).toMatchObject({
+      name: "agent.turnCompleted",
+      payload: {
+        inputRequired: false,
+      },
+    });
+  });
+
+  it("maps tool calls and input-required events to neutral names", () => {
+    expect(
+      normalizeCodexRuntimeEvents({
+        method: CODEX_PROTOCOL_EVENT_NAMES.toolCallRequested,
+        params: {
+          callId: "call-1",
+          tool: "github_graphql",
+          threadId: "thread-1",
+          turnId: "turn-1",
+          arguments: { query: "{ viewer { login } }" },
+        },
+      })
+    ).toEqual([
+      {
+        name: "agent.toolCallRequested",
+        payload: {
+          observabilityEvent: CODEX_PROTOCOL_EVENT_NAMES.toolCallRequested,
+          params: {
+            callId: "call-1",
+            tool: "github_graphql",
+            threadId: "thread-1",
+            turnId: "turn-1",
+            arguments: { query: "{ viewer { login } }" },
+          },
+          callId: "call-1",
+          toolName: "github_graphql",
+          threadId: "thread-1",
+          turnId: "turn-1",
+          arguments: { query: "{ viewer { login } }" },
+        },
+      },
+    ]);
+
+    expect(
+      normalizeCodexRuntimeEvents({
+        method: CODEX_PROTOCOL_EVENT_NAMES.inputRequired,
+        params: { prompt: "Need approval" },
+      })
+    ).toEqual([
+      {
+        name: "agent.inputRequired",
+        payload: {
+          observabilityEvent: CODEX_PROTOCOL_EVENT_NAMES.inputRequired,
+          params: { prompt: "Need approval" },
+          reason: "turn_input_required: agent requires user input",
+        },
+      },
+    ]);
   });
 });
 

--- a/packages/runtime-codex/src/runtime.test.ts
+++ b/packages/runtime-codex/src/runtime.test.ts
@@ -442,6 +442,36 @@ describe("normalizeCodexRuntimeEvents", () => {
     });
   });
 
+  it("does not treat unrelated nested quota payloads as rate-limit events", () => {
+    const events = normalizeCodexRuntimeEvents({
+      method: CODEX_PROTOCOL_EVENT_NAMES.turnCompleted,
+      params: {
+        result: {
+          quota: {
+            remaining: 3,
+          },
+        },
+      },
+    });
+
+    expect(events).toEqual([
+      {
+        name: "agent.turnCompleted",
+        payload: {
+          observabilityEvent: CODEX_PROTOCOL_EVENT_NAMES.turnCompleted,
+          params: {
+            result: {
+              quota: {
+                remaining: 3,
+              },
+            },
+          },
+          inputRequired: false,
+        },
+      },
+    ]);
+  });
+
   it("maps tool calls and input-required events to neutral names", () => {
     expect(
       normalizeCodexRuntimeEvents({

--- a/packages/runtime-codex/src/runtime.test.ts
+++ b/packages/runtime-codex/src/runtime.test.ts
@@ -388,6 +388,60 @@ describe("normalizeCodexRuntimeEvents", () => {
     });
   });
 
+  it("recognizes canonical message delta and wrapped rate-limit payloads", () => {
+    const messageDeltaEvents = normalizeCodexRuntimeEvents({
+      method: CODEX_PROTOCOL_EVENT_NAMES.messageDelta,
+      params: {
+        item_id: "item-1",
+        delta: "hello",
+      },
+    });
+    const completionEvents = normalizeCodexRuntimeEvents({
+      method: CODEX_PROTOCOL_EVENT_NAMES.turnCompleted,
+      params: {
+        result: {
+          rate_limits: {
+            remaining: 3,
+            reset_at: "2026-04-23T15:00:00Z",
+          },
+        },
+      },
+    });
+
+    expect(messageDeltaEvents).toEqual([
+      {
+        name: "agent.messageDelta",
+        payload: {
+          observabilityEvent: CODEX_PROTOCOL_EVENT_NAMES.messageDelta,
+          params: {
+            item_id: "item-1",
+            delta: "hello",
+          },
+          delta: "hello",
+          itemId: "item-1",
+        },
+      },
+    ]);
+    expect(completionEvents.map((event) => event.name)).toEqual([
+      "agent.rateLimit",
+      "agent.turnCompleted",
+    ]);
+    expect(completionEvents[0]).toMatchObject({
+      name: "agent.rateLimit",
+      payload: {
+        observabilityEvent: CODEX_PROTOCOL_EVENT_NAMES.turnCompleted,
+        params: {
+          result: {
+            rate_limits: {
+              remaining: 3,
+              reset_at: "2026-04-23T15:00:00Z",
+            },
+          },
+        },
+      },
+    });
+  });
+
   it("maps tool calls and input-required events to neutral names", () => {
     expect(
       normalizeCodexRuntimeEvents({

--- a/packages/runtime-codex/src/runtime.test.ts
+++ b/packages/runtime-codex/src/runtime.test.ts
@@ -472,6 +472,32 @@ describe("normalizeCodexRuntimeEvents", () => {
     ]);
   });
 
+  it("does not treat generic data wrappers as rate-limit events", () => {
+    const events = normalizeCodexRuntimeEvents({
+      method: CODEX_PROTOCOL_EVENT_NAMES.turnCompleted,
+      params: {
+        data: {
+          remaining: 3,
+        },
+      },
+    });
+
+    expect(events).toEqual([
+      {
+        name: "agent.turnCompleted",
+        payload: {
+          observabilityEvent: CODEX_PROTOCOL_EVENT_NAMES.turnCompleted,
+          params: {
+            data: {
+              remaining: 3,
+            },
+          },
+          inputRequired: false,
+        },
+      },
+    ]);
+  });
+
   it("maps tool calls and input-required events to neutral names", () => {
     expect(
       normalizeCodexRuntimeEvents({
@@ -508,15 +534,15 @@ describe("normalizeCodexRuntimeEvents", () => {
     expect(
       normalizeCodexRuntimeEvents({
         method: CODEX_PROTOCOL_EVENT_NAMES.inputRequired,
-        params: { prompt: "Need approval" },
+        params: { prompt: "  Need approval  " },
       })
     ).toEqual([
       {
         name: "agent.inputRequired",
         payload: {
           observabilityEvent: CODEX_PROTOCOL_EVENT_NAMES.inputRequired,
-          params: { prompt: "Need approval" },
-          reason: "turn_input_required: agent requires user input",
+          params: { prompt: "  Need approval  " },
+          reason: "turn_input_required: Need approval",
         },
       },
     ]);

--- a/packages/runtime-codex/src/runtime.ts
+++ b/packages/runtime-codex/src/runtime.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { homedir } from "node:os";
 import { fileURLToPath } from "node:url";
 import {
+  buildAgentInputRequiredReason,
   readAgentCredentialCache,
   shouldReuseAgentCredentialCache,
   writeAgentCredentialCache,
@@ -228,12 +229,7 @@ function hasNestedRateLimitPayload(value: unknown): boolean {
     "rateLimits",
     "rate_limit",
     "rateLimit",
-    "info",
-    "msg",
-    "event",
-    "data",
     "result",
-    "payload",
   ];
 
   for (const key of preferredKeys) {
@@ -296,7 +292,7 @@ export function normalizeCodexRuntimeEvents(
       payload: {
         observabilityEvent: method,
         params,
-        reason: "turn_input_required: agent requires user input",
+        reason: buildAgentInputRequiredReason(params.prompt),
       },
     });
     return events;
@@ -344,7 +340,7 @@ export function normalizeCodexRuntimeEvents(
         payload: {
           observabilityEvent: method,
           params: asRecord(params.usage),
-          shouldEmitUpdate: false,
+          suppressUpdate: true,
         },
       });
     }
@@ -355,7 +351,7 @@ export function normalizeCodexRuntimeEvents(
         payload: {
           observabilityEvent: method,
           params,
-          shouldEmitUpdate: false,
+          suppressUpdate: true,
         },
       });
     }

--- a/packages/runtime-codex/src/runtime.ts
+++ b/packages/runtime-codex/src/runtime.ts
@@ -108,6 +108,7 @@ export const CODEX_PROTOCOL_EVENT_NAMES = {
 } as const;
 
 const CODEX_MESSAGE_DELTA_METHODS = new Set([
+  CODEX_PROTOCOL_EVENT_NAMES.messageDelta,
   "codex/event/agent_message_content_delta",
   "codex/event/agent_message_delta",
   "item/agentMessage/delta",
@@ -202,6 +203,54 @@ function hasOwn(
   return Object.prototype.hasOwnProperty.call(record, key);
 }
 
+function hasNestedRateLimitPayload(value: unknown): boolean {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+
+  const record = value as Record<string, unknown>;
+  const directKeys = [
+    "limit",
+    "remaining",
+    "used",
+    "reset",
+    "resetAt",
+    "resets_at",
+    "reset_at",
+  ];
+
+  if (directKeys.some((key) => hasOwn(record, key))) {
+    return true;
+  }
+
+  const preferredKeys = [
+    "rate_limits",
+    "rateLimits",
+    "rate_limit",
+    "rateLimit",
+    "info",
+    "msg",
+    "event",
+    "data",
+    "result",
+    "payload",
+  ];
+
+  for (const key of preferredKeys) {
+    if (hasOwn(record, key) && hasNestedRateLimitPayload(record[key])) {
+      return true;
+    }
+  }
+
+  for (const nestedValue of Object.values(record)) {
+    if (hasNestedRateLimitPayload(nestedValue)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 function createObservabilityEvent(
   event: AgentEvent
 ): string | undefined {
@@ -234,6 +283,7 @@ export function normalizeCodexRuntimeEvents(
         params,
       },
     });
+    return events;
   }
 
   if (method === CODEX_PROTOCOL_EVENT_NAMES.toolCallRequested) {
@@ -311,11 +361,7 @@ export function normalizeCodexRuntimeEvents(
       });
     }
 
-    if (
-      hasOwn(params, "rate_limits") ||
-      hasOwn(params, "rateLimits") ||
-      hasOwn(params, "rate_limit")
-    ) {
+    if (hasNestedRateLimitPayload(params)) {
       events.push({
         name: "agent.rateLimit",
         payload: {
@@ -368,6 +414,7 @@ export function normalizeCodexRuntimeEvents(
         error: JSON.stringify(params),
       },
     });
+    return events;
   }
 
   return events;

--- a/packages/runtime-codex/src/runtime.ts
+++ b/packages/runtime-codex/src/runtime.ts
@@ -10,6 +10,7 @@ import {
   writeAgentCredentialCache,
   type AgentRuntimeAdapter,
   type AgentRuntimeCredentialBrokerResponse,
+  type AgentEvent,
   type AgentRuntimeEvent,
 } from "@gh-symphony/core";
 import { resolveGitHubGraphQLMcpServerEntryPoint } from "@gh-symphony/tool-github-graphql";
@@ -95,6 +96,31 @@ type SpawnLike = (
   options: SpawnOptions
 ) => ChildProcess;
 
+export const CODEX_PROTOCOL_EVENT_NAMES = {
+  turnStarted: "turn/started",
+  turnCompleted: "turn/completed",
+  turnFailed: "turn/failed",
+  turnCancelled: "turn/cancelled",
+  toolCallRequested: "dynamic_tool_call_request",
+  inputRequired: "item/tool/requestUserInput",
+  rateLimit: "turn/rate_limit",
+  messageDelta: "item/message/delta",
+} as const;
+
+const CODEX_MESSAGE_DELTA_METHODS = new Set([
+  "codex/event/agent_message_content_delta",
+  "codex/event/agent_message_delta",
+  "item/agentMessage/delta",
+]);
+
+const CODEX_TOKEN_USAGE_METHODS = new Set([
+  "thread/tokenUsage/updated",
+  "total_token_usage",
+  "codex/event/token_count",
+]);
+
+type CodexProtocolMessage = Record<string, unknown>;
+
 export function createGitHubGraphQLToolDefinition(
   config: Pick<
     CodexRuntimeConfig,
@@ -161,6 +187,190 @@ export function createGitHubGraphQLToolDefinition(
       additionalProperties: false,
     },
   };
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value != null && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function hasOwn(
+  record: Record<string, unknown>,
+  key: string
+): boolean {
+  return Object.prototype.hasOwnProperty.call(record, key);
+}
+
+function createObservabilityEvent(
+  event: AgentEvent
+): string | undefined {
+  return event.payload.observabilityEvent;
+}
+
+export function getCodexObservabilityEventName(
+  event: AgentEvent
+): string | undefined {
+  return createObservabilityEvent(event);
+}
+
+export function normalizeCodexRuntimeEvents(
+  message: CodexProtocolMessage
+): AgentEvent[] {
+  const method =
+    typeof message.method === "string" ? message.method : undefined;
+  if (!method) {
+    return [];
+  }
+
+  const params = asRecord(message.params);
+  const events: AgentEvent[] = [];
+
+  if (method === CODEX_PROTOCOL_EVENT_NAMES.turnStarted) {
+    events.push({
+      name: "agent.turnStarted",
+      payload: {
+        observabilityEvent: method,
+        params,
+      },
+    });
+  }
+
+  if (method === CODEX_PROTOCOL_EVENT_NAMES.toolCallRequested) {
+    events.push({
+      name: "agent.toolCallRequested",
+      payload: {
+        observabilityEvent: method,
+        params,
+        callId: typeof params.callId === "string" ? params.callId : "",
+        toolName: typeof params.tool === "string" ? params.tool : "",
+        threadId: typeof params.threadId === "string" ? params.threadId : "",
+        turnId: typeof params.turnId === "string" ? params.turnId : "",
+        arguments: params.arguments,
+      },
+    });
+    return events;
+  }
+
+  if (method === CODEX_PROTOCOL_EVENT_NAMES.inputRequired) {
+    events.push({
+      name: "agent.inputRequired",
+      payload: {
+        observabilityEvent: method,
+        params,
+        reason: "turn_input_required: agent requires user input",
+      },
+    });
+    return events;
+  }
+
+  if (CODEX_TOKEN_USAGE_METHODS.has(method)) {
+    events.push({
+      name: "agent.tokenUsageUpdated",
+      payload: {
+        observabilityEvent: method,
+        params,
+      },
+    });
+    return events;
+  }
+
+  if (CODEX_MESSAGE_DELTA_METHODS.has(method)) {
+    events.push({
+      name: "agent.messageDelta",
+      payload: {
+        observabilityEvent: method,
+        params,
+        delta: typeof params.delta === "string" ? params.delta : "",
+        itemId: typeof params.item_id === "string" ? params.item_id : "",
+      },
+    });
+    return events;
+  }
+
+  if (method === CODEX_PROTOCOL_EVENT_NAMES.rateLimit) {
+    events.push({
+      name: "agent.rateLimit",
+      payload: {
+        observabilityEvent: method,
+        params,
+      },
+    });
+    return events;
+  }
+
+  if (method === CODEX_PROTOCOL_EVENT_NAMES.turnCompleted) {
+    if (hasOwn(params, "usage")) {
+      events.push({
+        name: "agent.tokenUsageUpdated",
+        payload: {
+          observabilityEvent: method,
+          params: asRecord(params.usage),
+          shouldEmitUpdate: false,
+        },
+      });
+    }
+
+    if (
+      hasOwn(params, "rate_limits") ||
+      hasOwn(params, "rateLimits") ||
+      hasOwn(params, "rate_limit")
+    ) {
+      events.push({
+        name: "agent.rateLimit",
+        payload: {
+          observabilityEvent: method,
+          params,
+          shouldEmitUpdate: false,
+        },
+      });
+    }
+
+    events.push({
+      name: "agent.turnCompleted",
+      payload: {
+        observabilityEvent: method,
+        params,
+        inputRequired: params.inputRequired === true,
+      },
+    });
+    return events;
+  }
+
+  if (method === CODEX_PROTOCOL_EVENT_NAMES.turnFailed) {
+    events.push({
+      name: "agent.turnFailed",
+      payload: {
+        observabilityEvent: method,
+        params,
+      },
+    });
+    return events;
+  }
+
+  if (method === CODEX_PROTOCOL_EVENT_NAMES.turnCancelled) {
+    events.push({
+      name: "agent.turnCancelled",
+      payload: {
+        observabilityEvent: method,
+        params,
+      },
+    });
+    return events;
+  }
+
+  if (method === "error") {
+    events.push({
+      name: "agent.error",
+      payload: {
+        observabilityEvent: method,
+        params,
+        error: JSON.stringify(params),
+      },
+    });
+  }
+
+  return events;
 }
 
 export function resolveStagedCodexHome(workingDirectory: string): string {

--- a/packages/runtime-codex/src/runtime.ts
+++ b/packages/runtime-codex/src/runtime.ts
@@ -242,25 +242,13 @@ function hasNestedRateLimitPayload(value: unknown): boolean {
     }
   }
 
-  for (const nestedValue of Object.values(record)) {
-    if (hasNestedRateLimitPayload(nestedValue)) {
-      return true;
-    }
-  }
-
   return false;
-}
-
-function createObservabilityEvent(
-  event: AgentEvent
-): string | undefined {
-  return event.payload.observabilityEvent;
 }
 
 export function getCodexObservabilityEventName(
   event: AgentEvent
 ): string | undefined {
-  return createObservabilityEvent(event);
+  return event.payload.observabilityEvent;
 }
 
 export function normalizeCodexRuntimeEvents(

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -4,13 +4,16 @@ import { join } from "node:path";
 import {
   classifySessionExit,
   parseWorkflowMarkdown,
+  type AgentEvent,
   type OrchestratorChannelEvent,
   type RunAttemptPhase,
   type SessionExitClassification,
   type WorkflowExecutionPhase,
 } from "@gh-symphony/core";
 import {
+  getCodexObservabilityEventName,
   launchCodexAppServer,
+  normalizeCodexRuntimeEvents,
   prepareCodexRuntimePlan,
   type CodexRuntimePlan,
   type RuntimeToolDefinition,
@@ -548,7 +551,7 @@ async function startAssignedRun() {
  * 1. Initialize codex
  * 2. Start thread with prompt + tool definitions
  * 3. Start first turn with rendered prompt
- * 4. Multi-turn loop: on turn/completed, refresh tracker state,
+ * 4. Multi-turn loop: on agent turn completion, refresh tracker state,
  *    send continuation turn if issue is still active
  * 5. Exit when max_turns reached, issue non-actionable, or error
  */
@@ -630,11 +633,11 @@ async function runCodexClientProtocol(
   }
 
   function describeTurnTerminalEvent(
-    event: "turn/failed" | "turn/cancelled",
+    event: "agent.turnFailed" | "agent.turnCancelled",
     params: unknown
   ): string | null {
     const fallback =
-      event === "turn/failed"
+      event === "agent.turnFailed"
         ? "turn_failed: codex reported turn failure"
         : "turn_cancelled: codex reported turn cancellation";
 
@@ -648,7 +651,7 @@ async function runCodexClientProtocol(
     for (const key of directReasonKeys) {
       const value = record[key];
       if (typeof value === "string" && value.trim()) {
-        return `${event.replace("/", "_")}: ${value.trim()}`;
+        return `${event.replace(".", "_")}: ${value.trim()}`;
       }
       if (
         value &&
@@ -658,14 +661,14 @@ async function runCodexClientProtocol(
         const nested = value as Record<string, unknown>;
         const nestedMessage = String(nested.message).trim();
         if (nestedMessage) {
-          return `${event.replace("/", "_")}: ${nestedMessage}`;
+          return `${event.replace(".", "_")}: ${nestedMessage}`;
         }
       }
     }
 
     const serialized = JSON.stringify(params).slice(0, 300);
     return serialized && serialized !== "{}"
-      ? `${event.replace("/", "_")}: ${serialized}`
+      ? `${event.replace(".", "_")}: ${serialized}`
       : fallback;
   }
 
@@ -736,7 +739,7 @@ async function runCodexClientProtocol(
 
   /**
    * Wait for the current turn to complete. Returns a promise that resolves
-   * when `turn/completed` is received from the codex server.
+   * when the runtime reports that the active turn completed.
    */
   function waitForTurnCompletion(): Promise<void> {
     return new Promise((resolve) => {
@@ -846,6 +849,156 @@ async function runCodexClientProtocol(
     }
   }
 
+  function resolveAgentEventObservabilityName(
+    event: AgentEvent
+  ): string | undefined {
+    return getCodexObservabilityEventName(event);
+  }
+
+  function emitObservedAgentEvent(event: AgentEvent): void {
+    if (event.payload.shouldEmitUpdate === false) {
+      return;
+    }
+    emitOrchestratorChannelEvent(resolveAgentEventObservabilityName(event));
+  }
+
+  function handleInputRequired(reason: string, event: AgentEvent): void {
+    process.stderr.write(
+      "[worker] user_input_required detected — terminating agent process\n"
+    );
+    userInputRequired = true;
+    runtimeState.status = "failed";
+    if (runtimeState.run) {
+      runtimeState.run.lastError = reason;
+    }
+    if (child.pid) {
+      try {
+        process.kill(child.pid, "SIGTERM");
+      } catch {
+        // Already gone.
+      }
+    }
+    if (activeTurnTelemetry) {
+      emitTurnFailedEvent(
+        activeTurnTelemetry,
+        runtimeState.run?.lastError ?? null
+      );
+      activeTurnTelemetry = null;
+    }
+    resolvePendingTurnCompletion();
+    emitObservedAgentEvent(event);
+  }
+
+  function handleAgentEvent(event: AgentEvent): boolean {
+    switch (event.name) {
+      case "agent.turnStarted":
+        emitObservedAgentEvent(event);
+        return true;
+      case "agent.toolCallRequested":
+        void dispatchDynamicToolCall(
+          event.payload.callId,
+          event.payload.toolName,
+          event.payload.threadId,
+          event.payload.turnId,
+          event.payload.arguments
+        );
+        emitObservedAgentEvent(event);
+        return true;
+      case "agent.inputRequired":
+        handleInputRequired(event.payload.reason, event);
+        return true;
+      case "agent.tokenUsageUpdated": {
+        const tokenUsage = extractAbsoluteTokenUsage(event.payload.params);
+        if (tokenUsage) {
+          applyTokenUsageUpdate(
+            resolveAgentEventObservabilityName(event) ?? event.name,
+            tokenUsage
+          );
+        }
+        emitObservedAgentEvent(event);
+        return true;
+      }
+      case "agent.rateLimit": {
+        const rateLimits = extractRateLimitPayload(event.payload.params);
+        if (rateLimits) {
+          applyRateLimitUpdate(
+            resolveAgentEventObservabilityName(event) ?? event.name,
+            rateLimits
+          );
+        }
+        emitObservedAgentEvent(event);
+        return true;
+      }
+      case "agent.messageDelta": {
+        const { delta, itemId } = event.payload;
+        if (deltaBuffer?.itemId !== itemId) {
+          flushDeltaBuffer();
+          deltaBuffer = { itemId, text: delta };
+        } else {
+          deltaBuffer.text += delta;
+        }
+        emitObservedAgentEvent(event);
+        return true;
+      }
+      case "agent.turnCompleted":
+        flushDeltaBuffer();
+        if (event.payload.inputRequired) {
+          handleInputRequired(
+            "turn_input_required: agent requires user input",
+            event
+          );
+          return true;
+        }
+        emitObservedAgentEvent(event);
+        if (activeTurnTelemetry) {
+          emitTurnCompletedEvent(activeTurnTelemetry);
+          activeTurnTelemetry = null;
+        }
+        process.stderr.write("[worker] agent turn completed\n");
+        resolvePendingTurnCompletion();
+        return true;
+      case "agent.turnFailed": {
+        flushDeltaBuffer();
+        const lastError = describeTurnTerminalEvent(
+          "agent.turnFailed",
+          event.payload.params
+        );
+        process.stderr.write(
+          `[worker] agent turn failed ${JSON.stringify(event.payload.params).slice(0, 300)}\n`
+        );
+        markTurnTerminalFailure("failed", lastError);
+        emitObservedAgentEvent(event);
+        return true;
+      }
+      case "agent.turnCancelled": {
+        flushDeltaBuffer();
+        const lastError = describeTurnTerminalEvent(
+          "agent.turnCancelled",
+          event.payload.params
+        );
+        process.stderr.write(
+          `[worker] agent turn cancelled ${JSON.stringify(event.payload.params).slice(0, 300)}\n`
+        );
+        markTurnTerminalFailure("canceled_by_reconciliation", lastError);
+        emitObservedAgentEvent(event);
+        return true;
+      }
+      case "agent.error":
+        process.stderr.write(
+          `[worker] runtime error ${JSON.stringify(event.payload.params).slice(0, 300)}\n`
+        );
+        if (runtimeState.run) {
+          runtimeState.run.lastError = event.payload.error;
+        }
+        runtimeState.status = "failed";
+        runtimeState.runPhase = "failed";
+        emitObservedAgentEvent(event);
+        return true;
+      default:
+        return false;
+    }
+  }
+
   function handleServerMessage(msg: Record<string, unknown>): void {
     // JSON-RPC response to our requests
     if ("id" in msg && msg.id != null && ("result" in msg || "error" in msg)) {
@@ -865,149 +1018,12 @@ async function runCodexClientProtocol(
     // Track the timestamp of every server-initiated notification/event.
     // This powers stall detection in the orchestrator (§4.1.6 last_codex_timestamp).
     runtimeState.lastEventAt = new Date().toISOString();
-    const orchestratorEventName =
-      typeof msg.method === "string" ? msg.method : undefined;
-
-    // Server-initiated request (dynamic tool call)
-    if (msg.method === "dynamic_tool_call_request" && msg.params != null) {
-      const params = msg.params as {
-        callId: string;
-        tool: string;
-        threadId: string;
-        turnId: string;
-        arguments: unknown;
-      };
-      void dispatchDynamicToolCall(
-        params.callId,
-        params.tool,
-        params.threadId,
-        params.turnId,
-        params.arguments
-      );
-      emitOrchestratorChannelEvent(orchestratorEventName);
-      return;
+    const agentEvents = normalizeCodexRuntimeEvents(msg);
+    let handledAgentEvent = false;
+    for (const event of agentEvents) {
+      handledAgentEvent = handleAgentEvent(event) || handledAgentEvent;
     }
-
-    // User input required — hard failure (agent cannot proceed autonomously)
-    if (msg.method === "item/tool/requestUserInput") {
-      process.stderr.write(
-        "[worker] user_input_required detected — terminating codex process\n"
-      );
-      userInputRequired = true;
-      runtimeState.status = "failed";
-      if (runtimeState.run) {
-        runtimeState.run.lastError =
-          "turn_input_required: agent requires user input";
-      }
-      if (child.pid) {
-        try {
-          process.kill(child.pid, "SIGTERM");
-        } catch {
-          // Already gone.
-        }
-      }
-      // Resolve any pending turn completion
-      if (activeTurnTelemetry) {
-        emitTurnFailedEvent(
-          activeTurnTelemetry,
-          runtimeState.run?.lastError ?? null
-        );
-        activeTurnTelemetry = null;
-      }
-      resolvePendingTurnCompletion();
-      emitOrchestratorChannelEvent(orchestratorEventName);
-      return;
-    }
-
-    // Turn completed — signal the multi-turn loop
-    if (msg.method === "turn/completed") {
-      flushDeltaBuffer();
-      const turnParams = (msg.params ?? {}) as Record<string, unknown>;
-      const turnUsage = extractAbsoluteTokenUsage(turnParams.usage);
-      if (turnUsage) {
-        applyTokenUsageUpdate("turn/completed", turnUsage);
-      }
-      const rateLimits = extractRateLimitPayload(turnParams);
-      if (rateLimits) {
-        applyRateLimitUpdate("turn/completed", rateLimits);
-      }
-      if (turnParams.inputRequired === true) {
-        process.stderr.write(
-          "[worker] user_input_required detected — terminating codex process\n"
-        );
-        userInputRequired = true;
-        runtimeState.status = "failed";
-        if (runtimeState.run) {
-          runtimeState.run.lastError =
-            "turn_input_required: agent requires user input";
-        }
-        if (child.pid) {
-          try {
-            process.kill(child.pid, "SIGTERM");
-          } catch {
-            // Already gone.
-          }
-        }
-        if (activeTurnTelemetry) {
-          emitTurnFailedEvent(
-            activeTurnTelemetry,
-            runtimeState.run?.lastError ?? null
-          );
-          activeTurnTelemetry = null;
-        }
-        resolvePendingTurnCompletion();
-        emitOrchestratorChannelEvent(orchestratorEventName);
-        return;
-      }
-      emitOrchestratorChannelEvent(orchestratorEventName);
-      if (activeTurnTelemetry) {
-        emitTurnCompletedEvent(activeTurnTelemetry);
-        activeTurnTelemetry = null;
-      }
-      process.stderr.write("[worker] codex turn/completed\n");
-      resolvePendingTurnCompletion();
-      return;
-    }
-
-    if (msg.method === "turn/failed") {
-      flushDeltaBuffer();
-      const lastError = describeTurnTerminalEvent(
-        "turn/failed",
-        msg.params ?? null
-      );
-      process.stderr.write(
-        `[worker] codex turn/failed ${JSON.stringify(msg.params ?? {}).slice(0, 300)}\n`
-      );
-      markTurnTerminalFailure("failed", lastError);
-      emitOrchestratorChannelEvent(orchestratorEventName);
-      return;
-    }
-
-    if (msg.method === "turn/cancelled") {
-      flushDeltaBuffer();
-      const lastError = describeTurnTerminalEvent(
-        "turn/cancelled",
-        msg.params ?? null
-      );
-      process.stderr.write(
-        `[worker] codex turn/cancelled ${JSON.stringify(msg.params ?? {}).slice(0, 300)}\n`
-      );
-      markTurnTerminalFailure("canceled_by_reconciliation", lastError);
-      emitOrchestratorChannelEvent(orchestratorEventName);
-      return;
-    }
-
-    // Token usage events — track cumulative totals
-    if (
-      msg.method === "thread/tokenUsage/updated" ||
-      msg.method === "total_token_usage" ||
-      msg.method === "codex/event/token_count"
-    ) {
-      const tokenUsage = extractAbsoluteTokenUsage(msg.params);
-      if (tokenUsage) {
-        applyTokenUsageUpdate(msg.method, tokenUsage);
-      }
-      emitOrchestratorChannelEvent(orchestratorEventName);
+    if (handledAgentEvent) {
       return;
     }
 
@@ -1016,30 +1032,10 @@ async function runCodexClientProtocol(
       applyRateLimitUpdate(msg.method, rateLimits);
     }
 
-    // Accumulate streaming delta events into a single log line per message
-    if (
-      typeof msg.method === "string" &&
-      (msg.method === "codex/event/agent_message_content_delta" ||
-        msg.method === "codex/event/agent_message_delta" ||
-        msg.method === "item/agentMessage/delta")
-    ) {
-      const params = (msg.params ?? {}) as Record<string, unknown>;
-      const delta = typeof params.delta === "string" ? params.delta : "";
-      const itemId = typeof params.item_id === "string" ? params.item_id : "";
-      if (deltaBuffer?.itemId !== itemId) {
-        flushDeltaBuffer();
-        deltaBuffer = { itemId, text: delta };
-      } else {
-        deltaBuffer.text += delta;
-      }
-      emitOrchestratorChannelEvent(orchestratorEventName);
-      return;
-    }
-
     // Log all other server notifications for observability
     if (typeof msg.method === "string") {
       flushDeltaBuffer();
-      emitOrchestratorChannelEvent(orchestratorEventName);
+      emitOrchestratorChannelEvent(msg.method);
       process.stderr.write(
         `[worker] codex → ${msg.method} ${JSON.stringify(msg.params ?? {}).slice(0, 300)}\n`
       );

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -3,6 +3,7 @@ import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import {
   classifySessionExit,
+  DEFAULT_AGENT_INPUT_REQUIRED_REASON,
   parseWorkflowMarkdown,
   type AgentEvent,
   type OrchestratorChannelEvent,
@@ -851,17 +852,11 @@ async function runCodexClientProtocol(
     }
   }
 
-  function resolveAgentEventObservabilityName(
-    event: AgentEvent
-  ): string | undefined {
-    return getCodexObservabilityEventName(event);
-  }
-
   function emitObservedAgentEvent(event: AgentEvent): void {
-    if (event.payload.shouldEmitUpdate === false) {
+    if (event.payload.suppressUpdate) {
       return;
     }
-    emitOrchestratorChannelEvent(resolveAgentEventObservabilityName(event));
+    emitOrchestratorChannelEvent(getCodexObservabilityEventName(event));
   }
 
   function handleInputRequired(reason: string, event: AgentEvent): void {
@@ -913,7 +908,7 @@ async function runCodexClientProtocol(
         const tokenUsage = extractAbsoluteTokenUsage(event.payload.params);
         if (tokenUsage) {
           applyTokenUsageUpdate(
-            resolveAgentEventObservabilityName(event) ?? event.name,
+            getCodexObservabilityEventName(event) ?? event.name,
             tokenUsage
           );
         }
@@ -924,7 +919,7 @@ async function runCodexClientProtocol(
         const rateLimits = extractRateLimitPayload(event.payload.params);
         if (rateLimits) {
           applyRateLimitUpdate(
-            resolveAgentEventObservabilityName(event) ?? event.name,
+            getCodexObservabilityEventName(event) ?? event.name,
             rateLimits
           );
         }
@@ -945,10 +940,7 @@ async function runCodexClientProtocol(
       case "agent.turnCompleted":
         flushDeltaBuffer();
         if (event.payload.inputRequired) {
-          handleInputRequired(
-            "turn_input_required: agent requires user input",
-            event
-          );
+          handleInputRequired(DEFAULT_AGENT_INPUT_REQUIRED_REASON, event);
           return true;
         }
         emitObservedAgentEvent(event);

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -636,6 +636,8 @@ async function runCodexClientProtocol(
     event: "agent.turnFailed" | "agent.turnCancelled",
     params: unknown
   ): string | null {
+    const errorPrefix =
+      event === "agent.turnFailed" ? "turn_failed" : "turn_cancelled";
     const fallback =
       event === "agent.turnFailed"
         ? "turn_failed: codex reported turn failure"
@@ -651,7 +653,7 @@ async function runCodexClientProtocol(
     for (const key of directReasonKeys) {
       const value = record[key];
       if (typeof value === "string" && value.trim()) {
-        return `${event.replace(".", "_")}: ${value.trim()}`;
+        return `${errorPrefix}: ${value.trim()}`;
       }
       if (
         value &&
@@ -661,14 +663,14 @@ async function runCodexClientProtocol(
         const nested = value as Record<string, unknown>;
         const nestedMessage = String(nested.message).trim();
         if (nestedMessage) {
-          return `${event.replace(".", "_")}: ${nestedMessage}`;
+          return `${errorPrefix}: ${nestedMessage}`;
         }
       }
     }
 
     const serialized = JSON.stringify(params).slice(0, 300);
     return serialized && serialized !== "{}"
-      ? `${event.replace(".", "_")}: ${serialized}`
+      ? `${errorPrefix}: ${serialized}`
       : fallback;
   }
 
@@ -984,14 +986,11 @@ async function runCodexClientProtocol(
         return true;
       }
       case "agent.error":
+        flushDeltaBuffer();
         process.stderr.write(
           `[worker] runtime error ${JSON.stringify(event.payload.params).slice(0, 300)}\n`
         );
-        if (runtimeState.run) {
-          runtimeState.run.lastError = event.payload.error;
-        }
-        runtimeState.status = "failed";
-        runtimeState.runPhase = "failed";
+        markTurnTerminalFailure("failed", event.payload.error);
         emitObservedAgentEvent(event);
         return true;
       default:

--- a/packages/worker/src/worker-protocol.test.ts
+++ b/packages/worker/src/worker-protocol.test.ts
@@ -15,7 +15,10 @@ import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { PassThrough } from "node:stream";
 import type { ChildProcessWithoutNullStreams } from "node:child_process";
 import { EventEmitter } from "node:events";
-import type { AgentEvent } from "@gh-symphony/core";
+import {
+  DEFAULT_AGENT_INPUT_REQUIRED_REASON,
+  type AgentEvent,
+} from "@gh-symphony/core";
 import {
   CODEX_PROTOCOL_EVENT_NAMES,
   getCodexObservabilityEventName,
@@ -792,17 +795,11 @@ function createProtocolContext(options: {
     }
   }
 
-  function resolveAgentEventObservabilityName(
-    event: AgentEvent
-  ): string | undefined {
-    return getCodexObservabilityEventName(event);
-  }
-
   function emitObservedAgentEvent(event: AgentEvent): void {
-    if (event.payload.shouldEmitUpdate === false) {
+    if (event.payload.suppressUpdate) {
       return;
     }
-    emitOrchestratorChannelEvent(resolveAgentEventObservabilityName(event));
+    emitOrchestratorChannelEvent(getCodexObservabilityEventName(event));
   }
 
   function handleInputRequired(reason: string, event: AgentEvent): void {
@@ -830,7 +827,7 @@ function createProtocolContext(options: {
         const tokenUsage = extractAbsoluteTokenUsage(event.payload.params);
         if (tokenUsage) {
           applyTokenUsageUpdate(
-            resolveAgentEventObservabilityName(event) ?? event.name,
+            getCodexObservabilityEventName(event) ?? event.name,
             tokenUsage
           );
         }
@@ -841,7 +838,7 @@ function createProtocolContext(options: {
         const rateLimits = extractRateLimitPayload(event.payload.params);
         if (rateLimits) {
           applyRateLimitUpdate(
-            resolveAgentEventObservabilityName(event) ?? event.name,
+            getCodexObservabilityEventName(event) ?? event.name,
             rateLimits
           );
         }
@@ -853,10 +850,7 @@ function createProtocolContext(options: {
         return true;
       case "agent.turnCompleted":
         if (event.payload.inputRequired) {
-          handleInputRequired(
-            "turn_input_required: agent requires user input",
-            event
-          );
+          handleInputRequired(DEFAULT_AGENT_INPUT_REQUIRED_REASON, event);
           return true;
         }
         emitObservedAgentEvent(event);
@@ -1844,7 +1838,7 @@ describe("user input required hard failure (4.3)", () => {
     expect(ctx.userInputRequired).toBe(true);
     expect(ctx.runtimeState.status).toBe("failed");
     expect(ctx.runtimeState.run.lastError).toBe(
-      "turn_input_required: agent requires user input"
+      "turn_input_required: Enter API key"
     );
     expect(ctx.killCalled).toBe(true);
   });
@@ -1860,7 +1854,7 @@ describe("user input required hard failure (4.3)", () => {
     expect(ctx.userInputRequired).toBe(true);
     expect(ctx.runtimeState.status).toBe("failed");
     expect(ctx.runtimeState.run.lastError).toBe(
-      "turn_input_required: agent requires user input"
+      DEFAULT_AGENT_INPUT_REQUIRED_REASON
     );
     expect(ctx.killCalled).toBe(true);
   });
@@ -1903,7 +1897,7 @@ describe("user input required hard failure (4.3)", () => {
         outputTokens: 6,
         totalTokens: 21,
       },
-      error: "turn_input_required: agent requires user input",
+      error: DEFAULT_AGENT_INPUT_REQUIRED_REASON,
     });
     expect(ctx.runtimeState.tokenUsage).toEqual({
       inputTokens: 25,

--- a/packages/worker/src/worker-protocol.test.ts
+++ b/packages/worker/src/worker-protocol.test.ts
@@ -15,6 +15,12 @@ import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { PassThrough } from "node:stream";
 import type { ChildProcessWithoutNullStreams } from "node:child_process";
 import { EventEmitter } from "node:events";
+import type { AgentEvent } from "@gh-symphony/core";
+import {
+  CODEX_PROTOCOL_EVENT_NAMES,
+  getCodexObservabilityEventName,
+  normalizeCodexRuntimeEvents,
+} from "@gh-symphony/runtime-codex";
 import { resolveCodexPolicySettings } from "./codex-policy.js";
 
 // ---------------------------------------------------------------------------
@@ -784,6 +790,97 @@ function createProtocolContext(options: {
     }
   }
 
+  function resolveAgentEventObservabilityName(
+    event: AgentEvent
+  ): string | undefined {
+    return getCodexObservabilityEventName(event);
+  }
+
+  function emitObservedAgentEvent(event: AgentEvent): void {
+    if (event.payload.shouldEmitUpdate === false) {
+      return;
+    }
+    emitOrchestratorChannelEvent(resolveAgentEventObservabilityName(event));
+  }
+
+  function handleInputRequired(reason: string, event: AgentEvent): void {
+    userInputRequired = true;
+    runtimeState.status = "failed";
+    runtimeState.run.lastError = reason;
+    killCalled = true;
+    if (activeTurnTelemetry) {
+      emitTurnFailedEvent(activeTurnTelemetry, runtimeState.run.lastError);
+      activeTurnTelemetry = null;
+    }
+    resolvePendingTurnCompletion();
+    emitObservedAgentEvent(event);
+  }
+
+  function handleAgentEvent(event: AgentEvent): boolean {
+    switch (event.name) {
+      case "agent.inputRequired":
+        handleInputRequired(event.payload.reason, event);
+        return true;
+      case "agent.tokenUsageUpdated": {
+        const tokenUsage = extractAbsoluteTokenUsage(event.payload.params);
+        if (tokenUsage) {
+          applyTokenUsageUpdate(
+            resolveAgentEventObservabilityName(event) ?? event.name,
+            tokenUsage
+          );
+        }
+        emitObservedAgentEvent(event);
+        return true;
+      }
+      case "agent.rateLimit": {
+        const rateLimits = extractRateLimitPayload(event.payload.params);
+        if (rateLimits) {
+          applyRateLimitUpdate(
+            resolveAgentEventObservabilityName(event) ?? event.name,
+            rateLimits
+          );
+        }
+        emitObservedAgentEvent(event);
+        return true;
+      }
+      case "agent.turnCompleted":
+        if (event.payload.inputRequired) {
+          handleInputRequired(
+            "turn_input_required: agent requires user input",
+            event
+          );
+          return true;
+        }
+        emitObservedAgentEvent(event);
+        if (activeTurnTelemetry) {
+          emitTurnCompletedEvent(activeTurnTelemetry);
+          activeTurnTelemetry = null;
+        }
+        resolvePendingTurnCompletion();
+        return true;
+      case "agent.turnFailed": {
+        const lastError = describeTurnTerminalEvent(
+          "turn/failed",
+          event.payload.params
+        );
+        markTurnTerminalFailure("failed", lastError);
+        emitObservedAgentEvent(event);
+        return true;
+      }
+      case "agent.turnCancelled": {
+        const lastError = describeTurnTerminalEvent(
+          "turn/cancelled",
+          event.payload.params
+        );
+        markTurnTerminalFailure("canceled_by_reconciliation", lastError);
+        emitObservedAgentEvent(event);
+        return true;
+      }
+      default:
+        return false;
+    }
+  }
+
   function handleServerMessage(msg: Record<string, unknown>): void {
     // JSON-RPC response to our requests
     if ("id" in msg && msg.id != null && ("result" in msg || "error" in msg)) {
@@ -802,91 +899,12 @@ function createProtocolContext(options: {
 
     // Track the timestamp of every server-initiated notification/event.
     runtimeState.lastEventAt = new Date().toISOString();
-    const orchestratorEventName =
-      typeof msg.method === "string" ? msg.method : undefined;
-
-    // User input required — hard failure
-    if (msg.method === "item/tool/requestUserInput") {
-      userInputRequired = true;
-      runtimeState.status = "failed";
-      runtimeState.run.lastError =
-        "turn_input_required: agent requires user input";
-      killCalled = true;
-      // Resolve any pending turn completion
-      if (activeTurnTelemetry) {
-        emitTurnFailedEvent(activeTurnTelemetry, runtimeState.run.lastError);
-        activeTurnTelemetry = null;
-      }
-      resolvePendingTurnCompletion();
-      emitOrchestratorChannelEvent(orchestratorEventName);
-      return;
+    const agentEvents = normalizeCodexRuntimeEvents(msg);
+    let handledAgentEvent = false;
+    for (const event of agentEvents) {
+      handledAgentEvent = handleAgentEvent(event) || handledAgentEvent;
     }
-
-    // Turn completed — signal the multi-turn loop
-    if (msg.method === "turn/completed") {
-      const turnParams = (msg.params ?? {}) as Record<string, unknown>;
-      const turnUsage = extractAbsoluteTokenUsage(turnParams.usage);
-      if (turnUsage) {
-        applyTokenUsageUpdate("turn/completed", turnUsage);
-      }
-      const rateLimits = extractRateLimitPayload(turnParams);
-      if (rateLimits) {
-        applyRateLimitUpdate("turn/completed", rateLimits);
-      }
-      if (turnParams.inputRequired === true) {
-        userInputRequired = true;
-        runtimeState.status = "failed";
-        runtimeState.run.lastError =
-          "turn_input_required: agent requires user input";
-        killCalled = true;
-        if (activeTurnTelemetry) {
-          emitTurnFailedEvent(activeTurnTelemetry, runtimeState.run.lastError);
-          activeTurnTelemetry = null;
-        }
-        resolvePendingTurnCompletion();
-        emitOrchestratorChannelEvent(orchestratorEventName);
-        return;
-      }
-      emitOrchestratorChannelEvent(orchestratorEventName);
-      if (activeTurnTelemetry) {
-        emitTurnCompletedEvent(activeTurnTelemetry);
-        activeTurnTelemetry = null;
-      }
-      resolvePendingTurnCompletion();
-      return;
-    }
-
-    if (msg.method === "turn/failed") {
-      const lastError = describeTurnTerminalEvent(
-        "turn/failed",
-        msg.params ?? null
-      );
-      markTurnTerminalFailure("failed", lastError);
-      emitOrchestratorChannelEvent(orchestratorEventName);
-      return;
-    }
-
-    if (msg.method === "turn/cancelled") {
-      const lastError = describeTurnTerminalEvent(
-        "turn/cancelled",
-        msg.params ?? null
-      );
-      markTurnTerminalFailure("canceled_by_reconciliation", lastError);
-      emitOrchestratorChannelEvent(orchestratorEventName);
-      return;
-    }
-
-    // Token usage events — track cumulative totals
-    if (
-      msg.method === "thread/tokenUsage/updated" ||
-      msg.method === "total_token_usage" ||
-      msg.method === "codex/event/token_count"
-    ) {
-      const tokenUsage = extractAbsoluteTokenUsage(msg.params);
-      if (tokenUsage) {
-        applyTokenUsageUpdate(msg.method, tokenUsage);
-      }
-      emitOrchestratorChannelEvent(orchestratorEventName);
+    if (handledAgentEvent) {
       return;
     }
 
@@ -894,7 +912,10 @@ function createProtocolContext(options: {
     if (rateLimits && typeof msg.method === "string") {
       applyRateLimitUpdate(msg.method, rateLimits);
     }
-    emitOrchestratorChannelEvent(orchestratorEventName);
+
+    emitOrchestratorChannelEvent(
+      typeof msg.method === "string" ? msg.method : undefined
+    );
   }
 
   return {
@@ -1122,7 +1143,10 @@ describe("multi-turn loop (2.7)", () => {
 
         // Simulate codex completing the turn after a small delay
         setTimeout(() => {
-          ctx.handleServerMessage({ method: "turn/completed", params: {} });
+          ctx.handleServerMessage({
+            method: CODEX_PROTOCOL_EVENT_NAMES.turnCompleted,
+            params: {},
+          });
         }, 100);
 
         await vi.advanceTimersByTimeAsync(100);
@@ -1155,7 +1179,10 @@ describe("multi-turn loop (2.7)", () => {
 
         const turnPromise = ctx.waitForTurnWithTimeout();
         setTimeout(() => {
-          ctx.handleServerMessage({ method: "turn/completed", params: {} });
+          ctx.handleServerMessage({
+            method: CODEX_PROTOCOL_EVENT_NAMES.turnCompleted,
+            params: {},
+          });
         }, 50);
         await vi.advanceTimersByTimeAsync(50);
         await turnPromise;
@@ -1586,14 +1613,14 @@ describe("read timeout (3.5)", () => {
 });
 
 describe("rate-limit telemetry", () => {
-  it("captures rate limits from turn/completed payloads", () => {
+  it("captures rate limits from completion payloads", () => {
     const ctx = createProtocolContext({
       readTimeoutMs: 1000,
       turnTimeoutMs: 60000,
     });
 
     ctx.handleServerMessage({
-      method: "turn/completed",
+      method: CODEX_PROTOCOL_EVENT_NAMES.turnCompleted,
       params: {
         usage: {
           input_tokens: 10,
@@ -1676,7 +1703,10 @@ describe("turn timeout (3.6)", () => {
 
     // Signal turn completion before timeout
     setTimeout(() => {
-      ctx.handleServerMessage({ method: "turn/completed", params: {} });
+      ctx.handleServerMessage({
+        method: CODEX_PROTOCOL_EVENT_NAMES.turnCompleted,
+        params: {},
+      });
     }, 500);
 
     await vi.advanceTimersByTimeAsync(500);
@@ -1775,11 +1805,11 @@ describe("turn timeout (3.6)", () => {
 });
 
 describe("user input required hard failure (4.3)", () => {
-  it("detects item/tool/requestUserInput and marks failure", () => {
+  it("detects runtime input-required events and marks failure", () => {
     const ctx = createProtocolContext({});
 
     ctx.handleServerMessage({
-      method: "item/tool/requestUserInput",
+      method: CODEX_PROTOCOL_EVENT_NAMES.inputRequired,
       params: { prompt: "Enter API key" },
     });
 
@@ -1791,11 +1821,11 @@ describe("user input required hard failure (4.3)", () => {
     expect(ctx.killCalled).toBe(true);
   });
 
-  it("detects turn/completed with inputRequired=true and marks failure", () => {
+  it("detects completion payloads with inputRequired=true and marks failure", () => {
     const ctx = createProtocolContext({});
 
     ctx.handleServerMessage({
-      method: "turn/completed",
+      method: CODEX_PROTOCOL_EVENT_NAMES.turnCompleted,
       params: { inputRequired: true },
     });
 
@@ -1818,7 +1848,7 @@ describe("user input required hard failure (4.3)", () => {
     ctx.startTurnTelemetry("2026-03-08T00:01:00.000Z");
 
     ctx.handleServerMessage({
-      method: "turn/completed",
+      method: CODEX_PROTOCOL_EVENT_NAMES.turnCompleted,
       params: {
         inputRequired: true,
         usage: {
@@ -1854,11 +1884,11 @@ describe("user input required hard failure (4.3)", () => {
     });
   });
 
-  it("does NOT trigger on normal turn/completed (inputRequired absent)", () => {
+  it("does not trigger on normal completion events when inputRequired is absent", () => {
     const ctx = createProtocolContext({});
 
     ctx.handleServerMessage({
-      method: "turn/completed",
+      method: CODEX_PROTOCOL_EVENT_NAMES.turnCompleted,
       params: {},
     });
 
@@ -1878,7 +1908,7 @@ describe("user input required hard failure (4.3)", () => {
     // Simulate user input required detection
     setTimeout(() => {
       ctx.handleServerMessage({
-        method: "item/tool/requestUserInput",
+        method: CODEX_PROTOCOL_EVENT_NAMES.inputRequired,
         params: {},
       });
     }, 100);
@@ -2011,7 +2041,7 @@ describe("orchestrator channel telemetry", () => {
     const ctx = createProtocolContext({});
 
     ctx.handleServerMessage({
-      method: "turn/completed",
+      method: CODEX_PROTOCOL_EVENT_NAMES.turnCompleted,
       params: {
         usage: { input_tokens: 90, output_tokens: 30, total_tokens: 120 },
         rate_limits: {
@@ -2046,7 +2076,7 @@ describe("orchestrator channel telemetry", () => {
       executionPhase: "implementation",
       runPhase: "streaming_turn",
       lastError: null,
-      event: "turn/completed",
+      event: CODEX_PROTOCOL_EVENT_NAMES.turnCompleted,
     });
   });
 
@@ -2060,7 +2090,7 @@ describe("orchestrator channel telemetry", () => {
     };
     ctx.startTurnTelemetry("2026-03-08T00:00:00.000Z");
     ctx.handleServerMessage({
-      method: "turn/completed",
+      method: CODEX_PROTOCOL_EVENT_NAMES.turnCompleted,
       params: {
         usage: {
           input_tokens: 25,
@@ -2377,11 +2407,11 @@ describe("orchestrator channel telemetry", () => {
 });
 
 describe("token usage tracking", () => {
-  it("updates and logs token counts from turn/completed usage payloads", () => {
+  it("updates and logs token counts from completion usage payloads", () => {
     const ctx = createProtocolContext({});
 
     ctx.handleServerMessage({
-      method: "turn/completed",
+      method: CODEX_PROTOCOL_EVENT_NAMES.turnCompleted,
       params: {
         usage: { input_tokens: 90, output_tokens: 30, total_tokens: 120 },
       },
@@ -2393,7 +2423,7 @@ describe("token usage tracking", () => {
       totalTokens: 120,
     });
     expect(ctx.logs).toContain(
-      "[worker] token_usage source=turn/completed input=90 output=30 total=120"
+      `[worker] token_usage source=${CODEX_PROTOCOL_EVENT_NAMES.turnCompleted} input=90 output=30 total=120`
     );
   });
 
@@ -2606,12 +2636,12 @@ describe("token usage tracking", () => {
 });
 
 describe("lastEventAt timestamp tracking", () => {
-  it("updates lastEventAt on turn/completed", () => {
+  it("updates lastEventAt on completion events", () => {
     const ctx = createProtocolContext({});
     expect(ctx.runtimeState.lastEventAt).toBeNull();
 
     ctx.handleServerMessage({
-      method: "turn/completed",
+      method: CODEX_PROTOCOL_EVENT_NAMES.turnCompleted,
       params: {},
     });
 
@@ -2659,7 +2689,7 @@ describe("lastEventAt timestamp tracking", () => {
     const ctx = createProtocolContext({});
 
     ctx.handleServerMessage({
-      method: "item/tool/requestUserInput",
+      method: CODEX_PROTOCOL_EVENT_NAMES.inputRequired,
       params: {},
     });
 
@@ -2699,7 +2729,7 @@ describe("lastEventAt timestamp tracking", () => {
       vi.setSystemTime(laterTime);
 
       ctx.handleServerMessage({
-        method: "turn/completed",
+        method: CODEX_PROTOCOL_EVENT_NAMES.turnCompleted,
         params: {},
       });
       const second = ctx.runtimeState.lastEventAt;

--- a/packages/worker/src/worker-protocol.test.ts
+++ b/packages/worker/src/worker-protocol.test.ts
@@ -696,10 +696,12 @@ function createProtocolContext(options: {
     event: "agent.turnFailed" | "agent.turnCancelled",
     params: unknown
   ): string | null {
+    const errorPrefix =
+      event === "agent.turnFailed" ? "turn_failed" : "turn_cancelled";
     const fallback =
       event === "agent.turnFailed"
-        ? "agent_turnFailed: codex reported turn failure"
-        : "agent_turnCancelled: codex reported turn cancellation";
+        ? "turn_failed: codex reported turn failure"
+        : "turn_cancelled: codex reported turn cancellation";
 
     if (!params || typeof params !== "object") {
       return fallback;
@@ -711,7 +713,7 @@ function createProtocolContext(options: {
     for (const key of directReasonKeys) {
       const value = record[key];
       if (typeof value === "string" && value.trim()) {
-        return `${event.replace(".", "_")}: ${value.trim()}`;
+        return `${errorPrefix}: ${value.trim()}`;
       }
       if (
         value &&
@@ -721,14 +723,14 @@ function createProtocolContext(options: {
         const nested = value as Record<string, unknown>;
         const nestedMessage = String(nested.message).trim();
         if (nestedMessage) {
-          return `${event.replace(".", "_")}: ${nestedMessage}`;
+          return `${errorPrefix}: ${nestedMessage}`;
         }
       }
     }
 
     const serialized = JSON.stringify(params).slice(0, 300);
     return serialized && serialized !== "{}"
-      ? `${event.replace(".", "_")}: ${serialized}`
+      ? `${errorPrefix}: ${serialized}`
       : fallback;
   }
 
@@ -818,6 +820,9 @@ function createProtocolContext(options: {
 
   function handleAgentEvent(event: AgentEvent): boolean {
     switch (event.name) {
+      case "agent.turnStarted":
+        emitObservedAgentEvent(event);
+        return true;
       case "agent.inputRequired":
         handleInputRequired(event.payload.reason, event);
         return true;
@@ -843,6 +848,9 @@ function createProtocolContext(options: {
         emitObservedAgentEvent(event);
         return true;
       }
+      case "agent.messageDelta":
+        emitObservedAgentEvent(event);
+        return true;
       case "agent.turnCompleted":
         if (event.payload.inputRequired) {
           handleInputRequired(
@@ -876,6 +884,10 @@ function createProtocolContext(options: {
         emitObservedAgentEvent(event);
         return true;
       }
+      case "agent.error":
+        markTurnTerminalFailure("failed", event.payload.error);
+        emitObservedAgentEvent(event);
+        return true;
       default:
         return false;
     }
@@ -1230,9 +1242,7 @@ describe("multi-turn loop (2.7)", () => {
     expect(turnResults).toEqual(["turn-1"]);
     expect(ctx.runtimeState.status).toBe("failed");
     expect(ctx.runtimeState.runPhase).toBe("failed");
-    expect(ctx.runtimeState.run.lastError).toBe(
-      "agent_turnFailed: tool execution failed"
-    );
+    expect(ctx.runtimeState.run.lastError).toBe("turn_failed: tool execution failed");
   });
 
   it("stops immediately when turn/cancelled is received", async () => {
@@ -1269,7 +1279,7 @@ describe("multi-turn loop (2.7)", () => {
     expect(ctx.runtimeState.status).toBe("failed");
     expect(ctx.runtimeState.runPhase).toBe("canceled_by_reconciliation");
     expect(ctx.runtimeState.run.lastError).toBe(
-      "agent_turnCancelled: reconciled against tracker state"
+      "turn_cancelled: reconciled against tracker state"
     );
   });
 
@@ -1732,9 +1742,7 @@ describe("turn timeout (3.6)", () => {
 
     expect(ctx.runtimeState.status).toBe("failed");
     expect(ctx.runtimeState.runPhase).toBe("failed");
-    expect(ctx.runtimeState.run.lastError).toBe(
-      "agent_turnFailed: model backend failed"
-    );
+    expect(ctx.runtimeState.run.lastError).toBe("turn_failed: model backend failed");
   });
 
   it("resolves pending turn wait when turn/cancelled is received", async () => {
@@ -1754,8 +1762,28 @@ describe("turn timeout (3.6)", () => {
 
     expect(ctx.runtimeState.status).toBe("failed");
     expect(ctx.runtimeState.runPhase).toBe("canceled_by_reconciliation");
+    expect(ctx.runtimeState.run.lastError).toBe("turn_cancelled: superseded");
+  });
+
+  it("resolves pending turn wait when error is received", async () => {
+    const ctx = createProtocolContext({ turnTimeoutMs: 5000 });
+
+    const promise = ctx.waitForTurnWithTimeout();
+
+    setTimeout(() => {
+      ctx.handleServerMessage({
+        method: "error",
+        params: { message: "runtime crashed", code: "E_RUNTIME" },
+      });
+    }, 100);
+
+    await vi.advanceTimersByTimeAsync(100);
+    await promise;
+
+    expect(ctx.runtimeState.status).toBe("failed");
+    expect(ctx.runtimeState.runPhase).toBe("failed");
     expect(ctx.runtimeState.run.lastError).toBe(
-      "agent_turnCancelled: superseded"
+      JSON.stringify({ message: "runtime crashed", code: "E_RUNTIME" })
     );
   });
 
@@ -1777,7 +1805,7 @@ describe("turn timeout (3.6)", () => {
     expect(ctx.runtimeState.status).toBe("failed");
     expect(ctx.runtimeState.runPhase).toBe("failed");
     expect(ctx.runtimeState.run.lastError).toBe(
-      'agent_turnFailed: {"error":{"message":"   "},"code":"E_BACKEND"}'
+      'turn_failed: {"error":{"message":"   "},"code":"E_BACKEND"}'
     );
   });
 
@@ -1800,9 +1828,7 @@ describe("turn timeout (3.6)", () => {
 
     expect(ctx.runtimeState.status).toBe("failed");
     expect(ctx.runtimeState.runPhase).toBe("failed");
-    expect(ctx.runtimeState.run.lastError).toBe(
-      "agent_turnFailed: tool execution failed"
-    );
+    expect(ctx.runtimeState.run.lastError).toBe("turn_failed: tool execution failed");
   });
 });
 
@@ -2155,7 +2181,7 @@ describe("orchestrator channel telemetry", () => {
         outputTokens: 0,
         totalTokens: 0,
       },
-      error: "agent_turnFailed: tool execution failed",
+      error: "turn_failed: tool execution failed",
     });
   });
 

--- a/packages/worker/src/worker-protocol.test.ts
+++ b/packages/worker/src/worker-protocol.test.ts
@@ -693,13 +693,13 @@ function createProtocolContext(options: {
   }
 
   function describeTurnTerminalEvent(
-    event: "turn/failed" | "turn/cancelled",
+    event: "agent.turnFailed" | "agent.turnCancelled",
     params: unknown
   ): string | null {
     const fallback =
-      event === "turn/failed"
-        ? "turn_failed: codex reported turn failure"
-        : "turn_cancelled: codex reported turn cancellation";
+      event === "agent.turnFailed"
+        ? "agent_turnFailed: codex reported turn failure"
+        : "agent_turnCancelled: codex reported turn cancellation";
 
     if (!params || typeof params !== "object") {
       return fallback;
@@ -711,7 +711,7 @@ function createProtocolContext(options: {
     for (const key of directReasonKeys) {
       const value = record[key];
       if (typeof value === "string" && value.trim()) {
-        return `${event.replace("/", "_")}: ${value.trim()}`;
+        return `${event.replace(".", "_")}: ${value.trim()}`;
       }
       if (
         value &&
@@ -721,14 +721,14 @@ function createProtocolContext(options: {
         const nested = value as Record<string, unknown>;
         const nestedMessage = String(nested.message).trim();
         if (nestedMessage) {
-          return `${event.replace("/", "_")}: ${nestedMessage}`;
+          return `${event.replace(".", "_")}: ${nestedMessage}`;
         }
       }
     }
 
     const serialized = JSON.stringify(params).slice(0, 300);
     return serialized && serialized !== "{}"
-      ? `${event.replace("/", "_")}: ${serialized}`
+      ? `${event.replace(".", "_")}: ${serialized}`
       : fallback;
   }
 
@@ -860,7 +860,7 @@ function createProtocolContext(options: {
         return true;
       case "agent.turnFailed": {
         const lastError = describeTurnTerminalEvent(
-          "turn/failed",
+          "agent.turnFailed",
           event.payload.params
         );
         markTurnTerminalFailure("failed", lastError);
@@ -869,7 +869,7 @@ function createProtocolContext(options: {
       }
       case "agent.turnCancelled": {
         const lastError = describeTurnTerminalEvent(
-          "turn/cancelled",
+          "agent.turnCancelled",
           event.payload.params
         );
         markTurnTerminalFailure("canceled_by_reconciliation", lastError);
@@ -1211,7 +1211,7 @@ describe("multi-turn loop (2.7)", () => {
         const turnPromise = ctx.waitForTurnWithTimeout();
         setTimeout(() => {
           ctx.handleServerMessage({
-            method: "turn/failed",
+            method: CODEX_PROTOCOL_EVENT_NAMES.turnFailed,
             params: { message: "tool execution failed" },
           });
         }, 25);
@@ -1231,7 +1231,7 @@ describe("multi-turn loop (2.7)", () => {
     expect(ctx.runtimeState.status).toBe("failed");
     expect(ctx.runtimeState.runPhase).toBe("failed");
     expect(ctx.runtimeState.run.lastError).toBe(
-      "turn_failed: tool execution failed"
+      "agent_turnFailed: tool execution failed"
     );
   });
 
@@ -1250,7 +1250,7 @@ describe("multi-turn loop (2.7)", () => {
         const turnPromise = ctx.waitForTurnWithTimeout();
         setTimeout(() => {
           ctx.handleServerMessage({
-            method: "turn/cancelled",
+            method: CODEX_PROTOCOL_EVENT_NAMES.turnCancelled,
             params: { reason: "reconciled against tracker state" },
           });
         }, 25);
@@ -1269,7 +1269,7 @@ describe("multi-turn loop (2.7)", () => {
     expect(ctx.runtimeState.status).toBe("failed");
     expect(ctx.runtimeState.runPhase).toBe("canceled_by_reconciliation");
     expect(ctx.runtimeState.run.lastError).toBe(
-      "turn_cancelled: reconciled against tracker state"
+      "agent_turnCancelled: reconciled against tracker state"
     );
   });
 
@@ -1722,7 +1722,7 @@ describe("turn timeout (3.6)", () => {
 
     setTimeout(() => {
       ctx.handleServerMessage({
-        method: "turn/failed",
+        method: CODEX_PROTOCOL_EVENT_NAMES.turnFailed,
         params: { error: { message: "model backend failed" } },
       });
     }, 100);
@@ -1733,7 +1733,7 @@ describe("turn timeout (3.6)", () => {
     expect(ctx.runtimeState.status).toBe("failed");
     expect(ctx.runtimeState.runPhase).toBe("failed");
     expect(ctx.runtimeState.run.lastError).toBe(
-      "turn_failed: model backend failed"
+      "agent_turnFailed: model backend failed"
     );
   });
 
@@ -1744,7 +1744,7 @@ describe("turn timeout (3.6)", () => {
 
     setTimeout(() => {
       ctx.handleServerMessage({
-        method: "turn/cancelled",
+        method: CODEX_PROTOCOL_EVENT_NAMES.turnCancelled,
         params: { reason: "superseded" },
       });
     }, 100);
@@ -1754,7 +1754,9 @@ describe("turn timeout (3.6)", () => {
 
     expect(ctx.runtimeState.status).toBe("failed");
     expect(ctx.runtimeState.runPhase).toBe("canceled_by_reconciliation");
-    expect(ctx.runtimeState.run.lastError).toBe("turn_cancelled: superseded");
+    expect(ctx.runtimeState.run.lastError).toBe(
+      "agent_turnCancelled: superseded"
+    );
   });
 
   it("falls back when nested turn failure message is whitespace only", async () => {
@@ -1764,7 +1766,7 @@ describe("turn timeout (3.6)", () => {
 
     setTimeout(() => {
       ctx.handleServerMessage({
-        method: "turn/failed",
+        method: CODEX_PROTOCOL_EVENT_NAMES.turnFailed,
         params: { error: { message: "   " }, code: "E_BACKEND" },
       });
     }, 100);
@@ -1775,7 +1777,7 @@ describe("turn timeout (3.6)", () => {
     expect(ctx.runtimeState.status).toBe("failed");
     expect(ctx.runtimeState.runPhase).toBe("failed");
     expect(ctx.runtimeState.run.lastError).toBe(
-      'turn_failed: {"error":{"message":"   "},"code":"E_BACKEND"}'
+      'agent_turnFailed: {"error":{"message":"   "},"code":"E_BACKEND"}'
     );
   });
 
@@ -1786,7 +1788,7 @@ describe("turn timeout (3.6)", () => {
 
     setTimeout(() => {
       ctx.handleServerMessage({
-        method: "turn/failed",
+        method: CODEX_PROTOCOL_EVENT_NAMES.turnFailed,
         params: { message: "tool execution failed" },
       });
     }, 100);
@@ -1799,7 +1801,7 @@ describe("turn timeout (3.6)", () => {
     expect(ctx.runtimeState.status).toBe("failed");
     expect(ctx.runtimeState.runPhase).toBe("failed");
     expect(ctx.runtimeState.run.lastError).toBe(
-      "turn_failed: tool execution failed"
+      "agent_turnFailed: tool execution failed"
     );
   });
 });
@@ -2129,7 +2131,7 @@ describe("orchestrator channel telemetry", () => {
     };
     ctx.startTurnTelemetry("2026-03-08T00:01:00.000Z");
     ctx.handleServerMessage({
-      method: "turn/failed",
+      method: CODEX_PROTOCOL_EVENT_NAMES.turnFailed,
       params: {
         error: {
           message: "tool execution failed",
@@ -2153,7 +2155,7 @@ describe("orchestrator channel telemetry", () => {
         outputTokens: 0,
         totalTokens: 0,
       },
-      error: "turn_failed: tool execution failed",
+      error: "agent_turnFailed: tool execution failed",
     });
   });
 
@@ -2656,7 +2658,7 @@ describe("lastEventAt timestamp tracking", () => {
     const ctx = createProtocolContext({});
 
     ctx.handleServerMessage({
-      method: "turn/failed",
+      method: CODEX_PROTOCOL_EVENT_NAMES.turnFailed,
       params: { message: "some failure" },
     });
 
@@ -2667,7 +2669,7 @@ describe("lastEventAt timestamp tracking", () => {
     const ctx = createProtocolContext({});
 
     ctx.handleServerMessage({
-      method: "turn/cancelled",
+      method: CODEX_PROTOCOL_EVENT_NAMES.turnCancelled,
       params: { reason: "reconciliation" },
     });
 


### PR DESCRIPTION
## Issues

- Fixes #216

## Summary

- neutral `AgentEvent` contract 위에 남아 있던 review feedback를 정리해 worker/runtime-codex/core의 naming and diagnostics를 일치시켰습니다.
- `agent.inputRequired` reason이 prompt 내용을 반영하도록 보강했고, completion-derived token/rate-limit 보조 이벤트는 `suppressUpdate` 의미로 명확히 표현되도록 정리했습니다.
- Codex rate-limit normalizer는 `result.rate_limits` 같은 유효 wrapper는 계속 인식하면서 generic `data.remaining` 형태 false positive는 더 이상 만들지 않습니다.

## Changes

- `packages/core/src/runtime/events.ts`에 `DEFAULT_AGENT_INPUT_REQUIRED_REASON`, `buildAgentInputRequiredReason()`를 추가하고 `shouldEmitUpdate?: boolean`을 `suppressUpdate?: true`로 바꿨습니다.
- `packages/core/src/runtime/events.ts`의 `AgentRateLimitEvent` payload에 raw `params` 유지 이유를 주석으로 명시했습니다.
- `packages/runtime-codex/src/runtime.ts`에서 `agent.inputRequired` reason을 prompt 기반으로 생성하고, rate-limit recursion key를 `rate_limits` 계열과 `result`로 제한했습니다.
- `packages/worker/src/index.ts`와 `packages/worker/src/worker-protocol.test.ts`에서 redundant observability helper wrapper를 제거하고, shared input-required fallback constant를 사용하도록 맞췄습니다.
- `packages/runtime-codex/src/runtime.test.ts`와 `packages/worker/src/worker-protocol.test.ts`에 prompt-trimming / generic-wrapper false-positive / runtime input-required reason 회귀를 반영했습니다.

## Evidence

- `pnpm --filter @gh-symphony/runtime-codex test -- src/runtime.test.ts`
- `pnpm --filter @gh-symphony/worker test -- src/worker-protocol.test.ts`
- `pnpm lint`
- `pnpm test`
- `pnpm typecheck`
- `pnpm build`
- `rg -n "turn/completed|dynamic_tool_call_request|item/tool/requestUserInput|item/message/delta|turn/started|turn/rate_limit" packages/worker/src` (exit code `1`, no matches)
- Docker E2E blackbox: `docker compose -f docker-compose.e2e.yml -f docker-compose.e2e.events.yml up -d --build`, `/healthz`, `happy-path` fixture 주입, `POST /api/v1/refresh`, 상태 API에서 `running` 진입 확인, fixture를 `[]`로 비우고 다시 `POST /api/v1/refresh`, 최종 `health="idle"`, `summary.activeRuns=0` 확인, 컨테이너 내부 `events.ndjson`에서 `run-dispatched` 기록 확인

## Human Validation

- [ ] worker 소스에 Codex wire event literal이 남아 있지 않은지 확인
- [ ] Codex 경로에서 worker가 기존과 동일하게 multi-turn/continuation 흐름을 유지하는지 확인
- [ ] `agent.inputRequired` 상황에서 prompt 기반 진단과 즉시 실패 정책이 함께 유지되는지 확인
- [ ] completion-derived token/rate-limit 보조 이벤트가 중복 `codex_update`를 만들지 않는지 확인
- [ ] Docker happy-path blackbox 흐름이 최종 idle 복귀와 retry release를 보이는지 확인

## Risks

- observability event 이름 자체는 이번 이슈 범위 밖이므로, 후속 naming debt 정리 전까지는 `codex_update.event` 값이 여전히 Codex 계열 이름을 포함할 수 있습니다.
- `AgentRateLimitEvent`는 여전히 raw `params`를 유지하므로, 추가 runtime이 들어오면 structured rate-limit field lift 여부를 별도 결정해야 합니다.