### PR TITLE
feat(cli): add Claude runtime prompt constraints

### DIFF
--- a/packages/cli/src/prompts/runtime-claude-constraints.ts
+++ b/packages/cli/src/prompts/runtime-claude-constraints.ts
@@ -1,15 +1,15 @@
 export const CLAUDE_RUNTIME_CONSTRAINTS_SECTION = `## Runtime Constraints
 
-1. This run uses \`claude -p\` in non-interactive mode.
+1. This run uses \`claude-code\` (Claude Code CLI) in non-interactive mode via \`claude -p\`.
 2. Slash commands such as \`/commit\`, \`/push\`, \`/gh-project\`, \`/gh-pr-writeup\` are NOT available (CLI limitation, independent of isolation settings).
 3. Use \`gh\`, \`git\`, repository scripts, and configured MCP tools directly instead.
 4. If a required permission or tool is unavailable, post a blocker comment on the issue and exit. Do not wait for human input.`;
 
 export const CLAUDE_PERMISSIVE_ISOLATION_NOTE =
-  "<!-- Permissive preset requires an isolated workspace. Symphony runs each issue in `.runtime/symphony-workspaces/<workspace-id>/`, a throwaway clone. If you disable workspace isolation or mount host paths into worker containers, do not use this runtime in production. -->";
+  "<!-- Runtime trade-off note: Permissive preset requires an isolated workspace. Symphony runs each issue in `.runtime/symphony-workspaces/<workspace-id>/`, a throwaway clone. If you disable workspace isolation or mount host paths into worker containers, do not use this runtime in production. -->";
 
 export const CLAUDE_ISOLATION_OFF_NOTE =
-  "<!-- Isolation is off by default — the agent will pick up your `CLAUDE.md`, project skills, and personal MCPs from `~/.claude/`. Turn isolation on when running in multi-operator CI, shared infrastructure, or when reproducibility across machines matters. -->";
+  "<!-- Runtime trade-off note: Isolation is off by default — the agent will pick up your `CLAUDE.md`, project skills, and personal MCPs from `~/.claude/`. Turn isolation on when running in multi-operator CI, shared infrastructure, or when reproducibility across machines matters. -->";
 
 export const CLAUDE_RUNTIME_PROMPT_PREAMBLE = [
   CLAUDE_RUNTIME_CONSTRAINTS_SECTION,

--- a/packages/cli/src/prompts/runtime-claude-constraints.ts
+++ b/packages/cli/src/prompts/runtime-claude-constraints.ts
@@ -1,18 +1,18 @@
-export const CLAUDE_RUNTIME_CONSTRAINTS_SECTION = `### Runtime Constraints
+export const CLAUDE_RUNTIME_CONSTRAINTS_SECTION = `## Runtime Constraints
 
 1. This run uses \`claude -p\` in non-interactive mode.
 2. Slash commands such as \`/commit\`, \`/push\`, \`/gh-project\`, \`/gh-pr-writeup\` are NOT available (CLI limitation, independent of isolation settings).
 3. Use \`gh\`, \`git\`, repository scripts, and configured MCP tools directly instead.
 4. If a required permission or tool is unavailable, post a blocker comment on the issue and exit. Do not wait for human input.`;
 
-export const CLAUDE_PERMISSIVE_ISOLATION_COMMENT =
+export const CLAUDE_PERMISSIVE_ISOLATION_NOTE =
   "<!-- Permissive preset requires an isolated workspace. Symphony runs each issue in `.runtime/symphony-workspaces/<workspace-id>/`, a throwaway clone. If you disable workspace isolation or mount host paths into worker containers, do not use this runtime in production. -->";
 
-export const CLAUDE_ISOLATION_OFF_COMMENT =
+export const CLAUDE_ISOLATION_OFF_NOTE =
   "<!-- Isolation is off by default — the agent will pick up your `CLAUDE.md`, project skills, and personal MCPs from `~/.claude/`. Turn isolation on when running in multi-operator CI, shared infrastructure, or when reproducibility across machines matters. -->";
 
 export const CLAUDE_RUNTIME_PROMPT_PREAMBLE = [
   CLAUDE_RUNTIME_CONSTRAINTS_SECTION,
-  CLAUDE_PERMISSIVE_ISOLATION_COMMENT,
-  CLAUDE_ISOLATION_OFF_COMMENT,
+  CLAUDE_PERMISSIVE_ISOLATION_NOTE,
+  CLAUDE_ISOLATION_OFF_NOTE,
 ].join("\n\n");

--- a/packages/cli/src/prompts/runtime-claude-constraints.ts
+++ b/packages/cli/src/prompts/runtime-claude-constraints.ts
@@ -1,0 +1,18 @@
+export const CLAUDE_RUNTIME_CONSTRAINTS_SECTION = `### Runtime Constraints
+
+1. This run uses \`claude -p\` in non-interactive mode.
+2. Slash commands such as \`/commit\`, \`/push\`, \`/gh-project\`, \`/gh-pr-writeup\` are NOT available (CLI limitation, independent of isolation settings).
+3. Use \`gh\`, \`git\`, repository scripts, and configured MCP tools directly instead.
+4. If a required permission or tool is unavailable, post a blocker comment on the issue and exit. Do not wait for human input.`;
+
+export const CLAUDE_PERMISSIVE_ISOLATION_COMMENT =
+  "<!-- Permissive preset requires an isolated workspace. Symphony runs each issue in `.runtime/symphony-workspaces/<workspace-id>/`, a throwaway clone. If you disable workspace isolation or mount host paths into worker containers, do not use this runtime in production. -->";
+
+export const CLAUDE_ISOLATION_OFF_COMMENT =
+  "<!-- Isolation is off by default — the agent will pick up your `CLAUDE.md`, project skills, and personal MCPs from `~/.claude/`. Turn isolation on when running in multi-operator CI, shared infrastructure, or when reproducibility across machines matters. -->";
+
+export const CLAUDE_RUNTIME_PROMPT_PREAMBLE = [
+  CLAUDE_RUNTIME_CONSTRAINTS_SECTION,
+  CLAUDE_PERMISSIVE_ISOLATION_COMMENT,
+  CLAUDE_ISOLATION_OFF_COMMENT,
+].join("\n\n");

--- a/packages/cli/src/workflow/generate-workflow-md.test.ts
+++ b/packages/cli/src/workflow/generate-workflow-md.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
 import { parseWorkflowMarkdown, renderPrompt } from "@gh-symphony/core";
 import {
-  CLAUDE_ISOLATION_OFF_COMMENT,
-  CLAUDE_PERMISSIVE_ISOLATION_COMMENT,
+  CLAUDE_ISOLATION_OFF_NOTE,
+  CLAUDE_PERMISSIVE_ISOLATION_NOTE,
   CLAUDE_RUNTIME_CONSTRAINTS_SECTION,
   CLAUDE_RUNTIME_PROMPT_PREAMBLE,
 } from "../prompts/runtime-claude-constraints.js";
@@ -123,13 +123,24 @@ describe("generateWorkflowMarkdown", () => {
       parsed.promptTemplate.startsWith(CLAUDE_RUNTIME_PROMPT_PREAMBLE)
     ).toBe(true);
     expect(parsed.promptTemplate).toContain(CLAUDE_RUNTIME_CONSTRAINTS_SECTION);
-    expect(parsed.promptTemplate).toContain(
-      CLAUDE_PERMISSIVE_ISOLATION_COMMENT
-    );
-    expect(parsed.promptTemplate).toContain(CLAUDE_ISOLATION_OFF_COMMENT);
+    expect(parsed.promptTemplate).toContain(CLAUDE_PERMISSIVE_ISOLATION_NOTE);
+    expect(parsed.promptTemplate).toContain(CLAUDE_ISOLATION_OFF_NOTE);
     expect(
-      parsed.promptTemplate.indexOf("### Runtime Constraints")
+      parsed.promptTemplate.indexOf("## Runtime Constraints")
     ).toBeLessThan(parsed.promptTemplate.indexOf("## Status Map"));
+  });
+
+  it("prepends Claude runtime constraints for wrapped Claude command strings", () => {
+    const markdown = generateWorkflowMarkdown({
+      ...defaultInput,
+      runtime: "bash -lc claude-code",
+    });
+    const parsed = parseWorkflowMarkdown(markdown, {});
+
+    expect(markdown).toContain("command: bash -lc claude-code");
+    expect(
+      parsed.promptTemplate.startsWith(CLAUDE_RUNTIME_PROMPT_PREAMBLE)
+    ).toBe(true);
   });
 
   it("keeps the Codex prompt body unchanged while Claude only adds the runtime preamble", () => {
@@ -145,7 +156,7 @@ describe("generateWorkflowMarkdown", () => {
     ).promptTemplate;
 
     expect(codexPrompt.startsWith("## Status Map")).toBe(true);
-    expect(codexPrompt).not.toContain("### Runtime Constraints");
+    expect(codexPrompt).not.toContain("## Runtime Constraints");
     expect(codexPrompt).not.toContain("Permissive preset requires");
     expect(codexPrompt).not.toContain("Isolation is off by default");
     expect(claudePrompt).toBe(
@@ -158,8 +169,13 @@ describe("generateWorkflowMarkdown", () => {
       ...defaultInput,
       runtime: "node worker.js",
     });
+    const parsed = parseWorkflowMarkdown(markdown, {});
 
     expect(markdown).toContain("command: node worker.js");
+    expect(parsed.promptTemplate.startsWith("## Status Map")).toBe(true);
+    expect(parsed.promptTemplate).not.toContain("## Runtime Constraints");
+    expect(parsed.promptTemplate).not.toContain("Permissive preset requires");
+    expect(parsed.promptTemplate).not.toContain("Isolation is off by default");
   });
 
   it("points after_create at the scaffolded default hook path", () => {

--- a/packages/cli/src/workflow/generate-workflow-md.test.ts
+++ b/packages/cli/src/workflow/generate-workflow-md.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { parseWorkflowMarkdown, renderPrompt } from "@gh-symphony/core";
+import {
+  CLAUDE_ISOLATION_OFF_COMMENT,
+  CLAUDE_PERMISSIVE_ISOLATION_COMMENT,
+  CLAUDE_RUNTIME_CONSTRAINTS_SECTION,
+  CLAUDE_RUNTIME_PROMPT_PREAMBLE,
+} from "../prompts/runtime-claude-constraints.js";
 import { DEFAULT_AFTER_CREATE_HOOK_PATH } from "./default-hooks.js";
 import { generateWorkflowMarkdown } from "./generate-workflow-md.js";
 
@@ -106,6 +112,47 @@ describe("generateWorkflowMarkdown", () => {
     expect(markdown).toContain("command: claude-code");
   });
 
+  it("prepends Claude runtime constraints and trade-off comments to the prompt body", () => {
+    const markdown = generateWorkflowMarkdown({
+      ...defaultInput,
+      runtime: "claude-code",
+    });
+    const parsed = parseWorkflowMarkdown(markdown, {});
+
+    expect(
+      parsed.promptTemplate.startsWith(CLAUDE_RUNTIME_PROMPT_PREAMBLE)
+    ).toBe(true);
+    expect(parsed.promptTemplate).toContain(CLAUDE_RUNTIME_CONSTRAINTS_SECTION);
+    expect(parsed.promptTemplate).toContain(
+      CLAUDE_PERMISSIVE_ISOLATION_COMMENT
+    );
+    expect(parsed.promptTemplate).toContain(CLAUDE_ISOLATION_OFF_COMMENT);
+    expect(
+      parsed.promptTemplate.indexOf("### Runtime Constraints")
+    ).toBeLessThan(parsed.promptTemplate.indexOf("## Status Map"));
+  });
+
+  it("keeps the Codex prompt body unchanged while Claude only adds the runtime preamble", () => {
+    const codexMarkdown = generateWorkflowMarkdown(defaultInput);
+    const claudeMarkdown = generateWorkflowMarkdown({
+      ...defaultInput,
+      runtime: "claude-code",
+    });
+    const codexPrompt = parseWorkflowMarkdown(codexMarkdown, {}).promptTemplate;
+    const claudePrompt = parseWorkflowMarkdown(
+      claudeMarkdown,
+      {}
+    ).promptTemplate;
+
+    expect(codexPrompt.startsWith("## Status Map")).toBe(true);
+    expect(codexPrompt).not.toContain("### Runtime Constraints");
+    expect(codexPrompt).not.toContain("Permissive preset requires");
+    expect(codexPrompt).not.toContain("Isolation is off by default");
+    expect(claudePrompt).toBe(
+      `${CLAUDE_RUNTIME_PROMPT_PREAMBLE}\n\n${codexPrompt}`
+    );
+  });
+
   it("uses custom runtime string as agent command", () => {
     const markdown = generateWorkflowMarkdown({
       ...defaultInput,
@@ -118,7 +165,9 @@ describe("generateWorkflowMarkdown", () => {
   it("points after_create at the scaffolded default hook path", () => {
     const markdown = generateWorkflowMarkdown(defaultInput);
 
-    expect(markdown).toContain(`after_create: ${DEFAULT_AFTER_CREATE_HOOK_PATH}`);
+    expect(markdown).toContain(
+      `after_create: ${DEFAULT_AFTER_CREATE_HOOK_PATH}`
+    );
   });
 
   it("includes template variables that resolve without errors", () => {

--- a/packages/cli/src/workflow/generate-workflow-md.test.ts
+++ b/packages/cli/src/workflow/generate-workflow-md.test.ts
@@ -123,8 +123,12 @@ describe("generateWorkflowMarkdown", () => {
       parsed.promptTemplate.startsWith(CLAUDE_RUNTIME_PROMPT_PREAMBLE)
     ).toBe(true);
     expect(parsed.promptTemplate).toContain(CLAUDE_RUNTIME_CONSTRAINTS_SECTION);
+    expect(parsed.promptTemplate).toContain(
+      "This run uses `claude-code` (Claude Code CLI) in non-interactive mode via `claude -p`."
+    );
     expect(parsed.promptTemplate).toContain(CLAUDE_PERMISSIVE_ISOLATION_NOTE);
     expect(parsed.promptTemplate).toContain(CLAUDE_ISOLATION_OFF_NOTE);
+    expect(parsed.promptTemplate).toContain("Runtime trade-off note:");
     expect(
       parsed.promptTemplate.indexOf("## Runtime Constraints")
     ).toBeLessThan(parsed.promptTemplate.indexOf("## Status Map"));

--- a/packages/cli/src/workflow/generate-workflow-md.test.ts
+++ b/packages/cli/src/workflow/generate-workflow-md.test.ts
@@ -182,6 +182,23 @@ describe("generateWorkflowMarkdown", () => {
     expect(parsed.promptTemplate).not.toContain("Isolation is off by default");
   });
 
+  it("does not prepend Claude runtime constraints for substring-only custom runtime strings", () => {
+    for (const runtime of ["my-claude-code-wrapper", "not-claude-code"]) {
+      const markdown = generateWorkflowMarkdown({
+        ...defaultInput,
+        runtime,
+      });
+      const parsed = parseWorkflowMarkdown(markdown, {});
+
+      expect(markdown).toContain(`command: ${runtime}`);
+      expect(parsed.promptTemplate.startsWith("## Status Map")).toBe(true);
+      expect(parsed.promptTemplate).not.toContain("## Runtime Constraints");
+      expect(parsed.promptTemplate).not.toContain(
+        "Runtime trade-off note:"
+      );
+    }
+  });
+
   it("points after_create at the scaffolded default hook path", () => {
     const markdown = generateWorkflowMarkdown(defaultInput);
 

--- a/packages/cli/src/workflow/generate-workflow-md.ts
+++ b/packages/cli/src/workflow/generate-workflow-md.ts
@@ -164,13 +164,13 @@ Create a workpad comment on the issue with the following structure to track prog
 - Progress notes
 \`\`\``;
 
-  return runtimePreamble
-    ? `${runtimePreamble}\n\n${templateBody}`
-    : templateBody;
+  return [runtimePreamble, templateBody].filter(Boolean).join("\n\n");
 }
 
-function buildRuntimePromptPreamble(runtime: string): string | null {
-  return runtime === "claude-code" ? CLAUDE_RUNTIME_PROMPT_PREAMBLE : null;
+function buildRuntimePromptPreamble(runtime: string): string {
+  return runtime === "claude-code" || runtime.includes("claude-code")
+    ? CLAUDE_RUNTIME_PROMPT_PREAMBLE
+    : "";
 }
 
 function generateStatusMapWithDescriptions(

--- a/packages/cli/src/workflow/generate-workflow-md.ts
+++ b/packages/cli/src/workflow/generate-workflow-md.ts
@@ -1,6 +1,7 @@
 import type { WorkflowLifecycleConfig } from "@gh-symphony/core";
 import type { StateMapping } from "../config.js";
 import type { DetectedEnvironment } from "../detection/environment-detector.js";
+import { CLAUDE_RUNTIME_PROMPT_PREAMBLE } from "../prompts/runtime-claude-constraints.js";
 import { DEFAULT_AFTER_CREATE_HOOK_PATH } from "./default-hooks.js";
 import { buildRepositoryValidationGuidance } from "./repository-guidance.js";
 
@@ -15,7 +16,11 @@ export type GenerateWorkflowInput = {
   concurrency?: number;
   detectedEnvironment: Pick<
     DetectedEnvironment,
-    "packageManager" | "testCommand" | "lintCommand" | "buildCommand" | "monorepo"
+    | "packageManager"
+    | "testCommand"
+    | "lintCommand"
+    | "buildCommand"
+    | "monorepo"
   >;
 };
 
@@ -96,7 +101,8 @@ function buildPromptBody(input: GenerateWorkflowInput): string {
   const validationGuidance = buildRepositoryValidationGuidance(
     input.detectedEnvironment
   );
-  const template = `${statusMap}
+  const runtimePreamble = buildRuntimePromptPreamble(input.runtime);
+  const templateBody = `${statusMap}
 
 ## Agent Instructions
 
@@ -158,7 +164,13 @@ Create a workpad comment on the issue with the following structure to track prog
 - Progress notes
 \`\`\``;
 
-  return template;
+  return runtimePreamble
+    ? `${runtimePreamble}\n\n${templateBody}`
+    : templateBody;
+}
+
+function buildRuntimePromptPreamble(runtime: string): string | null {
+  return runtime === "claude-code" ? CLAUDE_RUNTIME_PROMPT_PREAMBLE : null;
 }
 
 function generateStatusMapWithDescriptions(

--- a/packages/cli/src/workflow/generate-workflow-md.ts
+++ b/packages/cli/src/workflow/generate-workflow-md.ts
@@ -168,7 +168,7 @@ Create a workpad comment on the issue with the following structure to track prog
 }
 
 function buildRuntimePromptPreamble(runtime: string): string {
-  return runtime === "claude-code" || runtime.includes("claude-code")
+  return runtime.includes("claude-code")
     ? CLAUDE_RUNTIME_PROMPT_PREAMBLE
     : "";
 }

--- a/packages/cli/src/workflow/generate-workflow-md.ts
+++ b/packages/cli/src/workflow/generate-workflow-md.ts
@@ -168,7 +168,7 @@ Create a workpad comment on the issue with the following structure to track prog
 }
 
 function buildRuntimePromptPreamble(runtime: string): string {
-  return runtime.includes("claude-code")
+  return runtime.split(/\s+/).includes("claude-code")
     ? CLAUDE_RUNTIME_PROMPT_PREAMBLE
     : "";
 }


### PR DESCRIPTION
## Issues

- Fixes #223

## Summary

- Claude 런타임용 `Runtime Constraints` preamble을 WORKFLOW.md prompt body 상단에 삽입합니다.
- 리뷰 피드백을 반영해 `claude-code` 실행 커맨드와 `claude -p` 비대화형 실행 맥락을 함께 설명합니다.
- §4.4/§4.8 trade-off HTML NOTE가 상충되는 현재 상태처럼 보이지 않도록 운영 trade-off 안내임을 명시하고, Codex/custom runtime diff 테스트를 유지했습니다.

## Changes

- `packages/cli/src/prompts/runtime-claude-constraints.ts`에 Claude non-interactive 제약과 §4.4/§4.8 trade-off 안내를 상수화했습니다.
- trade-off HTML NOTE에 `Runtime trade-off note:` 맥락을 추가해 agent prompt에 raw text로 전달되는 의도를 명확히 했습니다.
- `generateWorkflowMarkdown`가 `claude-code` 및 wrapped `claude-code` command 문자열일 때만 prompt body 앞에 Claude preamble을 붙이도록 분기했습니다.
- `runtime.includes("claude-code")` 기반 감지로 중복 조건을 정리하고 Claude/Codex/custom runtime 출력 diff 단위 테스트를 보강했습니다.

## Evidence

- `pnpm --filter @gh-symphony/cli test -- --run src/workflow/generate-workflow-md.test.ts` — passed, 23 tests.
- `pnpm lint && pnpm test && pnpm typecheck && pnpm build` — passed.
- Manual check: 이슈 요구사항을 재대조해 Claude preamble 삽입, §4.4/§4.8 주석 삽입, Codex prompt 유지, custom runtime 미삽입, wrapped Claude command 삽입을 확인했습니다.
- Docker E2E: CLI-generated prompt text 변경만 해당하며 orchestrator dispatch, worker lifecycle, tracker adapter, status API 변경이 없어 실행하지 않았습니다.

## Human Validation

- [ ] `gh-symphony workflow init --runtime claude-code`로 생성한 `WORKFLOW.md` prompt body 상단에 `## Runtime Constraints`가 표시되는지 확인
- [ ] 생성된 Claude prompt에 `claude-code` / `claude -p` 비대화형 제약과 permissive preset / isolation off trade-off HTML NOTE가 포함되는지 확인
- [ ] `gh-symphony workflow init --runtime codex` 출력에서 기존 prompt body가 변경되지 않았는지 확인
- [ ] `node worker.js` 같은 비-Claude custom runtime에는 Claude preamble이 삽입되지 않는지 확인

## Risks

- `runtime.includes("claude-code")` 기반 감지는 기존 skills 생성 경로의 normalization과 맞춘 동작입니다. `claude-code`라는 문자열을 포함하지만 실제 Claude 런타임이 아닌 custom command가 있다면 preamble이 삽입될 수 있습니다.