### PR TITLE
feat(runtime-claude): compose github graphql MCP config

### DIFF
--- a/packages/runtime-claude/package.json
+++ b/packages/runtime-claude/package.json
@@ -39,6 +39,7 @@
     "typecheck": "tsc -p tsconfig.typecheck.json"
   },
   "dependencies": {
-    "@gh-symphony/core": "workspace:*"
+    "@gh-symphony/core": "workspace:*",
+    "@gh-symphony/tool-github-graphql": "workspace:*"
   }
 }

--- a/packages/runtime-claude/src/adapter.test.ts
+++ b/packages/runtime-claude/src/adapter.test.ts
@@ -1,4 +1,7 @@
 import { EventEmitter } from "node:events";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { PassThrough } from "node:stream";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
@@ -42,8 +45,21 @@ function createStubChild() {
 }
 
 describe("ClaudePrintRuntimeAdapter", () => {
+  const tempRoots: string[] = [];
+
   afterEach(() => {
     delete process.env.GITHUB_TOKEN;
+  });
+
+  afterEach(async () => {
+    await Promise.all(
+      tempRoots.splice(0).map((root) =>
+        rm(root, {
+          force: true,
+          recursive: true,
+        })
+      )
+    );
   });
 
   it("spawns claude with default argv and merged env", async () => {
@@ -169,6 +185,59 @@ describe("ClaudePrintRuntimeAdapter", () => {
     });
 
     expect(calls[0]?.GITHUB_TOKEN).toBe("from-process-env");
+  });
+
+  it("prepares strict MCP config argv and removes the ephemeral file on shutdown", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "claude-adapter-"));
+    const runtimeRoot = join(workspaceRoot, "runtime");
+    tempRoots.push(workspaceRoot);
+    const calls: Array<{
+      args: ReadonlyArray<string>;
+    }> = [];
+    const { child, stdout, stderr } = createStubChild();
+
+    const spawnImpl: SpawnLike = (_command, args) => {
+      calls.push({ args });
+
+      queueMicrotask(() => {
+        stdout.end();
+        stderr.end();
+        child.emit("close", 0, null);
+      });
+
+      return child;
+    };
+
+    const adapter = new ClaudePrintRuntimeAdapter(
+      {
+        workingDirectory: workspaceRoot,
+        runtimeDirectory: runtimeRoot,
+        env: {
+          GITHUB_GRAPHQL_TOKEN: "runtime-token",
+        },
+        isolation: {
+          strictMcpConfig: true,
+        },
+      },
+      { spawnImpl }
+    );
+
+    await adapter.prepare({ runId: "run-1" });
+    await adapter.spawnTurn({
+      messages: [],
+    });
+
+    const mcpConfigPath = join(runtimeRoot, "mcp.json");
+    expect(calls[0]?.args).toContain("--strict-mcp-config");
+    expect(calls[0]?.args).toContain("--mcp-config");
+    expect(calls[0]?.args).toContain(mcpConfigPath);
+    expect(await readFile(mcpConfigPath, "utf8")).toContain("github_graphql");
+
+    await adapter.shutdown();
+
+    await expect(readFile(mcpConfigPath, "utf8")).rejects.toMatchObject({
+      code: "ENOENT",
+    });
   });
 
   it("terminates the in-flight child on cancel", async () => {

--- a/packages/runtime-claude/src/adapter.test.ts
+++ b/packages/runtime-claude/src/adapter.test.ts
@@ -329,6 +329,36 @@ describe("ClaudePrintRuntimeAdapter", () => {
     });
   });
 
+  it("replaces strict MCP ephemeral config when prepare is called again", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "claude-adapter-"));
+    const runtimeRoot = join(workspaceRoot, "runtime");
+    tempRoots.push(workspaceRoot);
+    const env = {
+      GITHUB_GRAPHQL_TOKEN: "first-token",
+    };
+
+    const adapter = new ClaudePrintRuntimeAdapter({
+      workingDirectory: workspaceRoot,
+      runtimeDirectory: runtimeRoot,
+      env,
+      isolation: {
+        strictMcpConfig: true,
+      },
+    });
+
+    await adapter.prepare({ runId: "run-1" });
+    const mcpConfigPath = join(runtimeRoot, "mcp.json");
+    expect(await readFile(mcpConfigPath, "utf8")).toContain("first-token");
+
+    env.GITHUB_GRAPHQL_TOKEN = "second-token";
+    await adapter.prepare({ runId: "run-2" });
+    const replacedConfig = await readFile(mcpConfigPath, "utf8");
+    expect(replacedConfig).toContain("second-token");
+    expect(replacedConfig).not.toContain("first-token");
+
+    await adapter.shutdown();
+  });
+
   it("terminates the in-flight child on cancel", async () => {
     const kill = vi.fn(() => true);
     const { child, stdout, stderr } = createStubChild();

--- a/packages/runtime-claude/src/adapter.test.ts
+++ b/packages/runtime-claude/src/adapter.test.ts
@@ -48,6 +48,7 @@ describe("ClaudePrintRuntimeAdapter", () => {
   const tempRoots: string[] = [];
 
   afterEach(() => {
+    delete process.env.GITHUB_GRAPHQL_TOKEN;
     delete process.env.GITHUB_TOKEN;
   });
 
@@ -240,6 +241,94 @@ describe("ClaudePrintRuntimeAdapter", () => {
     });
   });
 
+  it("does not inherit host MCP credentials during prepare unless enabled", async () => {
+    process.env.GITHUB_GRAPHQL_TOKEN = "host-token";
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "claude-adapter-"));
+    tempRoots.push(workspaceRoot);
+
+    const adapter = new ClaudePrintRuntimeAdapter({
+      workingDirectory: workspaceRoot,
+      env: {
+        GITHUB_PROJECT_ID: "project-from-config",
+      },
+    });
+
+    await adapter.prepare({ runId: "run-1" });
+
+    const config = JSON.parse(
+      await readFile(join(workspaceRoot, ".mcp.json"), "utf8")
+    ) as {
+      mcpServers?: {
+        github_graphql?: {
+          env?: Record<string, string>;
+        };
+      };
+    };
+
+    expect(config.mcpServers?.github_graphql?.env).toMatchObject({
+      GITHUB_PROJECT_ID: "project-from-config",
+    });
+    expect(
+      config.mcpServers?.github_graphql?.env?.GITHUB_GRAPHQL_TOKEN
+    ).toBeUndefined();
+  });
+
+  it("can opt in to inheriting host MCP credentials during prepare", async () => {
+    process.env.GITHUB_GRAPHQL_TOKEN = "host-token";
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "claude-adapter-"));
+    tempRoots.push(workspaceRoot);
+
+    const adapter = new ClaudePrintRuntimeAdapter({
+      workingDirectory: workspaceRoot,
+      inheritProcessEnv: true,
+    });
+
+    await adapter.prepare({ runId: "run-1" });
+
+    expect(await readFile(join(workspaceRoot, ".mcp.json"), "utf8")).toContain(
+      "host-token"
+    );
+  });
+
+  it("rejects strict MCP config spawns without prepare or explicit config path", async () => {
+    const adapter = new ClaudePrintRuntimeAdapter({
+      workingDirectory: "/workspace",
+      isolation: {
+        strictMcpConfig: true,
+      },
+    });
+
+    await expect(
+      adapter.spawnTurn({
+        messages: [],
+      })
+    ).rejects.toThrowError("requires prepare()");
+  });
+
+  it("removes strict MCP ephemeral config on cancel", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "claude-adapter-"));
+    const runtimeRoot = join(workspaceRoot, "runtime");
+    tempRoots.push(workspaceRoot);
+
+    const adapter = new ClaudePrintRuntimeAdapter({
+      workingDirectory: workspaceRoot,
+      runtimeDirectory: runtimeRoot,
+      isolation: {
+        strictMcpConfig: true,
+      },
+    });
+
+    await adapter.prepare({ runId: "run-1" });
+    const mcpConfigPath = join(runtimeRoot, "mcp.json");
+    expect(await readFile(mcpConfigPath, "utf8")).toContain("github_graphql");
+
+    await adapter.cancel("test");
+
+    await expect(readFile(mcpConfigPath, "utf8")).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
   it("terminates the in-flight child on cancel", async () => {
     const kill = vi.fn(() => true);
     const { child, stdout, stderr } = createStubChild();
@@ -263,7 +352,7 @@ describe("ClaudePrintRuntimeAdapter", () => {
       messages: [],
     });
 
-    adapter.cancel("test");
+    await adapter.cancel("test");
     stdout.end();
     stderr.end();
     child.emit("close", null, "SIGTERM");

--- a/packages/runtime-claude/src/adapter.ts
+++ b/packages/runtime-claude/src/adapter.ts
@@ -18,6 +18,7 @@ import {
 import {
   composeClaudeMcpConfig,
   type ClaudeMcpCompositionResult,
+  type ClaudeMcpTokenEnvironment,
 } from "./mcp-compose.js";
 import {
   spawnClaudeTurn,
@@ -83,15 +84,11 @@ export class ClaudePrintRuntimeAdapter
     this.preparedMcpConfig = await composeClaudeMcpConfig(
       this.config.workingDirectory,
       this.config.isolation?.strictMcpConfig === true,
-      {
-        ...process.env,
-        ...this.config.env,
-        ...(this.config.runtimeDirectory
-          ? {
-              WORKSPACE_RUNTIME_DIR: this.config.runtimeDirectory,
-            }
-          : {}),
-      }
+      buildClaudeMcpTokenEnvironment({
+        inheritProcessEnv: this.config.inheritProcessEnv === true,
+        configEnv: this.config.env,
+        runtimeDirectory: this.config.runtimeDirectory,
+      })
     );
   }
 
@@ -159,19 +156,37 @@ export class ClaudePrintRuntimeAdapter
   }
 
   private buildArgvOptions(input: ClaudeRuntimeTurnInput): ClaudePrintArgvOptions {
+    const isolation = {
+      ...this.config.isolation,
+      ...input.isolation,
+    };
+    const configuredExtraArgs = input.extraArgs ?? this.config.extraArgs ?? [];
+
+    if (this.preparedMcpConfig) {
+      return {
+        session: input.session,
+        isolation: {
+          ...isolation,
+          strictMcpConfig: false,
+          mcpConfigPath: undefined,
+        },
+        extraArgs: [
+          ...this.preparedMcpConfig.extraArgv,
+          ...configuredExtraArgs,
+        ],
+      };
+    }
+
+    if (isolation.strictMcpConfig && !isolation.mcpConfigPath) {
+      throw new Error(
+        "Claude strict MCP config requires prepare() or an explicit mcpConfigPath."
+      );
+    }
+
     return {
       session: input.session,
-      isolation: {
-        ...this.config.isolation,
-        ...(this.preparedMcpConfig?.cleanupPath
-          ? {
-              strictMcpConfig: true,
-              mcpConfigPath: this.preparedMcpConfig.finalPath,
-            }
-          : {}),
-        ...input.isolation,
-      },
-      extraArgs: input.extraArgs ?? this.config.extraArgs,
+      isolation,
+      extraArgs: configuredExtraArgs,
     };
   }
 
@@ -249,4 +264,30 @@ function buildClaudeSpawnEnv(options: {
   Object.assign(env, options.configEnv, options.inputEnv);
 
   return env;
+}
+
+function buildClaudeMcpTokenEnvironment(options: {
+  inheritProcessEnv: boolean;
+  configEnv?: NodeJS.ProcessEnv;
+  runtimeDirectory?: string;
+}): ClaudeMcpTokenEnvironment {
+  const source = options.inheritProcessEnv
+    ? {
+        ...process.env,
+        ...options.configEnv,
+      }
+    : {
+        ...options.configEnv,
+      };
+
+  return {
+    GITHUB_GRAPHQL_TOKEN: source.GITHUB_GRAPHQL_TOKEN,
+    GITHUB_GRAPHQL_API_URL: source.GITHUB_GRAPHQL_API_URL,
+    GITHUB_TOKEN_BROKER_URL: source.GITHUB_TOKEN_BROKER_URL,
+    GITHUB_TOKEN_BROKER_SECRET: source.GITHUB_TOKEN_BROKER_SECRET,
+    GITHUB_TOKEN_CACHE_PATH: source.GITHUB_TOKEN_CACHE_PATH,
+    GITHUB_PROJECT_ID: source.GITHUB_PROJECT_ID,
+    WORKSPACE_RUNTIME_DIR:
+      options.runtimeDirectory ?? source.WORKSPACE_RUNTIME_DIR,
+  };
 }

--- a/packages/runtime-claude/src/adapter.ts
+++ b/packages/runtime-claude/src/adapter.ts
@@ -1,4 +1,5 @@
 import type { ChildProcess } from "node:child_process";
+import { rm } from "node:fs/promises";
 import type {
   AgentRuntimeAdapter,
   AgentRuntimeCredentialBrokerResponse,
@@ -15,6 +16,10 @@ import {
   type ClaudeRuntimeSessionOptions,
 } from "./argv.js";
 import {
+  composeClaudeMcpConfig,
+  type ClaudeMcpCompositionResult,
+} from "./mcp-compose.js";
+import {
   spawnClaudeTurn,
   type ClaudeSpawnDependencies,
   type ClaudeSpawnTurnResult,
@@ -23,6 +28,7 @@ import {
 
 export type ClaudeRuntimeConfig = {
   workingDirectory: string;
+  runtimeDirectory?: string;
   command?: string;
   env?: NodeJS.ProcessEnv;
   extraArgs?: readonly string[];
@@ -65,15 +71,28 @@ export class ClaudePrintRuntimeAdapter
     >
 {
   private activeChild: ChildProcess | null = null;
+  private preparedMcpConfig: ClaudeMcpCompositionResult | null = null;
 
   constructor(
     private readonly config: ClaudeRuntimeConfig,
     private readonly dependencies: ClaudeSpawnDependencies = {}
   ) {}
 
-  prepare(_context: ClaudeRuntimePrepareContext): void {
-    // TODO(#7,#8,#10): MCP composition, session persistence, and preflight
-    // checks will populate this hook once the worker-side runtime wiring lands.
+  async prepare(_context: ClaudeRuntimePrepareContext): Promise<void> {
+    await this.cleanupPreparedMcpConfig();
+    this.preparedMcpConfig = await composeClaudeMcpConfig(
+      this.config.workingDirectory,
+      this.config.isolation?.strictMcpConfig === true,
+      {
+        ...process.env,
+        ...this.config.env,
+        ...(this.config.runtimeDirectory
+          ? {
+              WORKSPACE_RUNTIME_DIR: this.config.runtimeDirectory,
+            }
+          : {}),
+      }
+    );
   }
 
   async spawnTurn(input: ClaudeRuntimeTurnInput): Promise<ClaudeRuntimeTurnResult> {
@@ -127,14 +146,16 @@ export class ClaudePrintRuntimeAdapter
     return extractEnvForClaude(brokerResponse.env);
   }
 
-  shutdown(): void {
+  async shutdown(): Promise<void> {
     this.stopActiveChild();
+    await this.cleanupPreparedMcpConfig();
   }
 
-  cancel(_reason?: string): void {
+  async cancel(_reason?: string): Promise<void> {
     // TODO(#8,#9): replace direct process termination with session-aware
     // cancellation once Claude runtime turn orchestration is wired end-to-end.
     this.stopActiveChild();
+    await this.cleanupPreparedMcpConfig();
   }
 
   private buildArgvOptions(input: ClaudeRuntimeTurnInput): ClaudePrintArgvOptions {
@@ -142,6 +163,12 @@ export class ClaudePrintRuntimeAdapter
       session: input.session,
       isolation: {
         ...this.config.isolation,
+        ...(this.preparedMcpConfig?.cleanupPath
+          ? {
+              strictMcpConfig: true,
+              mcpConfigPath: this.preparedMcpConfig.finalPath,
+            }
+          : {}),
         ...input.isolation,
       },
       extraArgs: input.extraArgs ?? this.config.extraArgs,
@@ -156,6 +183,17 @@ export class ClaudePrintRuntimeAdapter
 
     this.activeChild.kill("SIGTERM");
     this.activeChild = null;
+  }
+
+  private async cleanupPreparedMcpConfig(): Promise<void> {
+    const cleanupPath = this.preparedMcpConfig?.cleanupPath;
+    this.preparedMcpConfig = null;
+
+    if (!cleanupPath) {
+      return;
+    }
+
+    await rm(cleanupPath, { force: true });
   }
 }
 

--- a/packages/runtime-claude/src/adapter.ts
+++ b/packages/runtime-claude/src/adapter.ts
@@ -165,6 +165,8 @@ export class ClaudePrintRuntimeAdapter
     if (this.preparedMcpConfig) {
       return {
         session: input.session,
+        // prepare() owns MCP argv injection through extraArgv; suppress the
+        // isolation flag here so buildClaudePrintArgv does not add it twice.
         isolation: {
           ...isolation,
           strictMcpConfig: false,

--- a/packages/runtime-claude/src/adapter.ts
+++ b/packages/runtime-claude/src/adapter.ts
@@ -167,6 +167,8 @@ export class ClaudePrintRuntimeAdapter
         session: input.session,
         // prepare() owns MCP argv injection through extraArgv; suppress the
         // isolation flag here so buildClaudePrintArgv does not add it twice.
+        // Any input mcpConfigPath is intentionally ignored while a prepared
+        // composition result is active.
         isolation: {
           ...isolation,
           strictMcpConfig: false,

--- a/packages/runtime-claude/src/index.ts
+++ b/packages/runtime-claude/src/index.ts
@@ -9,4 +9,5 @@ export const RUNTIME_CLAUDE_BOUNDARY = {
 
 export * from "./adapter.js";
 export * from "./argv.js";
+export * from "./mcp-compose.js";
 export * from "./spawn.js";

--- a/packages/runtime-claude/src/mcp-compose.test.ts
+++ b/packages/runtime-claude/src/mcp-compose.test.ts
@@ -1,0 +1,147 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, describe, expect, it } from "vitest";
+import { composeClaudeMcpConfig } from "./mcp-compose.js";
+
+const tempRoots: string[] = [];
+
+async function createTempWorkspace(): Promise<string> {
+  const workspaceRoot = await mkdtemp(join(tmpdir(), "claude-mcp-compose-"));
+  tempRoots.push(workspaceRoot);
+  return workspaceRoot;
+}
+
+async function readJson(path: string): Promise<Record<string, unknown>> {
+  return JSON.parse(await readFile(path, "utf8")) as Record<string, unknown>;
+}
+
+describe("composeClaudeMcpConfig", () => {
+  afterEach(async () => {
+    await Promise.all(tempRoots.splice(0).map((root) => rm(root, {
+      force: true,
+      recursive: true,
+    })));
+  });
+
+  it("creates a workspace .mcp.json with only github_graphql when none exists", async () => {
+    const workspaceRoot = await createTempWorkspace();
+
+    const result = await composeClaudeMcpConfig(workspaceRoot, false, {
+      GITHUB_GRAPHQL_TOKEN: "token-1",
+    });
+
+    expect(result).toEqual({
+      finalPath: join(workspaceRoot, ".mcp.json"),
+      extraArgv: [],
+    });
+    expect(await readJson(result.finalPath)).toEqual({
+      mcpServers: {
+        github_graphql: {
+          command: "node",
+          args: [expect.stringContaining("mcp-server.js")],
+          env: {
+            GITHUB_GRAPHQL_API_URL: "https://api.github.com/graphql",
+            GITHUB_GRAPHQL_TOKEN: "token-1",
+          },
+        },
+      },
+    });
+  });
+
+  it("preserves user-authored keys and overwrites github_graphql", async () => {
+    const workspaceRoot = await createTempWorkspace();
+    const workspaceMcpPath = join(workspaceRoot, ".mcp.json");
+    await writeFile(
+      workspaceMcpPath,
+      JSON.stringify({
+        customTopLevel: true,
+        mcpServers: {
+          user_server: {
+            command: "node",
+            args: ["user-server.js"],
+          },
+          github_graphql: {
+            command: "old",
+            env: {
+              GITHUB_GRAPHQL_TOKEN: "old-token",
+            },
+          },
+        },
+      }),
+      "utf8"
+    );
+
+    const result = await composeClaudeMcpConfig(workspaceRoot, false, {
+      GITHUB_GRAPHQL_TOKEN: "token-2",
+      GITHUB_PROJECT_ID: "project-1",
+    });
+
+    expect(result.finalPath).toBe(workspaceMcpPath);
+    expect(await readJson(workspaceMcpPath)).toEqual({
+      customTopLevel: true,
+      mcpServers: {
+        user_server: {
+          command: "node",
+          args: ["user-server.js"],
+        },
+        github_graphql: {
+          command: "node",
+          args: [expect.stringContaining("mcp-server.js")],
+          env: {
+            GITHUB_GRAPHQL_API_URL: "https://api.github.com/graphql",
+            GITHUB_GRAPHQL_TOKEN: "token-2",
+            GITHUB_PROJECT_ID: "project-1",
+          },
+        },
+      },
+    });
+  });
+
+  it("writes strict mode config to an ephemeral path without mutating the workspace file", async () => {
+    const workspaceRoot = await createTempWorkspace();
+    const runtimeRoot = join(workspaceRoot, "runtime-root");
+    const workspaceMcpPath = join(workspaceRoot, ".mcp.json");
+    const originalConfig = JSON.stringify({
+      mcpServers: {
+        user_server: {
+          command: "node",
+          args: ["user-server.js"],
+        },
+      },
+    }, null, 2) + "\n";
+    await writeFile(workspaceMcpPath, originalConfig, "utf8");
+
+    const result = await composeClaudeMcpConfig(workspaceRoot, true, {
+      GITHUB_GRAPHQL_TOKEN: "token-3",
+      WORKSPACE_RUNTIME_DIR: runtimeRoot,
+    });
+
+    expect(result).toEqual({
+      finalPath: join(runtimeRoot, "mcp.json"),
+      extraArgv: [
+        "--strict-mcp-config",
+        "--mcp-config",
+        join(runtimeRoot, "mcp.json"),
+      ],
+      cleanupPath: join(runtimeRoot, "mcp.json"),
+    });
+    expect(await readFile(workspaceMcpPath, "utf8")).toBe(originalConfig);
+    expect(await readJson(result.finalPath)).toEqual({
+      mcpServers: {
+        user_server: {
+          command: "node",
+          args: ["user-server.js"],
+        },
+        github_graphql: {
+          command: "node",
+          args: [expect.stringContaining("mcp-server.js")],
+          env: {
+            GITHUB_GRAPHQL_API_URL: "https://api.github.com/graphql",
+            GITHUB_GRAPHQL_TOKEN: "token-3",
+          },
+        },
+      },
+    });
+  });
+});

--- a/packages/runtime-claude/src/mcp-compose.test.ts
+++ b/packages/runtime-claude/src/mcp-compose.test.ts
@@ -144,4 +144,13 @@ describe("composeClaudeMcpConfig", () => {
       },
     });
   });
+
+  it("throws when the workspace .mcp.json contains invalid JSON", async () => {
+    const workspaceRoot = await createTempWorkspace();
+    await writeFile(join(workspaceRoot, ".mcp.json"), "{ invalid", "utf8");
+
+    await expect(
+      composeClaudeMcpConfig(workspaceRoot, false, {})
+    ).rejects.toThrow(SyntaxError);
+  });
 });

--- a/packages/runtime-claude/src/mcp-compose.test.ts
+++ b/packages/runtime-claude/src/mcp-compose.test.ts
@@ -153,4 +153,31 @@ describe("composeClaudeMcpConfig", () => {
       composeClaudeMcpConfig(workspaceRoot, false, {})
     ).rejects.toThrow(SyntaxError);
   });
+
+  it("treats a non-object mcpServers value as empty", async () => {
+    const workspaceRoot = await createTempWorkspace();
+    const workspaceMcpPath = join(workspaceRoot, ".mcp.json");
+    await writeFile(
+      workspaceMcpPath,
+      JSON.stringify({
+        mcpServers: null,
+      }),
+      "utf8"
+    );
+
+    const result = await composeClaudeMcpConfig(workspaceRoot, false, {});
+
+    expect(result.finalPath).toBe(workspaceMcpPath);
+    expect(await readJson(workspaceMcpPath)).toEqual({
+      mcpServers: {
+        github_graphql: {
+          command: "node",
+          args: [expect.stringContaining("mcp-server.js")],
+          env: {
+            GITHUB_GRAPHQL_API_URL: "https://api.github.com/graphql",
+          },
+        },
+      },
+    });
+  });
 });

--- a/packages/runtime-claude/src/mcp-compose.ts
+++ b/packages/runtime-claude/src/mcp-compose.ts
@@ -34,6 +34,8 @@ export async function composeClaudeMcpConfig(
   const baseConfig = await readBaseMcpConfig(workspaceMcpPath);
   const mergedConfig = mergeGitHubGraphQLMcpServer(baseConfig, symphonyTokenEnv);
 
+  // Non-strict mode intentionally mutates the throwaway workspace .mcp.json so
+  // Claude's auto-discovery can pick up both user-authored and Symphony entries.
   await mkdir(dirname(finalPath), { recursive: true });
   await writeFile(finalPath, JSON.stringify(mergedConfig, null, 2) + "\n", "utf8");
 

--- a/packages/runtime-claude/src/mcp-compose.ts
+++ b/packages/runtime-claude/src/mcp-compose.ts
@@ -88,6 +88,8 @@ function resolveStrictMcpConfigPath(
   workspaceRoot: string,
   env: ClaudeMcpTokenEnvironment
 ): string {
+  // Direct package tests and ad-hoc callers may not have the worker runtime
+  // directory yet; keep their strict config inside the throwaway workspace.
   const runtimeDir =
     env.WORKSPACE_RUNTIME_DIR ?? join(workspaceRoot, ".runtime", basename(workspaceRoot));
 

--- a/packages/runtime-claude/src/mcp-compose.ts
+++ b/packages/runtime-claude/src/mcp-compose.ts
@@ -1,0 +1,103 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { basename, dirname, join } from "node:path";
+import { createGitHubGraphQLMcpServerEntry } from "@gh-symphony/tool-github-graphql";
+
+export type ClaudeMcpTokenEnvironment = {
+  GITHUB_GRAPHQL_TOKEN?: string;
+  GITHUB_GRAPHQL_API_URL?: string;
+  GITHUB_TOKEN_BROKER_URL?: string;
+  GITHUB_TOKEN_BROKER_SECRET?: string;
+  GITHUB_TOKEN_CACHE_PATH?: string;
+  GITHUB_PROJECT_ID?: string;
+  WORKSPACE_RUNTIME_DIR?: string;
+};
+
+export type ClaudeMcpCompositionResult = {
+  finalPath: string;
+  extraArgv: string[];
+  cleanupPath?: string;
+};
+
+type McpConfig = Record<string, unknown> & {
+  mcpServers?: Record<string, unknown>;
+};
+
+export async function composeClaudeMcpConfig(
+  workspaceRoot: string,
+  strictMode: boolean,
+  symphonyTokenEnv: ClaudeMcpTokenEnvironment = {}
+): Promise<ClaudeMcpCompositionResult> {
+  const workspaceMcpPath = join(workspaceRoot, ".mcp.json");
+  const finalPath = strictMode
+    ? resolveStrictMcpConfigPath(workspaceRoot, symphonyTokenEnv)
+    : workspaceMcpPath;
+  const baseConfig = await readBaseMcpConfig(workspaceMcpPath);
+  const mergedConfig = mergeGitHubGraphQLMcpServer(baseConfig, symphonyTokenEnv);
+
+  await mkdir(dirname(finalPath), { recursive: true });
+  await writeFile(finalPath, JSON.stringify(mergedConfig, null, 2) + "\n", "utf8");
+
+  return {
+    finalPath,
+    extraArgv: strictMode
+      ? ["--strict-mcp-config", "--mcp-config", finalPath]
+      : [],
+    ...(strictMode ? { cleanupPath: finalPath } : {}),
+  };
+}
+
+async function readBaseMcpConfig(workspaceMcpPath: string): Promise<McpConfig> {
+  try {
+    const raw = await readFile(workspaceMcpPath, "utf8");
+    const parsed = JSON.parse(raw) as unknown;
+    return isRecord(parsed) ? parsed : { mcpServers: {} };
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return { mcpServers: {} };
+    }
+
+    throw error;
+  }
+}
+
+function mergeGitHubGraphQLMcpServer(
+  baseConfig: McpConfig,
+  env: ClaudeMcpTokenEnvironment
+): McpConfig {
+  const mcpServers = isRecord(baseConfig.mcpServers)
+    ? baseConfig.mcpServers
+    : {};
+
+  return {
+    ...baseConfig,
+    mcpServers: {
+      ...mcpServers,
+      github_graphql: createGitHubGraphQLMcpServerEntry({
+        githubToken: env.GITHUB_GRAPHQL_TOKEN,
+        githubGraphqlApiUrl: env.GITHUB_GRAPHQL_API_URL,
+        githubTokenBrokerUrl: env.GITHUB_TOKEN_BROKER_URL,
+        githubTokenBrokerSecret: env.GITHUB_TOKEN_BROKER_SECRET,
+        githubTokenCachePath: env.GITHUB_TOKEN_CACHE_PATH,
+        githubProjectId: env.GITHUB_PROJECT_ID,
+      }),
+    },
+  };
+}
+
+function resolveStrictMcpConfigPath(
+  workspaceRoot: string,
+  env: ClaudeMcpTokenEnvironment
+): string {
+  const runtimeDir =
+    env.WORKSPACE_RUNTIME_DIR ?? join(workspaceRoot, ".runtime", basename(workspaceRoot));
+
+  return join(runtimeDir, "mcp.json");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value != null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
+}

--- a/packages/runtime-claude/src/mcp-compose.ts
+++ b/packages/runtime-claude/src/mcp-compose.ts
@@ -1,5 +1,5 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
-import { basename, dirname, join } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
 import { createGitHubGraphQLMcpServerEntry } from "@gh-symphony/tool-github-graphql";
 
 export type ClaudeMcpTokenEnvironment = {
@@ -34,8 +34,8 @@ export async function composeClaudeMcpConfig(
   const baseConfig = await readBaseMcpConfig(workspaceMcpPath);
   const mergedConfig = mergeGitHubGraphQLMcpServer(baseConfig, symphonyTokenEnv);
 
-  // Non-strict mode intentionally mutates the throwaway workspace .mcp.json so
-  // Claude's auto-discovery can pick up both user-authored and Symphony entries.
+  // Non-strict mode mutates the workspace .mcp.json in-place so Claude's
+  // auto-discovery can pick up both user-authored and Symphony-managed entries.
   await mkdir(dirname(finalPath), { recursive: true });
   await writeFile(finalPath, JSON.stringify(mergedConfig, null, 2) + "\n", "utf8");
 
@@ -91,9 +91,11 @@ function resolveStrictMcpConfigPath(
   env: ClaudeMcpTokenEnvironment
 ): string {
   // Direct package tests and ad-hoc callers may not have the worker runtime
-  // directory yet; keep their strict config inside the throwaway workspace.
+  // directory yet; keep their strict config inside the workspace fallback path.
+  const normalizedWorkspaceRoot = resolve(workspaceRoot);
   const runtimeDir =
-    env.WORKSPACE_RUNTIME_DIR ?? join(workspaceRoot, ".runtime", basename(workspaceRoot));
+    env.WORKSPACE_RUNTIME_DIR ??
+    join(normalizedWorkspaceRoot, ".runtime", basename(normalizedWorkspaceRoot));
 
   return join(runtimeDir, "mcp.json");
 }

--- a/packages/runtime-claude/tsconfig.typecheck.json
+++ b/packages/runtime-claude/tsconfig.typecheck.json
@@ -5,7 +5,8 @@
     "rootDir": "..",
     "baseUrl": ".",
     "paths": {
-      "@gh-symphony/core": ["../core/src/index.ts"]
+      "@gh-symphony/core": ["../core/src/index.ts"],
+      "@gh-symphony/tool-github-graphql": ["../tool-github-graphql/src/index.ts"]
     }
   }
 }

--- a/packages/runtime-claude/vitest.config.ts
+++ b/packages/runtime-claude/vitest.config.ts
@@ -8,6 +8,10 @@ export default defineConfig({
   resolve: {
     alias: {
       "@gh-symphony/core": resolve(packageRoot, "../core/src/index.ts"),
+      "@gh-symphony/tool-github-graphql": resolve(
+        packageRoot,
+        "../tool-github-graphql/src/index.ts"
+      ),
     },
   },
   test: {

--- a/packages/runtime-codex/src/runtime.ts
+++ b/packages/runtime-codex/src/runtime.ts
@@ -14,9 +14,8 @@ import {
   type AgentEvent,
   type AgentRuntimeEvent,
 } from "@gh-symphony/core";
-import { resolveGitHubGraphQLMcpServerEntryPoint } from "@gh-symphony/tool-github-graphql";
+import { createGitHubGraphQLMcpServerEntry } from "@gh-symphony/tool-github-graphql";
 
-const DEFAULT_GITHUB_GRAPHQL_API_URL = "https://api.github.com/graphql";
 const DEFAULT_GITHUB_GIT_HOST = "github.com";
 const DEFAULT_GITHUB_GIT_USERNAME = "x-access-token";
 const STAGED_CODEX_HOME_DIRNAME = ".codex-agent";
@@ -134,41 +133,15 @@ export function createGitHubGraphQLToolDefinition(
     | "githubGraphqlApiUrl"
   >
 ): RuntimeToolDefinition {
+  const entry = createGitHubGraphQLMcpServerEntry(config);
+
   return {
     name: "github_graphql",
     description:
       "Execute GitHub GraphQL queries for the active workspace so the agent can mutate project and issue state directly.",
-    command: "node",
-    args: [resolveGitHubGraphQLMcpServerEntryPoint()],
-    env: {
-      GITHUB_GRAPHQL_API_URL:
-        config.githubGraphqlApiUrl ?? DEFAULT_GITHUB_GRAPHQL_API_URL,
-      ...(config.githubToken
-        ? {
-            GITHUB_GRAPHQL_TOKEN: config.githubToken,
-          }
-        : {}),
-      ...(config.githubTokenBrokerUrl
-        ? {
-            GITHUB_TOKEN_BROKER_URL: config.githubTokenBrokerUrl,
-          }
-        : {}),
-      ...(config.githubTokenBrokerSecret
-        ? {
-            GITHUB_TOKEN_BROKER_SECRET: config.githubTokenBrokerSecret,
-          }
-        : {}),
-      ...(config.githubTokenCachePath
-        ? {
-            GITHUB_TOKEN_CACHE_PATH: config.githubTokenCachePath,
-          }
-        : {}),
-      ...(config.githubProjectId
-        ? {
-            GITHUB_PROJECT_ID: config.githubProjectId,
-          }
-        : {}),
-    },
+    command: entry.command,
+    args: entry.args,
+    env: entry.env,
     inputSchema: {
       type: "object",
       properties: {

--- a/packages/tool-github-graphql/src/index.ts
+++ b/packages/tool-github-graphql/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./tool.js";
 export * from "./mcp-server.js";
+export * from "./mcp-entry.js";

--- a/packages/tool-github-graphql/src/mcp-entry.ts
+++ b/packages/tool-github-graphql/src/mcp-entry.ts
@@ -1,0 +1,56 @@
+import { resolveGitHubGraphQLMcpServerEntryPoint } from "./mcp-server.js";
+
+export const DEFAULT_GITHUB_GRAPHQL_API_URL = "https://api.github.com/graphql";
+
+export type GitHubGraphQLMcpServerEntryOptions = {
+  githubToken?: string;
+  githubTokenBrokerUrl?: string;
+  githubTokenBrokerSecret?: string;
+  githubTokenCachePath?: string;
+  githubProjectId?: string;
+  githubGraphqlApiUrl?: string;
+};
+
+export type GitHubGraphQLMcpServerEntry = {
+  command: "node";
+  args: string[];
+  env: Record<string, string>;
+};
+
+export function createGitHubGraphQLMcpServerEntry(
+  options: GitHubGraphQLMcpServerEntryOptions = {}
+): GitHubGraphQLMcpServerEntry {
+  return {
+    command: "node",
+    args: [resolveGitHubGraphQLMcpServerEntryPoint()],
+    env: {
+      GITHUB_GRAPHQL_API_URL:
+        options.githubGraphqlApiUrl ?? DEFAULT_GITHUB_GRAPHQL_API_URL,
+      ...(options.githubToken
+        ? {
+            GITHUB_GRAPHQL_TOKEN: options.githubToken,
+          }
+        : {}),
+      ...(options.githubTokenBrokerUrl
+        ? {
+            GITHUB_TOKEN_BROKER_URL: options.githubTokenBrokerUrl,
+          }
+        : {}),
+      ...(options.githubTokenBrokerSecret
+        ? {
+            GITHUB_TOKEN_BROKER_SECRET: options.githubTokenBrokerSecret,
+          }
+        : {}),
+      ...(options.githubTokenCachePath
+        ? {
+            GITHUB_TOKEN_CACHE_PATH: options.githubTokenCachePath,
+          }
+        : {}),
+      ...(options.githubProjectId
+        ? {
+            GITHUB_PROJECT_ID: options.githubProjectId,
+          }
+        : {}),
+    },
+  };
+}

--- a/packages/tool-github-graphql/src/tool.test.ts
+++ b/packages/tool-github-graphql/src/tool.test.ts
@@ -1,4 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
+import {
+  DEFAULT_GITHUB_GRAPHQL_API_URL,
+  createGitHubGraphQLMcpServerEntry,
+} from "./mcp-entry.js";
 import { resolveGitHubGraphQLToken } from "./tool.js";
 
 describe("resolveGitHubGraphQLToken", () => {
@@ -69,5 +73,39 @@ describe("resolveGitHubGraphQLToken", () => {
       }),
       "utf8"
     );
+  });
+});
+
+describe("createGitHubGraphQLMcpServerEntry", () => {
+  it("creates a default MCP server entry without optional env keys", () => {
+    expect(createGitHubGraphQLMcpServerEntry()).toEqual({
+      command: "node",
+      args: [expect.stringContaining("mcp-server.js")],
+      env: {
+        GITHUB_GRAPHQL_API_URL: DEFAULT_GITHUB_GRAPHQL_API_URL,
+      },
+    });
+  });
+
+  it("includes only provided optional environment values", () => {
+    expect(createGitHubGraphQLMcpServerEntry({
+      githubToken: "ghs_token",
+      githubTokenBrokerUrl: "http://127.0.0.1/runtime-token",
+      githubTokenBrokerSecret: "secret",
+      githubTokenCachePath: "/tmp/github-token-cache.json",
+      githubProjectId: "project-1",
+      githubGraphqlApiUrl: "https://github.example/api/graphql",
+    })).toEqual({
+      command: "node",
+      args: [expect.stringContaining("mcp-server.js")],
+      env: {
+        GITHUB_GRAPHQL_API_URL: "https://github.example/api/graphql",
+        GITHUB_GRAPHQL_TOKEN: "ghs_token",
+        GITHUB_TOKEN_BROKER_URL: "http://127.0.0.1/runtime-token",
+        GITHUB_TOKEN_BROKER_SECRET: "secret",
+        GITHUB_TOKEN_CACHE_PATH: "/tmp/github-token-cache.json",
+        GITHUB_PROJECT_ID: "project-1",
+      },
+    });
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -175,6 +175,9 @@ importers:
       '@gh-symphony/core':
         specifier: workspace:*
         version: link:../core
+      '@gh-symphony/tool-github-graphql':
+        specifier: workspace:*
+        version: link:../tool-github-graphql
 
   packages/runtime-codex:
     dependencies:


### PR DESCRIPTION
## Issues

- Fixes #219

## Summary

- Claude runtime `prepare()` 단계에서 workspace `.mcp.json`과 Symphony-managed `github_graphql` MCP entry를 합성합니다.
- `strictMcpConfig`가 켜진 경우 ephemeral `mcp.json`을 생성하고 `--strict-mcp-config --mcp-config <path>` argv를 주입한 뒤 shutdown/cancel 및 prepare 재호출 시 정리/교체합니다.
- MCP 합성 env 입력은 allowlist와 `inheritProcessEnv` 기준으로 제한해 host credential 격리 계약을 보존합니다.
- 최신 main(`3504718`) 병합 충돌을 해소해 Claude stream event mapping 변경과 MCP prepare/argv lifecycle 변경이 함께 동작하도록 갱신했습니다.

## Changes

- `packages/runtime-claude/src/mcp-compose.ts`에 strict/non-strict MCP config 합성 함수를 추가했습니다.
- `@gh-symphony/tool-github-graphql`의 `createGitHubGraphQLMcpServerEntry()` helper를 Claude/Codex 양쪽에서 재사용하도록 했습니다.
- Claude adapter lifecycle에 `prepare()` 합성 결과 저장, strict argv 주입, ephemeral cleanup을 연결했습니다.
- Adapter가 composition result의 `extraArgv`를 실제 spawn argv에 사용하도록 정리하고, prepared MCP config가 활성일 때 caller-provided `mcpConfigPath`를 의도적으로 무시하는 계약을 주석으로 명시했습니다.
- main 병합 후 Claude event subscription/emission 경로와 MCP cleanup/argv 주입 경로를 모두 보존했습니다.
- `.mcp.json` 없음, 사용자 key 보존 + overwrite, strict ephemeral 경로/argv, host MCP credential 격리, opt-in inheritance, cancel cleanup, prepare 재호출, invalid JSON, non-object `mcpServers`, shared MCP entry helper 테스트를 유지했습니다.

## Evidence

- `pnpm --filter @gh-symphony/runtime-claude test` — passed, 60 tests at `a69348d`
- `pnpm --filter @gh-symphony/tool-github-graphql test` — passed, 5 tests at `a69348d`
- `git diff --check` — passed
- `pnpm lint && pnpm test && pnpm typecheck && pnpm build` — passed at `a69348d`
- Docker E2E TC: `docker compose -f docker-compose.e2e.yml -f docker-compose.e2e.events.yml up -d --build`; `/healthz` returned `{"ok":true}`; fixture injection + `POST /api/v1/refresh` dispatched `test-owner/test-repo#1`; state reached `lastEvent: "completed"`, `retryKind: "continuation"`, `lastError: null`; cleanup reset fixture, removed evidence, and ran `docker compose ... down`.
- CI on `a69348d`: `Test` passed; `Container Smoke` passed.

## Human Validation

- [ ] Claude runtime with default isolation mutates workspace `.mcp.json` and preserves user-authored MCP servers.
- [ ] Claude runtime with `strictMcpConfig: true` launches with the ephemeral MCP config argv and cleans up the file at run shutdown/cancel/prepare replacement.
- [ ] `inheritProcessEnv: false` does not copy host GitHub MCP credentials into generated MCP config.
- [ ] Codex runtime still stages `CODEX_HOME` and does not enter the Claude MCP composition path.
- [ ] PR #249 is mergeable against current `main` after the `a69348d` merge commit.

## Risks

- Worker-level Claude runtime wiring is still scaffolded elsewhere; this PR wires the adapter lifecycle and unit coverage for the MCP composition behavior but does not add a new end-to-end Claude worker fixture.
- `prepare()` is treated as an orchestrator-sequenced lifecycle hook; concurrent calls are outside the current adapter contract and remain documented by review response rather than changing synchronization semantics in this PR.
