### PR TITLE
feat(runtime-claude): map stream-json events

### DIFF
--- a/packages/core/src/runtime/events.ts
+++ b/packages/core/src/runtime/events.ts
@@ -64,8 +64,8 @@ export type AgentToolCallRequestedEvent = {
     params: Record<string, unknown>;
     callId: string;
     toolName: string;
-    threadId: string;
-    turnId: string;
+    threadId?: string;
+    turnId?: string;
     arguments: unknown;
   };
 };

--- a/packages/runtime-claude/src/adapter.test.ts
+++ b/packages/runtime-claude/src/adapter.test.ts
@@ -2,7 +2,6 @@ import { EventEmitter } from "node:events";
 import { PassThrough } from "node:stream";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
-  ClaudeRuntimeNotImplementedError,
   ClaudePrintRuntimeAdapter,
   createClaudePrintRuntimeAdapter,
   resolveClaudeCredentials,
@@ -121,14 +120,40 @@ describe("ClaudePrintRuntimeAdapter", () => {
     expect(calls[0]?.env?.GITHUB_TOKEN).toBeUndefined();
   });
 
-  it("throws NotImplementedError on onEvent() until #9 lands", () => {
+  it("emits neutral events from Claude stream-json output", async () => {
+    const { child, stdout, stderr } = createStubChild();
+    const spawnImpl: SpawnLike = () => {
+      queueMicrotask(() => {
+        stdout.write('{"type":"message_start"}\n');
+        stdout.write('{"type":"content_block_delta","index":0,"delta":{"text":"hi"}}\n');
+        stdout.write('{"type":"result","subtype":"success"}\n');
+        stdout.end();
+        stderr.end();
+        child.emit("close", 0, null);
+      });
+
+      return child;
+    };
     const adapter = new ClaudePrintRuntimeAdapter({
       workingDirectory: "/workspace",
+    }, {
+      spawnImpl,
+    });
+    const events: string[] = [];
+    const unsubscribe = adapter.onEvent((event) => {
+      events.push(event.name);
     });
 
-    expect(() => adapter.onEvent(() => {})).toThrowError(
-      ClaudeRuntimeNotImplementedError
-    );
+    await adapter.spawnTurn({
+      messages: [],
+    });
+    unsubscribe();
+
+    expect(events).toEqual([
+      "agent.turnStarted",
+      "agent.messageDelta",
+      "agent.turnCompleted",
+    ]);
   });
 
   it("exposes a factory helper", () => {

--- a/packages/runtime-claude/src/adapter.test.ts
+++ b/packages/runtime-claude/src/adapter.test.ts
@@ -161,6 +161,45 @@ describe("ClaudePrintRuntimeAdapter", () => {
     ]);
   });
 
+  it("continues notifying event handlers when one handler throws", async () => {
+    const { child, stdout, stderr } = createStubChild();
+    const spawnImpl: SpawnLike = () => {
+      queueMicrotask(() => {
+        stdout.write('{"type":"message_start"}\n');
+        stdout.write('{"type":"result","subtype":"success"}\n');
+        stdout.end();
+        stderr.end();
+        child.emit("close", 0, null);
+      });
+
+      return child;
+    };
+    const adapter = new ClaudePrintRuntimeAdapter(
+      {
+        workingDirectory: "/workspace",
+      },
+      {
+        spawnImpl,
+      }
+    );
+    const laterEvents: string[] = [];
+
+    adapter.onEvent(() => {
+      throw new Error("handler failed");
+    });
+    adapter.onEvent((event) => {
+      laterEvents.push(event.name);
+    });
+
+    await expect(
+      adapter.spawnTurn({
+        messages: [],
+      })
+    ).resolves.toMatchObject({ result: "success" });
+
+    expect(laterEvents).toEqual(["agent.turnStarted", "agent.turnCompleted"]);
+  });
+
   it("exposes a factory helper", () => {
     const adapter = createClaudePrintRuntimeAdapter({
       workingDirectory: "/workspace",

--- a/packages/runtime-claude/src/adapter.test.ts
+++ b/packages/runtime-claude/src/adapter.test.ts
@@ -125,7 +125,9 @@ describe("ClaudePrintRuntimeAdapter", () => {
     const spawnImpl: SpawnLike = () => {
       queueMicrotask(() => {
         stdout.write('{"type":"message_start"}\n');
-        stdout.write('{"type":"content_block_delta","index":0,"delta":{"text":"hi"}}\n');
+        stdout.write(
+          '{"type":"content_block_delta","index":0,"delta":{"text":"hi"}}\n'
+        );
         stdout.write('{"type":"result","subtype":"success"}\n');
         stdout.end();
         stderr.end();
@@ -134,11 +136,14 @@ describe("ClaudePrintRuntimeAdapter", () => {
 
       return child;
     };
-    const adapter = new ClaudePrintRuntimeAdapter({
-      workingDirectory: "/workspace",
-    }, {
-      spawnImpl,
-    });
+    const adapter = new ClaudePrintRuntimeAdapter(
+      {
+        workingDirectory: "/workspace",
+      },
+      {
+        spawnImpl,
+      }
+    );
     const events: string[] = [];
     const unsubscribe = adapter.onEvent((event) => {
       events.push(event.name);

--- a/packages/runtime-claude/src/adapter.test.ts
+++ b/packages/runtime-claude/src/adapter.test.ts
@@ -200,6 +200,44 @@ describe("ClaudePrintRuntimeAdapter", () => {
     expect(laterEvents).toEqual(["agent.turnStarted", "agent.turnCompleted"]);
   });
 
+  it("continues stream processing when dependency onEvent throws", async () => {
+    const { child, stdout, stderr } = createStubChild();
+    const spawnImpl: SpawnLike = () => {
+      queueMicrotask(() => {
+        stdout.write('{"type":"message_start"}\n');
+        stdout.write('{"type":"result","subtype":"success"}\n');
+        stdout.end();
+        stderr.end();
+        child.emit("close", 0, null);
+      });
+
+      return child;
+    };
+    const adapter = new ClaudePrintRuntimeAdapter(
+      {
+        workingDirectory: "/workspace",
+      },
+      {
+        spawnImpl,
+        onEvent: () => {
+          throw new Error("dependency hook failed");
+        },
+      }
+    );
+    const events: string[] = [];
+    adapter.onEvent((event) => {
+      events.push(event.name);
+    });
+
+    await expect(
+      adapter.spawnTurn({
+        messages: [],
+      })
+    ).resolves.toMatchObject({ result: "success" });
+
+    expect(events).toEqual(["agent.turnStarted", "agent.turnCompleted"]);
+  });
+
   it("exposes a factory helper", () => {
     const adapter = createClaudePrintRuntimeAdapter({
       workingDirectory: "/workspace",

--- a/packages/runtime-claude/src/adapter.ts
+++ b/packages/runtime-claude/src/adapter.ts
@@ -3,9 +3,9 @@ import type {
   AgentRuntimeAdapter,
   AgentRuntimeCredentialBrokerResponse,
   AgentRuntimeEnv,
-  AgentRuntimeEvent,
   AgentRuntimeEventHandler,
   AgentRuntimeEventSubscription,
+  AgentEvent,
 } from "@gh-symphony/core";
 import { extractEnvForClaude } from "@gh-symphony/core";
 import {
@@ -46,14 +46,7 @@ export type ClaudeRuntimeTurnInput = {
 
 export type ClaudeRuntimeTurnResult = ClaudeSpawnTurnResult;
 
-export type ClaudeRuntimeEvent = AgentRuntimeEvent;
-
-export class ClaudeRuntimeNotImplementedError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "ClaudeRuntimeNotImplementedError";
-  }
-}
+export type ClaudeRuntimeEvent = AgentEvent;
 
 export class ClaudePrintRuntimeAdapter
   implements
@@ -65,6 +58,9 @@ export class ClaudePrintRuntimeAdapter
     >
 {
   private activeChild: ChildProcess | null = null;
+  private readonly eventHandlers = new Set<
+    AgentRuntimeEventHandler<ClaudeRuntimeEvent>
+  >();
 
   constructor(
     private readonly config: ClaudeRuntimeConfig,
@@ -106,6 +102,10 @@ export class ClaudePrintRuntimeAdapter
             this.activeChild = child;
             this.dependencies.onSpawned?.(child);
           },
+          onEvent: (event) => {
+            this.emitEvent(event);
+            this.dependencies.onEvent?.(event);
+          },
         }
       );
     } finally {
@@ -114,11 +114,12 @@ export class ClaudePrintRuntimeAdapter
   }
 
   onEvent(
-    _handler: AgentRuntimeEventHandler<ClaudeRuntimeEvent>
+    handler: AgentRuntimeEventHandler<ClaudeRuntimeEvent>
   ): AgentRuntimeEventSubscription {
-    throw new ClaudeRuntimeNotImplementedError(
-      "TODO(#9): Claude stream-json event mapping is not implemented yet."
-    );
+    this.eventHandlers.add(handler);
+    return () => {
+      this.eventHandlers.delete(handler);
+    };
   }
 
   resolveCredentials(
@@ -156,6 +157,12 @@ export class ClaudePrintRuntimeAdapter
 
     this.activeChild.kill("SIGTERM");
     this.activeChild = null;
+  }
+
+  private emitEvent(event: ClaudeRuntimeEvent): void {
+    for (const handler of this.eventHandlers) {
+      handler(event);
+    }
   }
 }
 

--- a/packages/runtime-claude/src/adapter.ts
+++ b/packages/runtime-claude/src/adapter.ts
@@ -101,7 +101,11 @@ export class ClaudePrintRuntimeAdapter implements AgentRuntimeAdapter<
           },
           onEvent: (event) => {
             this.emitEvent(event);
-            this.dependencies.onEvent?.(event);
+            try {
+              this.dependencies.onEvent?.(event);
+            } catch {
+              // Dependency hook failures must not block stream processing.
+            }
           },
         }
       );

--- a/packages/runtime-claude/src/adapter.ts
+++ b/packages/runtime-claude/src/adapter.ts
@@ -48,15 +48,12 @@ export type ClaudeRuntimeTurnResult = ClaudeSpawnTurnResult;
 
 export type ClaudeRuntimeEvent = AgentEvent;
 
-export class ClaudePrintRuntimeAdapter
-  implements
-    AgentRuntimeAdapter<
-      ClaudeRuntimePrepareContext,
-      ClaudeRuntimeTurnInput,
-      ClaudeRuntimeTurnResult,
-      ClaudeRuntimeEvent
-    >
-{
+export class ClaudePrintRuntimeAdapter implements AgentRuntimeAdapter<
+  ClaudeRuntimePrepareContext,
+  ClaudeRuntimeTurnInput,
+  ClaudeRuntimeTurnResult,
+  ClaudeRuntimeEvent
+> {
   private activeChild: ChildProcess | null = null;
   private readonly eventHandlers = new Set<
     AgentRuntimeEventHandler<ClaudeRuntimeEvent>
@@ -72,16 +69,16 @@ export class ClaudePrintRuntimeAdapter
     // checks will populate this hook once the worker-side runtime wiring lands.
   }
 
-  async spawnTurn(input: ClaudeRuntimeTurnInput): Promise<ClaudeRuntimeTurnResult> {
+  async spawnTurn(
+    input: ClaudeRuntimeTurnInput
+  ): Promise<ClaudeRuntimeTurnResult> {
     if (this.activeChild) {
       throw new Error(
         "TODO(#8): Claude print runtime adapter supports only one in-flight turn."
       );
     }
 
-    const argv = buildClaudePrintArgv(
-      this.buildArgvOptions(input)
-    );
+    const argv = buildClaudePrintArgv(this.buildArgvOptions(input));
 
     try {
       return await spawnClaudeTurn(
@@ -138,7 +135,9 @@ export class ClaudePrintRuntimeAdapter
     this.stopActiveChild();
   }
 
-  private buildArgvOptions(input: ClaudeRuntimeTurnInput): ClaudePrintArgvOptions {
+  private buildArgvOptions(
+    input: ClaudeRuntimeTurnInput
+  ): ClaudePrintArgvOptions {
     return {
       session: input.session,
       isolation: {

--- a/packages/runtime-claude/src/adapter.ts
+++ b/packages/runtime-claude/src/adapter.ts
@@ -160,7 +160,11 @@ export class ClaudePrintRuntimeAdapter implements AgentRuntimeAdapter<
 
   private emitEvent(event: ClaudeRuntimeEvent): void {
     for (const handler of this.eventHandlers) {
-      handler(event);
+      try {
+        handler(event);
+      } catch {
+        // Event subscriber failures must not block later subscribers or turns.
+      }
     }
   }
 }

--- a/packages/runtime-claude/src/argv.test.ts
+++ b/packages/runtime-claude/src/argv.test.ts
@@ -24,11 +24,7 @@ describe("buildClaudePrintArgv", () => {
           sessionId: "session-1",
         },
       })
-    ).toEqual([
-      ...DEFAULT_CLAUDE_PRINT_ARGS,
-      "--session-id",
-      "session-1",
-    ]);
+    ).toEqual([...DEFAULT_CLAUDE_PRINT_ARGS, "--session-id", "session-1"]);
   });
 
   it("appends resume and fork-session flags for resumed turns", () => {

--- a/packages/runtime-claude/src/events.test.ts
+++ b/packages/runtime-claude/src/events.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+import {
+  ClaudePrintEventMapper,
+  isClaudeResultError,
+  parseClaudePrintNdjsonLine,
+} from "./events.js";
+
+describe("ClaudePrintEventMapper", () => {
+  it("maps stream-json fixture events to neutral agent events", () => {
+    const mapper = new ClaudePrintEventMapper({
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+
+    const events = [
+      { type: "message_start", message: { id: "msg-1" } },
+      {
+        type: "content_block_start",
+        index: 0,
+        content_block: {
+          type: "tool_use",
+          id: "toolu-1",
+          name: "github_graphql",
+          input: { query: "{ viewer { login } }" },
+        },
+      },
+      {
+        type: "content_block_delta",
+        index: 1,
+        delta: { type: "text_delta", text: "hello" },
+      },
+      {
+        type: "result",
+        subtype: "success",
+        stop_reason: "end_turn",
+        usage: {
+          input_tokens: 10,
+          output_tokens: 2,
+          rate_limit: {
+            limit: 1000,
+            remaining: 998,
+            reset_at: "2026-04-26T10:00:00.000Z",
+          },
+        },
+      },
+      {
+        type: "error",
+        error: {
+          type: "api_error",
+          message: "temporary upstream error",
+        },
+      },
+    ].flatMap((message) => mapper.mapMessage(message));
+
+    expect(events.map((event) => event.name)).toEqual([
+      "agent.turnStarted",
+      "agent.toolCallRequested",
+      "agent.messageDelta",
+      "agent.rateLimit",
+      "agent.turnCompleted",
+      "agent.error",
+    ]);
+    expect(events[1]).toMatchObject({
+      name: "agent.toolCallRequested",
+      payload: {
+        callId: "toolu-1",
+        toolName: "github_graphql",
+        threadId: "thread-1",
+        turnId: "turn-1",
+        arguments: { query: "{ viewer { login } }" },
+      },
+    });
+    expect(events[2]).toMatchObject({
+      name: "agent.messageDelta",
+      payload: {
+        delta: "hello",
+        itemId: "1",
+      },
+    });
+    expect(events[3]).toMatchObject({
+      name: "agent.rateLimit",
+      payload: {
+        params: {
+          source: "claude",
+          rate_limit: {
+            limit: 1000,
+            remaining: 998,
+          },
+        },
+      },
+    });
+    expect(events[4]).toMatchObject({
+      name: "agent.turnCompleted",
+      payload: {
+        inputRequired: false,
+        params: {
+          usage: {
+            input_tokens: 10,
+            output_tokens: 2,
+          },
+        },
+      },
+    });
+  });
+
+  it("starts a turn from the first content_block_delta when message_start is absent", () => {
+    const mapper = new ClaudePrintEventMapper();
+
+    const events = mapper.mapMessage({
+      type: "content_block_delta",
+      index: 0,
+      delta: { text: "first token" },
+    });
+
+    expect(events.map((event) => event.name)).toEqual([
+      "agent.turnStarted",
+      "agent.messageDelta",
+    ]);
+  });
+
+  it("maps result error subtypes to agent.error instead of turnCompleted", () => {
+    const mapper = new ClaudePrintEventMapper();
+
+    const events = mapper.mapMessage({
+      type: "result",
+      subtype: "error_max_turns",
+      stop_reason: "error_max_turns",
+      message: "max turns reached",
+    });
+
+    expect(events.map((event) => event.name)).toEqual(["agent.error"]);
+    expect(isClaudeResultError(events[0]?.payload.params as never)).toBe(true);
+  });
+
+  it("parses NDJSON lines without throwing on invalid JSON", () => {
+    expect(parseClaudePrintNdjsonLine('{"type":"message_start"}')).toEqual({
+      line: '{"type":"message_start"}',
+      message: { type: "message_start" },
+    });
+    expect(parseClaudePrintNdjsonLine("not-json")?.parseError).toBeTypeOf(
+      "string"
+    );
+    expect(parseClaudePrintNdjsonLine("   ")).toBeNull();
+  });
+});

--- a/packages/runtime-claude/src/events.test.ts
+++ b/packages/runtime-claude/src/events.test.ts
@@ -118,6 +118,33 @@ describe("ClaudePrintEventMapper", () => {
     ]);
   });
 
+  it("starts a turn before a tool call when message_start is absent", () => {
+    const mapper = new ClaudePrintEventMapper();
+
+    const events = mapper.mapMessage({
+      type: "content_block_start",
+      index: 0,
+      content_block: {
+        type: "tool_use",
+        id: "toolu-first",
+        name: "github_graphql",
+        input: { query: "{ viewer { login } }" },
+      },
+    });
+
+    expect(events.map((event) => event.name)).toEqual([
+      "agent.turnStarted",
+      "agent.toolCallRequested",
+    ]);
+    expect(events[1]).toMatchObject({
+      name: "agent.toolCallRequested",
+      payload: {
+        callId: "toolu-first",
+        toolName: "github_graphql",
+      },
+    });
+  });
+
   it("maps result error subtypes to agent.error instead of turnCompleted", () => {
     const mapper = new ClaudePrintEventMapper();
 
@@ -143,8 +170,11 @@ describe("ClaudePrintEventMapper", () => {
       arguments: { command: "pwd" },
     });
 
-    expect(events).toHaveLength(1);
-    expect(events[0]).toMatchObject({
+    expect(events.map((event) => event.name)).toEqual([
+      "agent.turnStarted",
+      "agent.toolCallRequested",
+    ]);
+    expect(events[1]).toMatchObject({
       name: "agent.toolCallRequested",
       payload: {
         callId: "toolu-args",

--- a/packages/runtime-claude/src/events.test.ts
+++ b/packages/runtime-claude/src/events.test.ts
@@ -132,6 +132,28 @@ describe("ClaudePrintEventMapper", () => {
     expect(isClaudeResultError(events[0]?.payload.params as never)).toBe(true);
   });
 
+  it("falls back to tool arguments when input is undefined", () => {
+    const mapper = new ClaudePrintEventMapper();
+
+    const events = mapper.mapMessage({
+      type: "tool_use",
+      id: "toolu-args",
+      name: "shell",
+      input: undefined,
+      arguments: { command: "pwd" },
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      name: "agent.toolCallRequested",
+      payload: {
+        callId: "toolu-args",
+        toolName: "shell",
+        arguments: { command: "pwd" },
+      },
+    });
+  });
+
   it("parses NDJSON lines without throwing on invalid JSON", () => {
     expect(parseClaudePrintNdjsonLine('{"type":"message_start"}')).toEqual({
       line: '{"type":"message_start"}',

--- a/packages/runtime-claude/src/events.test.ts
+++ b/packages/runtime-claude/src/events.test.ts
@@ -184,6 +184,27 @@ describe("ClaudePrintEventMapper", () => {
     });
   });
 
+  it("does not invent blank thread or turn ids for tool calls", () => {
+    const mapper = new ClaudePrintEventMapper();
+
+    const events = mapper.mapMessage({
+      type: "tool_use",
+      id: "toolu-no-context",
+      name: "shell",
+      input: { command: "pwd" },
+    });
+
+    expect(events[1]).toMatchObject({
+      name: "agent.toolCallRequested",
+      payload: {
+        callId: "toolu-no-context",
+        toolName: "shell",
+      },
+    });
+    expect(events[1]?.payload.threadId).toBeUndefined();
+    expect(events[1]?.payload.turnId).toBeUndefined();
+  });
+
   it("parses NDJSON lines without throwing on invalid JSON", () => {
     expect(parseClaudePrintNdjsonLine('{"type":"message_start"}')).toEqual({
       line: '{"type":"message_start"}',

--- a/packages/runtime-claude/src/events.ts
+++ b/packages/runtime-claude/src/events.ts
@@ -1,0 +1,311 @@
+import type { AgentEvent } from "@gh-symphony/core";
+
+export type ClaudePrintWireEvent = Record<string, unknown>;
+
+export type ClaudePrintNdjsonRecord = {
+  line: string;
+  message?: ClaudePrintWireEvent;
+  parseError?: string;
+};
+
+export type ClaudePrintEventMapperOptions = {
+  threadId?: string;
+  turnId?: string;
+};
+
+export type ClaudePrintEventMapperState = {
+  hasStartedTurn: boolean;
+  latestResultEvent: ClaudePrintWireEvent | null;
+  latestErrorEvent: ClaudePrintWireEvent | null;
+  sawRateLimit: boolean;
+};
+
+const CLAUDE_OBSERVABILITY_PREFIX = "claude-print/";
+
+export function parseClaudePrintNdjsonLine(
+  line: string
+): ClaudePrintNdjsonRecord | null {
+  const trimmedLine = line.trim();
+  if (!trimmedLine) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(trimmedLine);
+    if (!asRecord(parsed)) {
+      return {
+        line: trimmedLine,
+        parseError: "Claude stream-json line is not a JSON object.",
+      };
+    }
+
+    return {
+      line: trimmedLine,
+      message: parsed,
+    };
+  } catch (error) {
+    return {
+      line: trimmedLine,
+      parseError:
+        error instanceof Error ? error.message : "Unknown JSON parse error.",
+    };
+  }
+}
+
+export class ClaudePrintEventMapper {
+  private hasStartedTurn = false;
+  private latestResultEvent: ClaudePrintWireEvent | null = null;
+  private latestErrorEvent: ClaudePrintWireEvent | null = null;
+  private sawRateLimit = false;
+
+  constructor(private readonly options: ClaudePrintEventMapperOptions = {}) {}
+
+  mapLine(line: string): AgentEvent[] {
+    const record = parseClaudePrintNdjsonLine(line);
+    if (!record?.message) {
+      return [];
+    }
+
+    return this.mapMessage(record.message);
+  }
+
+  mapMessage(message: ClaudePrintWireEvent): AgentEvent[] {
+    const type = getEventType(message);
+    const events: AgentEvent[] = [];
+
+    if (type === "message_start") {
+      events.push(this.buildTurnStartedEvent(message, type));
+      this.hasStartedTurn = true;
+      return events;
+    }
+
+    const toolUseEvent = mapToolUseEvent(message, this.options);
+    if (toolUseEvent) {
+      events.push(toolUseEvent);
+    }
+
+    if (type === "content_block_delta") {
+      if (!this.hasStartedTurn) {
+        events.push(this.buildTurnStartedEvent(message, type));
+        this.hasStartedTurn = true;
+      }
+
+      events.push({
+        name: "agent.messageDelta",
+        payload: {
+          observabilityEvent: observabilityEventName(type),
+          params: message,
+          delta: extractDeltaText(message),
+          itemId: extractItemId(message),
+        },
+      });
+    }
+
+    if (type === "result") {
+      this.latestResultEvent = message;
+      const rateLimit = extractRateLimit(message);
+
+      if (rateLimit) {
+        this.sawRateLimit = true;
+        events.push({
+          name: "agent.rateLimit",
+          payload: {
+            observabilityEvent: observabilityEventName(type),
+            params: {
+              source: "claude",
+              rate_limit: rateLimit,
+              usage: asRecord(message.usage),
+              result: message,
+            },
+          },
+        });
+      }
+
+      if (isClaudeResultError(message)) {
+        events.push(buildClaudeErrorEvent(message, type));
+      } else {
+        events.push({
+          name: "agent.turnCompleted",
+          payload: {
+            observabilityEvent: observabilityEventName(type),
+            params: message,
+            inputRequired: false,
+          },
+        });
+      }
+    }
+
+    if (type === "error") {
+      this.latestErrorEvent = message;
+      events.push(buildClaudeErrorEvent(message, type));
+    }
+
+    return events;
+  }
+
+  snapshot(): ClaudePrintEventMapperState {
+    return {
+      hasStartedTurn: this.hasStartedTurn,
+      latestResultEvent: this.latestResultEvent,
+      latestErrorEvent: this.latestErrorEvent,
+      sawRateLimit: this.sawRateLimit,
+    };
+  }
+
+  private buildTurnStartedEvent(
+    message: ClaudePrintWireEvent,
+    type: string
+  ): AgentEvent {
+    return {
+      name: "agent.turnStarted",
+      payload: {
+        observabilityEvent: observabilityEventName(type),
+        params: message,
+      },
+    };
+  }
+}
+
+export function mapClaudePrintEvent(
+  message: ClaudePrintWireEvent,
+  options: ClaudePrintEventMapperOptions = {}
+): AgentEvent[] {
+  return new ClaudePrintEventMapper(options).mapMessage(message);
+}
+
+export function isClaudeResultError(message: ClaudePrintWireEvent): boolean {
+  const subtype = getString(message.subtype);
+  const stopReason = getString(message.stop_reason);
+
+  return (
+    message.is_error === true ||
+    (subtype !== undefined && subtype.startsWith("error")) ||
+    (stopReason !== undefined && stopReason.startsWith("error"))
+  );
+}
+
+export function extractRateLimit(
+  message: ClaudePrintWireEvent
+): Record<string, unknown> | null {
+  const usage = asRecord(message.usage);
+  const rateLimit = usage ? asRecord(usage.rate_limit) : null;
+  if (rateLimit) {
+    return rateLimit;
+  }
+
+  return asRecord(message.rate_limit);
+}
+
+export function getClaudeResultStatus(
+  message: ClaudePrintWireEvent | null | undefined
+): string | undefined {
+  if (!message) {
+    return undefined;
+  }
+
+  return getString(message.subtype) ?? getString(message.stop_reason);
+}
+
+function mapToolUseEvent(
+  message: ClaudePrintWireEvent,
+  options: ClaudePrintEventMapperOptions
+): AgentEvent | null {
+  const type = getEventType(message);
+  const contentBlock = asRecord(message.content_block);
+  const toolUse =
+    type === "tool_use"
+      ? message
+      : contentBlock && getString(contentBlock.type) === "tool_use"
+        ? contentBlock
+        : null;
+
+  if (!toolUse) {
+    return null;
+  }
+
+  const input = "input" in toolUse ? toolUse.input : toolUse.arguments;
+
+  return {
+    name: "agent.toolCallRequested",
+    payload: {
+      observabilityEvent: observabilityEventName(type),
+      params: message,
+      callId: getString(toolUse.id) ?? "",
+      toolName: getString(toolUse.name) ?? "",
+      threadId: options.threadId ?? getString(message.thread_id) ?? "",
+      turnId: options.turnId ?? getString(message.turn_id) ?? "",
+      arguments: input,
+    },
+  };
+}
+
+function buildClaudeErrorEvent(
+  message: ClaudePrintWireEvent,
+  type: string
+): AgentEvent {
+  return {
+    name: "agent.error",
+    payload: {
+      observabilityEvent: observabilityEventName(type),
+      params: message,
+      error: describeClaudeError(message),
+    },
+  };
+}
+
+function describeClaudeError(message: ClaudePrintWireEvent): string {
+  const error = asRecord(message.error);
+  return (
+    getString(error?.message) ??
+    getString(error?.type) ??
+    getString(message.message) ??
+    getString(message.subtype) ??
+    getString(message.stop_reason) ??
+    JSON.stringify(message)
+  );
+}
+
+function extractDeltaText(message: ClaudePrintWireEvent): string {
+  const delta = asRecord(message.delta);
+  return (
+    getString(delta?.text) ??
+    getString(delta?.partial_json) ??
+    getString(message.text) ??
+    ""
+  );
+}
+
+function extractItemId(message: ClaudePrintWireEvent): string {
+  return (
+    getString(message.item_id) ??
+    getString(message.content_block_id) ??
+    getString(message.index) ??
+    ""
+  );
+}
+
+function getEventType(message: ClaudePrintWireEvent): string {
+  return getString(message.type) ?? "";
+}
+
+function observabilityEventName(type: string): string {
+  return `${CLAUDE_OBSERVABILITY_PREFIX}${type || "unknown"}`;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function getString(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (typeof value === "number") {
+    return String(value);
+  }
+
+  return undefined;
+}

--- a/packages/runtime-claude/src/events.ts
+++ b/packages/runtime-claude/src/events.ts
@@ -79,9 +79,11 @@ export class ClaudePrintEventMapper {
       return events;
     }
 
-    const toolUseEvent = mapToolUseEvent(message, this.options);
-    if (toolUseEvent) {
-      events.push(toolUseEvent);
+    if (type === "content_block_start" || type === "tool_use") {
+      const toolUseEvent = mapToolUseEvent(message, this.options);
+      if (toolUseEvent) {
+        events.push(toolUseEvent);
+      }
     }
 
     if (type === "content_block_delta") {
@@ -170,6 +172,8 @@ export function mapClaudePrintEvent(
   message: ClaudePrintWireEvent,
   options: ClaudePrintEventMapperOptions = {}
 ): AgentEvent[] {
+  // Single-message helper. Use ClaudePrintEventMapper directly for streams so
+  // turn-start inference and latest result/error state are preserved.
   return new ClaudePrintEventMapper(options).mapMessage(message);
 }
 

--- a/packages/runtime-claude/src/events.ts
+++ b/packages/runtime-claude/src/events.ts
@@ -82,6 +82,11 @@ export class ClaudePrintEventMapper {
     // Claude stream-json uses content_block_start; top-level tool_use keeps
     // compatibility with older/internal fixtures that already model the block.
     if (type === "content_block_start" || type === "tool_use") {
+      if (!this.hasStartedTurn) {
+        events.push(this.buildTurnStartedEvent(message, type));
+        this.hasStartedTurn = true;
+      }
+
       const toolUseEvent = mapToolUseEvent(message, this.options);
       if (toolUseEvent) {
         events.push(toolUseEvent);
@@ -168,15 +173,6 @@ export class ClaudePrintEventMapper {
       },
     };
   }
-}
-
-export function mapClaudePrintEvent(
-  message: ClaudePrintWireEvent,
-  options: ClaudePrintEventMapperOptions = {}
-): AgentEvent[] {
-  // Single-message helper. Use ClaudePrintEventMapper directly for streams so
-  // turn-start inference and latest result/error state are preserved.
-  return new ClaudePrintEventMapper(options).mapMessage(message);
 }
 
 export function isClaudeResultError(message: ClaudePrintWireEvent): boolean {
@@ -298,13 +294,13 @@ function observabilityEventName(type: string): string {
   return `${CLAUDE_OBSERVABILITY_PREFIX}${type || "unknown"}`;
 }
 
-function asRecord(value: unknown): Record<string, unknown> | null {
+export function asRecord(value: unknown): Record<string, unknown> | null {
   return value !== null && typeof value === "object" && !Array.isArray(value)
     ? (value as Record<string, unknown>)
     : null;
 }
 
-function getString(value: unknown): string | undefined {
+export function getString(value: unknown): string | undefined {
   if (typeof value === "string") {
     return value;
   }

--- a/packages/runtime-claude/src/events.ts
+++ b/packages/runtime-claude/src/events.ts
@@ -56,6 +56,8 @@ export function parseClaudePrintNdjsonLine(
 export class ClaudePrintEventMapper {
   private hasStartedTurn = false;
   private latestResultEvent: ClaudePrintWireEvent | null = null;
+  // Claude -p stream-json does not define an ordered collection of error
+  // records for one turn; keep the terminal/latest error for exit classification.
   private latestErrorEvent: ClaudePrintWireEvent | null = null;
   private sawRateLimit = false;
 
@@ -237,8 +239,8 @@ function mapToolUseEvent(
       params: message,
       callId: getString(toolUse.id) ?? "",
       toolName: getString(toolUse.name) ?? "",
-      threadId: options.threadId ?? getString(message.thread_id) ?? "",
-      turnId: options.turnId ?? getString(message.turn_id) ?? "",
+      threadId: options.threadId ?? getString(message.thread_id),
+      turnId: options.turnId ?? getString(message.turn_id),
       arguments: input,
     },
   };

--- a/packages/runtime-claude/src/events.ts
+++ b/packages/runtime-claude/src/events.ts
@@ -79,6 +79,8 @@ export class ClaudePrintEventMapper {
       return events;
     }
 
+    // Claude stream-json uses content_block_start; top-level tool_use keeps
+    // compatibility with older/internal fixtures that already model the block.
     if (type === "content_block_start" || type === "tool_use") {
       const toolUseEvent = mapToolUseEvent(message, this.options);
       if (toolUseEvent) {
@@ -227,7 +229,7 @@ function mapToolUseEvent(
     return null;
   }
 
-  const input = "input" in toolUse ? toolUse.input : toolUse.arguments;
+  const input = toolUse.input !== undefined ? toolUse.input : toolUse.arguments;
 
   return {
     name: "agent.toolCallRequested",

--- a/packages/runtime-claude/src/events.ts
+++ b/packages/runtime-claude/src/events.ts
@@ -1,4 +1,5 @@
 import type { AgentEvent } from "@gh-symphony/core";
+import { asRecord, getString } from "./internal.js";
 
 export type ClaudePrintWireEvent = Record<string, unknown>;
 
@@ -87,6 +88,8 @@ export class ClaudePrintEventMapper {
         this.hasStartedTurn = true;
       }
 
+      // Non-tool content_block_start records are intentionally not forwarded;
+      // text streaming is represented by content_block_delta events.
       const toolUseEvent = mapToolUseEvent(message, this.options);
       if (toolUseEvent) {
         events.push(toolUseEvent);
@@ -292,22 +295,4 @@ function getEventType(message: ClaudePrintWireEvent): string {
 
 function observabilityEventName(type: string): string {
   return `${CLAUDE_OBSERVABILITY_PREFIX}${type || "unknown"}`;
-}
-
-export function asRecord(value: unknown): Record<string, unknown> | null {
-  return value !== null && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : null;
-}
-
-export function getString(value: unknown): string | undefined {
-  if (typeof value === "string") {
-    return value;
-  }
-
-  if (typeof value === "number") {
-    return String(value);
-  }
-
-  return undefined;
 }

--- a/packages/runtime-claude/src/exit-classifier.test.ts
+++ b/packages/runtime-claude/src/exit-classifier.test.ts
@@ -96,4 +96,18 @@ describe("classifyClaudeTurnExit", () => {
       resultStatus: undefined,
     });
   });
+
+  it("classifies SIGINT as a non-transient process error", () => {
+    expect(
+      classifyClaudeTurnExit({
+        exitCode: null,
+        signal: "SIGINT",
+      })
+    ).toEqual({
+      kind: "process-error",
+      transient: false,
+      reason: "signal_SIGINT",
+      resultStatus: undefined,
+    });
+  });
 });

--- a/packages/runtime-claude/src/exit-classifier.test.ts
+++ b/packages/runtime-claude/src/exit-classifier.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import { classifyClaudeTurnExit } from "./exit-classifier.js";
+
+describe("classifyClaudeTurnExit", () => {
+  it("classifies exit 0 with success result as success", () => {
+    expect(
+      classifyClaudeTurnExit({
+        exitCode: 0,
+        signal: null,
+        resultEvent: {
+          type: "result",
+          subtype: "success",
+          stop_reason: "end_turn",
+        },
+      })
+    ).toEqual({
+      kind: "success",
+      transient: false,
+      reason: "result_success",
+      resultStatus: "success",
+    });
+  });
+
+  it("classifies exit 0 with error_* result as an application error", () => {
+    expect(
+      classifyClaudeTurnExit({
+        exitCode: 0,
+        signal: null,
+        resultEvent: {
+          type: "result",
+          subtype: "error_max_turns",
+          stop_reason: "error_max_turns",
+        },
+      })
+    ).toEqual({
+      kind: "app-error",
+      transient: false,
+      reason: "error_max_turns",
+      resultStatus: "error_max_turns",
+    });
+  });
+
+  it("marks rate-limit failures transient", () => {
+    expect(
+      classifyClaudeTurnExit({
+        exitCode: 1,
+        signal: null,
+        resultEvent: {
+          type: "result",
+          subtype: "error_rate_limit",
+          usage: {
+            rate_limit: {
+              limit: 100,
+              remaining: 0,
+              retry_after: 30,
+            },
+          },
+        },
+      })
+    ).toMatchObject({
+      kind: "process-error",
+      transient: true,
+    });
+  });
+
+  it("classifies non-zero exit with error wire event as transient when retryable", () => {
+    expect(
+      classifyClaudeTurnExit({
+        exitCode: 1,
+        signal: null,
+        errorEvent: {
+          type: "error",
+          error: {
+            type: "api_error",
+            message: "temporarily unavailable",
+          },
+        },
+      })
+    ).toMatchObject({
+      kind: "process-error",
+      transient: true,
+      reason: "exit_1",
+    });
+  });
+
+  it("classifies SIGTERM as a transient process error", () => {
+    expect(
+      classifyClaudeTurnExit({
+        exitCode: null,
+        signal: "SIGTERM",
+      })
+    ).toEqual({
+      kind: "process-error",
+      transient: true,
+      reason: "signal_SIGTERM",
+      resultStatus: undefined,
+    });
+  });
+});

--- a/packages/runtime-claude/src/exit-classifier.test.ts
+++ b/packages/runtime-claude/src/exit-classifier.test.ts
@@ -77,6 +77,22 @@ describe("classifyClaudeTurnExit", () => {
     });
   });
 
+  it("marks error_rate_limit without usage details as transient", () => {
+    expect(
+      classifyClaudeTurnExit({
+        exitCode: 1,
+        signal: null,
+        resultEvent: {
+          type: "result",
+          subtype: "error_rate_limit",
+        },
+      })
+    ).toMatchObject({
+      kind: "process-error",
+      transient: true,
+    });
+  });
+
   it("classifies non-zero exit with error wire event as transient when retryable", () => {
     expect(
       classifyClaudeTurnExit({

--- a/packages/runtime-claude/src/exit-classifier.test.ts
+++ b/packages/runtime-claude/src/exit-classifier.test.ts
@@ -40,6 +40,20 @@ describe("classifyClaudeTurnExit", () => {
     });
   });
 
+  it("classifies exit 0 without a result event as an application error", () => {
+    expect(
+      classifyClaudeTurnExit({
+        exitCode: 0,
+        signal: null,
+      })
+    ).toEqual({
+      kind: "app-error",
+      transient: false,
+      reason: "missing_result",
+      resultStatus: undefined,
+    });
+  });
+
   it("marks rate-limit failures transient", () => {
     expect(
       classifyClaudeTurnExit({
@@ -79,6 +93,29 @@ describe("classifyClaudeTurnExit", () => {
     ).toMatchObject({
       kind: "process-error",
       transient: true,
+      reason: "exit_1",
+    });
+  });
+
+  it("does not classify unrelated JSON fields as transient", () => {
+    expect(
+      classifyClaudeTurnExit({
+        exitCode: 1,
+        signal: null,
+        errorEvent: {
+          type: "error",
+          error: {
+            type: "api_error",
+            message: "validation failed",
+          },
+          retry_config: {
+            timeout: 0,
+          },
+        },
+      })
+    ).toMatchObject({
+      kind: "process-error",
+      transient: false,
       reason: "exit_1",
     });
   });

--- a/packages/runtime-claude/src/exit-classifier.ts
+++ b/packages/runtime-claude/src/exit-classifier.ts
@@ -1,0 +1,111 @@
+import {
+  extractRateLimit,
+  getClaudeResultStatus,
+  isClaudeResultError,
+  type ClaudePrintWireEvent,
+} from "./events.js";
+
+export type ClaudeTurnExitKind =
+  | "success"
+  | "app-error"
+  | "process-error";
+
+export type ClaudeTurnExitClassification = {
+  kind: ClaudeTurnExitKind;
+  transient: boolean;
+  reason: string;
+  resultStatus?: string;
+};
+
+export type ClaudeTurnExitClassificationInput = {
+  exitCode: number | null;
+  signal: NodeJS.Signals | null;
+  resultEvent?: ClaudePrintWireEvent | null;
+  errorEvent?: ClaudePrintWireEvent | null;
+  sawRateLimit?: boolean;
+  spawnErrorMessage?: string;
+};
+
+const TRANSIENT_ERROR_PATTERNS = [
+  /rate.?limit/i,
+  /429/,
+  /timeout/i,
+  /timed?.?out/i,
+  /temporar/i,
+  /overload/i,
+  /unavailable/i,
+  /ECONNRESET/,
+  /ETIMEDOUT/,
+  /EAI_AGAIN/,
+];
+
+export function classifyClaudeTurnExit(
+  input: ClaudeTurnExitClassificationInput
+): ClaudeTurnExitClassification {
+  const resultStatus = getClaudeResultStatus(input.resultEvent);
+
+  if (input.exitCode === 0 && input.resultEvent && !isClaudeResultError(input.resultEvent)) {
+    return {
+      kind: "success",
+      transient: false,
+      reason: "result_success",
+      resultStatus,
+    };
+  }
+
+  if (input.exitCode === 0 && input.resultEvent && isClaudeResultError(input.resultEvent)) {
+    return {
+      kind: "app-error",
+      transient: isTransientClaudeFailure(input),
+      reason: resultStatus ?? "result_error",
+      resultStatus,
+    };
+  }
+
+  return {
+    kind: "process-error",
+    transient: isTransientClaudeFailure(input),
+    reason: describeProcessFailure(input),
+    resultStatus,
+  };
+}
+
+export function isTransientClaudeFailure(
+  input: ClaudeTurnExitClassificationInput
+): boolean {
+  if (input.sawRateLimit || extractRateLimit(input.resultEvent ?? {}) !== null) {
+    return true;
+  }
+
+  if (input.signal === "SIGTERM" || input.signal === "SIGINT") {
+    return true;
+  }
+
+  const text = [
+    input.spawnErrorMessage,
+    input.errorEvent ? JSON.stringify(input.errorEvent) : undefined,
+    input.resultEvent ? JSON.stringify(input.resultEvent) : undefined,
+  ]
+    .filter((value): value is string => typeof value === "string")
+    .join("\n");
+
+  return TRANSIENT_ERROR_PATTERNS.some((pattern) => pattern.test(text));
+}
+
+function describeProcessFailure(
+  input: ClaudeTurnExitClassificationInput
+): string {
+  if (input.signal) {
+    return `signal_${input.signal}`;
+  }
+
+  if (input.spawnErrorMessage) {
+    return input.spawnErrorMessage;
+  }
+
+  if (typeof input.exitCode === "number") {
+    return `exit_${input.exitCode}`;
+  }
+
+  return "process_error";
+}

--- a/packages/runtime-claude/src/exit-classifier.ts
+++ b/packages/runtime-claude/src/exit-classifier.ts
@@ -73,11 +73,14 @@ export function classifyClaudeTurnExit(
 export function isTransientClaudeFailure(
   input: ClaudeTurnExitClassificationInput
 ): boolean {
-  if (input.sawRateLimit || extractRateLimit(input.resultEvent ?? {}) !== null) {
+  if (
+    input.sawRateLimit ||
+    (input.resultEvent && extractRateLimit(input.resultEvent) !== null)
+  ) {
     return true;
   }
 
-  if (input.signal === "SIGTERM" || input.signal === "SIGINT") {
+  if (input.signal === "SIGTERM") {
     return true;
   }
 

--- a/packages/runtime-claude/src/exit-classifier.ts
+++ b/packages/runtime-claude/src/exit-classifier.ts
@@ -1,11 +1,10 @@
 import {
   extractRateLimit,
   getClaudeResultStatus,
-  getString,
   isClaudeResultError,
-  asRecord,
   type ClaudePrintWireEvent,
 } from "./events.js";
+import { asRecord, getString } from "./internal.js";
 
 export type ClaudeTurnExitKind = "success" | "app-error" | "process-error";
 
@@ -91,7 +90,9 @@ export function isTransientClaudeFailure(
 ): boolean {
   if (
     input.sawRateLimit ||
-    (input.resultEvent && extractRateLimit(input.resultEvent) !== null)
+    (input.resultEvent &&
+      (extractRateLimit(input.resultEvent) !== null ||
+        getClaudeResultStatus(input.resultEvent) === "error_rate_limit"))
   ) {
     return true;
   }

--- a/packages/runtime-claude/src/exit-classifier.ts
+++ b/packages/runtime-claude/src/exit-classifier.ts
@@ -85,7 +85,7 @@ export function classifyClaudeTurnExit(
   };
 }
 
-export function isTransientClaudeFailure(
+function isTransientClaudeFailure(
   input: ClaudeTurnExitClassificationInput
 ): boolean {
   if (

--- a/packages/runtime-claude/src/exit-classifier.ts
+++ b/packages/runtime-claude/src/exit-classifier.ts
@@ -1,7 +1,9 @@
 import {
   extractRateLimit,
   getClaudeResultStatus,
+  getString,
   isClaudeResultError,
+  asRecord,
   type ClaudePrintWireEvent,
 } from "./events.js";
 
@@ -25,7 +27,7 @@ export type ClaudeTurnExitClassificationInput = {
 
 const TRANSIENT_ERROR_PATTERNS = [
   /rate.?limit/i,
-  /429/,
+  /\b429\b/,
   /timeout/i,
   /timed?.?out/i,
   /temporar/i,
@@ -140,22 +142,4 @@ function extractFailureMessage(
   ]
     .filter((value): value is string => value !== undefined)
     .join("\n");
-}
-
-function asRecord(value: unknown): Record<string, unknown> | null {
-  return value !== null && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : null;
-}
-
-function getString(value: unknown): string | undefined {
-  if (typeof value === "string") {
-    return value;
-  }
-
-  if (typeof value === "number") {
-    return String(value);
-  }
-
-  return undefined;
 }

--- a/packages/runtime-claude/src/exit-classifier.ts
+++ b/packages/runtime-claude/src/exit-classifier.ts
@@ -5,10 +5,7 @@ import {
   type ClaudePrintWireEvent,
 } from "./events.js";
 
-export type ClaudeTurnExitKind =
-  | "success"
-  | "app-error"
-  | "process-error";
+export type ClaudeTurnExitKind = "success" | "app-error" | "process-error";
 
 export type ClaudeTurnExitClassification = {
   kind: ClaudeTurnExitKind;
@@ -44,7 +41,11 @@ export function classifyClaudeTurnExit(
 ): ClaudeTurnExitClassification {
   const resultStatus = getClaudeResultStatus(input.resultEvent);
 
-  if (input.exitCode === 0 && input.resultEvent && !isClaudeResultError(input.resultEvent)) {
+  if (
+    input.exitCode === 0 &&
+    input.resultEvent &&
+    !isClaudeResultError(input.resultEvent)
+  ) {
     return {
       kind: "success",
       transient: false,
@@ -53,7 +54,20 @@ export function classifyClaudeTurnExit(
     };
   }
 
-  if (input.exitCode === 0 && input.resultEvent && isClaudeResultError(input.resultEvent)) {
+  if (input.exitCode === 0 && !input.resultEvent) {
+    return {
+      kind: "app-error",
+      transient: false,
+      reason: "missing_result",
+      resultStatus,
+    };
+  }
+
+  if (
+    input.exitCode === 0 &&
+    input.resultEvent &&
+    isClaudeResultError(input.resultEvent)
+  ) {
     return {
       kind: "app-error",
       transient: isTransientClaudeFailure(input),
@@ -86,11 +100,9 @@ export function isTransientClaudeFailure(
 
   const text = [
     input.spawnErrorMessage,
-    input.errorEvent ? JSON.stringify(input.errorEvent) : undefined,
-    input.resultEvent ? JSON.stringify(input.resultEvent) : undefined,
-  ]
-    .filter((value): value is string => typeof value === "string")
-    .join("\n");
+    extractFailureMessage(input.errorEvent),
+    extractFailureMessage(input.resultEvent),
+  ].join("\n");
 
   return TRANSIENT_ERROR_PATTERNS.some((pattern) => pattern.test(text));
 }
@@ -111,4 +123,39 @@ function describeProcessFailure(
   }
 
   return "process_error";
+}
+
+function extractFailureMessage(
+  event: ClaudePrintWireEvent | null | undefined
+): string {
+  if (!event) {
+    return "";
+  }
+
+  const error = asRecord(event.error);
+  return [
+    getString(error?.message),
+    getString(error?.type),
+    getString(event.message),
+  ]
+    .filter((value): value is string => value !== undefined)
+    .join("\n");
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function getString(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (typeof value === "number") {
+    return String(value);
+  }
+
+  return undefined;
 }

--- a/packages/runtime-claude/src/index.ts
+++ b/packages/runtime-claude/src/index.ts
@@ -9,4 +9,6 @@ export const RUNTIME_CLAUDE_BOUNDARY = {
 
 export * from "./adapter.js";
 export * from "./argv.js";
+export * from "./events.js";
+export * from "./exit-classifier.js";
 export * from "./spawn.js";

--- a/packages/runtime-claude/src/internal.ts
+++ b/packages/runtime-claude/src/internal.ts
@@ -1,0 +1,17 @@
+export function asRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+export function getString(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (typeof value === "number") {
+    return String(value);
+  }
+
+  return undefined;
+}

--- a/packages/runtime-claude/src/spawn.test.ts
+++ b/packages/runtime-claude/src/spawn.test.ts
@@ -208,6 +208,80 @@ describe("spawnClaudeTurn", () => {
     expect(eventNames).toEqual(["agent.error"]);
   });
 
+  it("records stderr JSON without emitting neutral events or mutating stdout state", async () => {
+    const stdin = new PassThrough();
+    const stdout = new PassThrough();
+    const stderr = new PassThrough();
+
+    const { EventEmitter } = await import("node:events");
+    const emitter = new EventEmitter();
+
+    const child = {
+      stdin,
+      stdout,
+      stderr,
+      emit(event: string, ...args: unknown[]) {
+        emitter.emit(event, ...args);
+      },
+      once(event: string, listener: (...args: unknown[]) => void) {
+        emitter.once(event, listener);
+        return child;
+      },
+      on(event: string, listener: (...args: unknown[]) => void) {
+        emitter.on(event, listener);
+        return child;
+      },
+      removeListener(event: string, listener: (...args: unknown[]) => void) {
+        emitter.removeListener(event, listener);
+        return child;
+      },
+    } as unknown as ReturnType<SpawnLike>;
+
+    const spawnImpl: SpawnLike = () => {
+      queueMicrotask(() => {
+        stderr.write(
+          '{"type":"error","error":{"type":"api_error","message":"stderr debug"}}\n'
+        );
+        stdout.write('{"type":"message_start"}\n');
+        stdout.write('{"type":"result","subtype":"success"}\n');
+        stdout.end();
+        stderr.end();
+        child.emit("close", 0, null);
+      });
+
+      return child;
+    };
+    const eventNames: string[] = [];
+
+    const result = await spawnClaudeTurn(
+      {
+        cwd: "/workspace",
+        args: ["-p"],
+        stdinMessages: [],
+      },
+      {
+        spawnImpl,
+        onEvent: (event) => {
+          eventNames.push(event.name);
+        },
+      }
+    );
+
+    expect(result.result).toBe("success");
+    expect(eventNames).toEqual(["agent.turnStarted", "agent.turnCompleted"]);
+    expect(result.records).toContainEqual({
+      stream: "stderr",
+      line: '{"type":"error","error":{"type":"api_error","message":"stderr debug"}}',
+      message: {
+        type: "error",
+        error: {
+          type: "api_error",
+          message: "stderr debug",
+        },
+      },
+    });
+  });
+
   it("returns a structured process error when spawn emits error", async () => {
     const stdin = new PassThrough();
     const stdout = new PassThrough();

--- a/packages/runtime-claude/src/spawn.test.ts
+++ b/packages/runtime-claude/src/spawn.test.ts
@@ -54,17 +54,25 @@ describe("spawnClaudeTurn", () => {
     const { EventEmitter } = await import("node:events");
     const emitter = new EventEmitter();
 
+    const events: string[] = [];
     const result = await spawnClaudeTurn(
       {
         cwd: "/workspace",
         args: ["-p"],
         stdinMessages: [{ type: "user", text: "hello" }],
       },
-      { spawnImpl }
+      {
+        spawnImpl,
+        onEvent: (event) => {
+          events.push(event.name);
+        },
+      }
     );
 
     expect(writtenStdin).toBe('{"type":"user","text":"hello"}\n');
     expect(result.result).toBe("success");
+    expect(result.classification.kind).toBe("success");
+    expect(events).toEqual(["agent.turnStarted", "agent.turnCompleted"]);
     expect(result.records).toEqual([
       {
         stream: "stdout",
@@ -132,6 +140,72 @@ describe("spawnClaudeTurn", () => {
     expect(result.records).toHaveLength(1);
     expect(result.records[0]?.stream).toBe("stderr");
     expect(result.records[0]?.parseError).toBeTypeOf("string");
+  });
+
+  it("classifies non-zero exits with error wire events and emits agent.error", async () => {
+    const stdin = new PassThrough();
+    const stdout = new PassThrough();
+    const stderr = new PassThrough();
+
+    const { EventEmitter } = await import("node:events");
+    const emitter = new EventEmitter();
+
+    const child = {
+      stdin,
+      stdout,
+      stderr,
+      emit(event: string, ...args: unknown[]) {
+        emitter.emit(event, ...args);
+      },
+      once(event: string, listener: (...args: unknown[]) => void) {
+        emitter.once(event, listener);
+        return child;
+      },
+      on(event: string, listener: (...args: unknown[]) => void) {
+        emitter.on(event, listener);
+        return child;
+      },
+      removeListener(event: string, listener: (...args: unknown[]) => void) {
+        emitter.removeListener(event, listener);
+        return child;
+      },
+    } as unknown as ReturnType<SpawnLike>;
+
+    const spawnImpl: SpawnLike = () => {
+      queueMicrotask(() => {
+        stdout.write(
+          '{"type":"error","error":{"type":"api_error","message":"temporarily unavailable"}}\n'
+        );
+        stdout.end();
+        stderr.end();
+        child.emit("close", 1, null);
+      });
+
+      return child;
+    };
+    const eventNames: string[] = [];
+
+    const result = await spawnClaudeTurn(
+      {
+        cwd: "/workspace",
+        args: ["-p"],
+        stdinMessages: [],
+      },
+      {
+        spawnImpl,
+        onEvent: (event) => {
+          eventNames.push(event.name);
+        },
+      }
+    );
+
+    expect(result.result).toBe("process-error");
+    expect(result.classification).toMatchObject({
+      kind: "process-error",
+      transient: true,
+      reason: "exit_1",
+    });
+    expect(eventNames).toEqual(["agent.error"]);
   });
 
   it("returns a structured process error when spawn emits error", async () => {
@@ -324,12 +398,12 @@ describe("spawnClaudeTurn", () => {
 });
 
 describe("classifyClaudeTurnResult", () => {
-  it("classifies SIGTERM as cancelled", () => {
-    expect(classifyClaudeTurnResult(null, "SIGTERM")).toBe("cancelled");
+  it("classifies SIGTERM as a process error", () => {
+    expect(classifyClaudeTurnResult(null, "SIGTERM")).toBe("process-error");
   });
 
-  it("classifies SIGINT and SIGKILL as cancelled", () => {
-    expect(classifyClaudeTurnResult(null, "SIGINT")).toBe("cancelled");
-    expect(classifyClaudeTurnResult(null, "SIGKILL")).toBe("cancelled");
+  it("classifies SIGINT and SIGKILL as process errors", () => {
+    expect(classifyClaudeTurnResult(null, "SIGINT")).toBe("process-error");
+    expect(classifyClaudeTurnResult(null, "SIGKILL")).toBe("process-error");
   });
 });

--- a/packages/runtime-claude/src/spawn.test.ts
+++ b/packages/runtime-claude/src/spawn.test.ts
@@ -282,6 +282,83 @@ describe("spawnClaudeTurn", () => {
     });
   });
 
+  it("emits agent.error when exit 0 has no final result event", async () => {
+    const stdin = new PassThrough();
+    const stdout = new PassThrough();
+    const stderr = new PassThrough();
+
+    const { EventEmitter } = await import("node:events");
+    const emitter = new EventEmitter();
+
+    const child = {
+      stdin,
+      stdout,
+      stderr,
+      emit(event: string, ...args: unknown[]) {
+        emitter.emit(event, ...args);
+      },
+      once(event: string, listener: (...args: unknown[]) => void) {
+        emitter.once(event, listener);
+        return child;
+      },
+      on(event: string, listener: (...args: unknown[]) => void) {
+        emitter.on(event, listener);
+        return child;
+      },
+      removeListener(event: string, listener: (...args: unknown[]) => void) {
+        emitter.removeListener(event, listener);
+        return child;
+      },
+    } as unknown as ReturnType<SpawnLike>;
+
+    const spawnImpl: SpawnLike = () => {
+      queueMicrotask(() => {
+        stdout.write('{"type":"message_start"}\n');
+        stdout.end();
+        stderr.end();
+        child.emit("close", 0, null);
+      });
+
+      return child;
+    };
+    const events: Array<{ name: string; reason?: unknown }> = [];
+
+    const result = await spawnClaudeTurn(
+      {
+        cwd: "/workspace",
+        args: ["-p"],
+        stdinMessages: [],
+      },
+      {
+        spawnImpl,
+        onEvent: (event) => {
+          events.push({
+            name: event.name,
+            reason:
+              typeof event.payload.params === "object" &&
+              event.payload.params !== null &&
+              "classification" in event.payload.params
+                ? event.payload.params.classification
+                : undefined,
+          });
+        },
+      }
+    );
+
+    expect(result.classification).toMatchObject({
+      kind: "app-error",
+      reason: "missing_result",
+    });
+    expect(events.map((event) => event.name)).toEqual([
+      "agent.turnStarted",
+      "agent.error",
+    ]);
+    expect(events[1]?.reason).toMatchObject({
+      kind: "app-error",
+      reason: "missing_result",
+    });
+  });
+
   it("returns a structured process error when spawn emits error", async () => {
     const stdin = new PassThrough();
     const stdout = new PassThrough();

--- a/packages/runtime-claude/src/spawn.ts
+++ b/packages/runtime-claude/src/spawn.ts
@@ -87,8 +87,8 @@ export async function spawnClaudeTurn(
     child.stderr,
     "stderr",
     records,
-    eventMapper,
-    emitEvent
+    new ClaudePrintEventMapper(),
+    () => {}
   );
   const exitDone = waitForChildExit(child, records);
 

--- a/packages/runtime-claude/src/spawn.ts
+++ b/packages/runtime-claude/src/spawn.ts
@@ -2,8 +2,19 @@ import { spawn } from "node:child_process";
 import type { ChildProcess, SpawnOptions } from "node:child_process";
 import type { Writable } from "node:stream";
 import { finished } from "node:stream/promises";
+import type { AgentEvent } from "@gh-symphony/core";
+import {
+  classifyClaudeTurnExit,
+  type ClaudeTurnExitKind,
+  type ClaudeTurnExitClassification,
+} from "./exit-classifier.js";
+import {
+  ClaudePrintEventMapper,
+  parseClaudePrintNdjsonLine,
+  type ClaudePrintWireEvent,
+} from "./events.js";
 
-export type ClaudeWireMessage = Record<string, unknown>;
+export type ClaudeWireMessage = ClaudePrintWireEvent;
 
 export type ClaudeSpawnRecord = {
   stream: "stdout" | "stderr";
@@ -27,7 +38,8 @@ export type ClaudeSpawnTurnResult = {
   records: ClaudeSpawnRecord[];
   exitCode: number | null;
   signal: NodeJS.Signals | null;
-  result: "success" | "process-error" | "cancelled";
+  result: ClaudeTurnExitKind;
+  classification: ClaudeTurnExitClassification;
   errorMessage?: string;
 };
 
@@ -40,6 +52,7 @@ export type SpawnLike = (
 export type ClaudeSpawnDependencies = {
   spawnImpl?: SpawnLike;
   onSpawned?: (child: ChildProcess) => void;
+  onEvent?: (event: AgentEvent) => void;
 };
 
 export async function spawnClaudeTurn(
@@ -55,8 +68,28 @@ export async function spawnClaudeTurn(
   dependencies.onSpawned?.(child);
 
   const records: ClaudeSpawnRecord[] = [];
-  const stdoutDone = collectNdjsonStream(child.stdout, "stdout", records);
-  const stderrDone = collectNdjsonStream(child.stderr, "stderr", records);
+  const eventMapper = new ClaudePrintEventMapper();
+  let emittedErrorEvent = false;
+  const emitEvent = (event: AgentEvent) => {
+    if (event.name === "agent.error") {
+      emittedErrorEvent = true;
+    }
+    dependencies.onEvent?.(event);
+  };
+  const stdoutDone = collectNdjsonStream(
+    child.stdout,
+    "stdout",
+    records,
+    eventMapper,
+    emitEvent
+  );
+  const stderrDone = collectNdjsonStream(
+    child.stderr,
+    "stderr",
+    records,
+    eventMapper,
+    emitEvent
+  );
   const exitDone = waitForChildExit(child, records);
 
   const stdinMessages = Array.isArray(input.stdinMessages)
@@ -85,6 +118,33 @@ export async function spawnClaudeTurn(
   const outcome = await exitDone;
 
   await Promise.all([stdoutDone, stderrDone]);
+  const mapperState = eventMapper.snapshot();
+  const classification = classifyClaudeTurnExit({
+    exitCode: outcome.exitCode,
+    signal: outcome.signal,
+    resultEvent: mapperState.latestResultEvent,
+    errorEvent: mapperState.latestErrorEvent,
+    sawRateLimit: mapperState.sawRateLimit,
+    spawnErrorMessage:
+      "errorMessage" in outcome ? outcome.errorMessage : undefined,
+  });
+
+  if (classification.kind === "process-error" && !emittedErrorEvent) {
+    emitEvent({
+      name: "agent.error",
+      payload: {
+        observabilityEvent: "claude-print/process-exit",
+        params: {
+          exitCode: outcome.exitCode,
+          signal: outcome.signal,
+          classification,
+          errorMessage:
+            "errorMessage" in outcome ? outcome.errorMessage : undefined,
+        },
+        error: classification.reason,
+      },
+    });
+  }
 
   return {
     command,
@@ -93,7 +153,8 @@ export async function spawnClaudeTurn(
     records,
     exitCode: outcome.exitCode,
     signal: outcome.signal,
-    result: classifyClaudeTurnResult(outcome.exitCode, outcome.signal),
+    result: classification.kind,
+    classification,
     errorMessage: "errorMessage" in outcome ? outcome.errorMessage : undefined,
   };
 }
@@ -102,21 +163,15 @@ export function classifyClaudeTurnResult(
   exitCode: number | null,
   signal: NodeJS.Signals | null
 ): ClaudeSpawnTurnResult["result"] {
-  if (signal !== null) {
-    return "cancelled";
-  }
-
-  if (exitCode === 0) {
-    return "success";
-  }
-
-  return "process-error";
+  return classifyClaudeTurnExit({ exitCode, signal }).kind;
 }
 
 async function collectNdjsonStream(
   stream: NodeJS.ReadableStream | null | undefined,
   channel: ClaudeSpawnRecord["stream"],
-  records: ClaudeSpawnRecord[]
+  records: ClaudeSpawnRecord[],
+  eventMapper: ClaudePrintEventMapper,
+  onEvent: (event: AgentEvent) => void
 ): Promise<void> {
   if (!stream) {
     return;
@@ -141,7 +196,7 @@ async function collectNdjsonStream(
         continue;
       }
 
-      records.push(parseClaudeRecord(channel, line));
+      records.push(parseClaudeRecord(channel, line, eventMapper, onEvent));
     }
   });
 
@@ -158,28 +213,48 @@ async function collectNdjsonStream(
 
   const trailingLine = buffer.trim();
   if (trailingLine.length > 0) {
-    records.push(parseClaudeRecord(channel, trailingLine));
+    records.push(parseClaudeRecord(channel, trailingLine, eventMapper, onEvent));
   }
 }
 
 function parseClaudeRecord(
   stream: ClaudeSpawnRecord["stream"],
-  line: string
+  line: string,
+  eventMapper: ClaudePrintEventMapper,
+  onEvent: (event: AgentEvent) => void
 ): ClaudeSpawnRecord {
-  try {
+  const record = parseClaudePrintNdjsonLine(line);
+  if (!record) {
     return {
       stream,
       line,
-      message: JSON.parse(line) as ClaudeWireMessage,
-    };
-  } catch (error) {
-    return {
-      stream,
-      line,
-      parseError:
-        error instanceof Error ? error.message : "Unknown JSON parse error.",
     };
   }
+
+  if (record.message) {
+    for (const event of eventMapper.mapMessage(record.message)) {
+      onEvent(event);
+    }
+
+    return {
+      stream,
+      line: record.line,
+      message: record.message,
+    };
+  }
+
+  if (record.parseError) {
+    return {
+      stream,
+      line: record.line,
+      parseError: record.parseError,
+    };
+  }
+
+  return {
+    stream,
+    line,
+  };
 }
 
 async function writeToStdin(

--- a/packages/runtime-claude/src/spawn.ts
+++ b/packages/runtime-claude/src/spawn.ts
@@ -255,17 +255,10 @@ function parseClaudeRecord(
     };
   }
 
-  if (record.parseError) {
-    return {
-      stream,
-      line: record.line,
-      parseError: record.parseError,
-    };
-  }
-
   return {
     stream,
-    line,
+    line: record.line,
+    parseError: record.parseError!,
   };
 }
 

--- a/packages/runtime-claude/src/spawn.ts
+++ b/packages/runtime-claude/src/spawn.ts
@@ -225,13 +225,7 @@ function parseClaudeRecord(
   eventMapper: ClaudePrintEventMapper | null,
   onEvent: ((event: AgentEvent) => void) | null
 ): ClaudeSpawnRecord {
-  const record = parseClaudePrintNdjsonLine(line);
-  if (!record) {
-    return {
-      stream,
-      line,
-    };
-  }
+  const record = parseClaudePrintNdjsonLine(line)!;
 
   if (record.message) {
     if (!eventMapper) {

--- a/packages/runtime-claude/src/spawn.ts
+++ b/packages/runtime-claude/src/spawn.ts
@@ -87,8 +87,8 @@ export async function spawnClaudeTurn(
     child.stderr,
     "stderr",
     records,
-    new ClaudePrintEventMapper(),
-    () => {}
+    null,
+    null
   );
   const exitDone = waitForChildExit(child, records);
 
@@ -170,8 +170,8 @@ async function collectNdjsonStream(
   stream: NodeJS.ReadableStream | null | undefined,
   channel: ClaudeSpawnRecord["stream"],
   records: ClaudeSpawnRecord[],
-  eventMapper: ClaudePrintEventMapper,
-  onEvent: (event: AgentEvent) => void
+  eventMapper: ClaudePrintEventMapper | null,
+  onEvent: ((event: AgentEvent) => void) | null
 ): Promise<void> {
   if (!stream) {
     return;
@@ -213,15 +213,17 @@ async function collectNdjsonStream(
 
   const trailingLine = buffer.trim();
   if (trailingLine.length > 0) {
-    records.push(parseClaudeRecord(channel, trailingLine, eventMapper, onEvent));
+    records.push(
+      parseClaudeRecord(channel, trailingLine, eventMapper, onEvent)
+    );
   }
 }
 
 function parseClaudeRecord(
   stream: ClaudeSpawnRecord["stream"],
   line: string,
-  eventMapper: ClaudePrintEventMapper,
-  onEvent: (event: AgentEvent) => void
+  eventMapper: ClaudePrintEventMapper | null,
+  onEvent: ((event: AgentEvent) => void) | null
 ): ClaudeSpawnRecord {
   const record = parseClaudePrintNdjsonLine(line);
   if (!record) {
@@ -232,8 +234,16 @@ function parseClaudeRecord(
   }
 
   if (record.message) {
+    if (!eventMapper) {
+      return {
+        stream,
+        line: record.line,
+        message: record.message,
+      };
+    }
+
     for (const event of eventMapper.mapMessage(record.message)) {
-      onEvent(event);
+      onEvent?.(event);
     }
 
     return {
@@ -320,7 +330,10 @@ function waitForChildExit(
     }
 > {
   return new Promise((resolve) => {
-    const handleClose = (exitCode: number | null, signal: NodeJS.Signals | null) => {
+    const handleClose = (
+      exitCode: number | null,
+      signal: NodeJS.Signals | null
+    ) => {
       cleanup();
       resolve({ exitCode, signal });
     };

--- a/packages/runtime-claude/src/spawn.ts
+++ b/packages/runtime-claude/src/spawn.ts
@@ -129,11 +129,18 @@ export async function spawnClaudeTurn(
       "errorMessage" in outcome ? outcome.errorMessage : undefined,
   });
 
-  if (classification.kind === "process-error" && !emittedErrorEvent) {
+  if (
+    (classification.kind === "app-error" ||
+      classification.kind === "process-error") &&
+    !emittedErrorEvent
+  ) {
     emitEvent({
       name: "agent.error",
       payload: {
-        observabilityEvent: "claude-print/process-exit",
+        observabilityEvent:
+          classification.kind === "app-error"
+            ? "claude-print/app-error"
+            : "claude-print/process-exit",
         params: {
           exitCode: outcome.exitCode,
           signal: outcome.signal,
@@ -225,6 +232,7 @@ function parseClaudeRecord(
   eventMapper: ClaudePrintEventMapper | null,
   onEvent: ((event: AgentEvent) => void) | null
 ): ClaudeSpawnRecord {
+  // collectNdjsonStream filters empty lines before parsing, so this is non-null.
   const record = parseClaudePrintNdjsonLine(line)!;
 
   if (record.message) {

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -34,9 +34,7 @@ import {
   resolveMaxNonProductiveTurns,
 } from "./convergence-detection.js";
 import { resolveExitRunPhase } from "./run-phase.js";
-import {
-  buildContinuationTurnInput,
-} from "./thread-resume.js";
+import { buildContinuationTurnInput } from "./thread-resume.js";
 import { resolveMaxTurns } from "./turn-limits.js";
 import { persistTokenUsageArtifact, type TokenUsage } from "./token-usage.js";
 
@@ -892,6 +890,13 @@ async function runCodexClientProtocol(
         emitObservedAgentEvent(event);
         return true;
       case "agent.toolCallRequested":
+        if (!event.payload.threadId || !event.payload.turnId) {
+          process.stderr.write(
+            `[worker] dynamic tool call ${event.payload.callId} is missing threadId/turnId; cannot send response\n`
+          );
+          emitObservedAgentEvent(event);
+          return true;
+        }
         void dispatchDynamicToolCall(
           event.payload.callId,
           event.payload.toolName,
@@ -1088,10 +1093,14 @@ async function runCodexClientProtocol(
       `[worker] starting codex thread (mcp_servers: ${Object.keys(mcpServers).join(", ")})\n`
     );
 
-    const threadResult = (await sendRequestWithTimeout("thread-1", "thread/start", {
-      ...baseThreadParams,
-      ephemeral: false,
-    })) as Record<string, unknown>;
+    const threadResult = (await sendRequestWithTimeout(
+      "thread-1",
+      "thread/start",
+      {
+        ...baseThreadParams,
+        ephemeral: false,
+      }
+    )) as Record<string, unknown>;
 
     const threadId =
       (threadResult.thread_id as string | undefined) ??


### PR DESCRIPTION
## Issues

- Fixes #221

## Summary

- Claude `-p --output-format stream-json` NDJSON을 neutral `AgentEvent` stream으로 매핑합니다.
- Claude result/error event와 process exit code를 결합해 `success | app-error | process-error` 및 transient 여부를 분류합니다.
- 최신 리뷰 대응으로 event hook 예외 격리, tool call routing id 누락 방어, public API 노출 축소를 보강했습니다.

## Changes

- `runtime-claude`에 NDJSON parser, stateful `ClaudePrintEventMapper`, exit classifier를 추가했습니다.
- `spawnClaudeTurn` stdout parser를 neutral event emission에 연결하고, stderr는 record 수집만 수행하도록 분리했습니다.
- `adapter.onEvent`와 dependency `onEvent` 경로를 격리해 한 handler 실패가 stream 처리와 다른 subscriber를 막지 않게 했습니다.
- `agent.toolCallRequested`의 `threadId` / `turnId`는 누락 시 빈 문자열을 만들지 않고 optional로 유지하며, worker는 routing id 누락 시 tool response dispatch를 중단합니다.
- `isTransientClaudeFailure`는 classifier 내부 구현으로 되돌리고, parser dead branch와 다중 Claude error event 가정을 정리했습니다.

## Evidence

- `pnpm --filter @gh-symphony/runtime-claude test` (42 passed)
- `pnpm --filter @gh-symphony/runtime-claude lint`
- `pnpm --filter @gh-symphony/runtime-claude typecheck`
- `pnpm --filter @gh-symphony/worker test` (110 passed)
- `pnpm --filter @gh-symphony/worker lint`
- `pnpm --filter @gh-symphony/worker typecheck`
- `pnpm --filter @gh-symphony/core typecheck`
- `pnpm exec prettier --check packages/runtime-claude/src/adapter.ts packages/runtime-claude/src/adapter.test.ts packages/runtime-claude/src/events.ts packages/runtime-claude/src/events.test.ts packages/runtime-claude/src/exit-classifier.ts packages/runtime-claude/src/spawn.ts packages/core/src/runtime/events.ts packages/worker/src/index.ts`
- `pnpm lint && pnpm test && pnpm typecheck && pnpm build`
- Docker E2E TC: `docker compose -f docker-compose.e2e.yml -f docker-compose.e2e.events.yml up -d --build`; `/healthz` 확인, happy-path fixture 주입, refresh 후 `status: "retrying"`, `executionPhase: "implementation"`, `lastEvent: "completed"`, `retryKind: "continuation"`, `lastError: null` 관찰, cleanup 완료

## Human Validation

- [ ] Confirm Claude stream-json output drives the same lifecycle events expected by worker consumers.
- [ ] Confirm tool-call handling behavior is acceptable when Claude omits routing ids.
- [ ] Confirm retry classification policy matches ADR §4.2.2.

## Risks

- Claude `tool_use` records without `threadId` / `turnId` are now preserved as neutral events but intentionally not dispatched to tool response routing by the worker, because there is no safe response address.