### PR TITLE
feat(runtime-claude): persist claude session ids

### DIFF
--- a/packages/core/src/observability/event-formatter.test.ts
+++ b/packages/core/src/observability/event-formatter.test.ts
@@ -79,6 +79,17 @@ describe("event-formatter", () => {
         error: "tool execution failed",
       })
     ).toBe("tool execution failed");
+
+    expect(
+      formatEventMessage({
+        at: "2026-04-26T00:00:00.000Z",
+        event: "session_invalidated",
+        runId: "run-1",
+        sessionId: "session-old",
+        replacementSessionId: "session-new",
+        reason: "claude resume session was rejected with a 4xx response",
+      })
+    ).toBe("claude resume session was rejected with a 4xx response");
   });
 
   it("formats run-recovered events", () => {

--- a/packages/core/src/observability/event-formatter.ts
+++ b/packages/core/src/observability/event-formatter.ts
@@ -29,6 +29,8 @@ export function formatEventMessage(event: OrchestratorEvent): string | null {
       return `Turn ${event.turnCount} completed in ${event.durationMs}ms`;
     case "turn_failed":
       return event.error ?? `Turn ${event.turnCount} failed`;
+    case "session_invalidated":
+      return event.reason;
     default:
       return null;
   }

--- a/packages/core/src/observability/structured-events.ts
+++ b/packages/core/src/observability/structured-events.ts
@@ -148,6 +148,18 @@ export type TurnFailedEvent = {
   error: string | null;
 };
 
+export type SessionInvalidatedEvent = {
+  at: string;
+  event: "session_invalidated";
+  projectId?: string;
+  runId: string;
+  issueIdentifier?: string;
+  issueId?: string;
+  sessionId: string;
+  replacementSessionId: string;
+  reason: string;
+};
+
 /**
  * Union of all structured orchestration events. Discriminated on `event`.
  */
@@ -163,4 +175,5 @@ export type OrchestratorEvent =
   | WorkerErrorEvent
   | TurnStartedEvent
   | TurnCompletedEvent
-  | TurnFailedEvent;
+  | TurnFailedEvent
+  | SessionInvalidatedEvent;

--- a/packages/core/src/runtime/events.ts
+++ b/packages/core/src/runtime/events.ts
@@ -8,6 +8,7 @@ export type AgentEventName =
   | "agent.rateLimit"
   | "agent.messageDelta"
   | "agent.tokenUsageUpdated"
+  | "agent.sessionInvalidated"
   | "agent.error";
 
 type AgentEventPayloadBase = {
@@ -103,6 +104,17 @@ export type AgentTokenUsageUpdatedEvent = {
   };
 };
 
+export type AgentSessionInvalidatedEvent = {
+  name: "agent.sessionInvalidated";
+  payload: AgentEventPayloadBase & {
+    params: Record<string, unknown>;
+    runId: string;
+    sessionId: string;
+    replacementSessionId: string;
+    reason: string;
+  };
+};
+
 export type AgentErrorEvent = {
   name: "agent.error";
   payload: AgentEventPayloadBase & {
@@ -121,4 +133,5 @@ export type AgentEvent =
   | AgentRateLimitEvent
   | AgentMessageDeltaEvent
   | AgentTokenUsageUpdatedEvent
+  | AgentSessionInvalidatedEvent
   | AgentErrorEvent;

--- a/packages/core/src/workflow-loader.test.ts
+++ b/packages/core/src/workflow-loader.test.ts
@@ -163,6 +163,24 @@ Prompt body.
       "Continue from turn {{cumulativeTurnCount}}."
     );
   });
+
+  it("does not expose runtime session controls from WORKFLOW.md", () => {
+    const workflow = parseWorkflowMarkdown(`---
+tracker:
+  kind: github-project
+runtime:
+  kind: claude-print
+  session:
+    resume: true
+codex:
+  command: codex app-server
+---
+Prompt body.
+`);
+
+    expect("runtime" in workflow).toBe(false);
+    expect("session" in workflow).toBe(false);
+  });
 });
 
 describe("WorkflowConfigStore", () => {

--- a/packages/runtime-claude/src/adapter.test.ts
+++ b/packages/runtime-claude/src/adapter.test.ts
@@ -1,13 +1,23 @@
 import { EventEmitter } from "node:events";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { PassThrough } from "node:stream";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
-  ClaudeRuntimeNotImplementedError,
   ClaudePrintRuntimeAdapter,
   createClaudePrintRuntimeAdapter,
   resolveClaudeCredentials,
 } from "./adapter.js";
 import type { SpawnLike } from "./spawn.js";
+
+const tempDirs: string[] = [];
+
+async function createTempDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "claude-adapter-"));
+  tempDirs.push(dir);
+  return dir;
+}
 
 function createStubChild() {
   const emitter = new EventEmitter();
@@ -42,8 +52,12 @@ function createStubChild() {
 }
 
 describe("ClaudePrintRuntimeAdapter", () => {
-  afterEach(() => {
+  afterEach(async () => {
     delete process.env.GITHUB_TOKEN;
+    await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, {
+      recursive: true,
+      force: true,
+    })));
   });
 
   it("spawns claude with default argv and merged env", async () => {
@@ -121,14 +135,14 @@ describe("ClaudePrintRuntimeAdapter", () => {
     expect(calls[0]?.env?.GITHUB_TOKEN).toBeUndefined();
   });
 
-  it("throws NotImplementedError on onEvent() until #9 lands", () => {
+  it("subscribes to runtime events", () => {
     const adapter = new ClaudePrintRuntimeAdapter({
       workingDirectory: "/workspace",
     });
 
-    expect(() => adapter.onEvent(() => {})).toThrowError(
-      ClaudeRuntimeNotImplementedError
-    );
+    const unsubscribe = adapter.onEvent(() => {});
+    expect(unsubscribe).toEqual(expect.any(Function));
+    unsubscribe();
   });
 
   it("exposes a factory helper", () => {
@@ -267,6 +281,222 @@ describe("ClaudePrintRuntimeAdapter", () => {
     }
 
     expect(calls[0]).toEqual({});
+  });
+
+  it("prepares a first turn with --session-id and persists the session file", async () => {
+    const runtimeRoot = await createTempDir();
+    const calls: Array<ReadonlyArray<string>> = [];
+    const { child, stdout, stderr } = createStubChild();
+    const spawnImpl: SpawnLike = (_command, args) => {
+      calls.push(args);
+      queueMicrotask(() => {
+        stdout.write('{"type":"result"}\n');
+        stdout.end();
+        stderr.end();
+        child.emit("close", 0, null);
+      });
+      return child;
+    };
+    const adapter = new ClaudePrintRuntimeAdapter(
+      {
+        workingDirectory: "/workspace",
+        runtimeRoot,
+      },
+      {
+        spawnImpl,
+        createSessionId: () => "session-first",
+        now: () => new Date("2026-04-26T00:00:00.000Z"),
+      }
+    );
+
+    await adapter.prepare({ runId: "run-1" });
+    await adapter.spawnTurn({ messages: [] });
+
+    expect(calls[0]).toContain("--session-id");
+    expect(calls[0]).toContain("session-first");
+    const session = JSON.parse(
+      await readFile(join(runtimeRoot, "runs", "run-1", "claude-session.json"), "utf8")
+    ) as Record<string, unknown>;
+    expect(session).toMatchObject({
+      protocol: "claude-print",
+      sessionId: "session-first",
+      createdAt: "2026-04-26T00:00:00.000Z",
+      protocolState: {},
+    });
+  });
+
+  it("uses --resume without fork for an intra-run retry", async () => {
+    const runtimeRoot = await createTempDir();
+    const calls: Array<ReadonlyArray<string>> = [];
+    const children = [createStubChild(), createStubChild(), createStubChild()];
+    const spawnImpl: SpawnLike = (_command, args) => {
+      const stub = children[calls.length]!;
+      calls.push(args);
+      queueMicrotask(() => {
+        stub.stdout.end();
+        stub.stderr.end();
+        stub.child.emit("close", 0, null);
+      });
+      return stub.child;
+    };
+    const adapter = new ClaudePrintRuntimeAdapter(
+      {
+        workingDirectory: "/workspace",
+        runtimeRoot,
+      },
+      {
+        spawnImpl,
+        createSessionId: () => "session-1",
+        now: () => new Date("2026-04-26T00:00:00.000Z"),
+      }
+    );
+
+    await adapter.prepare({ runId: "run-1" });
+    await adapter.spawnTurn({ messages: [] });
+    await adapter.spawnTurn({ messages: [] });
+
+    expect(calls[1]).toEqual(
+      expect.arrayContaining(["--resume", "session-1"])
+    );
+    expect(calls[1]).not.toContain("--fork-session");
+  });
+
+  it("uses --resume with --fork-session for inter-run recover and links the parent run", async () => {
+    const runtimeRoot = await createTempDir();
+    const calls: Array<ReadonlyArray<string>> = [];
+    const children = [createStubChild(), createStubChild()];
+    const spawnImpl: SpawnLike = (_command, args) => {
+      const stub = children[calls.length]!;
+      calls.push(args);
+      queueMicrotask(() => {
+        stub.stdout.write('{"session_id":"session-forked"}\n');
+        stub.stdout.end();
+        stub.stderr.end();
+        stub.child.emit("close", 0, null);
+      });
+      return stub.child;
+    };
+    const adapter = new ClaudePrintRuntimeAdapter(
+      {
+        workingDirectory: "/workspace",
+        runtimeRoot,
+      },
+      {
+        spawnImpl,
+        createSessionId: () => "unused",
+        now: () => new Date("2026-04-26T00:00:00.000Z"),
+      }
+    );
+    await adapter.prepare({ runId: "run-prev" });
+    await adapter.spawnTurn({ messages: [] });
+
+    await adapter.prepare({
+      runId: "run-next",
+      previousRunId: "run-prev",
+    });
+    await adapter.spawnTurn({ messages: [] });
+
+    expect(calls[1]).toEqual(
+      expect.arrayContaining(["--resume", "session-forked", "--fork-session"])
+    );
+    const session = JSON.parse(
+      await readFile(
+        join(runtimeRoot, "runs", "run-next", "claude-session.json"),
+        "utf8"
+      )
+    ) as Record<string, unknown>;
+    expect(session.parentRunId).toBe("run-prev");
+    expect(session.sessionId).toBe("session-forked");
+    expect(session.protocol).toBe("claude-print");
+  });
+
+  it("falls back to a new session id and emits sessionInvalidated when resume returns 4xx", async () => {
+    const runtimeRoot = await createTempDir();
+    const calls: Array<ReadonlyArray<string>> = [];
+    const emitted: string[] = [];
+    const children = [createStubChild(), createStubChild(), createStubChild()];
+    const spawnImpl: SpawnLike = (_command, args) => {
+      const callIndex = calls.length;
+      const stub = children[callIndex]!;
+      calls.push(args);
+      queueMicrotask(() => {
+        if (callIndex === 1) {
+          stub.stderr.write("resume failed: 401 Unauthorized\n");
+          stub.stdout.end();
+          stub.stderr.end();
+          stub.child.emit("close", 1, null);
+          return;
+        }
+        stub.stdout.end();
+        stub.stderr.end();
+        stub.child.emit("close", 0, null);
+      });
+      return stub.child;
+    };
+    const sessionIds = ["session-fresh"];
+    const adapter = new ClaudePrintRuntimeAdapter(
+      {
+        workingDirectory: "/workspace",
+        runtimeRoot,
+      },
+      {
+        spawnImpl,
+        createSessionId: () => sessionIds.shift() ?? "session-new",
+        now: () => new Date("2026-04-26T00:00:00.000Z"),
+      }
+    );
+    await adapter.prepare({ runId: "run-1" });
+    await adapter.spawnTurn({ messages: [] });
+    adapter.onEvent((event) => {
+      emitted.push(event.name);
+    });
+
+    const result = await adapter.spawnTurn({ messages: [] });
+
+    expect(result.result).toBe("success");
+    expect(calls[1]).toEqual(
+      expect.arrayContaining(["--resume", "session-fresh"])
+    );
+    expect(calls[2]).toEqual(
+      expect.arrayContaining(["--session-id", "session-new"])
+    );
+    expect(calls[2]).not.toContain("--fork-session");
+    expect(emitted).toEqual(["agent.sessionInvalidated"]);
+    const session = JSON.parse(
+      await readFile(join(runtimeRoot, "runs", "run-1", "claude-session.json"), "utf8")
+    ) as Record<string, unknown>;
+    expect(session.sessionId).toBe("session-new");
+    expect(session.protocol).toBe("claude-print");
+  });
+
+  it("replays a prepare-time sessionInvalidated event to later subscribers", async () => {
+    const runtimeRoot = await createTempDir();
+    const runDir = join(runtimeRoot, "runs", "run-1");
+    await mkdir(runDir, { recursive: true });
+    await writeFile(join(runDir, "claude-session.json"), "{bad json", "utf8");
+    const emitted: string[] = [];
+    const adapter = new ClaudePrintRuntimeAdapter(
+      {
+        workingDirectory: "/workspace",
+        runtimeRoot,
+      },
+      {
+        createSessionId: () => "session-recovered",
+        now: () => new Date("2026-04-26T00:00:00.000Z"),
+      }
+    );
+
+    await adapter.prepare({ runId: "run-1" });
+    adapter.onEvent((event) => {
+      emitted.push(event.name);
+    });
+
+    expect(emitted).toEqual(["agent.sessionInvalidated"]);
+    const session = JSON.parse(
+      await readFile(join(runDir, "claude-session.json"), "utf8")
+    ) as Record<string, unknown>;
+    expect(session.sessionId).toBe("session-recovered");
+    expect(session.protocol).toBe("claude-print");
   });
 });
 

--- a/packages/runtime-claude/src/adapter.test.ts
+++ b/packages/runtime-claude/src/adapter.test.ts
@@ -410,6 +410,100 @@ describe("ClaudePrintRuntimeAdapter", () => {
     expect(session.protocol).toBe("claude-print");
   });
 
+  it("clears fork mode after the first inter-run resume even when no new session id is emitted", async () => {
+    const runtimeRoot = await createTempDir();
+    const calls: Array<ReadonlyArray<string>> = [];
+    const children = [createStubChild(), createStubChild(), createStubChild()];
+    const spawnImpl: SpawnLike = (_command, args) => {
+      const stub = children[calls.length]!;
+      calls.push(args);
+      queueMicrotask(() => {
+        stub.stdout.end();
+        stub.stderr.end();
+        stub.child.emit("close", 0, null);
+      });
+      return stub.child;
+    };
+    const adapter = new ClaudePrintRuntimeAdapter(
+      {
+        workingDirectory: "/workspace",
+        runtimeRoot,
+      },
+      {
+        spawnImpl,
+        createSessionId: () => "session-prev",
+        now: () => new Date("2026-04-26T00:00:00.000Z"),
+      }
+    );
+    await adapter.prepare({ runId: "run-prev" });
+    await adapter.spawnTurn({ messages: [] });
+
+    await adapter.prepare({
+      runId: "run-next",
+      previousRunId: "run-prev",
+    });
+    await adapter.spawnTurn({ messages: [] });
+    await adapter.spawnTurn({ messages: [] });
+
+    expect(calls[1]).toEqual(
+      expect.arrayContaining(["--resume", "session-prev", "--fork-session"])
+    );
+    expect(calls[2]).toEqual(
+      expect.arrayContaining(["--resume", "session-prev"])
+    );
+    expect(calls[2]).not.toContain("--fork-session");
+  });
+
+  it("starts a fresh linked session when previousRunId has no session file", async () => {
+    const runtimeRoot = await createTempDir();
+    const calls: Array<ReadonlyArray<string>> = [];
+    const emitted: string[] = [];
+    const { child, stdout, stderr } = createStubChild();
+    const spawnImpl: SpawnLike = (_command, args) => {
+      calls.push(args);
+      queueMicrotask(() => {
+        stdout.end();
+        stderr.end();
+        child.emit("close", 0, null);
+      });
+      return child;
+    };
+    const adapter = new ClaudePrintRuntimeAdapter(
+      {
+        workingDirectory: "/workspace",
+        runtimeRoot,
+      },
+      {
+        spawnImpl,
+        createSessionId: () => "session-fresh",
+        now: () => new Date("2026-04-26T00:00:00.000Z"),
+      }
+    );
+    adapter.onEvent((event) => {
+      emitted.push(event.name);
+    });
+
+    await adapter.prepare({
+      runId: "run-next",
+      previousRunId: "run-missing",
+    });
+    await adapter.spawnTurn({ messages: [] });
+
+    expect(calls[0]).toEqual(
+      expect.arrayContaining(["--session-id", "session-fresh"])
+    );
+    expect(calls[0]).not.toContain("--resume");
+    expect(calls[0]).not.toContain("--fork-session");
+    expect(emitted).toEqual([]);
+    const session = JSON.parse(
+      await readFile(
+        join(runtimeRoot, "runs", "run-next", "claude-session.json"),
+        "utf8"
+      )
+    ) as Record<string, unknown>;
+    expect(session.parentRunId).toBe("run-missing");
+  });
+
   it("falls back to a new session id and emits sessionInvalidated when resume returns 4xx", async () => {
     const runtimeRoot = await createTempDir();
     const calls: Array<ReadonlyArray<string>> = [];
@@ -469,12 +563,12 @@ describe("ClaudePrintRuntimeAdapter", () => {
     expect(session.protocol).toBe("claude-print");
   });
 
-  it("replays a prepare-time sessionInvalidated event to later subscribers", async () => {
+  it("replays a prepare-time sessionInvalidated event to later subscribers with the read error", async () => {
     const runtimeRoot = await createTempDir();
     const runDir = join(runtimeRoot, "runs", "run-1");
     await mkdir(runDir, { recursive: true });
     await writeFile(join(runDir, "claude-session.json"), "{bad json", "utf8");
-    const emitted: string[] = [];
+    const emitted: Array<{ name: string; reason?: string }> = [];
     const adapter = new ClaudePrintRuntimeAdapter(
       {
         workingDirectory: "/workspace",
@@ -488,15 +582,53 @@ describe("ClaudePrintRuntimeAdapter", () => {
 
     await adapter.prepare({ runId: "run-1" });
     adapter.onEvent((event) => {
-      emitted.push(event.name);
+      emitted.push({
+        name: event.name,
+        reason:
+          event.name === "agent.sessionInvalidated"
+            ? event.payload.reason
+            : undefined,
+      });
     });
 
-    expect(emitted).toEqual(["agent.sessionInvalidated"]);
+    expect(emitted).toEqual([
+      {
+        name: "agent.sessionInvalidated",
+        reason: expect.stringContaining("session file could not be read:"),
+      },
+    ]);
     const session = JSON.parse(
       await readFile(join(runDir, "claude-session.json"), "utf8")
     ) as Record<string, unknown>;
     expect(session.sessionId).toBe("session-recovered");
     expect(session.protocol).toBe("claude-print");
+  });
+
+  it("does not replay prepare-time sessionInvalidated events across later prepare calls", async () => {
+    const runtimeRoot = await createTempDir();
+    const runDir = join(runtimeRoot, "runs", "run-1");
+    await mkdir(runDir, { recursive: true });
+    await writeFile(join(runDir, "claude-session.json"), "{bad json", "utf8");
+    const emitted: string[] = [];
+    const sessionIds = ["session-recovered", "session-next"];
+    const adapter = new ClaudePrintRuntimeAdapter(
+      {
+        workingDirectory: "/workspace",
+        runtimeRoot,
+      },
+      {
+        createSessionId: () => sessionIds.shift() ?? "session-extra",
+        now: () => new Date("2026-04-26T00:00:00.000Z"),
+      }
+    );
+
+    await adapter.prepare({ runId: "run-1" });
+    await adapter.prepare({ runId: "run-2" });
+    adapter.onEvent((event) => {
+      emitted.push(event.name);
+    });
+
+    expect(emitted).toEqual([]);
   });
 });
 

--- a/packages/runtime-claude/src/adapter.test.ts
+++ b/packages/runtime-claude/src/adapter.test.ts
@@ -662,7 +662,9 @@ describe("ClaudePrintRuntimeAdapter", () => {
     expect(emitted).toEqual([
       {
         name: "agent.sessionInvalidated",
-        reason: expect.stringContaining("session file could not be read:"),
+        reason: expect.stringContaining(
+          "session file could not be read or parsed:"
+        ),
       },
     ]);
     const session = JSON.parse(

--- a/packages/runtime-claude/src/adapter.test.ts
+++ b/packages/runtime-claude/src/adapter.test.ts
@@ -563,6 +563,74 @@ describe("ClaudePrintRuntimeAdapter", () => {
     expect(session.protocol).toBe("claude-print");
   });
 
+  it("falls back to a new session when inter-run fork resume returns 4xx", async () => {
+    const runtimeRoot = await createTempDir();
+    const calls: Array<ReadonlyArray<string>> = [];
+    const emitted: string[] = [];
+    const children = [createStubChild(), createStubChild(), createStubChild()];
+    const spawnImpl: SpawnLike = (_command, args) => {
+      const callIndex = calls.length;
+      const stub = children[callIndex]!;
+      calls.push(args);
+      queueMicrotask(() => {
+        if (callIndex === 1) {
+          stub.stderr.write("Claude resume failed: 401 Unauthorized\n");
+          stub.stdout.end();
+          stub.stderr.end();
+          stub.child.emit("close", 1, null);
+          return;
+        }
+        stub.stdout.end();
+        stub.stderr.end();
+        stub.child.emit("close", 0, null);
+      });
+      return stub.child;
+    };
+    const sessionIds = ["session-prev", "session-new"];
+    const adapter = new ClaudePrintRuntimeAdapter(
+      {
+        workingDirectory: "/workspace",
+        runtimeRoot,
+      },
+      {
+        spawnImpl,
+        createSessionId: () => sessionIds.shift() ?? "session-extra",
+        now: () => new Date("2026-04-26T00:00:00.000Z"),
+      }
+    );
+
+    await adapter.prepare({ runId: "run-prev" });
+    await adapter.spawnTurn({ messages: [] });
+    await adapter.prepare({
+      runId: "run-next",
+      previousRunId: "run-prev",
+    });
+    adapter.onEvent((event) => {
+      emitted.push(event.name);
+    });
+
+    const result = await adapter.spawnTurn({ messages: [] });
+
+    expect(result.result).toBe("success");
+    expect(calls[1]).toEqual(
+      expect.arrayContaining(["--resume", "session-prev", "--fork-session"])
+    );
+    expect(calls[2]).toEqual(
+      expect.arrayContaining(["--session-id", "session-new"])
+    );
+    expect(calls[2]).not.toContain("--resume");
+    expect(calls[2]).not.toContain("--fork-session");
+    expect(emitted).toEqual(["agent.sessionInvalidated"]);
+    const session = JSON.parse(
+      await readFile(
+        join(runtimeRoot, "runs", "run-next", "claude-session.json"),
+        "utf8"
+      )
+    ) as Record<string, unknown>;
+    expect(session.sessionId).toBe("session-new");
+    expect(session.parentRunId).toBe("run-prev");
+  });
+
   it("replays a prepare-time sessionInvalidated event to later subscribers with the read error", async () => {
     const runtimeRoot = await createTempDir();
     const runDir = join(runtimeRoot, "runs", "run-1");
@@ -602,6 +670,36 @@ describe("ClaudePrintRuntimeAdapter", () => {
     ) as Record<string, unknown>;
     expect(session.sessionId).toBe("session-recovered");
     expect(session.protocol).toBe("claude-print");
+  });
+
+  it("replays prepare-time sessionInvalidated events to every later subscriber", async () => {
+    const runtimeRoot = await createTempDir();
+    const runDir = join(runtimeRoot, "runs", "run-1");
+    await mkdir(runDir, { recursive: true });
+    await writeFile(join(runDir, "claude-session.json"), "{bad json", "utf8");
+    const firstSubscriber: string[] = [];
+    const secondSubscriber: string[] = [];
+    const adapter = new ClaudePrintRuntimeAdapter(
+      {
+        workingDirectory: "/workspace",
+        runtimeRoot,
+      },
+      {
+        createSessionId: () => "session-recovered",
+        now: () => new Date("2026-04-26T00:00:00.000Z"),
+      }
+    );
+
+    await adapter.prepare({ runId: "run-1" });
+    adapter.onEvent((event) => {
+      firstSubscriber.push(event.name);
+    });
+    adapter.onEvent((event) => {
+      secondSubscriber.push(event.name);
+    });
+
+    expect(firstSubscriber).toEqual(["agent.sessionInvalidated"]);
+    expect(secondSubscriber).toEqual(["agent.sessionInvalidated"]);
   });
 
   it("does not replay prepare-time sessionInvalidated events across later prepare calls", async () => {

--- a/packages/runtime-claude/src/adapter.ts
+++ b/packages/runtime-claude/src/adapter.ts
@@ -100,6 +100,7 @@ export class ClaudePrintRuntimeAdapter
   }
 
   async prepare(context: ClaudeRuntimePrepareContext): Promise<void> {
+    this.pendingEvents.length = 0;
     this.preparedSession = await this.prepareSession(context);
   }
 
@@ -192,9 +193,9 @@ export class ClaudePrintRuntimeAdapter
           },
         };
       }
-    } catch {
+    } catch (error) {
       return await this.createFreshSession(context, {
-        reason: "session file could not be read",
+        reason: `session file could not be read: ${formatErrorMessage(error)}`,
         invalidatedSessionId: "unknown",
         parentRunId,
       });
@@ -224,9 +225,9 @@ export class ClaudePrintRuntimeAdapter
             },
           };
         }
-      } catch {
+      } catch (error) {
         return await this.createFreshSession(context, {
-          reason: "parent session file could not be read",
+          reason: `parent session file could not be read: ${formatErrorMessage(error)}`,
           invalidatedSessionId: "unknown",
           parentRunId,
         });
@@ -284,7 +285,7 @@ export class ClaudePrintRuntimeAdapter
     const invalidatedSessionId = this.preparedSession.session.sessionId;
     const replacementSessionId = this.createSessionId();
     const parentRunId = this.preparedSession.sessionFile.parentRunId;
-    const sessionFile = await this.sessionStore.invalidate({
+    const sessionFile = await this.sessionStore.save({
       runId: this.preparedSession.runId,
       runDirectory: this.preparedSession.runDirectory,
       sessionId: replacementSessionId,
@@ -351,23 +352,21 @@ export class ClaudePrintRuntimeAdapter
     }
 
     const forkedSessionId = findSessionIdInResult(result);
-    if (!forkedSessionId) {
-      return;
-    }
+    const sessionId = forkedSessionId ?? this.preparedSession.session.sessionId;
 
     this.preparedSession = {
       ...this.preparedSession,
       sessionFile: await this.sessionStore.save({
         runId: this.preparedSession.runId,
         runDirectory: this.preparedSession.runDirectory,
-        sessionId: forkedSessionId,
+        sessionId,
         createdAt: this.preparedSession.sessionFile.createdAt,
         parentRunId: this.preparedSession.sessionFile.parentRunId,
         protocolState: this.preparedSession.sessionFile.protocolState,
       }),
       session: {
         mode: "resume",
-        sessionId: forkedSessionId,
+        sessionId,
       },
     };
   }
@@ -525,7 +524,10 @@ function findSessionIdInResult(result: ClaudeSpawnTurnResult): string | null {
   return null;
 }
 
-function findSessionId(value: unknown): string | null {
+function findSessionId(value: unknown, depth = 0): string | null {
+  if (depth > 5) {
+    return null;
+  }
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     return null;
   }
@@ -537,7 +539,7 @@ function findSessionId(value: unknown): string | null {
     return record.session_id;
   }
   for (const nested of Object.values(record)) {
-    const sessionId = findSessionId(nested);
+    const sessionId = findSessionId(nested, depth + 1);
     if (sessionId) {
       return sessionId;
     }
@@ -549,13 +551,6 @@ function isResumeRejectedWith4xx(result: ClaudeSpawnTurnResult): boolean {
   if (result.result !== "process-error") {
     return false;
   }
-  if (
-    typeof result.exitCode === "number" &&
-    result.exitCode >= 400 &&
-    result.exitCode < 500
-  ) {
-    return true;
-  }
 
   return result.records.some((record) => {
     const text = record.line.toLowerCase();
@@ -564,4 +559,11 @@ function isResumeRejectedWith4xx(result: ClaudeSpawnTurnResult): boolean {
       /\b4\d\d\b/.test(text)
     );
   });
+}
+
+function formatErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return String(error);
 }

--- a/packages/runtime-claude/src/adapter.ts
+++ b/packages/runtime-claude/src/adapter.ts
@@ -1,5 +1,8 @@
 import type { ChildProcess } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { join } from "node:path";
 import type {
+  AgentSessionInvalidatedEvent,
   AgentRuntimeAdapter,
   AgentRuntimeCredentialBrokerResponse,
   AgentRuntimeEnv,
@@ -20,6 +23,10 @@ import {
   type ClaudeSpawnTurnResult,
   type ClaudeWireMessage,
 } from "./spawn.js";
+import {
+  ClaudeSessionStore,
+  type ClaudeSessionFile,
+} from "./session-store.js";
 
 export type ClaudeRuntimeConfig = {
   workingDirectory: string;
@@ -28,10 +35,14 @@ export type ClaudeRuntimeConfig = {
   extraArgs?: readonly string[];
   isolation?: ClaudeRuntimeIsolationOptions;
   inheritProcessEnv?: boolean;
+  runtimeRoot?: string;
 };
 
 export type ClaudeRuntimePrepareContext = {
-  runId?: string;
+  runId: string;
+  runDirectory?: string;
+  previousRunId?: string;
+  previousRunDirectory?: string;
 };
 
 export type ClaudeRuntimeTurnInput = {
@@ -46,7 +57,12 @@ export type ClaudeRuntimeTurnInput = {
 
 export type ClaudeRuntimeTurnResult = ClaudeSpawnTurnResult;
 
-export type ClaudeRuntimeEvent = AgentRuntimeEvent;
+export type ClaudeRuntimeEvent = AgentRuntimeEvent | AgentSessionInvalidatedEvent;
+
+export type ClaudeRuntimeDependencies = ClaudeSpawnDependencies & {
+  createSessionId?: () => string;
+  now?: () => Date;
+};
 
 export class ClaudeRuntimeNotImplementedError extends Error {
   constructor(message: string) {
@@ -65,15 +81,26 @@ export class ClaudePrintRuntimeAdapter
     >
 {
   private activeChild: ChildProcess | null = null;
+  private preparedSession: PreparedClaudeSession | null = null;
+  private readonly eventHandlers = new Set<
+    AgentRuntimeEventHandler<ClaudeRuntimeEvent>
+  >();
+  private readonly pendingEvents: ClaudeRuntimeEvent[] = [];
+  private readonly sessionStore: ClaudeSessionStore;
 
   constructor(
     private readonly config: ClaudeRuntimeConfig,
-    private readonly dependencies: ClaudeSpawnDependencies = {}
-  ) {}
+    private readonly dependencies: ClaudeRuntimeDependencies = {}
+  ) {
+    this.sessionStore = new ClaudeSessionStore({
+      runtimeRoot:
+        config.runtimeRoot ??
+        join(config.workingDirectory, ".runtime", "orchestrator"),
+    });
+  }
 
-  prepare(_context: ClaudeRuntimePrepareContext): void {
-    // TODO(#7,#8,#10): MCP composition, session persistence, and preflight
-    // checks will populate this hook once the worker-side runtime wiring lands.
+  async prepare(context: ClaudeRuntimePrepareContext): Promise<void> {
+    this.preparedSession = await this.prepareSession(context);
   }
 
   async spawnTurn(input: ClaudeRuntimeTurnInput): Promise<ClaudeRuntimeTurnResult> {
@@ -83,42 +110,34 @@ export class ClaudePrintRuntimeAdapter
       );
     }
 
-    const argv = buildClaudePrintArgv(
-      this.buildArgvOptions(input)
-    );
+    const session = input.session ?? this.preparedSession?.session;
+    const argv = buildClaudePrintArgv(this.buildArgvOptions(input, session));
 
     try {
-      return await spawnClaudeTurn(
-        {
-          command: input.command ?? this.config.command,
-          args: argv,
-          cwd: input.cwd ?? this.config.workingDirectory,
-          env: buildClaudeSpawnEnv({
-            inheritProcessEnv: this.config.inheritProcessEnv === true,
-            configEnv: this.config.env,
-            inputEnv: input.env,
-          }),
-          stdinMessages: input.messages,
-        },
-        {
-          ...this.dependencies,
-          onSpawned: (child) => {
-            this.activeChild = child;
-            this.dependencies.onSpawned?.(child);
-          },
-        }
-      );
+      const result = await this.spawnWithArgv(input, argv);
+      await this.persistStartedSessionId(result);
+      await this.persistForkedSessionId(result);
+
+      if (this.shouldInvalidatePreparedResume(session, result)) {
+        return await this.retryWithFreshSession(input, result);
+      }
+
+      return result;
     } finally {
       this.activeChild = null;
     }
   }
 
   onEvent(
-    _handler: AgentRuntimeEventHandler<ClaudeRuntimeEvent>
+    handler: AgentRuntimeEventHandler<ClaudeRuntimeEvent>
   ): AgentRuntimeEventSubscription {
-    throw new ClaudeRuntimeNotImplementedError(
-      "TODO(#9): Claude stream-json event mapping is not implemented yet."
-    );
+    this.eventHandlers.add(handler);
+    for (const event of this.pendingEvents.splice(0)) {
+      handler(event);
+    }
+    return () => {
+      this.eventHandlers.delete(handler);
+    };
   }
 
   resolveCredentials(
@@ -137,15 +156,291 @@ export class ClaudePrintRuntimeAdapter
     this.stopActiveChild();
   }
 
-  private buildArgvOptions(input: ClaudeRuntimeTurnInput): ClaudePrintArgvOptions {
+  private buildArgvOptions(
+    input: ClaudeRuntimeTurnInput,
+    session: ClaudeRuntimeSessionOptions | undefined
+  ): ClaudePrintArgvOptions {
     return {
-      session: input.session,
+      session,
       isolation: {
         ...this.config.isolation,
         ...input.isolation,
       },
       extraArgs: input.extraArgs ?? this.config.extraArgs,
     };
+  }
+
+  private async prepareSession(
+    context: ClaudeRuntimePrepareContext
+  ): Promise<PreparedClaudeSession> {
+    const currentOptions = {
+      runId: context.runId,
+      runDirectory: context.runDirectory,
+    };
+    const parentRunId = context.previousRunId;
+
+    try {
+      const current = await this.sessionStore.load(currentOptions);
+      if (current) {
+        return {
+          runId: context.runId,
+          runDirectory: context.runDirectory,
+          sessionFile: current,
+          session: {
+            mode: "resume",
+            sessionId: current.sessionId,
+          },
+        };
+      }
+    } catch {
+      return await this.createFreshSession(context, {
+        reason: "session file could not be read",
+        invalidatedSessionId: "unknown",
+        parentRunId,
+      });
+    }
+
+    if (context.previousRunId) {
+      try {
+        const previous = await this.sessionStore.load({
+          runId: context.previousRunId,
+          runDirectory: context.previousRunDirectory,
+        });
+        if (previous) {
+          const sessionFile = await this.sessionStore.save({
+            ...currentOptions,
+            sessionId: previous.sessionId,
+            createdAt: this.nowIso(),
+            parentRunId: context.previousRunId,
+          });
+          return {
+            runId: context.runId,
+            runDirectory: context.runDirectory,
+            sessionFile,
+            session: {
+              mode: "resume",
+              sessionId: previous.sessionId,
+              forkSession: true,
+            },
+          };
+        }
+      } catch {
+        return await this.createFreshSession(context, {
+          reason: "parent session file could not be read",
+          invalidatedSessionId: "unknown",
+          parentRunId,
+        });
+      }
+    }
+
+    return await this.createFreshSession(context, { parentRunId });
+  }
+
+  private async createFreshSession(
+    context: ClaudeRuntimePrepareContext,
+    options: {
+      reason?: string;
+      invalidatedSessionId?: string;
+      parentRunId?: string;
+    } = {}
+  ): Promise<PreparedClaudeSession> {
+    const replacementSessionId = this.createSessionId();
+    const sessionFile = await this.sessionStore.save({
+      runId: context.runId,
+      runDirectory: context.runDirectory,
+      sessionId: replacementSessionId,
+      createdAt: this.nowIso(),
+      parentRunId: options.parentRunId,
+    });
+
+    if (options.reason) {
+      this.emitSessionInvalidated({
+        runId: context.runId,
+        sessionId: options.invalidatedSessionId ?? "unknown",
+        replacementSessionId,
+        reason: options.reason,
+      });
+    }
+
+    return {
+      runId: context.runId,
+      runDirectory: context.runDirectory,
+      sessionFile,
+      session: {
+        mode: "start",
+        sessionId: replacementSessionId,
+      },
+    };
+  }
+
+  private async retryWithFreshSession(
+    input: ClaudeRuntimeTurnInput,
+    failedResult: ClaudeSpawnTurnResult
+  ): Promise<ClaudeSpawnTurnResult> {
+    if (!this.preparedSession) {
+      return failedResult;
+    }
+
+    const invalidatedSessionId = this.preparedSession.session.sessionId;
+    const replacementSessionId = this.createSessionId();
+    const parentRunId = this.preparedSession.sessionFile.parentRunId;
+    const sessionFile = await this.sessionStore.invalidate({
+      runId: this.preparedSession.runId,
+      runDirectory: this.preparedSession.runDirectory,
+      sessionId: replacementSessionId,
+      createdAt: this.nowIso(),
+      parentRunId,
+    });
+    this.preparedSession = {
+      ...this.preparedSession,
+      sessionFile,
+      session: {
+        mode: "start",
+        sessionId: replacementSessionId,
+      },
+    };
+    this.emitSessionInvalidated({
+      runId: this.preparedSession.runId,
+      sessionId: invalidatedSessionId,
+      replacementSessionId,
+      reason: "claude resume session was rejected with a 4xx response",
+    });
+
+    const retryArgv = buildClaudePrintArgv(
+      this.buildArgvOptions(input, this.preparedSession.session)
+    );
+    const retryResult = await this.spawnWithArgv(input, retryArgv);
+    await this.persistStartedSessionId(retryResult);
+    return retryResult;
+  }
+
+  private async spawnWithArgv(
+    input: ClaudeRuntimeTurnInput,
+    argv: string[]
+  ): Promise<ClaudeSpawnTurnResult> {
+    return await spawnClaudeTurn(
+      {
+        command: input.command ?? this.config.command,
+        args: argv,
+        cwd: input.cwd ?? this.config.workingDirectory,
+        env: buildClaudeSpawnEnv({
+          inheritProcessEnv: this.config.inheritProcessEnv === true,
+          configEnv: this.config.env,
+          inputEnv: input.env,
+        }),
+        stdinMessages: input.messages,
+      },
+      {
+        ...this.dependencies,
+        onSpawned: (child) => {
+          this.activeChild = child;
+          this.dependencies.onSpawned?.(child);
+        },
+      }
+    );
+  }
+
+  private async persistForkedSessionId(
+    result: ClaudeSpawnTurnResult
+  ): Promise<void> {
+    if (
+      this.preparedSession?.session.mode !== "resume" ||
+      !this.preparedSession.session.forkSession
+    ) {
+      return;
+    }
+
+    const forkedSessionId = findSessionIdInResult(result);
+    if (!forkedSessionId) {
+      return;
+    }
+
+    this.preparedSession = {
+      ...this.preparedSession,
+      sessionFile: await this.sessionStore.save({
+        runId: this.preparedSession.runId,
+        runDirectory: this.preparedSession.runDirectory,
+        sessionId: forkedSessionId,
+        createdAt: this.preparedSession.sessionFile.createdAt,
+        parentRunId: this.preparedSession.sessionFile.parentRunId,
+        protocolState: this.preparedSession.sessionFile.protocolState,
+      }),
+      session: {
+        mode: "resume",
+        sessionId: forkedSessionId,
+      },
+    };
+  }
+
+  private async persistStartedSessionId(
+    result: ClaudeSpawnTurnResult
+  ): Promise<void> {
+    if (this.preparedSession?.session.mode !== "start") {
+      return;
+    }
+    if (result.result !== "success") {
+      return;
+    }
+
+    const sessionId =
+      findSessionIdInResult(result) ?? this.preparedSession.session.sessionId;
+    this.preparedSession = {
+      ...this.preparedSession,
+      sessionFile: await this.sessionStore.save({
+        runId: this.preparedSession.runId,
+        runDirectory: this.preparedSession.runDirectory,
+        sessionId,
+        createdAt: this.preparedSession.sessionFile.createdAt,
+        parentRunId: this.preparedSession.sessionFile.parentRunId,
+        protocolState: this.preparedSession.sessionFile.protocolState,
+      }),
+      session: {
+        mode: "resume",
+        sessionId,
+      },
+    };
+  }
+
+  private shouldInvalidatePreparedResume(
+    session: ClaudeRuntimeSessionOptions | undefined,
+    result: ClaudeSpawnTurnResult
+  ): boolean {
+    return (
+      session === this.preparedSession?.session &&
+      session?.mode === "resume" &&
+      isResumeRejectedWith4xx(result)
+    );
+  }
+
+  private emitSessionInvalidated(payload: {
+    runId: string;
+    sessionId: string;
+    replacementSessionId: string;
+    reason: string;
+  }): void {
+    const event: AgentSessionInvalidatedEvent = {
+      name: "agent.sessionInvalidated",
+      payload: {
+        params: {},
+        ...payload,
+        observabilityEvent: "session_invalidated",
+      },
+    };
+    if (this.eventHandlers.size === 0) {
+      this.pendingEvents.push(event);
+      return;
+    }
+    for (const handler of this.eventHandlers) {
+      handler(event);
+    }
+  }
+
+  private createSessionId(): string {
+    return this.dependencies.createSessionId?.() ?? randomUUID();
+  }
+
+  private nowIso(): string {
+    return (this.dependencies.now?.() ?? new Date()).toISOString();
   }
 
   private stopActiveChild(): void {
@@ -161,7 +456,7 @@ export class ClaudePrintRuntimeAdapter
 
 export function createClaudePrintRuntimeAdapter(
   config: ClaudeRuntimeConfig,
-  dependencies: ClaudeSpawnDependencies = {}
+  dependencies: ClaudeRuntimeDependencies = {}
 ): ClaudePrintRuntimeAdapter {
   return new ClaudePrintRuntimeAdapter(config, dependencies);
 }
@@ -211,4 +506,62 @@ function buildClaudeSpawnEnv(options: {
   Object.assign(env, options.configEnv, options.inputEnv);
 
   return env;
+}
+
+type PreparedClaudeSession = {
+  runId: string;
+  runDirectory?: string;
+  sessionFile: ClaudeSessionFile;
+  session: ClaudeRuntimeSessionOptions;
+};
+
+function findSessionIdInResult(result: ClaudeSpawnTurnResult): string | null {
+  for (const record of result.records) {
+    const sessionId = findSessionId(record.message);
+    if (sessionId) {
+      return sessionId;
+    }
+  }
+  return null;
+}
+
+function findSessionId(value: unknown): string | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  const record = value as Record<string, unknown>;
+  if (typeof record.sessionId === "string") {
+    return record.sessionId;
+  }
+  if (typeof record.session_id === "string") {
+    return record.session_id;
+  }
+  for (const nested of Object.values(record)) {
+    const sessionId = findSessionId(nested);
+    if (sessionId) {
+      return sessionId;
+    }
+  }
+  return null;
+}
+
+function isResumeRejectedWith4xx(result: ClaudeSpawnTurnResult): boolean {
+  if (result.result !== "process-error") {
+    return false;
+  }
+  if (
+    typeof result.exitCode === "number" &&
+    result.exitCode >= 400 &&
+    result.exitCode < 500
+  ) {
+    return true;
+  }
+
+  return result.records.some((record) => {
+    const text = record.line.toLowerCase();
+    return (
+      text.includes("resume") &&
+      /\b4\d\d\b/.test(text)
+    );
+  });
 }

--- a/packages/runtime-claude/src/adapter.ts
+++ b/packages/runtime-claude/src/adapter.ts
@@ -64,13 +64,6 @@ export type ClaudeRuntimeDependencies = ClaudeSpawnDependencies & {
   now?: () => Date;
 };
 
-export class ClaudeRuntimeNotImplementedError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "ClaudeRuntimeNotImplementedError";
-  }
-}
-
 export class ClaudePrintRuntimeAdapter
   implements
     AgentRuntimeAdapter<
@@ -134,6 +127,9 @@ export class ClaudePrintRuntimeAdapter
     handler: AgentRuntimeEventHandler<ClaudeRuntimeEvent>
   ): AgentRuntimeEventSubscription {
     this.eventHandlers.add(handler);
+    // Pending events are scoped to the current prepare cycle and intentionally
+    // replayed to each later subscriber. Live events after subscription are not
+    // replayed to handlers registered later.
     for (const event of this.pendingEvents) {
       handler(event);
     }
@@ -196,7 +192,7 @@ export class ClaudePrintRuntimeAdapter
       }
     } catch (error) {
       return await this.createFreshSession(context, {
-        reason: `session file could not be read: ${formatErrorMessage(error)}`,
+        reason: `session file could not be read or parsed: ${formatErrorMessage(error)}`,
         invalidatedSessionId: "unknown",
         parentRunId,
       });
@@ -228,7 +224,7 @@ export class ClaudePrintRuntimeAdapter
         }
       } catch (error) {
         return await this.createFreshSession(context, {
-          reason: `parent session file could not be read: ${formatErrorMessage(error)}`,
+          reason: `parent session file could not be read or parsed: ${formatErrorMessage(error)}`,
           invalidatedSessionId: "unknown",
           parentRunId,
         });
@@ -280,6 +276,8 @@ export class ClaudePrintRuntimeAdapter
     failedResult: ClaudeSpawnTurnResult
   ): Promise<ClaudeSpawnTurnResult> {
     if (!this.preparedSession) {
+      // Unreachable from shouldInvalidatePreparedResume(); keep the original
+      // failed result if this method is called defensively in the future.
       return failedResult;
     }
 
@@ -405,6 +403,9 @@ export class ClaudePrintRuntimeAdapter
     session: ClaudeRuntimeSessionOptions | undefined,
     result: ClaudeSpawnTurnResult
   ): boolean {
+    // Only sessions selected by prepare() are persisted and eligible for
+    // automatic invalidation. Explicit input.session callers own their retry
+    // policy, so reference equality is the boundary between the two paths.
     return (
       session === this.preparedSession?.session &&
       session?.mode === "resume" &&
@@ -525,6 +526,9 @@ function findSessionIdInResult(result: ClaudeSpawnTurnResult): string | null {
   return null;
 }
 
+// Claude print result records are expected to carry sessionId/session_id near
+// the top-level result object. The depth guard keeps malformed records bounded
+// without treating arbitrary nested metadata as authoritative session state.
 function findSessionId(value: unknown, depth = 0): string | null {
   if (depth > 5) {
     return null;

--- a/packages/runtime-claude/src/adapter.ts
+++ b/packages/runtime-claude/src/adapter.ts
@@ -116,12 +116,13 @@ export class ClaudePrintRuntimeAdapter
 
     try {
       const result = await this.spawnWithArgv(input, argv);
-      await this.persistStartedSessionId(result);
-      await this.persistForkedSessionId(result);
 
       if (this.shouldInvalidatePreparedResume(session, result)) {
         return await this.retryWithFreshSession(input, result);
       }
+
+      await this.persistStartedSessionId(result);
+      await this.persistForkedSessionId(result);
 
       return result;
     } finally {
@@ -133,7 +134,7 @@ export class ClaudePrintRuntimeAdapter
     handler: AgentRuntimeEventHandler<ClaudeRuntimeEvent>
   ): AgentRuntimeEventSubscription {
     this.eventHandlers.add(handler);
-    for (const event of this.pendingEvents.splice(0)) {
+    for (const event of this.pendingEvents) {
       handler(event);
     }
     return () => {
@@ -427,10 +428,10 @@ export class ClaudePrintRuntimeAdapter
     };
     if (this.eventHandlers.size === 0) {
       this.pendingEvents.push(event);
-      return;
-    }
-    for (const handler of this.eventHandlers) {
-      handler(event);
+    } else {
+      for (const handler of this.eventHandlers) {
+        handler(event);
+      }
     }
   }
 
@@ -552,6 +553,9 @@ function isResumeRejectedWith4xx(result: ClaudeSpawnTurnResult): boolean {
     return false;
   }
 
+  // Claude print currently surfaces rejected resume sessions through stderr text
+  // rather than a structured error field, so fallback detection is intentionally
+  // constrained to resume-related lines that include an HTTP 4xx code.
   return result.records.some((record) => {
     const text = record.line.toLowerCase();
     return (

--- a/packages/runtime-claude/src/index.ts
+++ b/packages/runtime-claude/src/index.ts
@@ -9,4 +9,5 @@ export const RUNTIME_CLAUDE_BOUNDARY = {
 
 export * from "./adapter.js";
 export * from "./argv.js";
+export * from "./session-store.js";
 export * from "./spawn.js";

--- a/packages/runtime-claude/src/session-store.test.ts
+++ b/packages/runtime-claude/src/session-store.test.ts
@@ -1,0 +1,80 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  CLAUDE_SESSION_PROTOCOL,
+  ClaudeSessionStore,
+  parseClaudeSessionFile,
+} from "./session-store.js";
+
+const tempDirs: string[] = [];
+
+async function createTempDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "claude-session-store-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+describe("ClaudeSessionStore", () => {
+  afterEach(async () => {
+    await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, {
+      recursive: true,
+      force: true,
+    })));
+  });
+
+  it("saves claude-print session files with protocol discriminator", async () => {
+    const runtimeRoot = await createTempDir();
+    const store = new ClaudeSessionStore({ runtimeRoot });
+
+    await store.save({
+      runId: "run-1",
+      sessionId: "session-1",
+      createdAt: "2026-04-26T00:00:00.000Z",
+      parentRunId: "run-prev",
+    });
+
+    const raw = await readFile(
+      join(runtimeRoot, "runs", "run-1", "claude-session.json"),
+      "utf8"
+    );
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    expect(parsed.protocol).toBe(CLAUDE_SESSION_PROTOCOL);
+    expect(parsed.sessionId).toBe("session-1");
+    expect(parsed.parentRunId).toBe("run-prev");
+    expect(parsed.protocolState).toEqual({});
+  });
+
+  it("loads null for missing session files and rejects other protocols", async () => {
+    const runtimeRoot = await createTempDir();
+    const store = new ClaudeSessionStore({ runtimeRoot });
+
+    await expect(store.load({ runId: "missing" })).resolves.toBeNull();
+
+    const runDir = join(runtimeRoot, "runs", "run-1");
+    await mkdir(runDir, { recursive: true });
+    await writeFile(
+      join(runDir, "claude-session.json"),
+      JSON.stringify({
+        protocol: "acp",
+        sessionId: "session-1",
+        createdAt: "2026-04-26T00:00:00.000Z",
+      })
+    );
+
+    await expect(store.load({ runId: "run-1" })).rejects.toThrowError(
+      "protocol"
+    );
+  });
+
+  it("normalizes absent protocolState to an empty object", () => {
+    expect(
+      parseClaudeSessionFile({
+        protocol: "claude-print",
+        sessionId: "session-1",
+        createdAt: "2026-04-26T00:00:00.000Z",
+      }).protocolState
+    ).toEqual({});
+  });
+});

--- a/packages/runtime-claude/src/session-store.ts
+++ b/packages/runtime-claude/src/session-store.ts
@@ -1,0 +1,136 @@
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+
+export const CLAUDE_SESSION_PROTOCOL = "claude-print" as const;
+export const CLAUDE_SESSION_FILENAME = "claude-session.json";
+
+export type ClaudeSessionProtocol = typeof CLAUDE_SESSION_PROTOCOL;
+
+export type ClaudeSessionFile = {
+  protocol: ClaudeSessionProtocol;
+  sessionId: string;
+  createdAt: string;
+  parentRunId?: string;
+  protocolState: Record<string, unknown>;
+};
+
+export type ClaudeSessionStoreOptions = {
+  runtimeRoot: string;
+};
+
+export type SaveClaudeSessionOptions = {
+  runId: string;
+  sessionId: string;
+  createdAt: string;
+  parentRunId?: string;
+  protocolState?: Record<string, unknown>;
+  runDirectory?: string;
+};
+
+export type LoadClaudeSessionOptions = {
+  runId: string;
+  runDirectory?: string;
+};
+
+export class ClaudeSessionStore {
+  constructor(private readonly options: ClaudeSessionStoreOptions) {}
+
+  sessionFilePath(options: LoadClaudeSessionOptions): string {
+    return join(
+      options.runDirectory ?? this.runDirectory(options.runId),
+      CLAUDE_SESSION_FILENAME
+    );
+  }
+
+  async load(
+    options: LoadClaudeSessionOptions
+  ): Promise<ClaudeSessionFile | null> {
+    let raw: string;
+    try {
+      raw = await readFile(this.sessionFilePath(options), "utf8");
+    } catch (error) {
+      if (isFileNotFoundError(error)) {
+        return null;
+      }
+      throw error;
+    }
+
+    return parseClaudeSessionFile(JSON.parse(raw));
+  }
+
+  async save(options: SaveClaudeSessionOptions): Promise<ClaudeSessionFile> {
+    const session: ClaudeSessionFile = {
+      protocol: CLAUDE_SESSION_PROTOCOL,
+      sessionId: options.sessionId,
+      createdAt: options.createdAt,
+      protocolState: options.protocolState ?? {},
+    };
+
+    if (options.parentRunId) {
+      session.parentRunId = options.parentRunId;
+    }
+
+    const path = this.sessionFilePath(options);
+    await mkdir(dirname(path), { recursive: true });
+    await writeFile(`${path}.tmp`, `${JSON.stringify(session, null, 2)}\n`, "utf8");
+    await rename(`${path}.tmp`, path);
+    return session;
+  }
+
+  async invalidate(options: SaveClaudeSessionOptions): Promise<ClaudeSessionFile> {
+    return this.save(options);
+  }
+
+  runDirectory(runId: string): string {
+    return join(this.options.runtimeRoot, "runs", runId);
+  }
+}
+
+export function parseClaudeSessionFile(value: unknown): ClaudeSessionFile {
+  if (!isRecord(value)) {
+    throw new Error("Claude session file must be a JSON object.");
+  }
+  if (value.protocol !== CLAUDE_SESSION_PROTOCOL) {
+    throw new Error("Claude session file protocol must be claude-print.");
+  }
+  if (typeof value.sessionId !== "string" || value.sessionId.length === 0) {
+    throw new Error("Claude session file sessionId must be a non-empty string.");
+  }
+  if (typeof value.createdAt !== "string" || value.createdAt.length === 0) {
+    throw new Error("Claude session file createdAt must be a non-empty string.");
+  }
+  if (
+    "parentRunId" in value &&
+    value.parentRunId !== undefined &&
+    typeof value.parentRunId !== "string"
+  ) {
+    throw new Error("Claude session file parentRunId must be a string.");
+  }
+  if (
+    "protocolState" in value &&
+    value.protocolState !== undefined &&
+    !isRecord(value.protocolState)
+  ) {
+    throw new Error("Claude session file protocolState must be an object.");
+  }
+
+  return {
+    protocol: CLAUDE_SESSION_PROTOCOL,
+    sessionId: value.sessionId,
+    createdAt: value.createdAt,
+    parentRunId: typeof value.parentRunId === "string" ? value.parentRunId : undefined,
+    protocolState: isRecord(value.protocolState) ? value.protocolState : {},
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function isFileNotFoundError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    "code" in error &&
+    (error as NodeJS.ErrnoException).code === "ENOENT"
+  );
+}

--- a/packages/runtime-claude/src/session-store.ts
+++ b/packages/runtime-claude/src/session-store.ts
@@ -77,10 +77,6 @@ export class ClaudeSessionStore {
     return session;
   }
 
-  async invalidate(options: SaveClaudeSessionOptions): Promise<ClaudeSessionFile> {
-    return this.save(options);
-  }
-
   runDirectory(runId: string): string {
     return join(this.options.runtimeRoot, "runs", runId);
   }

--- a/packages/runtime-claude/src/session-store.ts
+++ b/packages/runtime-claude/src/session-store.ts
@@ -35,7 +35,7 @@ export type LoadClaudeSessionOptions = {
 export class ClaudeSessionStore {
   constructor(private readonly options: ClaudeSessionStoreOptions) {}
 
-  sessionFilePath(options: LoadClaudeSessionOptions): string {
+  private sessionFilePath(options: LoadClaudeSessionOptions): string {
     return join(
       options.runDirectory ?? this.runDirectory(options.runId),
       CLAUDE_SESSION_FILENAME
@@ -77,7 +77,7 @@ export class ClaudeSessionStore {
     return session;
   }
 
-  runDirectory(runId: string): string {
+  private runDirectory(runId: string): string {
     return join(this.options.runtimeRoot, "runs", runId);
   }
 }

--- a/packages/runtime-claude/src/session-store.ts
+++ b/packages/runtime-claude/src/session-store.ts
@@ -87,7 +87,9 @@ export function parseClaudeSessionFile(value: unknown): ClaudeSessionFile {
     throw new Error("Claude session file must be a JSON object.");
   }
   if (value.protocol !== CLAUDE_SESSION_PROTOCOL) {
-    throw new Error("Claude session file protocol must be claude-print.");
+    throw new Error(
+      `Claude session file protocol must be ${CLAUDE_SESSION_PROTOCOL}.`
+    );
   }
   if (typeof value.sessionId !== "string" || value.sessionId.length === 0) {
     throw new Error("Claude session file sessionId must be a non-empty string.");


### PR DESCRIPTION
## Issues

- Fixes #220

## Summary

- Claude print runtime adapter가 run별 `claude-session.json`을 저장하고 `protocol: "claude-print"` discriminator를 항상 기록합니다.
- 첫 턴, intra-run retry, inter-run recover, resume 4xx fallback의 session argv 선택을 adapter prepare/spawn 흐름에 연결했습니다.
- 이번 사이클에서는 최신 `origin/main`의 Claude event/MCP compose 변경과 세션 persistence 변경의 merge conflict를 해소했습니다.

## Changes

- `packages/runtime-claude/src/session-store.ts`를 추가해 `.runtime/orchestrator/runs/<run-id>/claude-session.json` schema load/save를 제공합니다.
- `ClaudePrintRuntimeAdapter.prepare()`가 현재 run session, 이전 run session, 신규 session을 판별해 `--session-id`, `--resume`, `--resume --fork-session`을 선택합니다.
- `--resume` 4xx 실패 시 새 session id로 한 번 fallback하고 `agent.sessionInvalidated` / `session_invalidated` event surface를 추가했습니다.
- 최신 main의 stream-json neutral event dispatch와 MCP compose prepare 경로를 유지하면서 prepared session selection이 `buildArgvOptions()`에 적용되도록 충돌을 해소했습니다.
- WORKFLOW parser가 session control을 노출하지 않는 회귀 테스트와 runtime-claude acceptance/review regression 단위 테스트를 유지했습니다.

## Evidence

- `pnpm --filter @gh-symphony/runtime-claude test` — 74 tests passed
- `pnpm --filter @gh-symphony/runtime-claude typecheck`
- `pnpm --filter @gh-symphony/runtime-claude lint`
- `pnpm --filter @gh-symphony/core test -- workflow-loader event-formatter` — 25 tests passed
- `pnpm lint && pnpm test && pnpm typecheck && pnpm build` — 최종 merge 상태에서 통과
- `pnpm install --frozen-lockfile` — merge 후 workspace symlink refresh
- `pnpm build` — workspace link refresh 후 통과
- Docker E2E blackbox: `timeout 300 bash -lc ... docker compose -f docker-compose.e2e.yml -f docker-compose.e2e.events.yml up -d --build ...` — image build/health check 통과, `happy-path.json` 주입 후 refresh, `health: "running"`, `activeRuns: 1`, `lastError: null` 확인, trap cleanup 후 `symphony-e2e` 컨테이너 없음
- Push evidence: merge commit `2d3f2b6`; GitHub reports `mergeable: MERGEABLE`; CI `Test`/`Container Smoke` success for pushed head

## Human Validation

- [ ] 첫 턴에서 `--session-id <uuid>`와 session file 저장이 요구사항과 맞는지 확인
- [ ] intra-run retry와 inter-run recover argv가 기대한 resume/fork 조합인지 확인
- [ ] session invalidation event surface가 downstream run event 연결 계획과 맞는지 확인
- [ ] 최신 main 병합 후 Claude event/MCP compose 경로와 session persistence 경로가 함께 유지되는지 확인

## Risks

- Claude print가 `--fork-session` 후 새 session id를 어떤 필드명으로 출력하는지는 실제 CLI wire 출력에 의존합니다. 현재 구현은 `sessionId`와 `session_id`를 depth-limited로 감지하고, 없으면 parent link를 보존한 기존 resume id로 이후 turn을 계속합니다.
- Resume 4xx fallback은 Claude print가 구조화된 error field를 제공하지 않아 stderr 텍스트의 resume-related HTTP 4xx code에 의존합니다. 이 의존성은 코드 주석과 테스트 fixture로 명시했습니다.