### PR TITLE
feat(core): parse workflow runtime block

### DIFF
--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -11,6 +11,7 @@
       "@gh-symphony/dashboard": ["../dashboard/src/index.ts"],
       "@gh-symphony/extension-github-workflow": ["../extension-github-workflow/src/index.ts"],
       "@gh-symphony/orchestrator": ["../orchestrator/src/index.ts"],
+      "@gh-symphony/runtime-claude": ["../runtime-claude/src/index.ts"],
       "@gh-symphony/runtime-codex": ["../runtime-codex/src/index.ts"],
       "@gh-symphony/tool-github-graphql": ["../tool-github-graphql/src/index.ts"],
       "@gh-symphony/tracker-file": ["../tracker-file/src/index.ts"],

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -24,6 +24,10 @@ export default defineConfig({
         packageRoot,
         "../orchestrator/src/index.ts"
       ),
+      "@gh-symphony/runtime-claude": resolve(
+        packageRoot,
+        "../runtime-claude/src/index.ts"
+      ),
       "@gh-symphony/runtime-codex": resolve(
         packageRoot,
         "../runtime-codex/src/index.ts"

--- a/packages/core/src/runtime/credentials.ts
+++ b/packages/core/src/runtime/credentials.ts
@@ -29,18 +29,19 @@ export function extractEnvForCodex(
 }
 
 export function extractEnvForClaude(
-  env: AgentRuntimeEnvSource
+  env: AgentRuntimeEnvSource,
+  envKey = "ANTHROPIC_API_KEY"
 ): AgentRuntimeEnv {
-  const apiKey = env.ANTHROPIC_API_KEY;
+  const apiKey = env[envKey];
 
   if (!apiKey) {
     throw new AgentRuntimeCredentialError(
-      "ANTHROPIC_API_KEY is required in the credential broker response."
+      `${envKey} is required in the credential broker response.`
     );
   }
 
   return {
-    ANTHROPIC_API_KEY: apiKey,
+    [envKey]: apiKey,
   };
 }
 

--- a/packages/core/src/workflow-loader.test.ts
+++ b/packages/core/src/workflow-loader.test.ts
@@ -188,6 +188,37 @@ Prompt body.
     expect(workflow.agentCommand).toBe("node worker.js --flag");
   });
 
+  it("parses quoted inline array entries containing commas", () => {
+    const workflow = parseWorkflowMarkdown(`---
+tracker:
+  kind: github-project
+runtime:
+  kind: custom
+  command: node
+  args: ["worker, one.js", "--flag"]
+---
+Prompt body.
+`);
+
+    expect(workflow.runtime?.args).toEqual(["worker, one.js", "--flag"]);
+    expect(workflow.agentCommand).toBe("node worker, one.js --flag");
+  });
+
+  it("rejects malformed inline arrays instead of silently accepting them", () => {
+    expect(() =>
+      parseWorkflowMarkdown(`---
+tracker:
+  kind: github-project
+runtime:
+  kind: custom
+  command: node
+  args: ["unterminated, --flag]
+---
+Prompt body.
+`)
+    ).toThrow(/inline array has an unterminated string/);
+  });
+
   it("rejects unsupported runtime kind values", () => {
     expect(() =>
       parseWorkflowMarkdown(`---

--- a/packages/core/src/workflow-loader.test.ts
+++ b/packages/core/src/workflow-loader.test.ts
@@ -4,6 +4,10 @@ import { tmpdir } from "node:os";
 import { afterEach, describe, expect, it } from "vitest";
 import { WorkflowConfigStore } from "./workflow/loader.js";
 import { parseWorkflowMarkdown } from "./workflow/parser.js";
+import {
+  resolveWorkflowRuntimeCommand,
+  resolveWorkflowRuntimeTimeouts,
+} from "./workflow/config.js";
 
 const tempDirs: string[] = [];
 
@@ -98,6 +102,119 @@ Render with env indirection.
     );
 
     expect(workflow.agentCommand).toBe("custom-app-server");
+  });
+
+  it("parses runtime-only claude-print front matter", () => {
+    const workflow = parseWorkflowMarkdown(`---
+tracker:
+  kind: github-project
+runtime:
+  kind: claude-print
+  command: claude
+  args:
+    - -p
+    - --verbose
+  isolation:
+    bare: true
+    strict_mcp_config: true
+  auth:
+    env: ANTHROPIC_API_KEY
+  timeouts:
+    read_timeout_ms: 7000
+    turn_timeout_ms: 120000
+    stall_timeout_ms: 60000
+---
+Prompt body.
+`);
+
+    expect(workflow.runtime).toEqual({
+      kind: "claude-print",
+      command: "claude",
+      args: ["-p", "--verbose"],
+      isolation: {
+        bare: true,
+        strictMcpConfig: true,
+      },
+      auth: {
+        env: "ANTHROPIC_API_KEY",
+      },
+      timeouts: {
+        readTimeoutMs: 7000,
+        turnTimeoutMs: 120000,
+        stallTimeoutMs: 60000,
+      },
+    });
+    expect(workflow.agentCommand).toBe("claude -p --verbose");
+    expect(workflow.codex.command).toBe("codex app-server");
+    expect(resolveWorkflowRuntimeCommand(workflow)).toBe("claude -p --verbose");
+    expect(resolveWorkflowRuntimeTimeouts(workflow).stallTimeoutMs).toBe(60000);
+  });
+
+  it("keeps legacy codex fallback without reverse-mapping a runtime", () => {
+    const workflow = parseWorkflowMarkdown(`---
+tracker:
+  kind: github-project
+codex:
+  command: claude -p --output-format stream-json
+---
+Prompt body.
+`);
+
+    expect(workflow.runtime).toBeNull();
+    expect(workflow.codex.command).toBe("claude -p --output-format stream-json");
+    expect(workflow.agentCommand).toBe("claude -p --output-format stream-json");
+  });
+
+  it("prefers runtime when runtime and legacy codex coexist", () => {
+    const workflow = parseWorkflowMarkdown(`---
+tracker:
+  kind: github-project
+runtime:
+  kind: custom
+  command: node
+  args: [worker.js, --flag]
+codex:
+  command: codex app-server
+---
+Prompt body.
+`);
+
+    expect(workflow.runtime).toMatchObject({
+      kind: "custom",
+      command: "node",
+      args: ["worker.js", "--flag"],
+    });
+    expect(workflow.codex.command).toBe("codex app-server");
+    expect(workflow.agentCommand).toBe("node worker.js --flag");
+  });
+
+  it("rejects unsupported runtime kind values", () => {
+    expect(() =>
+      parseWorkflowMarkdown(`---
+tracker:
+  kind: github-project
+runtime:
+  kind: unsupported-runtime
+---
+Prompt body.
+`)
+    ).toThrow(/Unsupported workflow runtime kind/);
+  });
+
+  it("does not expose session resume fields in runtime schema", () => {
+    const workflow = parseWorkflowMarkdown(`---
+tracker:
+  kind: github-project
+runtime:
+  kind: claude-print
+  command: claude
+  session:
+    resume: true
+---
+Prompt body.
+`);
+
+    expect(workflow.runtime).not.toHaveProperty("session");
   });
 
   it("rejects old schema in strict mode", () => {

--- a/packages/core/src/workflow-loader.test.ts
+++ b/packages/core/src/workflow-loader.test.ts
@@ -275,6 +275,23 @@ Prompt body.
     ).toThrow(/Workflow front matter field "runtime\.isolation" must be an object/);
   });
 
+  it("reports nested runtime boolean paths clearly", () => {
+    expect(() =>
+      parseWorkflowMarkdown(`---
+tracker:
+  kind: github-project
+runtime:
+  kind: claude-print
+  isolation:
+    bare: "yes"
+---
+Prompt body.
+`)
+    ).toThrow(
+      /Workflow front matter field "runtime\.isolation\.bare" must be a boolean/
+    );
+  });
+
   it("does not expose session resume fields in runtime schema", () => {
     const workflow = parseWorkflowMarkdown(`---
 tracker:

--- a/packages/core/src/workflow-loader.test.ts
+++ b/packages/core/src/workflow-loader.test.ts
@@ -247,6 +247,20 @@ Prompt body.
     ).toThrow(/Unsupported workflow runtime kind/);
   });
 
+  it("rejects non-object runtime blocks clearly", () => {
+    expect(() =>
+      parseWorkflowMarkdown(`---
+tracker:
+  kind: github-project
+runtime: false
+codex:
+  command: codex app-server
+---
+Prompt body.
+`)
+    ).toThrow(/Workflow front matter field "runtime" must be an object/);
+  });
+
   it("does not expose session resume fields in runtime schema", () => {
     const workflow = parseWorkflowMarkdown(`---
 tracker:

--- a/packages/core/src/workflow-loader.test.ts
+++ b/packages/core/src/workflow-loader.test.ts
@@ -234,6 +234,23 @@ Prompt body.
     ).toThrow(/inline array has a trailing comma/);
   });
 
+  it("requires runtime args to be an array of strings", () => {
+    expect(() =>
+      parseWorkflowMarkdown(`---
+tracker:
+  kind: github-project
+runtime:
+  kind: custom
+  command: node
+  args: node,worker.js
+---
+Prompt body.
+`)
+    ).toThrow(
+      /Workflow front matter field "runtime\.args" must be an array of strings/
+    );
+  });
+
   it("rejects unsupported runtime kind values", () => {
     expect(() =>
       parseWorkflowMarkdown(`---

--- a/packages/core/src/workflow-loader.test.ts
+++ b/packages/core/src/workflow-loader.test.ts
@@ -261,6 +261,20 @@ Prompt body.
     ).toThrow(/Workflow front matter field "runtime" must be an object/);
   });
 
+  it("reports nested runtime object paths clearly", () => {
+    expect(() =>
+      parseWorkflowMarkdown(`---
+tracker:
+  kind: github-project
+runtime:
+  kind: claude-print
+  isolation: false
+---
+Prompt body.
+`)
+    ).toThrow(/Workflow front matter field "runtime\.isolation" must be an object/);
+  });
+
   it("does not expose session resume fields in runtime schema", () => {
     const workflow = parseWorkflowMarkdown(`---
 tracker:

--- a/packages/core/src/workflow-loader.test.ts
+++ b/packages/core/src/workflow-loader.test.ts
@@ -219,6 +219,21 @@ Prompt body.
     ).toThrow(/inline array has an unterminated string/);
   });
 
+  it("reports trailing commas in inline arrays clearly", () => {
+    expect(() =>
+      parseWorkflowMarkdown(`---
+tracker:
+  kind: github-project
+runtime:
+  kind: custom
+  command: node
+  args: [worker.js, --flag,]
+---
+Prompt body.
+`)
+    ).toThrow(/inline array has a trailing comma/);
+  });
+
   it("rejects unsupported runtime kind values", () => {
     expect(() =>
       parseWorkflowMarkdown(`---

--- a/packages/core/src/workflow/config.ts
+++ b/packages/core/src/workflow/config.ts
@@ -52,6 +52,35 @@ export type WorkflowCodexConfig = {
   stallTimeoutMs: number;
 };
 
+export type WorkflowRuntimeKind =
+  | "codex-app-server"
+  | "claude-print"
+  | "custom";
+
+export type WorkflowRuntimeIsolationConfig = {
+  bare: boolean;
+  strictMcpConfig: boolean;
+};
+
+export type WorkflowRuntimeAuthConfig = {
+  env: string | null;
+};
+
+export type WorkflowRuntimeTimeoutsConfig = {
+  turnTimeoutMs: number;
+  readTimeoutMs: number;
+  stallTimeoutMs: number;
+};
+
+export type WorkflowRuntimeConfig = {
+  kind: WorkflowRuntimeKind;
+  command: string;
+  args: string[];
+  isolation: WorkflowRuntimeIsolationConfig;
+  auth: WorkflowRuntimeAuthConfig;
+  timeouts: WorkflowRuntimeTimeoutsConfig;
+};
+
 export type WorkflowSourceFormat =
   | "front-matter"
   | "legacy-sectioned"
@@ -67,6 +96,7 @@ export type WorkflowDefinition = {
   workspace: WorkflowWorkspaceConfig;
   hooks: WorkflowHooksConfig;
   agent: WorkflowAgentConfig;
+  runtime: WorkflowRuntimeConfig | null;
   codex: WorkflowCodexConfig;
   lifecycle: WorkflowLifecycleConfig;
   format: WorkflowSourceFormat;
@@ -80,6 +110,7 @@ export type ParsedWorkflow = WorkflowDefinition & {
 };
 
 export const DEFAULT_CODEX_COMMAND = "codex app-server";
+export const DEFAULT_CLAUDE_COMMAND = "claude";
 export const DEFAULT_AGENT_COMMAND = DEFAULT_CODEX_COMMAND;
 export const DEFAULT_HOOK_TIMEOUT_MS = 60_000;
 export const DEFAULT_POLL_INTERVAL_MS = 30_000;
@@ -147,6 +178,7 @@ export const DEFAULT_WORKFLOW_DEFINITION: ParsedWorkflow = {
   workspace: DEFAULT_WORKFLOW_WORKSPACE,
   hooks: DEFAULT_WORKFLOW_HOOKS,
   agent: DEFAULT_WORKFLOW_AGENT,
+  runtime: null,
   codex: DEFAULT_WORKFLOW_CODEX,
   lifecycle: DEFAULT_WORKFLOW_LIFECYCLE,
   format: "default",
@@ -155,3 +187,23 @@ export const DEFAULT_WORKFLOW_DEFINITION: ParsedWorkflow = {
   hookPath: null,
   maxConcurrentByState: {},
 };
+
+export function resolveWorkflowRuntimeCommand(
+  workflow: Pick<WorkflowDefinition, "runtime" | "codex">
+): string {
+  if (!workflow.runtime) {
+    return workflow.codex.command;
+  }
+
+  if (workflow.runtime.args.length === 0) {
+    return workflow.runtime.command;
+  }
+
+  return [workflow.runtime.command, ...workflow.runtime.args].join(" ");
+}
+
+export function resolveWorkflowRuntimeTimeouts(
+  workflow: Pick<WorkflowDefinition, "runtime" | "codex">
+): WorkflowRuntimeTimeoutsConfig {
+  return workflow.runtime?.timeouts ?? workflow.codex;
+}

--- a/packages/core/src/workflow/config.ts
+++ b/packages/core/src/workflow/config.ts
@@ -75,7 +75,7 @@ export type WorkflowRuntimeTimeoutsConfig = {
 export type WorkflowRuntimeConfig = {
   kind: WorkflowRuntimeKind;
   command: string;
-  args: string[];
+  args: readonly string[];
   isolation: WorkflowRuntimeIsolationConfig;
   auth: WorkflowRuntimeAuthConfig;
   timeouts: WorkflowRuntimeTimeoutsConfig;
@@ -199,6 +199,8 @@ export function resolveWorkflowRuntimeCommand(
     return workflow.runtime.command;
   }
 
+  // This value is a display/logging command string. Do not parse it back into
+  // argv; args containing whitespace cannot be represented losslessly here.
   return [workflow.runtime.command, ...workflow.runtime.args].join(" ");
 }
 

--- a/packages/core/src/workflow/config.ts
+++ b/packages/core/src/workflow/config.ts
@@ -199,8 +199,10 @@ export function resolveWorkflowRuntimeCommand(
     return workflow.runtime.command;
   }
 
-  // This value is a display/logging command string. Do not parse it back into
-  // argv; args containing whitespace cannot be represented losslessly here.
+  // This value is also exported as SYMPHONY_AGENT_COMMAND for the current Codex
+  // fallback path. Do not parse it back into argv; args containing whitespace
+  // cannot be represented losslessly here. Full non-Codex routing is tracked in
+  // #254.
   return [workflow.runtime.command, ...workflow.runtime.args].join(" ");
 }
 

--- a/packages/core/src/workflow/parser.ts
+++ b/packages/core/src/workflow/parser.ts
@@ -1,6 +1,7 @@
 import {
   DEFAULT_AGENT_COMMAND,
   DEFAULT_BASE_DELAY_MS,
+  DEFAULT_CLAUDE_COMMAND,
   DEFAULT_HOOK_TIMEOUT_MS,
   DEFAULT_MAX_CONCURRENT_AGENTS,
   DEFAULT_MAX_FAILURE_RETRIES,
@@ -13,6 +14,8 @@ import {
   DEFAULT_WORKFLOW_DEFINITION,
   DEFAULT_WORKFLOW_TRACKER,
   type ParsedWorkflow,
+  type WorkflowRuntimeConfig,
+  type WorkflowRuntimeKind,
 } from "./config.js";
 
 type WorkflowFrontMatterNode =
@@ -51,7 +54,11 @@ export function parseWorkflowMarkdown(
   const workspace = readObject(frontMatter, "workspace");
   const hooks = readObject(frontMatter, "hooks");
   const agent = readObject(frontMatter, "agent");
-  const codex = readRequiredObject(frontMatter, "codex");
+  const hasRuntime = frontMatter.runtime !== undefined && frontMatter.runtime !== null;
+  const runtimeNode = readObject(frontMatter, "runtime");
+  const codex = hasRuntime
+    ? readObject(frontMatter, "codex")
+    : readRequiredObject(frontMatter, "codex");
 
   const trackerKind = readRequiredString(tracker, "kind", env);
   const activeStates =
@@ -69,8 +76,12 @@ export function parseWorkflowMarkdown(
     "max_concurrent_agents_by_state"
   );
 
+  const runtime = hasRuntime ? parseRuntimeConfig(runtimeNode, env) : null;
   const command =
     readOptionalString(codex, "command", env) ?? DEFAULT_AGENT_COMMAND;
+  const agentCommand = runtime
+    ? [runtime.command, ...runtime.args].join(" ")
+    : command;
 
   const parsed: ParsedWorkflow = {
     promptTemplate,
@@ -127,6 +138,7 @@ export function parseWorkflowMarkdown(
         readOptionalIntegerLike(agent, "retry_base_delay_ms") ??
         DEFAULT_BASE_DELAY_MS,
     },
+    runtime,
     codex: {
       command,
       approvalPolicy: readOptionalString(codex, "approval_policy", env),
@@ -152,7 +164,7 @@ export function parseWorkflowMarkdown(
     },
     format: "front-matter",
     githubProjectId: readOptionalString(tracker, "project_id", env),
-    agentCommand: command,
+    agentCommand,
     hookPath: readOptionalString(hooks, "after_create", env),
     maxConcurrentByState: maxConcurrentAgentsByState,
   };
@@ -317,6 +329,9 @@ function parseScalar(value: string): WorkflowFrontMatterNode {
   if (value === "null") return null;
   if (value === "true") return true;
   if (value === "false") return false;
+  if (value.startsWith("[") && value.endsWith("]")) {
+    return parseInlineArray(value);
+  }
   if (/^-?\d+$/.test(value)) return Number.parseInt(value, 10);
   if (
     (value.startsWith('"') && value.endsWith('"')) ||
@@ -325,6 +340,86 @@ function parseScalar(value: string): WorkflowFrontMatterNode {
     return value.slice(1, -1);
   }
   return value;
+}
+
+function parseInlineArray(value: string): WorkflowFrontMatterNode[] {
+  const inner = value.slice(1, -1).trim();
+  if (!inner) {
+    return [];
+  }
+
+  return inner.split(",").map((entry) => parseScalar(entry.trim()));
+}
+
+function parseRuntimeConfig(
+  runtime: Record<string, WorkflowFrontMatterNode>,
+  env: NodeJS.ProcessEnv
+): WorkflowRuntimeConfig {
+  const kind = readRuntimeKind(runtime, env);
+  const isolation = readObject(runtime, "isolation");
+  const auth = readObject(runtime, "auth");
+  const timeouts = readObject(runtime, "timeouts");
+  const command =
+    readOptionalString(runtime, "command", env) ?? defaultRuntimeCommand(kind);
+
+  if (kind === "custom" && !readOptionalString(runtime, "command", env)) {
+    throw new Error(
+      'Workflow front matter field "runtime.command" is required for runtime.kind "custom".'
+    );
+  }
+
+  return {
+    kind,
+    command,
+    args: readStringList(runtime, "args") ?? [],
+    isolation: {
+      bare: readOptionalBoolean(isolation, "bare") ?? false,
+      strictMcpConfig:
+        readOptionalBoolean(isolation, "strict_mcp_config") ?? false,
+    },
+    auth: {
+      env: readOptionalString(auth, "env", env),
+    },
+    timeouts: {
+      turnTimeoutMs:
+        readOptionalIntegerLike(timeouts, "turn_timeout_ms") ??
+        DEFAULT_TURN_TIMEOUT_MS,
+      readTimeoutMs:
+        readOptionalIntegerLike(timeouts, "read_timeout_ms") ??
+        DEFAULT_READ_TIMEOUT_MS,
+      stallTimeoutMs:
+        readOptionalIntegerLike(timeouts, "stall_timeout_ms") ??
+        DEFAULT_STALL_TIMEOUT_MS,
+    },
+  };
+}
+
+function readRuntimeKind(
+  runtime: Record<string, WorkflowFrontMatterNode>,
+  env: NodeJS.ProcessEnv
+): WorkflowRuntimeKind {
+  const kind = readRequiredString(runtime, "kind", env);
+  if (
+    kind === "codex-app-server" ||
+    kind === "claude-print" ||
+    kind === "custom"
+  ) {
+    return kind;
+  }
+
+  throw new Error(
+    `Unsupported workflow runtime kind "${kind}". Supported values: codex-app-server, claude-print, custom.`
+  );
+}
+
+function defaultRuntimeCommand(kind: WorkflowRuntimeKind): string {
+  if (kind === "claude-print") {
+    return DEFAULT_CLAUDE_COMMAND;
+  }
+  if (kind === "codex-app-server") {
+    return DEFAULT_AGENT_COMMAND;
+  }
+  return "";
 }
 
 function readObject(
@@ -413,6 +508,20 @@ function readStringList(
     );
   }
   return value as string[];
+}
+
+function readOptionalBoolean(
+  input: Record<string, WorkflowFrontMatterNode>,
+  key: string
+): boolean | null {
+  const value = input[key];
+  if (value === undefined || value === null) {
+    return null;
+  }
+  if (typeof value !== "boolean") {
+    throw new Error(`Workflow front matter field "${key}" must be a boolean.`);
+  }
+  return value;
 }
 
 function readOptionalIntegerLike(

--- a/packages/core/src/workflow/parser.ts
+++ b/packages/core/src/workflow/parser.ts
@@ -16,6 +16,7 @@ import {
   type ParsedWorkflow,
   type WorkflowRuntimeConfig,
   type WorkflowRuntimeKind,
+  resolveWorkflowRuntimeCommand,
 } from "./config.js";
 
 type WorkflowFrontMatterNode =
@@ -77,11 +78,25 @@ export function parseWorkflowMarkdown(
   );
 
   const runtime = hasRuntime ? parseRuntimeConfig(runtimeNode, env) : null;
-  const command =
-    readOptionalString(codex, "command", env) ?? DEFAULT_AGENT_COMMAND;
-  const agentCommand = runtime
-    ? [runtime.command, ...runtime.args].join(" ")
-    : command;
+  const codexConfig = {
+    command: readOptionalString(codex, "command", env) ?? DEFAULT_AGENT_COMMAND,
+    approvalPolicy: readOptionalString(codex, "approval_policy", env),
+    threadSandbox: readOptionalString(codex, "thread_sandbox", env),
+    turnSandboxPolicy: readOptionalString(codex, "turn_sandbox_policy", env),
+    turnTimeoutMs:
+      readOptionalIntegerLike(codex, "turn_timeout_ms") ??
+      DEFAULT_TURN_TIMEOUT_MS,
+    readTimeoutMs:
+      readOptionalIntegerLike(codex, "read_timeout_ms") ??
+      DEFAULT_READ_TIMEOUT_MS,
+    stallTimeoutMs:
+      readOptionalIntegerLike(codex, "stall_timeout_ms") ??
+      DEFAULT_STALL_TIMEOUT_MS,
+  };
+  const agentCommand = resolveWorkflowRuntimeCommand({
+    runtime,
+    codex: codexConfig,
+  });
 
   const parsed: ParsedWorkflow = {
     promptTemplate,
@@ -139,21 +154,7 @@ export function parseWorkflowMarkdown(
         DEFAULT_BASE_DELAY_MS,
     },
     runtime,
-    codex: {
-      command,
-      approvalPolicy: readOptionalString(codex, "approval_policy", env),
-      threadSandbox: readOptionalString(codex, "thread_sandbox", env),
-      turnSandboxPolicy: readOptionalString(codex, "turn_sandbox_policy", env),
-      turnTimeoutMs:
-        readOptionalIntegerLike(codex, "turn_timeout_ms") ??
-        DEFAULT_TURN_TIMEOUT_MS,
-      readTimeoutMs:
-        readOptionalIntegerLike(codex, "read_timeout_ms") ??
-        DEFAULT_READ_TIMEOUT_MS,
-      stallTimeoutMs:
-        readOptionalIntegerLike(codex, "stall_timeout_ms") ??
-        DEFAULT_STALL_TIMEOUT_MS,
-    },
+    codex: codexConfig,
     lifecycle: {
       stateFieldName:
         readOptionalString(tracker, "state_field", env) ??
@@ -348,7 +349,54 @@ function parseInlineArray(value: string): WorkflowFrontMatterNode[] {
     return [];
   }
 
-  return inner.split(",").map((entry) => parseScalar(entry.trim()));
+  return splitInlineArrayEntries(inner).map((entry) =>
+    parseScalar(entry.trim())
+  );
+}
+
+function splitInlineArrayEntries(inner: string): string[] {
+  const entries: string[] = [];
+  let current = "";
+  let quote: '"' | "'" | null = null;
+
+  for (const char of inner) {
+    if (quote) {
+      current += char;
+      if (char === quote) {
+        quote = null;
+      }
+      continue;
+    }
+
+    if (char === '"' || char === "'") {
+      quote = char;
+      current += char;
+      continue;
+    }
+
+    if (char === ",") {
+      pushInlineArrayEntry(entries, current);
+      current = "";
+      continue;
+    }
+
+    current += char;
+  }
+
+  if (quote) {
+    throw new Error("Workflow front matter inline array has an unterminated string.");
+  }
+
+  pushInlineArrayEntry(entries, current);
+  return entries;
+}
+
+function pushInlineArrayEntry(entries: string[], entry: string): void {
+  const trimmed = entry.trim();
+  if (!trimmed) {
+    throw new Error("Workflow front matter inline array contains an empty item.");
+  }
+  entries.push(trimmed);
 }
 
 function parseRuntimeConfig(
@@ -359,10 +407,10 @@ function parseRuntimeConfig(
   const isolation = readObject(runtime, "isolation");
   const auth = readObject(runtime, "auth");
   const timeouts = readObject(runtime, "timeouts");
-  const command =
-    readOptionalString(runtime, "command", env) ?? defaultRuntimeCommand(kind);
+  const configuredCommand = readOptionalString(runtime, "command", env);
+  const command = configuredCommand ?? defaultRuntimeCommand(kind);
 
-  if (kind === "custom" && !readOptionalString(runtime, "command", env)) {
+  if (!command) {
     throw new Error(
       'Workflow front matter field "runtime.command" is required for runtime.kind "custom".'
     );
@@ -412,14 +460,14 @@ function readRuntimeKind(
   );
 }
 
-function defaultRuntimeCommand(kind: WorkflowRuntimeKind): string {
+function defaultRuntimeCommand(kind: WorkflowRuntimeKind): string | null {
   if (kind === "claude-print") {
     return DEFAULT_CLAUDE_COMMAND;
   }
   if (kind === "codex-app-server") {
     return DEFAULT_AGENT_COMMAND;
   }
-  return "";
+  return null;
 }
 
 function readObject(

--- a/packages/core/src/workflow/parser.ts
+++ b/packages/core/src/workflow/parser.ts
@@ -425,7 +425,7 @@ function parseRuntimeConfig(
   return {
     kind,
     command,
-    args: readStringList(runtime, "args") ?? [],
+    args: readRuntimeArgs(runtime),
     isolation: {
       bare:
         readOptionalBoolean(isolation, "bare", "runtime.isolation.bare") ??
@@ -575,6 +575,24 @@ function readStringList(
   ) {
     throw new Error(
       `Workflow front matter field "${key}" must be an array of strings or comma-separated string.`
+    );
+  }
+  return value as string[];
+}
+
+function readRuntimeArgs(
+  input: Record<string, WorkflowFrontMatterNode>
+): string[] {
+  const value = input.args;
+  if (value === undefined || value === null) {
+    return [];
+  }
+  if (
+    !Array.isArray(value) ||
+    value.some((entry) => typeof entry !== "string")
+  ) {
+    throw new Error(
+      'Workflow front matter field "runtime.args" must be an array of strings.'
     );
   }
   return value as string[];

--- a/packages/core/src/workflow/parser.ts
+++ b/packages/core/src/workflow/parser.ts
@@ -349,9 +349,7 @@ function parseInlineArray(value: string): WorkflowFrontMatterNode[] {
     return [];
   }
 
-  return splitInlineArrayEntries(inner).map((entry) =>
-    parseScalar(entry.trim())
-  );
+  return splitInlineArrayEntries(inner).map((entry) => parseScalar(entry));
 }
 
 function splitInlineArrayEntries(inner: string): string[] {
@@ -375,7 +373,7 @@ function splitInlineArrayEntries(inner: string): string[] {
     }
 
     if (char === ",") {
-      pushInlineArrayEntry(entries, current);
+      pushInlineArrayEntry(entries, current, "middle");
       current = "";
       continue;
     }
@@ -387,14 +385,22 @@ function splitInlineArrayEntries(inner: string): string[] {
     throw new Error("Workflow front matter inline array has an unterminated string.");
   }
 
-  pushInlineArrayEntry(entries, current);
+  pushInlineArrayEntry(entries, current, "end");
   return entries;
 }
 
-function pushInlineArrayEntry(entries: string[], entry: string): void {
+function pushInlineArrayEntry(
+  entries: string[],
+  entry: string,
+  position: "middle" | "end"
+): void {
   const trimmed = entry.trim();
   if (!trimmed) {
-    throw new Error("Workflow front matter inline array contains an empty item.");
+    const reason =
+      position === "end"
+        ? "has a trailing comma"
+        : "contains an empty item";
+    throw new Error(`Workflow front matter inline array ${reason}.`);
   }
   entries.push(trimmed);
 }

--- a/packages/core/src/workflow/parser.ts
+++ b/packages/core/src/workflow/parser.ts
@@ -427,9 +427,15 @@ function parseRuntimeConfig(
     command,
     args: readStringList(runtime, "args") ?? [],
     isolation: {
-      bare: readOptionalBoolean(isolation, "bare") ?? false,
+      bare:
+        readOptionalBoolean(isolation, "bare", "runtime.isolation.bare") ??
+        false,
       strictMcpConfig:
-        readOptionalBoolean(isolation, "strict_mcp_config") ?? false,
+        readOptionalBoolean(
+          isolation,
+          "strict_mcp_config",
+          "runtime.isolation.strict_mcp_config"
+        ) ?? false,
     },
     auth: {
       env: readOptionalString(auth, "env", env),
@@ -576,14 +582,15 @@ function readStringList(
 
 function readOptionalBoolean(
   input: Record<string, WorkflowFrontMatterNode>,
-  key: string
+  key: string,
+  path = key
 ): boolean | null {
   const value = input[key];
   if (value === undefined || value === null) {
     return null;
   }
   if (typeof value !== "boolean") {
-    throw new Error(`Workflow front matter field "${key}" must be a boolean.`);
+    throw new Error(`Workflow front matter field "${path}" must be a boolean.`);
   }
   return value;
 }

--- a/packages/core/src/workflow/parser.ts
+++ b/packages/core/src/workflow/parser.ts
@@ -410,9 +410,9 @@ function parseRuntimeConfig(
   env: NodeJS.ProcessEnv
 ): WorkflowRuntimeConfig {
   const kind = readRuntimeKind(runtime, env);
-  const isolation = readObject(runtime, "isolation");
-  const auth = readObject(runtime, "auth");
-  const timeouts = readObject(runtime, "timeouts");
+  const isolation = readObject(runtime, "isolation", "runtime.isolation");
+  const auth = readObject(runtime, "auth", "runtime.auth");
+  const timeouts = readObject(runtime, "timeouts", "runtime.timeouts");
   const configuredCommand = readOptionalString(runtime, "command", env);
   const command = configuredCommand ?? defaultRuntimeCommand(kind);
 
@@ -478,14 +478,15 @@ function defaultRuntimeCommand(kind: WorkflowRuntimeKind): string | null {
 
 function readObject(
   input: Record<string, WorkflowFrontMatterNode>,
-  key: string
+  key: string,
+  path = key
 ): Record<string, WorkflowFrontMatterNode> {
   const value = input[key];
   if (value === undefined || value === null) {
     return {};
   }
   if (typeof value !== "object" || Array.isArray(value)) {
-    throw new Error(`Workflow front matter field "${key}" must be an object.`);
+    throw new Error(`Workflow front matter field "${path}" must be an object.`);
   }
   return value as Record<string, WorkflowFrontMatterNode>;
 }

--- a/packages/core/src/workflow/parser.ts
+++ b/packages/core/src/workflow/parser.ts
@@ -55,8 +55,8 @@ export function parseWorkflowMarkdown(
   const workspace = readObject(frontMatter, "workspace");
   const hooks = readObject(frontMatter, "hooks");
   const agent = readObject(frontMatter, "agent");
-  const hasRuntime = frontMatter.runtime !== undefined && frontMatter.runtime !== null;
-  const runtimeNode = readObject(frontMatter, "runtime");
+  const runtimeNode = readOptionalRuntimeObject(frontMatter);
+  const hasRuntime = runtimeNode !== null;
   const codex = hasRuntime
     ? readObject(frontMatter, "codex")
     : readRequiredObject(frontMatter, "codex");
@@ -488,6 +488,15 @@ function readObject(
     throw new Error(`Workflow front matter field "${key}" must be an object.`);
   }
   return value as Record<string, WorkflowFrontMatterNode>;
+}
+
+function readOptionalRuntimeObject(
+  input: Record<string, WorkflowFrontMatterNode>
+): Record<string, WorkflowFrontMatterNode> | null {
+  if (input.runtime === undefined || input.runtime === null) {
+    return null;
+  }
+  return readObject(input, "runtime");
 }
 
 function readRequiredObject(

--- a/packages/orchestrator/package.json
+++ b/packages/orchestrator/package.json
@@ -42,6 +42,8 @@
   },
   "dependencies": {
     "@gh-symphony/core": "workspace:*",
+    "@gh-symphony/runtime-claude": "workspace:*",
+    "@gh-symphony/runtime-codex": "workspace:*",
     "@gh-symphony/tracker-file": "workspace:*",
     "@gh-symphony/tracker-github": "workspace:*"
   }

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -14,6 +14,7 @@ import {
 
 export { OrchestratorService, createStore };
 export type { OrchestratorLogLevel };
+export * from "./runtime-factory.js";
 export {
   acquireProjectLock,
   assertValidProjectId,

--- a/packages/orchestrator/src/runtime-factory.test.ts
+++ b/packages/orchestrator/src/runtime-factory.test.ts
@@ -1,0 +1,158 @@
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+import { parseWorkflowMarkdown } from "@gh-symphony/core";
+import { ClaudePrintRuntimeAdapter } from "@gh-symphony/runtime-claude";
+import { CodexRuntimeAdapter } from "@gh-symphony/runtime-codex";
+import { describe, expect, it } from "vitest";
+import {
+  createWorkflowRuntimeAdapter,
+  CustomCommandRuntimeAdapter,
+} from "./runtime-factory.js";
+import type { SpawnLike } from "@gh-symphony/runtime-claude";
+
+function parseWorkflow(frontMatter: string) {
+  return parseWorkflowMarkdown(`---
+tracker:
+  kind: github-project
+${frontMatter}
+---
+Prompt.
+`);
+}
+
+function createStubChild() {
+  const emitter = new EventEmitter();
+  const stdin = new PassThrough();
+  const stdout = new PassThrough();
+  const stderr = new PassThrough();
+
+  return {
+    child: {
+      stdin,
+      stdout,
+      stderr,
+      once(event: string, listener: (...args: unknown[]) => void) {
+        emitter.once(event, listener);
+        return this;
+      },
+      on(event: string, listener: (...args: unknown[]) => void) {
+        emitter.on(event, listener);
+        return this;
+      },
+      removeListener(event: string, listener: (...args: unknown[]) => void) {
+        emitter.removeListener(event, listener);
+        return this;
+      },
+      emit(event: string, ...args: unknown[]) {
+        emitter.emit(event, ...args);
+      },
+    } as unknown as ReturnType<SpawnLike>,
+    stdout,
+    stderr,
+  };
+}
+
+describe("createWorkflowRuntimeAdapter", () => {
+  it("falls back to the legacy codex adapter when runtime is absent", () => {
+    const workflow = parseWorkflow(`codex:
+  command: codex app-server --model gpt-5
+`);
+
+    const adapter = createWorkflowRuntimeAdapter(workflow, {
+      projectId: "project-1",
+      workingDirectory: "/workspace",
+    });
+
+    expect(adapter).toBeInstanceOf(CodexRuntimeAdapter);
+  });
+
+  it("creates a claude-print adapter with isolation argv context", async () => {
+    const calls: Array<ReadonlyArray<string>> = [];
+    const { child, stdout, stderr } = createStubChild();
+    const spawnImpl: SpawnLike = (_command, args) => {
+      calls.push(args);
+      queueMicrotask(() => {
+        stdout.end();
+        stderr.end();
+        child.emit("close", 0, null);
+      });
+      return child;
+    };
+    const workflow = parseWorkflow(`runtime:
+  kind: claude-print
+  command: claude
+  args:
+    - -p
+    - --verbose
+  isolation:
+    bare: true
+    strict_mcp_config: true
+  auth:
+    env: ANTHROPIC_API_KEY
+`);
+
+    const adapter = createWorkflowRuntimeAdapter(workflow, {
+      projectId: "project-1",
+      workingDirectory: "/workspace",
+      mcpConfigPath: "/tmp/ephemeral-mcp.json",
+      claudeDependencies: {
+        spawnImpl,
+      },
+    });
+
+    expect(adapter).toBeInstanceOf(ClaudePrintRuntimeAdapter);
+    await adapter.spawnTurn({
+      messages: [],
+    });
+
+    expect(calls[0]).toEqual([
+      "-p",
+      "--verbose",
+      "--bare",
+      "--strict-mcp-config",
+      "--mcp-config",
+      "/tmp/ephemeral-mcp.json",
+    ]);
+  });
+
+  it("creates a custom adapter that spawns command and args exactly", async () => {
+    const calls: Array<{ command: string; args: ReadonlyArray<string> }> = [];
+    const { child, stdout, stderr } = createStubChild();
+    const spawnImpl: SpawnLike = (command, args) => {
+      calls.push({ command, args });
+      queueMicrotask(() => {
+        stdout.end();
+        stderr.end();
+        child.emit("close", 0, null);
+      });
+      return child;
+    };
+    const workflow = parseWorkflow(`runtime:
+  kind: custom
+  command: node
+  args:
+    - worker.js
+    - --direct
+`);
+
+    const adapter = createWorkflowRuntimeAdapter(workflow, {
+      projectId: "project-1",
+      workingDirectory: "/workspace",
+      claudeDependencies: {
+        spawnImpl,
+      },
+    });
+
+    expect(adapter).toBeInstanceOf(CustomCommandRuntimeAdapter);
+    await adapter.spawnTurn({
+      messages: [],
+    });
+
+    expect(calls).toEqual([
+      {
+        command: "node",
+        args: ["worker.js", "--direct"],
+      },
+    ]);
+  });
+});

--- a/packages/orchestrator/src/runtime-factory.test.ts
+++ b/packages/orchestrator/src/runtime-factory.test.ts
@@ -66,6 +66,34 @@ describe("createWorkflowRuntimeAdapter", () => {
     expect(adapter).toBeInstanceOf(CodexRuntimeAdapter);
   });
 
+  it("creates a codex-app-server adapter with runtime command args", async () => {
+    const workflow = parseWorkflow(`runtime:
+  kind: codex-app-server
+  command: codex
+  args:
+    - app-server
+    - --model
+    - gpt-5
+`);
+
+    const adapter = createWorkflowRuntimeAdapter(workflow, {
+      projectId: "project-1",
+      workingDirectory: "/workspace",
+      codexDependencies: {
+        mkdirImpl: async () => undefined,
+        writeFileImpl: async () => undefined,
+        copyFileImpl: async () => undefined,
+      },
+    });
+
+    expect(adapter).toBeInstanceOf(CodexRuntimeAdapter);
+    const codexAdapter = adapter as CodexRuntimeAdapter;
+    await codexAdapter.prepare();
+
+    const plan = codexAdapter.getPreparedPlan();
+    expect(plan?.args).toEqual(["-lc", "codex app-server --model gpt-5"]);
+  });
+
   it("creates a claude-print adapter with isolation argv context", async () => {
     const calls: Array<ReadonlyArray<string>> = [];
     const { child, stdout, stderr } = createStubChild();

--- a/packages/orchestrator/src/runtime-factory.test.ts
+++ b/packages/orchestrator/src/runtime-factory.test.ts
@@ -94,6 +94,29 @@ describe("createWorkflowRuntimeAdapter", () => {
     expect(plan?.args).toEqual(["-lc", "codex app-server --model gpt-5"]);
   });
 
+  it("uses the default codex-app-server command when runtime command is absent", async () => {
+    const workflow = parseWorkflow(`runtime:
+  kind: codex-app-server
+`);
+
+    const adapter = createWorkflowRuntimeAdapter(workflow, {
+      projectId: "project-1",
+      workingDirectory: "/workspace",
+      codexDependencies: {
+        mkdirImpl: async () => undefined,
+        writeFileImpl: async () => undefined,
+        copyFileImpl: async () => undefined,
+      },
+    });
+
+    expect(adapter).toBeInstanceOf(CodexRuntimeAdapter);
+    const codexAdapter = adapter as CodexRuntimeAdapter;
+    await codexAdapter.prepare();
+
+    const plan = codexAdapter.getPreparedPlan();
+    expect(plan?.args).toEqual(["-lc", "codex app-server"]);
+  });
+
   it("creates a claude-print adapter with isolation argv context", async () => {
     const calls: Array<ReadonlyArray<string>> = [];
     const { child, stdout, stderr } = createStubChild();
@@ -145,6 +168,48 @@ describe("createWorkflowRuntimeAdapter", () => {
       "--strict-mcp-config",
       "--mcp-config",
       "/tmp/ephemeral-mcp.json",
+    ]);
+  });
+
+  it("passes explicit empty claude-print args through to argv construction", async () => {
+    const calls: Array<ReadonlyArray<string>> = [];
+    const { child, stdout, stderr } = createStubChild();
+    const spawnImpl: SpawnLike = (_command, args) => {
+      calls.push(args);
+      queueMicrotask(() => {
+        stdout.end();
+        stderr.end();
+        child.emit("close", 0, null);
+      });
+      return child;
+    };
+    const workflow = parseWorkflow(`runtime:
+  kind: claude-print
+  command: claude
+  args: []
+`);
+
+    const adapter = createWorkflowRuntimeAdapter(workflow, {
+      projectId: "project-1",
+      workingDirectory: "/workspace",
+      claudeDependencies: {
+        spawnImpl,
+      },
+    });
+
+    expect(adapter).toBeInstanceOf(ClaudePrintRuntimeAdapter);
+    await adapter.spawnTurn({});
+
+    expect(calls[0]).toEqual([
+      "-p",
+      "--output-format",
+      "stream-json",
+      "--input-format",
+      "stream-json",
+      "--include-partial-messages",
+      "--verbose",
+      "--permission-mode",
+      "bypassPermissions",
     ]);
   });
 

--- a/packages/orchestrator/src/runtime-factory.test.ts
+++ b/packages/orchestrator/src/runtime-factory.test.ts
@@ -136,6 +136,13 @@ describe("createWorkflowRuntimeAdapter", () => {
     expect(calls[0]).toEqual([
       "-p",
       "--verbose",
+      "--output-format",
+      "stream-json",
+      "--input-format",
+      "stream-json",
+      "--include-partial-messages",
+      "--permission-mode",
+      "bypassPermissions",
       "--bare",
       "--strict-mcp-config",
       "--mcp-config",
@@ -172,6 +179,9 @@ describe("createWorkflowRuntimeAdapter", () => {
     });
 
     expect(adapter).toBeInstanceOf(CustomCommandRuntimeAdapter);
+    const unsubscribe = adapter.onEvent(() => undefined);
+    expect(unsubscribe()).toBeUndefined();
+
     await adapter.spawnTurn({
       messages: [],
     });

--- a/packages/orchestrator/src/runtime-factory.test.ts
+++ b/packages/orchestrator/src/runtime-factory.test.ts
@@ -129,9 +129,7 @@ describe("createWorkflowRuntimeAdapter", () => {
     });
 
     expect(adapter).toBeInstanceOf(ClaudePrintRuntimeAdapter);
-    await adapter.spawnTurn({
-      messages: [],
-    });
+    await adapter.spawnTurn({});
 
     expect(calls[0]).toEqual([
       "-p",

--- a/packages/orchestrator/src/runtime-factory.ts
+++ b/packages/orchestrator/src/runtime-factory.ts
@@ -1,0 +1,181 @@
+import { join } from "node:path";
+import type {
+  AgentRuntimeAdapter,
+  AgentRuntimeCredentialBrokerResponse,
+  AgentRuntimeEnv,
+  AgentRuntimeEvent,
+  AgentRuntimeEventHandler,
+  AgentRuntimeEventSubscription,
+  WorkflowDefinition,
+  WorkflowRuntimeConfig,
+} from "@gh-symphony/core";
+import { extractEnvForClaude } from "@gh-symphony/core";
+import {
+  createCodexRuntimeAdapter,
+  type CodexRuntimeAdapter,
+  type CodexRuntimeDependencies,
+} from "@gh-symphony/runtime-codex";
+import {
+  createClaudePrintRuntimeAdapter,
+  spawnClaudeTurn,
+  type ClaudePrintRuntimeAdapter,
+  type ClaudeSpawnDependencies,
+  type ClaudeSpawnTurnResult,
+  type ClaudeWireMessage,
+} from "@gh-symphony/runtime-claude";
+
+export type WorkflowRuntimeFactoryContext = {
+  projectId: string;
+  workingDirectory: string;
+  mcpConfigPath?: string;
+  env?: NodeJS.ProcessEnv;
+  codexDependencies?: CodexRuntimeDependencies;
+  claudeDependencies?: ClaudeSpawnDependencies;
+};
+
+export type WorkflowRuntimeAdapter =
+  | CodexRuntimeAdapter
+  | ClaudePrintRuntimeAdapter
+  | CustomCommandRuntimeAdapter;
+
+export type CustomCommandRuntimeConfig = {
+  workingDirectory: string;
+  command: string;
+  args: readonly string[];
+  authEnvKey?: string;
+  env?: NodeJS.ProcessEnv;
+};
+
+export type CustomRuntimeTurnInput = {
+  messages: ClaudeWireMessage | readonly ClaudeWireMessage[];
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  command?: string;
+  args?: readonly string[];
+};
+
+export class CustomCommandRuntimeAdapter
+  implements
+    AgentRuntimeAdapter<
+      void,
+      CustomRuntimeTurnInput,
+      ClaudeSpawnTurnResult,
+      AgentRuntimeEvent
+    >
+{
+  constructor(
+    private readonly config: CustomCommandRuntimeConfig,
+    private readonly dependencies: ClaudeSpawnDependencies = {}
+  ) {}
+
+  prepare(): void {}
+
+  spawnTurn(input: CustomRuntimeTurnInput): Promise<ClaudeSpawnTurnResult> {
+    return spawnClaudeTurn(
+      {
+        command: input.command ?? this.config.command,
+        args: input.args ?? this.config.args,
+        cwd: input.cwd ?? this.config.workingDirectory,
+        env: {
+          ...this.config.env,
+          ...input.env,
+        },
+        stdinMessages: input.messages,
+      },
+      this.dependencies
+    );
+  }
+
+  onEvent(
+    _handler: AgentRuntimeEventHandler<AgentRuntimeEvent>
+  ): AgentRuntimeEventSubscription {
+    return () => {};
+  }
+
+  resolveCredentials(
+    brokerResponse: AgentRuntimeCredentialBrokerResponse
+  ): AgentRuntimeEnv {
+    if (!this.config.authEnvKey) {
+      return {};
+    }
+    return extractEnvForClaude(brokerResponse.env, this.config.authEnvKey);
+  }
+
+  shutdown(): void {}
+
+  cancel(): void {}
+}
+
+export function createWorkflowRuntimeAdapter(
+  workflow: WorkflowDefinition,
+  context: WorkflowRuntimeFactoryContext
+): WorkflowRuntimeAdapter {
+  const runtime = workflow.runtime;
+
+  if (!runtime) {
+    return createCodexRuntimeAdapter(
+      {
+        projectId: context.projectId,
+        workingDirectory: context.workingDirectory,
+        agentCommand: workflow.codex.command,
+        extraEnv: context.env,
+      },
+      context.codexDependencies
+    );
+  }
+
+  switch (runtime.kind) {
+    case "codex-app-server":
+      return createCodexRuntimeAdapter(
+        {
+          projectId: context.projectId,
+          workingDirectory: context.workingDirectory,
+          agentCommand: buildCommand(runtime),
+          extraEnv: context.env,
+        },
+        context.codexDependencies
+      );
+    case "claude-print":
+      return createClaudePrintRuntimeAdapter(
+        {
+          workingDirectory: context.workingDirectory,
+          command: runtime.command,
+          args: runtime.args.length > 0 ? runtime.args : undefined,
+          env: context.env,
+          authEnvKey: runtime.auth.env ?? undefined,
+          isolation: {
+            bare: runtime.isolation.bare,
+            strictMcpConfig: runtime.isolation.strictMcpConfig,
+            mcpConfigPath: runtime.isolation.strictMcpConfig
+              ? (context.mcpConfigPath ?? defaultEphemeralMcpConfigPath(context))
+              : undefined,
+          },
+        },
+        context.claudeDependencies
+      );
+    case "custom":
+      return new CustomCommandRuntimeAdapter(
+        {
+          workingDirectory: context.workingDirectory,
+          command: runtime.command,
+          args: runtime.args,
+          env: context.env,
+          authEnvKey: runtime.auth.env ?? undefined,
+        },
+        context.claudeDependencies
+      );
+  }
+}
+
+function buildCommand(runtime: WorkflowRuntimeConfig): string {
+  if (runtime.args.length === 0) {
+    return runtime.command;
+  }
+  return [runtime.command, ...runtime.args].join(" ");
+}
+
+function defaultEphemeralMcpConfigPath(
+  context: Pick<WorkflowRuntimeFactoryContext, "workingDirectory">
+): string {
+  return join(context.workingDirectory, ".runtime", "mcp.json");
+}

--- a/packages/orchestrator/src/runtime-factory.ts
+++ b/packages/orchestrator/src/runtime-factory.ts
@@ -21,7 +21,6 @@ import {
   type ClaudePrintRuntimeAdapter,
   type ClaudeSpawnDependencies,
   type ClaudeSpawnTurnResult,
-  type ClaudeWireMessage,
 } from "@gh-symphony/runtime-claude";
 
 export type WorkflowRuntimeFactoryContext = {
@@ -46,8 +45,10 @@ export type CustomCommandRuntimeConfig = {
   env?: NodeJS.ProcessEnv;
 };
 
+export type CustomRuntimeMessage = Record<string, unknown>;
+
 export type CustomRuntimeTurnInput = {
-  messages: ClaudeWireMessage | readonly ClaudeWireMessage[];
+  messages?: CustomRuntimeMessage | readonly CustomRuntimeMessage[];
   cwd?: string;
   env?: NodeJS.ProcessEnv;
   command?: string;
@@ -80,7 +81,7 @@ export class CustomCommandRuntimeAdapter
           ...this.config.env,
           ...input.env,
         },
-        stdinMessages: input.messages,
+        stdinMessages: input.messages ?? [],
       },
       this.dependencies
     );

--- a/packages/orchestrator/src/runtime-factory.ts
+++ b/packages/orchestrator/src/runtime-factory.ts
@@ -20,7 +20,6 @@ import {
 import {
   createClaudePrintRuntimeAdapter,
   spawnClaudeTurn,
-  type ClaudeWireMessage,
   type ClaudePrintRuntimeAdapter,
   type ClaudeSpawnDependencies,
   type ClaudeSpawnTurnResult,
@@ -31,6 +30,10 @@ export type WorkflowRuntimeFactoryContext = {
   workingDirectory: string;
   mcpConfigPath?: string;
   env?: NodeJS.ProcessEnv;
+  /**
+   * Optional dependencies for codex-app-server. When omitted, the codex
+   * adapter uses its production filesystem/process defaults.
+   */
   codexDependencies?: CodexRuntimeDependencies;
   claudeDependencies?: ClaudeSpawnDependencies;
 };
@@ -49,7 +52,6 @@ export type CustomCommandRuntimeConfig = {
 };
 
 export type CustomRuntimeTurnInput = {
-  messages?: ClaudeWireMessage | readonly ClaudeWireMessage[];
   cwd?: string;
   env?: NodeJS.ProcessEnv;
   command?: string;
@@ -82,7 +84,7 @@ export class CustomCommandRuntimeAdapter
           ...this.config.env,
           ...input.env,
         },
-        stdinMessages: input.messages ?? [],
+        stdinMessages: [],
       },
       this.dependencies
     );
@@ -150,9 +152,7 @@ export function createWorkflowRuntimeAdapter(
           isolation: {
             bare: runtime.isolation.bare,
             strictMcpConfig: runtime.isolation.strictMcpConfig,
-            mcpConfigPath: runtime.isolation.strictMcpConfig
-              ? (context.mcpConfigPath ?? defaultEphemeralMcpConfigPath(context))
-              : undefined,
+            mcpConfigPath: resolveMcpConfigPath(runtime, context),
           },
         },
         context.claudeDependencies
@@ -169,6 +169,17 @@ export function createWorkflowRuntimeAdapter(
         context.claudeDependencies
       );
   }
+}
+
+function resolveMcpConfigPath(
+  runtime: NonNullable<WorkflowDefinition["runtime"]>,
+  context: WorkflowRuntimeFactoryContext
+): string | undefined {
+  if (!runtime.isolation.strictMcpConfig) {
+    return undefined;
+  }
+
+  return context.mcpConfigPath ?? defaultEphemeralMcpConfigPath(context);
 }
 
 function defaultEphemeralMcpConfigPath(

--- a/packages/orchestrator/src/runtime-factory.ts
+++ b/packages/orchestrator/src/runtime-factory.ts
@@ -74,6 +74,8 @@ export class CustomCommandRuntimeAdapter
 
   prepare(): void {}
 
+  // TODO(#254): replace ClaudeSpawnTurnResult with a generic turn result once
+  // custom process spawning is separated from the Claude adapter layer.
   spawnTurn(input: CustomRuntimeTurnInput): Promise<ClaudeSpawnTurnResult> {
     return spawnClaudeTurn(
       {

--- a/packages/orchestrator/src/runtime-factory.ts
+++ b/packages/orchestrator/src/runtime-factory.ts
@@ -7,9 +7,11 @@ import type {
   AgentRuntimeEventHandler,
   AgentRuntimeEventSubscription,
   WorkflowDefinition,
-  WorkflowRuntimeConfig,
 } from "@gh-symphony/core";
-import { extractEnvForClaude } from "@gh-symphony/core";
+import {
+  extractEnvForClaude,
+  resolveWorkflowRuntimeCommand,
+} from "@gh-symphony/core";
 import {
   createCodexRuntimeAdapter,
   type CodexRuntimeAdapter,
@@ -18,6 +20,7 @@ import {
 import {
   createClaudePrintRuntimeAdapter,
   spawnClaudeTurn,
+  type ClaudeWireMessage,
   type ClaudePrintRuntimeAdapter,
   type ClaudeSpawnDependencies,
   type ClaudeSpawnTurnResult,
@@ -45,10 +48,8 @@ export type CustomCommandRuntimeConfig = {
   env?: NodeJS.ProcessEnv;
 };
 
-export type CustomRuntimeMessage = Record<string, unknown>;
-
 export type CustomRuntimeTurnInput = {
-  messages?: CustomRuntimeMessage | readonly CustomRuntimeMessage[];
+  messages?: ClaudeWireMessage | readonly ClaudeWireMessage[];
   cwd?: string;
   env?: NodeJS.ProcessEnv;
   command?: string;
@@ -90,6 +91,8 @@ export class CustomCommandRuntimeAdapter
   onEvent(
     _handler: AgentRuntimeEventHandler<AgentRuntimeEvent>
   ): AgentRuntimeEventSubscription {
+    // Custom runtimes currently expose only process-level turn results; they do
+    // not emit structured runtime events.
     return () => {};
   }
 
@@ -131,7 +134,7 @@ export function createWorkflowRuntimeAdapter(
         {
           projectId: context.projectId,
           workingDirectory: context.workingDirectory,
-          agentCommand: buildCommand(runtime),
+          agentCommand: resolveWorkflowRuntimeCommand(workflow),
           extraEnv: context.env,
         },
         context.codexDependencies
@@ -166,13 +169,6 @@ export function createWorkflowRuntimeAdapter(
         context.claudeDependencies
       );
   }
-}
-
-function buildCommand(runtime: WorkflowRuntimeConfig): string {
-  if (runtime.args.length === 0) {
-    return runtime.command;
-  }
-  return [runtime.command, ...runtime.args].join(" ");
 }
 
 function defaultEphemeralMcpConfigPath(

--- a/packages/orchestrator/src/runtime-factory.ts
+++ b/packages/orchestrator/src/runtime-factory.ts
@@ -146,7 +146,7 @@ export function createWorkflowRuntimeAdapter(
         {
           workingDirectory: context.workingDirectory,
           command: runtime.command,
-          args: runtime.args.length > 0 ? runtime.args : undefined,
+          args: runtime.args,
           env: context.env,
           authEnvKey: runtime.auth.env ?? undefined,
           isolation: {

--- a/packages/orchestrator/src/runtime-factory.ts
+++ b/packages/orchestrator/src/runtime-factory.ts
@@ -35,6 +35,11 @@ export type WorkflowRuntimeFactoryContext = {
    * adapter uses its production filesystem/process defaults.
    */
   codexDependencies?: CodexRuntimeDependencies;
+  /**
+   * Temporary shared process-spawn dependencies for claude-print and custom.
+   * TODO(#254): rename/split once custom process spawning leaves the Claude
+   * adapter layer.
+   */
   claudeDependencies?: ClaudeSpawnDependencies;
 };
 
@@ -86,6 +91,7 @@ export class CustomCommandRuntimeAdapter
           ...this.config.env,
           ...input.env,
         },
+        // Custom runtimes do not expose Claude wire-protocol stdin.
         stdinMessages: [],
       },
       this.dependencies

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -22,6 +22,8 @@ import {
   mapIssueOrchestrationStateToStatus,
   readEnvFile,
   renderPrompt,
+  resolveWorkflowRuntimeCommand,
+  resolveWorkflowRuntimeTimeouts,
   resolveIssueWorkspaceDirectory,
   scheduleRetryAt,
   type HookResult,
@@ -1274,6 +1276,7 @@ export class OrchestratorService {
       }
     );
 
+    const runtimeTimeouts = resolveWorkflowRuntimeTimeouts(workflow.workflow);
     mkdirSync(runDir, { recursive: true });
     const workerLogStream = (
       this.dependencies.createWriteStreamImpl ?? createWriteStream
@@ -1331,7 +1334,9 @@ export class OrchestratorService {
           ...trackerAdapter.buildWorkerEnvironment(tenant, issue),
           SYMPHONY_RENDERED_PROMPT: renderedPrompt,
           SYMPHONY_WORKFLOW_PATH: workflow.workflowPath ?? "",
-          SYMPHONY_AGENT_COMMAND: workflow.workflow.codex.command,
+          SYMPHONY_AGENT_COMMAND: resolveWorkflowRuntimeCommand(
+            workflow.workflow
+          ),
           SYMPHONY_APPROVAL_POLICY:
             workflow.workflow.codex.approvalPolicy ?? "",
           SYMPHONY_THREAD_SANDBOX: workflow.workflow.codex.threadSandbox ?? "",
@@ -1354,10 +1359,10 @@ export class OrchestratorService {
           SYMPHONY_LAST_TURN_SUMMARY: "",
           SYMPHONY_SESSION_STARTED_AT: "",
           SYMPHONY_READ_TIMEOUT_MS: String(
-            workflow.workflow.codex.readTimeoutMs
+            runtimeTimeouts.readTimeoutMs
           ),
           SYMPHONY_TURN_TIMEOUT_MS: String(
-            workflow.workflow.codex.turnTimeoutMs
+            runtimeTimeouts.turnTimeoutMs
           ),
         }),
         detached: true,
@@ -2588,7 +2593,8 @@ export class OrchestratorService {
         maxDelayMs:
           this.dependencies.retryBackoffMs ??
           resolution.workflow.agent.maxRetryBackoffMs,
-        stallTimeoutMs: resolution.workflow.codex.stallTimeoutMs,
+        stallTimeoutMs:
+          resolveWorkflowRuntimeTimeouts(resolution.workflow).stallTimeoutMs,
       };
     } catch {
       if (!this.dependencies.retryBackoffMs) {

--- a/packages/orchestrator/tsconfig.typecheck.json
+++ b/packages/orchestrator/tsconfig.typecheck.json
@@ -6,6 +6,11 @@
     "baseUrl": ".",
     "paths": {
       "@gh-symphony/core": ["../core/src/index.ts"],
+      "@gh-symphony/runtime-claude": ["../runtime-claude/src/index.ts"],
+      "@gh-symphony/runtime-codex": ["../runtime-codex/src/index.ts"],
+      "@gh-symphony/tool-github-graphql": [
+        "../tool-github-graphql/src/index.ts"
+      ],
       "@gh-symphony/tracker-file": ["../tracker-file/src/index.ts"],
       "@gh-symphony/tracker-github": ["../tracker-github/src/index.ts"]
     }

--- a/packages/orchestrator/vitest.config.ts
+++ b/packages/orchestrator/vitest.config.ts
@@ -8,6 +8,18 @@ export default defineConfig({
   resolve: {
     alias: {
       "@gh-symphony/core": resolve(packageRoot, "../core/src/index.ts"),
+      "@gh-symphony/runtime-claude": resolve(
+        packageRoot,
+        "../runtime-claude/src/index.ts"
+      ),
+      "@gh-symphony/runtime-codex": resolve(
+        packageRoot,
+        "../runtime-codex/src/index.ts"
+      ),
+      "@gh-symphony/tool-github-graphql": resolve(
+        packageRoot,
+        "../tool-github-graphql/src/index.ts"
+      ),
       "@gh-symphony/tracker-file": resolve(
         packageRoot,
         "../tracker-file/src/index.ts"

--- a/packages/runtime-claude/src/adapter.test.ts
+++ b/packages/runtime-claude/src/adapter.test.ts
@@ -171,6 +171,47 @@ describe("ClaudePrintRuntimeAdapter", () => {
     expect(calls[0]?.GITHUB_TOKEN).toBe("from-process-env");
   });
 
+  it("uses configured args and strict mcp isolation for spawned argv", async () => {
+    const calls: Array<ReadonlyArray<string>> = [];
+    const { child, stdout, stderr } = createStubChild();
+
+    const spawnImpl: SpawnLike = (_command, args) => {
+      calls.push(args);
+
+      queueMicrotask(() => {
+        stdout.end();
+        stderr.end();
+        child.emit("close", 0, null);
+      });
+
+      return child;
+    };
+
+    const adapter = new ClaudePrintRuntimeAdapter(
+      {
+        workingDirectory: "/workspace",
+        args: ["-p", "--verbose"],
+        isolation: {
+          strictMcpConfig: true,
+          mcpConfigPath: "/workspace/.runtime/mcp.json",
+        },
+      },
+      { spawnImpl }
+    );
+
+    await adapter.spawnTurn({
+      messages: [],
+    });
+
+    expect(calls[0]).toEqual([
+      "-p",
+      "--verbose",
+      "--strict-mcp-config",
+      "--mcp-config",
+      "/workspace/.runtime/mcp.json",
+    ]);
+  });
+
   it("terminates the in-flight child on cancel", async () => {
     const kill = vi.fn(() => true);
     const { child, stdout, stderr } = createStubChild();
@@ -291,5 +332,21 @@ describe("resolveClaudeCredentials", () => {
         env: {},
       })
     ).toThrowError("ANTHROPIC_API_KEY");
+  });
+
+  it("can extract a runtime-configured auth env key", () => {
+    expect(
+      resolveClaudeCredentials(
+        {
+          env: {
+            CUSTOM_ANTHROPIC_KEY: "custom-key",
+            ANTHROPIC_API_KEY: "default-key",
+          },
+        },
+        "CUSTOM_ANTHROPIC_KEY"
+      )
+    ).toEqual({
+      CUSTOM_ANTHROPIC_KEY: "custom-key",
+    });
   });
 });

--- a/packages/runtime-claude/src/adapter.test.ts
+++ b/packages/runtime-claude/src/adapter.test.ts
@@ -206,6 +206,13 @@ describe("ClaudePrintRuntimeAdapter", () => {
     expect(calls[0]).toEqual([
       "-p",
       "--verbose",
+      "--output-format",
+      "stream-json",
+      "--input-format",
+      "stream-json",
+      "--include-partial-messages",
+      "--permission-mode",
+      "bypassPermissions",
       "--strict-mcp-config",
       "--mcp-config",
       "/workspace/.runtime/mcp.json",

--- a/packages/runtime-claude/src/adapter.ts
+++ b/packages/runtime-claude/src/adapter.ts
@@ -24,9 +24,11 @@ import {
 export type ClaudeRuntimeConfig = {
   workingDirectory: string;
   command?: string;
+  args?: readonly string[];
   env?: NodeJS.ProcessEnv;
   extraArgs?: readonly string[];
   isolation?: ClaudeRuntimeIsolationOptions;
+  authEnvKey?: string;
   inheritProcessEnv?: boolean;
 };
 
@@ -124,7 +126,7 @@ export class ClaudePrintRuntimeAdapter
   resolveCredentials(
     brokerResponse: AgentRuntimeCredentialBrokerResponse
   ): AgentRuntimeEnv {
-    return extractEnvForClaude(brokerResponse.env);
+    return extractEnvForClaude(brokerResponse.env, this.config.authEnvKey);
   }
 
   shutdown(): void {
@@ -139,6 +141,7 @@ export class ClaudePrintRuntimeAdapter
 
   private buildArgvOptions(input: ClaudeRuntimeTurnInput): ClaudePrintArgvOptions {
     return {
+      baseArgs: this.config.args,
       session: input.session,
       isolation: {
         ...this.config.isolation,
@@ -167,9 +170,10 @@ export function createClaudePrintRuntimeAdapter(
 }
 
 export function resolveClaudeCredentials(
-  brokerResponse: AgentRuntimeCredentialBrokerResponse
+  brokerResponse: AgentRuntimeCredentialBrokerResponse,
+  envKey?: string
 ): AgentRuntimeEnv {
-  return extractEnvForClaude(brokerResponse.env);
+  return extractEnvForClaude(brokerResponse.env, envKey);
 }
 
 const DEFAULT_INHERITED_ENV_KEYS = [

--- a/packages/runtime-claude/src/argv.test.ts
+++ b/packages/runtime-claude/src/argv.test.ts
@@ -76,4 +76,24 @@ describe("buildClaudePrintArgv", () => {
       "/tmp/claude-mcp.json",
     ]);
   });
+
+  it("uses configured base args before isolation flags", () => {
+    expect(
+      buildClaudePrintArgv({
+        baseArgs: ["-p", "--verbose"],
+        isolation: {
+          bare: true,
+          strictMcpConfig: true,
+          mcpConfigPath: "/tmp/runtime-mcp.json",
+        },
+      })
+    ).toEqual([
+      "-p",
+      "--verbose",
+      "--bare",
+      "--strict-mcp-config",
+      "--mcp-config",
+      "/tmp/runtime-mcp.json",
+    ]);
+  });
 });

--- a/packages/runtime-claude/src/argv.test.ts
+++ b/packages/runtime-claude/src/argv.test.ts
@@ -154,4 +154,31 @@ describe("buildClaudePrintArgv", () => {
       "bypassPermissions",
     ]);
   });
+
+  it("inserts required flag values without removing following flags", () => {
+    expect(
+      buildClaudePrintArgv({
+        baseArgs: ["--mcp-config", "--bare"],
+        isolation: {
+          bare: true,
+          strictMcpConfig: true,
+          mcpConfigPath: "/tmp/runtime-mcp.json",
+        },
+      })
+    ).toEqual([
+      "--mcp-config",
+      "/tmp/runtime-mcp.json",
+      "--bare",
+      "-p",
+      "--output-format",
+      "stream-json",
+      "--input-format",
+      "stream-json",
+      "--include-partial-messages",
+      "--verbose",
+      "--permission-mode",
+      "bypassPermissions",
+      "--strict-mcp-config",
+    ]);
+  });
 });

--- a/packages/runtime-claude/src/argv.test.ts
+++ b/packages/runtime-claude/src/argv.test.ts
@@ -77,7 +77,7 @@ describe("buildClaudePrintArgv", () => {
     ]);
   });
 
-  it("uses configured base args before isolation flags", () => {
+  it("uses configured base args while preserving required stream-json flags", () => {
     expect(
       buildClaudePrintArgv({
         baseArgs: ["-p", "--verbose"],
@@ -90,10 +90,35 @@ describe("buildClaudePrintArgv", () => {
     ).toEqual([
       "-p",
       "--verbose",
+      "--output-format",
+      "stream-json",
+      "--input-format",
+      "stream-json",
+      "--include-partial-messages",
+      "--permission-mode",
+      "bypassPermissions",
       "--bare",
       "--strict-mcp-config",
       "--mcp-config",
       "/tmp/runtime-mcp.json",
+    ]);
+  });
+
+  it("forces the required claude print protocol when base args override it", () => {
+    expect(
+      buildClaudePrintArgv({
+        baseArgs: ["-p", "--output-format", "text", "--input-format", "text"],
+      })
+    ).toEqual([
+      "-p",
+      "--output-format",
+      "stream-json",
+      "--input-format",
+      "stream-json",
+      "--include-partial-messages",
+      "--verbose",
+      "--permission-mode",
+      "bypassPermissions",
     ]);
   });
 });

--- a/packages/runtime-claude/src/argv.test.ts
+++ b/packages/runtime-claude/src/argv.test.ts
@@ -48,6 +48,32 @@ describe("buildClaudePrintArgv", () => {
     ]);
   });
 
+  it("deduplicates configured session flags", () => {
+    expect(
+      buildClaudePrintArgv({
+        baseArgs: ["--resume", "old-session", "--fork-session"],
+        session: {
+          mode: "resume",
+          sessionId: "new-session",
+          forkSession: true,
+        },
+      })
+    ).toEqual([
+      "--resume",
+      "new-session",
+      "--fork-session",
+      "-p",
+      "--output-format",
+      "stream-json",
+      "--input-format",
+      "stream-json",
+      "--include-partial-messages",
+      "--verbose",
+      "--permission-mode",
+      "bypassPermissions",
+    ]);
+  });
+
   it("skips isolation flags when isolation is off", () => {
     expect(
       buildClaudePrintArgv({

--- a/packages/runtime-claude/src/argv.test.ts
+++ b/packages/runtime-claude/src/argv.test.ts
@@ -121,4 +121,37 @@ describe("buildClaudePrintArgv", () => {
       "bypassPermissions",
     ]);
   });
+
+  it("deduplicates configured isolation flags", () => {
+    expect(
+      buildClaudePrintArgv({
+        baseArgs: [
+          "-p",
+          "--bare",
+          "--strict-mcp-config",
+          "--mcp-config",
+          "/tmp/old-mcp.json",
+        ],
+        isolation: {
+          bare: true,
+          strictMcpConfig: true,
+          mcpConfigPath: "/tmp/runtime-mcp.json",
+        },
+      })
+    ).toEqual([
+      "-p",
+      "--bare",
+      "--strict-mcp-config",
+      "--mcp-config",
+      "/tmp/runtime-mcp.json",
+      "--output-format",
+      "stream-json",
+      "--input-format",
+      "stream-json",
+      "--include-partial-messages",
+      "--verbose",
+      "--permission-mode",
+      "bypassPermissions",
+    ]);
+  });
 });

--- a/packages/runtime-claude/src/argv.ts
+++ b/packages/runtime-claude/src/argv.ts
@@ -28,6 +28,7 @@ export type ClaudeRuntimeIsolationOptions = {
 };
 
 export type ClaudePrintArgvOptions = {
+  baseArgs?: readonly string[];
   session?: ClaudeRuntimeSessionOptions;
   isolation?: ClaudeRuntimeIsolationOptions;
   extraArgs?: readonly string[];
@@ -36,7 +37,7 @@ export type ClaudePrintArgvOptions = {
 export function buildClaudePrintArgv(
   options: ClaudePrintArgvOptions = {}
 ): string[] {
-  const args = [...DEFAULT_CLAUDE_PRINT_ARGS] as string[];
+  const args = [...(options.baseArgs ?? DEFAULT_CLAUDE_PRINT_ARGS)] as string[];
   const { session, isolation, extraArgs } = options;
 
   if (session?.mode === "start") {

--- a/packages/runtime-claude/src/argv.ts
+++ b/packages/runtime-claude/src/argv.ts
@@ -54,13 +54,13 @@ export function buildClaudePrintArgv(
   }
 
   if (isolation?.bare) {
-    args.push("--bare");
+    ensureFlag(args, "--bare");
   }
 
   if (isolation?.strictMcpConfig) {
-    args.push("--strict-mcp-config");
+    ensureFlag(args, "--strict-mcp-config");
     if (isolation.mcpConfigPath) {
-      args.push("--mcp-config", isolation.mcpConfigPath);
+      ensureFlagValue(args, "--mcp-config", isolation.mcpConfigPath);
     }
   }
 

--- a/packages/runtime-claude/src/argv.ts
+++ b/packages/runtime-claude/src/argv.ts
@@ -5,6 +5,8 @@ export const DEFAULT_CLAUDE_PRINT_ARGS = [
   "--input-format",
   "stream-json",
   "--include-partial-messages",
+  // Claude stream-json output requires verbose mode when partial message
+  // events are included; keep this even when callers provide custom args.
   "--verbose",
   "--permission-mode",
   "bypassPermissions",
@@ -99,6 +101,11 @@ function ensureFlagValue(args: string[], flag: string, value: string): void {
   }
 
   const existingValue = args[index + 1];
+  if (existingValue?.startsWith("-")) {
+    args.splice(index + 1, 0, value);
+    return;
+  }
+
   if (existingValue !== value) {
     args.splice(index + 1, existingValue === undefined ? 0 : 1, value);
   }

--- a/packages/runtime-claude/src/argv.ts
+++ b/packages/runtime-claude/src/argv.ts
@@ -37,7 +37,9 @@ export type ClaudePrintArgvOptions = {
 export function buildClaudePrintArgv(
   options: ClaudePrintArgvOptions = {}
 ): string[] {
-  const args = [...(options.baseArgs ?? DEFAULT_CLAUDE_PRINT_ARGS)] as string[];
+  const args = options.baseArgs
+    ? withRequiredClaudePrintArgs(options.baseArgs)
+    : ([...DEFAULT_CLAUDE_PRINT_ARGS] as string[]);
   const { session, isolation, extraArgs } = options;
 
   if (session?.mode === "start") {
@@ -67,4 +69,37 @@ export function buildClaudePrintArgv(
   }
 
   return args;
+}
+
+function withRequiredClaudePrintArgs(baseArgs: readonly string[]): string[] {
+  const args = [...baseArgs];
+
+  ensureFlag(args, "-p");
+  ensureFlagValue(args, "--output-format", "stream-json");
+  ensureFlagValue(args, "--input-format", "stream-json");
+  ensureFlag(args, "--include-partial-messages");
+  ensureFlag(args, "--verbose");
+  ensureFlagValue(args, "--permission-mode", "bypassPermissions");
+
+  return args;
+}
+
+function ensureFlag(args: string[], flag: string): void {
+  if (!args.includes(flag)) {
+    args.push(flag);
+  }
+}
+
+function ensureFlagValue(args: string[], flag: string, value: string): void {
+  const index = args.indexOf(flag);
+
+  if (index === -1) {
+    args.push(flag, value);
+    return;
+  }
+
+  const existingValue = args[index + 1];
+  if (existingValue !== value) {
+    args.splice(index + 1, existingValue === undefined ? 0 : 1, value);
+  }
 }

--- a/packages/runtime-claude/src/argv.ts
+++ b/packages/runtime-claude/src/argv.ts
@@ -56,6 +56,8 @@ export function buildClaudePrintArgv(
   }
 
   if (isolation?.bare) {
+    // `--verbose` is still required for stream-json partial-message output;
+    // `--bare` only suppresses Claude's interactive UI.
     ensureFlag(args, "--bare");
   }
 
@@ -101,6 +103,8 @@ function ensureFlagValue(args: string[], flag: string, value: string): void {
   }
 
   const existingValue = args[index + 1];
+  // Flag values used here must not start with "-"; negative-number values are
+  // treated as adjacent flags rather than supported option values.
   if (existingValue?.startsWith("-")) {
     args.splice(index + 1, 0, value);
     return;

--- a/packages/runtime-claude/src/argv.ts
+++ b/packages/runtime-claude/src/argv.ts
@@ -45,13 +45,13 @@ export function buildClaudePrintArgv(
   const { session, isolation, extraArgs } = options;
 
   if (session?.mode === "start") {
-    args.push("--session-id", session.sessionId);
+    ensureFlagValue(args, "--session-id", session.sessionId);
   }
 
   if (session?.mode === "resume") {
-    args.push("--resume", session.sessionId);
+    ensureFlagValue(args, "--resume", session.sessionId);
     if (session.forkSession) {
-      args.push("--fork-session");
+      ensureFlag(args, "--fork-session");
     }
   }
 

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -483,6 +483,8 @@ async function startAssignedRun() {
     const config = resolveLocalRuntimeLaunchConfig(launcherEnv);
     config.agentCommand = resolveWorkflowRuntimeCommand(workflow);
     runtimeState.runPhase = "launching_agent";
+    // TODO(#254): route claude-print/custom runtime kinds through runtime
+    // adapters instead of the Codex app-server client protocol.
     const plan = await prepareCodexRuntimePlan(config);
     childProcess = launchCodexAppServer(plan);
     runtimeState.status = "running";

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -5,6 +5,7 @@ import {
   classifySessionExit,
   DEFAULT_AGENT_INPUT_REQUIRED_REASON,
   parseWorkflowMarkdown,
+  resolveWorkflowRuntimeCommand,
   type AgentEvent,
   type OrchestratorChannelEvent,
   type RunAttemptPhase,
@@ -480,7 +481,7 @@ async function startAssignedRun() {
       activeStates: workflow.lifecycle.activeStates,
     });
     const config = resolveLocalRuntimeLaunchConfig(launcherEnv);
-    config.agentCommand = workflow.codex.command;
+    config.agentCommand = resolveWorkflowRuntimeCommand(workflow);
     runtimeState.runPhase = "launching_agent";
     const plan = await prepareCodexRuntimePlan(config);
     childProcess = launchCodexAppServer(plan);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -163,6 +163,12 @@ importers:
       '@gh-symphony/core':
         specifier: workspace:*
         version: link:../core
+      '@gh-symphony/runtime-claude':
+        specifier: workspace:*
+        version: link:../runtime-claude
+      '@gh-symphony/runtime-codex':
+        specifier: workspace:*
+        version: link:../runtime-codex
       '@gh-symphony/tracker-file':
         specifier: workspace:*
         version: link:../tracker-file


### PR DESCRIPTION
## Issues

- Fixes #225
- Follow-up: #254

## Summary

- Adds first-class `runtime:` parsing for `codex-app-server`, `claude-print`, and `custom` workflow runtimes.
- Keeps legacy `codex:` behavior as the fallback path without reverse-mapping legacy commands into runtime presets.
- Addresses the latest review feedback by making `runtime.args` array-only, deduplicating session flags, and documenting the remaining custom/Claude spawn boundary tracked by #254.

## Changes

- Added `WorkflowRuntimeConfig` types, runtime parser validation, effective runtime command/timeout helpers, and parser tests for runtime-only, codex-only, runtime-over-codex priority, invalid kind, hidden session schema behavior, quoted inline arrays, trailing comma errors, non-object `runtime:` errors, nested runtime object/boolean path errors, and array-only `runtime.args` validation.
- Added an orchestrator runtime factory that selects Codex, Claude print, or custom direct command adapters from parsed workflow config; `codex-app-server` runtime args and default command fallback are covered by tests.
- Extended `runtime-claude` argv/config handling so configured args preserve required `claude -p` stream-json protocol flags while `bare`, `strict_mcp_config`, ephemeral MCP config paths, runtime auth env keys, and session flags flow into spawn/credential behavior without duplicate managed flags.
- Deduplicated `--bare`, `--strict-mcp-config`, `--mcp-config`, `--session-id`, `--resume`, and `--fork-session` when already present in configured args, replacing stale managed values with runtime values while preserving adjacent flags.
- Removed custom runtime stdin message exposure so `custom` direct command spawning no longer exposes a Claude wire-protocol input surface; custom turns spawn the configured command/args with empty Claude stdin until #254 separates the spawn abstraction.
- Added explicit comments for intentional `--bare`/`--verbose` coexistence, `ensureFlagValue` value constraints, `SYMPHONY_AGENT_COMMAND` fallback usage, temporary `claudeDependencies` naming, and the remaining custom runtime `ClaudeSpawnTurnResult` coupling tracked by #254.

## Evidence

- `pnpm --filter @gh-symphony/core test -- workflow-loader` (20 passed)
- `pnpm --filter @gh-symphony/runtime-claude test -- argv adapter` (21 passed)
- `pnpm --filter @gh-symphony/orchestrator test -- runtime-factory` (6 passed)
- `pnpm lint && pnpm test && pnpm typecheck && pnpm build`
- Docker E2E TC: `docker compose -f docker-compose.e2e.yml -f docker-compose.e2e.events.yml up -d --build`, inject `e2e/fixtures/happy-path.json`, `POST /api/v1/refresh`, poll `/api/v1/state`; observed active run enter `running`, then `lastEvent: completed` with `retryKind: continuation`; cleanup completed with fixture reset, `docker compose -f docker-compose.e2e.yml down`, and `rm -rf evidence`.
- CI for commit `994810a`: GitHub Actions `Test` and `Container Smoke` passed.

## Human Validation

- [ ] Confirm `WORKFLOW.md` with `runtime.kind: claude-print` launches with the intended Claude command/args in a real runtime environment.
- [ ] Confirm legacy `codex:` workflows still run unchanged in an existing project.
- [ ] Confirm strict MCP config generation path from #219 supplies the expected ephemeral file path in production orchestration.
- [ ] Confirm #254 covers the worker-side non-codex runtime lifecycle and custom spawn abstraction follow-up expected by reviewers.

## Risks

- `runtime-claude` is still constrained by the existing Claude adapter scaffold; this PR wires config selection and argv construction, while worker-side non-codex lifecycle routing and custom spawn abstraction cleanup are tracked separately in #254.

