### PR TITLE
feat(cli): add init runtime selection

### DIFF
--- a/packages/cli/src/commands/init.test.ts
+++ b/packages/cli/src/commands/init.test.ts
@@ -343,6 +343,7 @@ describe("init priority field detection", () => {
       ],
     });
     vi.mocked(p.select)
+      .mockResolvedValueOnce("codex-app-server" as never)
       .mockResolvedValueOnce("project-1" as never)
       .mockResolvedValueOnce("active" as never)
       .mockResolvedValueOnce("active" as never)
@@ -363,7 +364,7 @@ describe("init priority field detection", () => {
         [
           expect.objectContaining({
             message:
-              "Step 3/3 — Multiple GitHub Project priority fields look plausible. Select the one Symphony should use:",
+              "Step 4/4 — Multiple GitHub Project priority fields look plausible. Select the one Symphony should use:",
           }),
         ],
       ])
@@ -683,6 +684,126 @@ describe("init ecosystem generation", () => {
     expect(plan.workflowMd).toContain("Use `uv` conventions");
     expect(plan.ecosystemPlan.files.some((file) => file.path.endsWith("reference-workflow.md"))).toBe(
       true
+    );
+  });
+
+  it("scaffolds codex-app-server runtime defaults into WORKFLOW.md", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "cli-workflow-codex-runtime-"));
+
+    const plan = await planWorkflowArtifacts({
+      cwd,
+      outputPath: join(cwd, "WORKFLOW.md"),
+      projectDetail: MOCK_PROJECT_DETAIL,
+      statusField: MOCK_STATUS_FIELD,
+      priorityField: null,
+      mappings: {
+        Todo: { role: "active" },
+        "In Progress": { role: "active" },
+        Done: { role: "terminal" },
+      },
+      runtime: "codex-app-server",
+      skipSkills: true,
+      skipContext: false,
+    });
+
+    expect(plan.workflowMd).toContain("runtime:");
+    expect(plan.workflowMd).toContain("  kind: codex-app-server");
+    expect(plan.workflowMd).toContain("  command: codex");
+    expect(plan.workflowMd).toContain("    - app-server");
+    expect(plan.workflowMd).toContain("    bare: false");
+    expect(plan.workflowMd).toContain("    strict_mcp_config: false");
+    expect(plan.workflowMd).not.toContain("## Runtime Constraints");
+  });
+
+  it("scaffolds claude-print runtime defaults and constraints into WORKFLOW.md", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "cli-workflow-claude-runtime-"));
+
+    const plan = await planWorkflowArtifacts({
+      cwd,
+      outputPath: join(cwd, "WORKFLOW.md"),
+      projectDetail: MOCK_PROJECT_DETAIL,
+      statusField: MOCK_STATUS_FIELD,
+      priorityField: null,
+      mappings: {
+        Todo: { role: "active" },
+        "In Progress": { role: "active" },
+        Done: { role: "terminal" },
+      },
+      runtime: "claude-print",
+      skipSkills: true,
+      skipContext: false,
+    });
+
+    expect(plan.workflowMd).toContain("  kind: claude-print");
+    expect(plan.workflowMd).toContain("  command: claude");
+    expect(plan.workflowMd).toContain("    - -p");
+    expect(plan.workflowMd).toContain("    - --output-format");
+    expect(plan.workflowMd).toContain("    - stream-json");
+    expect(plan.workflowMd).toContain("    - --permission-mode");
+    expect(plan.workflowMd).toContain("    - bypassPermissions");
+    expect(plan.workflowMd).toContain("    bare: false");
+    expect(plan.workflowMd).toContain("    strict_mcp_config: false");
+    expect(plan.workflowMd).toContain("    env: ANTHROPIC_API_KEY");
+    expect(plan.workflowMd).toContain("## Runtime Constraints");
+    expect(plan.workflowMd).toContain("Runtime trade-off note:");
+  });
+
+  it("prompts for runtime selection and reports preflight during interactive init", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "cli-init-runtime-int-"));
+    const stdout = vi
+      .spyOn(process.stdout, "write")
+      .mockReturnValue(true as never);
+    vi.spyOn(ghAuth, "resolveGitHubAuth").mockResolvedValue({
+      source: "env",
+      login: "env-user",
+      token: "env-token",
+      scopes: ["repo", "read:org", "project"],
+    });
+    vi.spyOn(githubClient, "createClient").mockReturnValue({} as never);
+    vi.spyOn(githubClient, "discoverUserProjects").mockResolvedValue({
+      projects: [
+        {
+          id: "project-1",
+          title: "Roadmap",
+          shortDescription: "",
+          url: "https://github.com/users/tester/projects/1",
+          openItemCount: 3,
+          owner: { login: "tester", type: "User" },
+        },
+      ],
+      partial: false,
+      reason: null,
+      requests: 1,
+    });
+    vi.spyOn(githubClient, "getProjectDetail").mockResolvedValue({
+      ...MOCK_PROJECT_DETAIL,
+      id: "project-1",
+      statusFields: [MOCK_STATUS_FIELD],
+    });
+    vi.mocked(p.select)
+      .mockResolvedValueOnce("claude-print" as never)
+      .mockResolvedValueOnce("project-1" as never)
+      .mockResolvedValueOnce("active" as never)
+      .mockResolvedValueOnce("active" as never)
+      .mockResolvedValueOnce("terminal" as never);
+
+    await initCommand(["--dry-run", "--output", join(configDir, "WORKFLOW.md")], {
+      configDir,
+      verbose: false,
+      json: false,
+      noColor: true,
+    });
+
+    const rendered = stdout.mock.calls.map(([chunk]) => String(chunk)).join("");
+    expect(rendered).toContain("Runtime   claude-print");
+    expect(p.select).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "Step 1/3 — Select the agent runtime:",
+      })
+    );
+    expect(p.note).toHaveBeenCalledWith(
+      expect.stringContaining("Claude auth"),
+      "Runtime preflight — claude-print"
     );
   });
 

--- a/packages/cli/src/commands/init.test.ts
+++ b/packages/cli/src/commands/init.test.ts
@@ -71,6 +71,7 @@ describe("init interactive auth", () => {
   });
 
   afterEach(() => {
+    vi.unstubAllEnvs();
     process.exitCode = undefined;
   });
 
@@ -144,6 +145,28 @@ describe("init interactive auth", () => {
 });
 
 describe("init command config output", () => {
+  afterEach(() => {
+    process.exitCode = undefined;
+  });
+
+  it("rejects unsupported runtime presets in non-interactive mode", async () => {
+    const stderr = vi
+      .spyOn(process.stderr, "write")
+      .mockReturnValue(true as never);
+
+    await initCommand(["--non-interactive", "--runtime", "claud-print"], {
+      configDir: await mkdtemp(join(tmpdir(), "cli-init-runtime-invalid-")),
+      verbose: false,
+      json: false,
+      noColor: true,
+    });
+
+    expect(process.exitCode).toBe(1);
+    expect(stderr).toHaveBeenCalledWith(
+      "Error: Unsupported runtime 'claud-print'. Choose one of: codex-app-server, claude-print.\n"
+    );
+  });
+
   it("writes the simplified project config", async () => {
     const configDir = await mkdtemp(join(tmpdir(), "cli-init-"));
 
@@ -744,6 +767,7 @@ describe("init ecosystem generation", () => {
     expect(plan.workflowMd).toContain("    bare: false");
     expect(plan.workflowMd).toContain("    strict_mcp_config: false");
     expect(plan.workflowMd).toContain("    env: ANTHROPIC_API_KEY");
+    expect(plan.workflowMd).toContain("    stall_timeout_ms: 900000");
     expect(plan.workflowMd).toContain("## Runtime Constraints");
     expect(plan.workflowMd).toContain("Runtime trade-off note:");
   });
@@ -780,6 +804,7 @@ describe("init ecosystem generation", () => {
       id: "project-1",
       statusFields: [MOCK_STATUS_FIELD],
     });
+    vi.stubEnv("ANTHROPIC_API_KEY", "");
     vi.mocked(p.select)
       .mockResolvedValueOnce("claude-print" as never)
       .mockResolvedValueOnce("project-1" as never)
@@ -805,6 +830,11 @@ describe("init ecosystem generation", () => {
       expect.stringContaining("Claude auth"),
       "Runtime preflight — claude-print"
     );
+    expect(p.note).toHaveBeenCalledWith(
+      expect.stringContaining("FAIL Claude auth"),
+      "Runtime preflight — claude-print"
+    );
+    vi.unstubAllEnvs();
   });
 
   it("generates codex skills when runtime is the codex agent command", async () => {
@@ -828,6 +858,27 @@ describe("init ecosystem generation", () => {
     expect(skill).toContain("name: gh-symphony");
     expect(skill).toContain("description: Design, refine, and validate");
     expect(skill).toContain("gh-symphony");
+  });
+
+  it("does not double-wrap shell commands in context.yaml", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "cli-eco-shell-command-"));
+
+    await writeEcosystem({
+      cwd,
+      projectDetail: MOCK_PROJECT_DETAIL,
+      statusField: MOCK_STATUS_FIELD,
+      priorityField: null,
+      runtime: "bash -lc codex app-server",
+      skipSkills: true,
+      skipContext: false,
+    });
+
+    const contextYaml = await readFile(
+      join(cwd, ".gh-symphony", "context.yaml"),
+      "utf8"
+    );
+    expect(contextYaml).toContain("agent_command: bash -lc codex app-server");
+    expect(contextYaml).not.toContain("agent_command: bash -lc bash -lc");
   });
 
   it("generates frontmatter for all scaffolded codex skills", async () => {

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,4 +1,5 @@
 import * as p from "@clack/prompts";
+import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { chmod, mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { basename, dirname, join, relative, resolve } from "node:path";
@@ -51,6 +52,13 @@ import {
 import { generateReferenceWorkflow } from "../workflow/generate-reference-workflow.js";
 import { buildSkillFilePlans, resolveSkillsDir } from "../skills/skill-writer.js";
 import { ALL_SKILL_TEMPLATES } from "../skills/templates/index.js";
+import {
+  isClaudeRuntime,
+  normalizeInitRuntime,
+  resolveRuntimeAgentCommand,
+  resolveRuntimeCommand,
+  type InitRuntimeKind,
+} from "../workflow/workflow-runtime.js";
 
 // ── Scope error display ───────────────────────────────────────────────────────
 
@@ -113,6 +121,7 @@ type InitFlags = {
   nonInteractive: boolean;
   project?: string;
   output?: string;
+  runtime?: string;
   skipSkills: boolean;
   skipContext: boolean;
 };
@@ -141,6 +150,10 @@ function parseInitFlags(args: string[]): InitFlags {
         break;
       case "--output":
         flags.output = next;
+        i += 1;
+        break;
+      case "--runtime":
+        flags.runtime = next;
         i += 1;
         break;
       case "--skip-skills":
@@ -172,6 +185,78 @@ const handler = async (
 };
 
 export default handler;
+
+// ── Runtime selection and preflight ─────────────────────────────────────────
+
+function resolveInitRuntime(runtime: string | undefined): string {
+  return normalizeInitRuntime(runtime ?? "codex-app-server");
+}
+
+async function promptRuntimeSelection(): Promise<InitRuntimeKind> {
+  return abortIfCancelled(
+    p.select({
+      message: "Step 1/3 — Select the agent runtime:",
+      options: [
+        {
+          value: "codex-app-server",
+          label: "codex-app-server",
+          hint: "Codex app-server JSON-RPC runtime",
+        },
+        {
+          value: "claude-print",
+          label: "claude-print",
+          hint: "Claude Code non-interactive stream-json runtime",
+        },
+      ],
+    })
+  );
+}
+
+function commandRuns(binary: string, args: string[]): boolean {
+  const result = spawnSync(binary, args, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  return result.error === undefined && result.status === 0;
+}
+
+function runRuntimePreflight(runtime: string): void {
+  const command = resolveRuntimeCommand(runtime);
+  const checks: Array<{ label: string; ok: boolean; detail: string }> = [];
+  const versionOk = commandRuns(command, ["--version"]);
+  checks.push({
+    label: "Runtime binary",
+    ok: versionOk,
+    detail: versionOk
+      ? `${command} is available on PATH.`
+      : `${command} was not found or did not run with --version.`,
+  });
+
+  if (isClaudeRuntime(runtime)) {
+    const hasAnthropicKey = Boolean(process.env.ANTHROPIC_API_KEY);
+    checks.push({
+      label: "Claude auth",
+      ok: hasAnthropicKey,
+      detail: hasAnthropicKey
+        ? "ANTHROPIC_API_KEY is set."
+        : "ANTHROPIC_API_KEY is not set. Set it before running Claude workers.",
+    });
+  }
+
+  const okIcon = "OK";
+  const failIcon = "CHECK";
+  const lines = checks.map(
+    (check) =>
+      `${check.ok ? okIcon : failIcon} ${check.label.padEnd(16)} ${check.detail}`
+  );
+  p.note(lines.join("\n"), `Runtime preflight — ${runtime}`);
+
+  if (checks.some((check) => !check.ok)) {
+    p.log.warn(
+      "Runtime preflight found missing local prerequisites. Generated files still include the selected runtime defaults."
+    );
+  }
+}
 
 // ── Ecosystem file generation ────────────────────────────────────────────────
 
@@ -531,12 +616,7 @@ export async function planEcosystem(
       detectedEnvironment: environment,
       runtime: {
         agent: runtime,
-        agent_command:
-          runtime === "codex"
-            ? "bash -lc codex app-server"
-            : runtime === "claude-code"
-              ? "bash -lc claude-code"
-              : runtime,
+        agent_command: `bash -lc ${resolveRuntimeAgentCommand(runtime)}`,
       },
     });
     files.push(
@@ -719,7 +799,12 @@ function printEcosystemSummary(
     for (const name of result.skillsSkipped) {
       lines.push(`  – ${name}  (already exists, skipped)`);
     }
-  } else if (result.runtime !== "codex" && result.runtime !== "claude-code") {
+  } else if (
+    result.runtime !== "codex-app-server" &&
+    result.runtime !== "codex" &&
+    result.runtime !== "claude-print" &&
+    result.runtime !== "claude-code"
+  ) {
     lines.push("");
     lines.push("Skills  →  (skipped — custom runtime)");
   }
@@ -897,6 +982,7 @@ async function runNonInteractive(
   }
 
   const outputPath = resolve(flags.output ?? "WORKFLOW.md");
+  const runtime = resolveInitRuntime(flags.runtime);
   const { workflowPlan, ecosystemPlan } = await planWorkflowArtifacts({
     cwd: process.cwd(),
     outputPath,
@@ -904,7 +990,7 @@ async function runNonInteractive(
     statusField,
     priorityField: autoPriorityField,
     mappings,
-    runtime: "codex",
+    runtime,
     skipSkills: flags.skipSkills,
     skipContext: flags.skipContext,
   });
@@ -929,7 +1015,7 @@ async function runNonInteractive(
     projectDetail: githubProject,
     statusField,
     priorityField: autoPriorityField,
-    runtime: "codex",
+    runtime,
     skipSkills: flags.skipSkills,
     skipContext: flags.skipContext,
   });
@@ -984,7 +1070,7 @@ async function runInteractiveStandalone(
     return;
   }
 
-  // Step 1/2: Project selection
+  // Project selection
   const s2 = p.spinner();
   s2.start("Loading projects...");
   let projects: ProjectSummary[];
@@ -1014,9 +1100,12 @@ async function runInteractiveStandalone(
     return;
   }
 
+  const runtime = await promptRuntimeSelection();
+  runRuntimePreflight(runtime);
+
   const selectedGithubProjectId = await abortIfCancelled(
     p.select({
-      message: "Step 1/2 — Select a GitHub Project board:",
+      message: "Step 2/3 — Select a GitHub Project board:",
       options: projects.map((proj) => ({
         value: proj.id,
         label: `${proj.owner.login}/${proj.title}`,
@@ -1053,12 +1142,12 @@ async function runInteractiveStandalone(
   const priorityResolution = resolvePriorityField(projectDetail, statusField);
   const mappings = await promptStateMappings(statusField, {
     stepLabel:
-      priorityResolution.ambiguous.length > 0 ? "Step 2/3" : "Step 2/2",
+      priorityResolution.ambiguous.length > 0 ? "Step 3/4" : "Step 3/3",
   });
   let priorityField = priorityResolution.field;
   if (priorityResolution.ambiguous.length > 0) {
     priorityField = await promptPriorityField(priorityResolution.ambiguous, {
-      stepLabel: "Step 3/3",
+      stepLabel: "Step 4/4",
     });
   }
 
@@ -1083,7 +1172,7 @@ async function runInteractiveStandalone(
     statusField,
     priorityField,
     mappings,
-    runtime: "codex",
+    runtime,
     skipSkills: flags.skipSkills,
     skipContext: flags.skipContext,
   });
@@ -1100,7 +1189,7 @@ async function runInteractiveStandalone(
     projectDetail,
     statusField,
     priorityField,
-    runtime: "codex",
+    runtime,
     skipSkills: flags.skipSkills,
     skipContext: flags.skipContext,
   });

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -55,8 +55,9 @@ import { ALL_SKILL_TEMPLATES } from "../skills/templates/index.js";
 import {
   isClaudeRuntime,
   normalizeInitRuntime,
-  resolveRuntimeAgentCommand,
   resolveRuntimeCommand,
+  resolveShellAgentCommand,
+  isSupportedInitRuntime,
   type InitRuntimeKind,
 } from "../workflow/workflow-runtime.js";
 
@@ -192,6 +193,13 @@ function resolveInitRuntime(runtime: string | undefined): string {
   return normalizeInitRuntime(runtime ?? "codex-app-server");
 }
 
+function validateInitRuntime(runtime: string): string | null {
+  if (isSupportedInitRuntime(runtime)) {
+    return null;
+  }
+  return `Unsupported runtime '${runtime}'. Choose one of: codex-app-server, claude-print.`;
+}
+
 async function promptRuntimeSelection(): Promise<InitRuntimeKind> {
   return abortIfCancelled(
     p.select({
@@ -216,6 +224,7 @@ function commandRuns(binary: string, args: string[]): boolean {
   const result = spawnSync(binary, args, {
     encoding: "utf8",
     stdio: ["ignore", "pipe", "pipe"],
+    timeout: 3000,
   });
   return result.error === undefined && result.status === 0;
 }
@@ -244,7 +253,7 @@ function runRuntimePreflight(runtime: string): void {
   }
 
   const okIcon = "OK";
-  const failIcon = "CHECK";
+  const failIcon = "FAIL";
   const lines = checks.map(
     (check) =>
       `${check.ok ? okIcon : failIcon} ${check.label.padEnd(16)} ${check.detail}`
@@ -277,6 +286,7 @@ export type EcosystemResult = {
   runtime: string;
   priorityFieldName: string | null;
   skillsDir: string | null;
+  skipSkills: boolean;
   afterCreateHookWritten: boolean;
   contextYamlWritten: boolean;
   referenceWorkflowWritten: boolean;
@@ -302,6 +312,7 @@ export type EcosystemPlan = {
   runtime: string;
   priorityFieldName: string | null;
   skillsDir: string | null;
+  skipSkills: boolean;
   environment: Awaited<ReturnType<typeof detectEnvironment>>;
   files: PlannedFileChange[];
 };
@@ -616,7 +627,7 @@ export async function planEcosystem(
       detectedEnvironment: environment,
       runtime: {
         agent: runtime,
-        agent_command: `bash -lc ${resolveRuntimeAgentCommand(runtime)}`,
+        agent_command: resolveShellAgentCommand(runtime),
       },
     });
     files.push(
@@ -692,6 +703,7 @@ export async function planEcosystem(
     runtime,
     priorityFieldName: priorityField?.name ?? null,
     skillsDir,
+    skipSkills,
     environment,
     files,
   };
@@ -746,6 +758,7 @@ export async function writeEcosystem(
     runtime: plan.runtime,
     priorityFieldName: plan.priorityFieldName,
     skillsDir: plan.skillsDir,
+    skipSkills: plan.skipSkills,
     afterCreateHookWritten,
     contextYamlWritten,
     referenceWorkflowWritten,
@@ -799,12 +812,7 @@ function printEcosystemSummary(
     for (const name of result.skillsSkipped) {
       lines.push(`  – ${name}  (already exists, skipped)`);
     }
-  } else if (
-    result.runtime !== "codex-app-server" &&
-    result.runtime !== "codex" &&
-    result.runtime !== "claude-print" &&
-    result.runtime !== "claude-code"
-  ) {
+  } else if (!result.skipSkills) {
     lines.push("");
     lines.push("Skills  →  (skipped — custom runtime)");
   }
@@ -899,6 +907,14 @@ async function runNonInteractive(
   flags: InitFlags,
   options: GlobalOptions
 ): Promise<void> {
+  const runtime = resolveInitRuntime(flags.runtime);
+  const runtimeError = validateInitRuntime(runtime);
+  if (runtimeError) {
+    process.stderr.write(`Error: ${runtimeError}\n`);
+    process.exitCode = 1;
+    return;
+  }
+
   let token: string;
   try {
     token = getGhTokenWithSource().token;
@@ -982,7 +998,6 @@ async function runNonInteractive(
   }
 
   const outputPath = resolve(flags.output ?? "WORKFLOW.md");
-  const runtime = resolveInitRuntime(flags.runtime);
   const { workflowPlan, ecosystemPlan } = await planWorkflowArtifacts({
     cwd: process.cwd(),
     outputPath,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -59,6 +59,7 @@ type CliOptionValues = Partial<
     projectId?: string;
     prune?: boolean;
     run?: string;
+    runtime?: string;
     skipContext?: boolean;
     skipSkills?: boolean;
     version?: boolean;
@@ -196,6 +197,7 @@ function createProgram(): { program: Command; wasInvoked: () => boolean } {
       .option("--non-interactive", "Run without prompts")
       .option("--project <id>", "GitHub Project ID or URL")
       .option("--output <path>", "Write WORKFLOW.md to a custom path")
+      .option("--runtime <kind>", "Runtime preset: codex-app-server or claude-print")
       .option("--skip-skills", "Skip runtime skill generation")
       .option("--skip-context", "Skip .gh-symphony/context.yaml generation")
       .option("--dry-run", "Preview generated files without writing them")
@@ -207,6 +209,7 @@ function createProgram(): { program: Command; wasInvoked: () => boolean } {
     pushOption(args, "--non-interactive", values.nonInteractive);
     pushOption(args, "--project", values.project);
     pushOption(args, "--output", values.output);
+    pushOption(args, "--runtime", values.runtime);
     pushOption(args, "--skip-skills", values.skipSkills);
     pushOption(args, "--skip-context", values.skipContext);
     pushOption(args, "--dry-run", values.dryRun);
@@ -233,6 +236,7 @@ function createProgram(): { program: Command; wasInvoked: () => boolean } {
       .option("--non-interactive", "Run without prompts")
       .option("--project <id>", "GitHub Project ID or URL")
       .option("--output <path>", "Write WORKFLOW.md to a custom path")
+      .option("--runtime <kind>", "Runtime preset: codex-app-server or claude-print")
       .option("--skip-skills", "Skip runtime skill generation")
       .option("--skip-context", "Skip .gh-symphony/context.yaml generation")
       .option("--dry-run", "Preview generated files without writing them")
@@ -244,6 +248,7 @@ function createProgram(): { program: Command; wasInvoked: () => boolean } {
     pushOption(args, "--non-interactive", values.nonInteractive);
     pushOption(args, "--project", values.project);
     pushOption(args, "--output", values.output);
+    pushOption(args, "--runtime", values.runtime);
     pushOption(args, "--skip-skills", values.skipSkills);
     pushOption(args, "--skip-context", values.skipContext);
     pushOption(args, "--dry-run", values.dryRun);

--- a/packages/cli/src/prompts/runtime-claude-constraints.ts
+++ b/packages/cli/src/prompts/runtime-claude-constraints.ts
@@ -1,6 +1,6 @@
 export const CLAUDE_RUNTIME_CONSTRAINTS_SECTION = `## Runtime Constraints
 
-1. This run uses \`claude-code\` (Claude Code CLI) in non-interactive mode via \`claude -p\`.
+1. This run uses \`claude-print\` (Claude Code CLI) in non-interactive mode via \`claude -p\`.
 2. Slash commands such as \`/commit\`, \`/push\`, \`/gh-project\`, \`/gh-pr-writeup\` are NOT available (CLI limitation, independent of isolation settings).
 3. Use \`gh\`, \`git\`, repository scripts, and configured MCP tools directly instead.
 4. If a required permission or tool is unavailable, post a blocker comment on the issue and exit. Do not wait for human input.`;

--- a/packages/cli/src/skills/skill-writer.test.ts
+++ b/packages/cli/src/skills/skill-writer.test.ts
@@ -24,8 +24,18 @@ describe("skill-writer", () => {
       expect(result).toBe(join("/repo", ".claude", "skills"));
     });
 
+    it("resolves claude-print runtime to .claude/skills", () => {
+      const result = resolveSkillsDir("/repo", "claude-print");
+      expect(result).toBe(join("/repo", ".claude", "skills"));
+    });
+
     it("resolves codex runtime to .codex/skills", () => {
       const result = resolveSkillsDir("/repo", "codex");
+      expect(result).toBe(join("/repo", ".codex", "skills"));
+    });
+
+    it("resolves codex-app-server runtime to .codex/skills", () => {
+      const result = resolveSkillsDir("/repo", "codex-app-server");
       expect(result).toBe(join("/repo", ".codex", "skills"));
     });
 

--- a/packages/cli/src/skills/skill-writer.test.ts
+++ b/packages/cli/src/skills/skill-writer.test.ts
@@ -49,6 +49,12 @@ describe("skill-writer", () => {
       expect(result).toBe(join("/repo", ".claude", "skills"));
     });
 
+    it("does not resolve substring-only runtime names to skill dirs", () => {
+      expect(resolveSkillsDir("/repo", "my-claude-fork")).toBeNull();
+      expect(resolveSkillsDir("/repo", "claudette-runner")).toBeNull();
+      expect(resolveSkillsDir("/repo", "my-codex-fork")).toBeNull();
+    });
+
     it("returns null for unknown runtime", () => {
       const result = resolveSkillsDir("/repo", "unknown");
       expect(result).toBeNull();

--- a/packages/cli/src/skills/skill-writer.ts
+++ b/packages/cli/src/skills/skill-writer.ts
@@ -1,5 +1,6 @@
 import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { join } from "node:path";
+import { isClaudeRuntime, isCodexRuntime } from "../workflow/workflow-runtime.js";
 import type { SkillTemplate, SkillTemplateContext } from "./types.js";
 
 export type SkillFilePlan = {
@@ -10,19 +11,10 @@ export type SkillFilePlan = {
 function normalizeRuntimeForSkills(
   runtime: string
 ): "claude-code" | "codex" | null {
-  if (
-    runtime === "claude-print" ||
-    runtime === "claude-code" ||
-    runtime.includes("claude-code") ||
-    runtime.includes("claude")
-  ) {
+  if (isClaudeRuntime(runtime)) {
     return "claude-code";
   }
-  if (
-    runtime === "codex-app-server" ||
-    runtime === "codex" ||
-    runtime.includes("codex")
-  ) {
+  if (isCodexRuntime(runtime)) {
     return "codex";
   }
   return null;

--- a/packages/cli/src/skills/skill-writer.ts
+++ b/packages/cli/src/skills/skill-writer.ts
@@ -10,10 +10,19 @@ export type SkillFilePlan = {
 function normalizeRuntimeForSkills(
   runtime: string
 ): "claude-code" | "codex" | null {
-  if (runtime === "claude-code" || runtime.includes("claude-code")) {
+  if (
+    runtime === "claude-print" ||
+    runtime === "claude-code" ||
+    runtime.includes("claude-code") ||
+    runtime.includes("claude")
+  ) {
     return "claude-code";
   }
-  if (runtime === "codex" || runtime.includes("codex")) {
+  if (
+    runtime === "codex-app-server" ||
+    runtime === "codex" ||
+    runtime.includes("codex")
+  ) {
     return "codex";
   }
   return null;

--- a/packages/cli/src/workflow/generate-reference-workflow.test.ts
+++ b/packages/cli/src/workflow/generate-reference-workflow.test.ts
@@ -46,6 +46,7 @@ describe("generateReferenceWorkflow", () => {
     expect(output).toContain("kind: claude-print");
     expect(output).toContain("command: claude");
     expect(output).toContain("    env: ANTHROPIC_API_KEY");
+    expect(output).toContain("    stall_timeout_ms: 900000");
   });
 
   it("custom runtime string is used as codex.command verbatim", () => {

--- a/packages/cli/src/workflow/generate-reference-workflow.test.ts
+++ b/packages/cli/src/workflow/generate-reference-workflow.test.ts
@@ -9,7 +9,7 @@ import {
 } from "./generate-reference-workflow.js";
 
 const defaultInput: ReferenceWorkflowInput = {
-  runtime: "codex",
+  runtime: "codex-app-server",
   statusColumns: [
     { name: "Todo", role: "active" },
     { name: "In Progress", role: "active" },
@@ -28,20 +28,24 @@ const defaultInput: ReferenceWorkflowInput = {
 };
 
 describe("generateReferenceWorkflow", () => {
-  it("codex runtime produces codex.command containing codex", () => {
+  it("codex runtime produces a codex-app-server runtime block", () => {
     const output = generateReferenceWorkflow({
       ...defaultInput,
-      runtime: "codex",
+      runtime: "codex-app-server",
     });
-    expect(output).toContain("command: codex app-server");
+    expect(output).toContain("kind: codex-app-server");
+    expect(output).toContain("command: codex");
+    expect(output).toContain("    - app-server");
   });
 
-  it("claude-code runtime produces codex.command containing claude-code", () => {
+  it("claude-print runtime produces a claude-print runtime block", () => {
     const output = generateReferenceWorkflow({
       ...defaultInput,
-      runtime: "claude-code",
+      runtime: "claude-print",
     });
-    expect(output).toContain("command: claude-code");
+    expect(output).toContain("kind: claude-print");
+    expect(output).toContain("command: claude");
+    expect(output).toContain("    env: ANTHROPIC_API_KEY");
   });
 
   it("custom runtime string is used as codex.command verbatim", () => {

--- a/packages/cli/src/workflow/generate-reference-workflow.ts
+++ b/packages/cli/src/workflow/generate-reference-workflow.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_AFTER_CREATE_HOOK_PATH,
 } from "./default-hooks.js";
 import { buildRepositoryValidationGuidance } from "./repository-guidance.js";
+import { buildRuntimeFrontMatter } from "./workflow-runtime.js";
 
 export type ReferenceWorkflowInput = {
   runtime: "codex" | "claude-code" | string;
@@ -85,7 +86,6 @@ export function generateReferenceWorkflow(
 
   lines.push("");
 
-  const agentCommand = resolveAgentCommand(input.runtime);
   lines.push("polling:");
   lines.push("  interval_ms: 30000");
   lines.push("");
@@ -111,11 +111,7 @@ export function generateReferenceWorkflow(
   lines.push("  max_turns: 20");
   lines.push("");
 
-  lines.push("codex:");
-  lines.push(`  command: ${agentCommand}`);
-  lines.push("  read_timeout_ms: 5000");
-  lines.push("  turn_timeout_ms: 3600000");
-  lines.push("  stall_timeout_ms: 300000");
+  lines.push(...buildRuntimeFrontMatter(input.runtime));
   lines.push("");
 
   lines.push("---");
@@ -375,16 +371,6 @@ export function generateReferenceWorkflow(
   return lines.join("\n");
 }
 
-function resolveAgentCommand(runtime: string): string {
-  switch (runtime) {
-    case "codex":
-      return "codex app-server";
-    case "claude-code":
-      return "claude-code";
-    default:
-      return runtime;
-  }
-}
 
 function resolveRoleAction(
   role: "active" | "wait" | "terminal" | null

--- a/packages/cli/src/workflow/generate-workflow-md.test.ts
+++ b/packages/cli/src/workflow/generate-workflow-md.test.ts
@@ -115,6 +115,7 @@ describe("generateWorkflowMarkdown", () => {
     expect(markdown).toContain("command: claude");
     expect(markdown).toContain("    - -p");
     expect(markdown).toContain("    env: ANTHROPIC_API_KEY");
+    expect(markdown).toContain("    stall_timeout_ms: 900000");
   });
 
   it("prepends Claude runtime constraints and trade-off comments to the prompt body", () => {
@@ -147,6 +148,20 @@ describe("generateWorkflowMarkdown", () => {
     const parsed = parseWorkflowMarkdown(markdown, {});
 
     expect(markdown).toContain("kind: claude-print");
+    expect(
+      parsed.promptTemplate.startsWith(CLAUDE_RUNTIME_PROMPT_PREAMBLE)
+    ).toBe(true);
+  });
+
+  it("prepends Claude runtime constraints for wrapped claude-code commands", () => {
+    const markdown = generateWorkflowMarkdown({
+      ...defaultInput,
+      runtime: "bash -lc claude-code",
+    });
+    const parsed = parseWorkflowMarkdown(markdown, {});
+
+    expect(markdown).toContain("kind: custom");
+    expect(markdown).toContain("command: bash -lc claude-code");
     expect(
       parsed.promptTemplate.startsWith(CLAUDE_RUNTIME_PROMPT_PREAMBLE)
     ).toBe(true);

--- a/packages/cli/src/workflow/generate-workflow-md.test.ts
+++ b/packages/cli/src/workflow/generate-workflow-md.test.ts
@@ -26,7 +26,7 @@ describe("generateWorkflowMarkdown", () => {
       terminalStates: ["Done"],
       blockerCheckStates: ["Queued"],
     },
-    runtime: "codex",
+    runtime: "codex-app-server",
     detectedEnvironment: {
       packageManager: "pnpm" as const,
       testCommand: "pnpm test",
@@ -100,22 +100,27 @@ describe("generateWorkflowMarkdown", () => {
   it("resolves runtime agent command for codex", () => {
     const markdown = generateWorkflowMarkdown(defaultInput);
 
-    expect(markdown).toContain("command: codex app-server");
+    expect(markdown).toContain("kind: codex-app-server");
+    expect(markdown).toContain("command: codex");
+    expect(markdown).toContain("    - app-server");
   });
 
-  it("resolves runtime agent command for claude-code", () => {
+  it("resolves runtime config for claude-print", () => {
     const markdown = generateWorkflowMarkdown({
       ...defaultInput,
-      runtime: "claude-code",
+      runtime: "claude-print",
     });
 
-    expect(markdown).toContain("command: claude-code");
+    expect(markdown).toContain("kind: claude-print");
+    expect(markdown).toContain("command: claude");
+    expect(markdown).toContain("    - -p");
+    expect(markdown).toContain("    env: ANTHROPIC_API_KEY");
   });
 
   it("prepends Claude runtime constraints and trade-off comments to the prompt body", () => {
     const markdown = generateWorkflowMarkdown({
       ...defaultInput,
-      runtime: "claude-code",
+      runtime: "claude-print",
     });
     const parsed = parseWorkflowMarkdown(markdown, {});
 
@@ -124,7 +129,7 @@ describe("generateWorkflowMarkdown", () => {
     ).toBe(true);
     expect(parsed.promptTemplate).toContain(CLAUDE_RUNTIME_CONSTRAINTS_SECTION);
     expect(parsed.promptTemplate).toContain(
-      "This run uses `claude-code` (Claude Code CLI) in non-interactive mode via `claude -p`."
+      "This run uses `claude-print` (Claude Code CLI) in non-interactive mode via `claude -p`."
     );
     expect(parsed.promptTemplate).toContain(CLAUDE_PERMISSIVE_ISOLATION_NOTE);
     expect(parsed.promptTemplate).toContain(CLAUDE_ISOLATION_OFF_NOTE);
@@ -134,14 +139,14 @@ describe("generateWorkflowMarkdown", () => {
     ).toBeLessThan(parsed.promptTemplate.indexOf("## Status Map"));
   });
 
-  it("prepends Claude runtime constraints for wrapped Claude command strings", () => {
+  it("prepends Claude runtime constraints for legacy claude-code runtime aliases", () => {
     const markdown = generateWorkflowMarkdown({
       ...defaultInput,
-      runtime: "bash -lc claude-code",
+      runtime: "claude-code",
     });
     const parsed = parseWorkflowMarkdown(markdown, {});
 
-    expect(markdown).toContain("command: bash -lc claude-code");
+    expect(markdown).toContain("kind: claude-print");
     expect(
       parsed.promptTemplate.startsWith(CLAUDE_RUNTIME_PROMPT_PREAMBLE)
     ).toBe(true);
@@ -151,7 +156,7 @@ describe("generateWorkflowMarkdown", () => {
     const codexMarkdown = generateWorkflowMarkdown(defaultInput);
     const claudeMarkdown = generateWorkflowMarkdown({
       ...defaultInput,
-      runtime: "claude-code",
+      runtime: "claude-print",
     });
     const codexPrompt = parseWorkflowMarkdown(codexMarkdown, {}).promptTemplate;
     const claudePrompt = parseWorkflowMarkdown(
@@ -175,6 +180,7 @@ describe("generateWorkflowMarkdown", () => {
     });
     const parsed = parseWorkflowMarkdown(markdown, {});
 
+    expect(markdown).toContain("kind: custom");
     expect(markdown).toContain("command: node worker.js");
     expect(parsed.promptTemplate.startsWith("## Status Map")).toBe(true);
     expect(parsed.promptTemplate).not.toContain("## Runtime Constraints");
@@ -190,6 +196,7 @@ describe("generateWorkflowMarkdown", () => {
       });
       const parsed = parseWorkflowMarkdown(markdown, {});
 
+      expect(markdown).toContain("kind: custom");
       expect(markdown).toContain(`command: ${runtime}`);
       expect(parsed.promptTemplate.startsWith("## Status Map")).toBe(true);
       expect(parsed.promptTemplate).not.toContain("## Runtime Constraints");

--- a/packages/cli/src/workflow/generate-workflow-md.ts
+++ b/packages/cli/src/workflow/generate-workflow-md.ts
@@ -4,6 +4,10 @@ import type { DetectedEnvironment } from "../detection/environment-detector.js";
 import { CLAUDE_RUNTIME_PROMPT_PREAMBLE } from "../prompts/runtime-claude-constraints.js";
 import { DEFAULT_AFTER_CREATE_HOOK_PATH } from "./default-hooks.js";
 import { buildRepositoryValidationGuidance } from "./repository-guidance.js";
+import {
+  buildRuntimeFrontMatter,
+  isClaudeRuntime,
+} from "./workflow-runtime.js";
 
 export type GenerateWorkflowInput = {
   projectId: string;
@@ -62,7 +66,6 @@ function buildFrontMatter(input: GenerateWorkflowInput): string {
     }
   }
 
-  const agentCommand = resolveAgentCommand(input.runtime);
   lines.push("polling:");
   lines.push(`  interval_ms: ${input.pollIntervalMs ?? 30000}`);
 
@@ -77,23 +80,9 @@ function buildFrontMatter(input: GenerateWorkflowInput): string {
   lines.push("  max_retry_backoff_ms: 30000");
   lines.push("  retry_base_delay_ms: 10000");
 
-  lines.push("codex:");
-  lines.push(`  command: ${agentCommand}`);
-  lines.push("  read_timeout_ms: 5000");
-  lines.push("  turn_timeout_ms: 3600000");
+  lines.push(...buildRuntimeFrontMatter(input.runtime));
 
   return lines.join("\n") + "\n";
-}
-
-function resolveAgentCommand(runtime: string): string {
-  switch (runtime) {
-    case "codex":
-      return "codex app-server";
-    case "claude-code":
-      return "claude-code";
-    default:
-      return runtime;
-  }
 }
 
 function buildPromptBody(input: GenerateWorkflowInput): string {
@@ -168,9 +157,7 @@ Create a workpad comment on the issue with the following structure to track prog
 }
 
 function buildRuntimePromptPreamble(runtime: string): string {
-  return runtime.split(/\s+/).includes("claude-code")
-    ? CLAUDE_RUNTIME_PROMPT_PREAMBLE
-    : "";
+  return isClaudeRuntime(runtime) ? CLAUDE_RUNTIME_PROMPT_PREAMBLE : "";
 }
 
 function generateStatusMapWithDescriptions(

--- a/packages/cli/src/workflow/workflow-runtime.test.ts
+++ b/packages/cli/src/workflow/workflow-runtime.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import {
+  isClaudeRuntime,
+  resolveShellAgentCommand,
+} from "./workflow-runtime.js";
+
+describe("workflow runtime helpers", () => {
+  it("keeps shell-wrapped runtime commands unchanged", () => {
+    expect(resolveShellAgentCommand("bash -lc codex app-server")).toBe(
+      "bash -lc codex app-server"
+    );
+  });
+
+  it("wraps supported preset commands for context metadata", () => {
+    expect(resolveShellAgentCommand("codex-app-server")).toBe(
+      "bash -lc codex app-server"
+    );
+    expect(resolveShellAgentCommand("claude-print")).toBe(
+      "bash -lc claude -p --output-format stream-json --input-format stream-json --include-partial-messages --verbose --permission-mode bypassPermissions"
+    );
+  });
+
+  it("leaves custom runtime commands unwrapped", () => {
+    expect(resolveShellAgentCommand("node worker.js")).toBe("node worker.js");
+  });
+
+  it("matches wrapped Claude commands without broad substring matching", () => {
+    expect(isClaudeRuntime("bash -lc claude-code")).toBe(true);
+    expect(isClaudeRuntime("my-claude-code-wrapper")).toBe(false);
+  });
+});

--- a/packages/cli/src/workflow/workflow-runtime.ts
+++ b/packages/cli/src/workflow/workflow-runtime.ts
@@ -1,5 +1,8 @@
 export type InitRuntimeKind = "codex-app-server" | "claude-print";
 
+const CODEX_RUNTIME_TOKENS = ["codex-app-server", "codex"] as const;
+const CLAUDE_RUNTIME_TOKENS = ["claude-print", "claude-code"] as const;
+
 export const DEFAULT_CODEX_APP_SERVER_ARGS = ["app-server"] as const;
 
 export const DEFAULT_CLAUDE_PRINT_ARGS = [
@@ -24,12 +27,35 @@ export function normalizeInitRuntime(runtime: string): InitRuntimeKind | string 
   return runtime;
 }
 
+export function isSupportedInitRuntime(runtime: string): boolean {
+  const normalized = normalizeInitRuntime(runtime);
+  return normalized === "codex-app-server" || normalized === "claude-print";
+}
+
+function containsRuntimeToken(
+  runtime: string,
+  tokens: readonly string[]
+): boolean {
+  return tokens.some((token) => {
+    const escaped = token.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    return new RegExp(`(^|[\\s"'\\\`])${escaped}(?=$|[\\s"'\\\`])`).test(
+      runtime
+    );
+  });
+}
+
 export function isCodexRuntime(runtime: string): boolean {
-  return normalizeInitRuntime(runtime) === "codex-app-server";
+  return (
+    normalizeInitRuntime(runtime) === "codex-app-server" ||
+    containsRuntimeToken(runtime, CODEX_RUNTIME_TOKENS)
+  );
 }
 
 export function isClaudeRuntime(runtime: string): boolean {
-  return normalizeInitRuntime(runtime) === "claude-print";
+  return (
+    normalizeInitRuntime(runtime) === "claude-print" ||
+    containsRuntimeToken(runtime, CLAUDE_RUNTIME_TOKENS)
+  );
 }
 
 export function resolveRuntimeCommand(runtime: string): string {
@@ -58,6 +84,17 @@ export function resolveRuntimeAgentCommand(runtime: string): string {
   const command = resolveRuntimeCommand(runtime);
   const args = resolveRuntimeArgs(runtime);
   return args.length === 0 ? command : [command, ...args].join(" ");
+}
+
+export function resolveShellAgentCommand(runtime: string): string {
+  if (/^\s*bash\s+-lc\s+/.test(runtime)) {
+    return runtime;
+  }
+  const normalized = normalizeInitRuntime(runtime);
+  if (normalized === "codex-app-server" || normalized === "claude-print") {
+    return `bash -lc ${resolveRuntimeAgentCommand(normalized)}`;
+  }
+  return runtime;
 }
 
 export function buildRuntimeFrontMatter(runtime: string): string[] {
@@ -95,7 +132,7 @@ export function buildRuntimeFrontMatter(runtime: string): string[] {
       "  timeouts:",
       "    read_timeout_ms: 5000",
       "    turn_timeout_ms: 3600000",
-      "    stall_timeout_ms: 300000",
+      "    stall_timeout_ms: 900000",
     ];
   }
 

--- a/packages/cli/src/workflow/workflow-runtime.ts
+++ b/packages/cli/src/workflow/workflow-runtime.ts
@@ -1,0 +1,114 @@
+export type InitRuntimeKind = "codex-app-server" | "claude-print";
+
+export const DEFAULT_CODEX_APP_SERVER_ARGS = ["app-server"] as const;
+
+export const DEFAULT_CLAUDE_PRINT_ARGS = [
+  "-p",
+  "--output-format",
+  "stream-json",
+  "--input-format",
+  "stream-json",
+  "--include-partial-messages",
+  "--verbose",
+  "--permission-mode",
+  "bypassPermissions",
+] as const;
+
+export function normalizeInitRuntime(runtime: string): InitRuntimeKind | string {
+  if (runtime === "codex") {
+    return "codex-app-server";
+  }
+  if (runtime === "claude-code") {
+    return "claude-print";
+  }
+  return runtime;
+}
+
+export function isCodexRuntime(runtime: string): boolean {
+  return normalizeInitRuntime(runtime) === "codex-app-server";
+}
+
+export function isClaudeRuntime(runtime: string): boolean {
+  return normalizeInitRuntime(runtime) === "claude-print";
+}
+
+export function resolveRuntimeCommand(runtime: string): string {
+  const normalized = normalizeInitRuntime(runtime);
+  if (normalized === "codex-app-server") {
+    return "codex";
+  }
+  if (normalized === "claude-print") {
+    return "claude";
+  }
+  return runtime;
+}
+
+export function resolveRuntimeArgs(runtime: string): readonly string[] {
+  const normalized = normalizeInitRuntime(runtime);
+  if (normalized === "codex-app-server") {
+    return DEFAULT_CODEX_APP_SERVER_ARGS;
+  }
+  if (normalized === "claude-print") {
+    return DEFAULT_CLAUDE_PRINT_ARGS;
+  }
+  return [];
+}
+
+export function resolveRuntimeAgentCommand(runtime: string): string {
+  const command = resolveRuntimeCommand(runtime);
+  const args = resolveRuntimeArgs(runtime);
+  return args.length === 0 ? command : [command, ...args].join(" ");
+}
+
+export function buildRuntimeFrontMatter(runtime: string): string[] {
+  const normalized = normalizeInitRuntime(runtime);
+
+  if (normalized === "codex-app-server") {
+    return [
+      "runtime:",
+      "  kind: codex-app-server",
+      "  command: codex",
+      "  args:",
+      "    - app-server",
+      "  isolation:",
+      "    bare: false",
+      "    strict_mcp_config: false",
+      "  timeouts:",
+      "    read_timeout_ms: 5000",
+      "    turn_timeout_ms: 3600000",
+      "    stall_timeout_ms: 300000",
+    ];
+  }
+
+  if (normalized === "claude-print") {
+    return [
+      "runtime:",
+      "  kind: claude-print",
+      "  command: claude",
+      "  args:",
+      ...DEFAULT_CLAUDE_PRINT_ARGS.map((arg) => `    - ${arg}`),
+      "  isolation:",
+      "    bare: false",
+      "    strict_mcp_config: false",
+      "  auth:",
+      "    env: ANTHROPIC_API_KEY",
+      "  timeouts:",
+      "    read_timeout_ms: 5000",
+      "    turn_timeout_ms: 3600000",
+      "    stall_timeout_ms: 300000",
+    ];
+  }
+
+  return [
+    "runtime:",
+    "  kind: custom",
+    `  command: ${runtime}`,
+    "  isolation:",
+    "    bare: false",
+    "    strict_mcp_config: false",
+    "  timeouts:",
+    "    read_timeout_ms: 5000",
+    "    turn_timeout_ms: 3600000",
+    "    stall_timeout_ms: 300000",
+  ];
+}


### PR DESCRIPTION
## Issues

- Fixes #226

## Summary

- `gh-symphony init` 에 `codex-app-server` / `claude-print` runtime 선택 프롬프트와 `--runtime` preset 검증을 추가했습니다.
- 선택 runtime에 맞는 `runtime:` scaffold, Claude constraints/trade-off 고지, 선택 직후 preflight 보고를 생성합니다.
- PR 리뷰 반영으로 wrapped runtime 호환성, Claude timeout, preflight UX/timeout, skill runtime matching을 보강했습니다.

## Changes

- `workflow-runtime` helper가 runtime preset normalization, supported preset validation, wrapped command detection, context `agent_command` 렌더링을 담당하도록 정리했습니다.
- `init` non-interactive `--runtime` 오타는 즉시 에러로 중단하고, preflight 실패 표시는 `FAIL`로 출력하며 `--version` 체크에 timeout을 둡니다.
- `claude-print` scaffold의 `stall_timeout_ms`를 ADR §5.2 기본값 `900000`에 맞췄습니다.
- `.claude/skills` / `.codex/skills` 선택은 명시 alias와 shell-wrapped command token만 인식하도록 좁혔습니다.
- wrapped `bash -lc claude-code`의 Runtime Constraints preamble 유지, `bash -lc bash -lc ...` 이중 prefix 방지, runtime별 scaffold 회귀 테스트를 추가했습니다.

## Evidence

- `pnpm --filter @gh-symphony/cli test -- workflow-runtime.test.ts generate-workflow-md.test.ts generate-reference-workflow.test.ts init.test.ts skill-writer.test.ts` — pass (89 tests)
- `pnpm --filter @gh-symphony/cli typecheck` — pass
- `pnpm --filter @gh-symphony/cli lint` — pass
- `pnpm install --frozen-lockfile` — pass; `origin/main` 병합 후 workspace symlink 갱신
- `pnpm lint && pnpm test && pnpm typecheck && pnpm build` — pass
- Manual/spec check: `docs/symphony-spec.md` 는 수정하지 않았고, 변경은 repository-local CLI scaffold/runtime readiness 경로에 한정됩니다. 의도적 divergence 없음.

## Human Validation

- [ ] `gh-symphony init` interactive flow에서 runtime 선택 prompt가 적절한 순서로 보이는지 확인
- [ ] `codex-app-server` 선택 시 생성된 `WORKFLOW.md`가 기존 Codex 실행과 호환되는지 확인
- [ ] `claude-print` 선택 시 실제 로컬 환경에서 preflight 메시지와 `ANTHROPIC_API_KEY` 안내가 충분히 명확한지 확인

## Risks

- `init --runtime`은 issue scope에 맞춰 preset selector로 검증합니다. 임의 custom runtime scaffold는 lower-level generator API에는 남겨 두었지만 CLI init flag에서는 허용하지 않습니다.
- CI는 커밋 `a02f1b2`에서 실행 중입니다.
