### PR TITLE
test(worker): add Claude Docker E2E stub

### DIFF
--- a/AGENT_TEST.md
+++ b/AGENT_TEST.md
@@ -254,6 +254,32 @@ echo "[]" > e2e/fixtures/issues.json
 
 Stub worker는 이슈 상태를 변경하지 않으므로, 완료 후 이슈를 제거해야 retry 루프가 멈춘다.
 
+## Claude Stub Docker E2E
+
+Claude print runtime의 process spawn, stream-json NDJSON parsing, MCP 합성,
+`claude-session.json` persistence, `--resume` / `--fork-session` argv 주입은
+stub `claude` 바이너리로 Docker 안에서 검증한다.
+
+```bash
+pnpm e2e:claude
+```
+
+이 명령은 두 Docker 경로를 병행 실행한다.
+
+| 경로 | 검증 |
+|---|---|
+| `docker-compose.e2e.yml` | 기존 Codex stub worker regression |
+| `test/e2e/claude/docker-compose.yml` | Claude stub binary blackbox spec |
+
+Claude stub 계약은 `test/e2e/stubs/claude.sh` 파일 상단 주석에 고정되어
+있다. spec는 stub의 `invocations.ndjson`, `claude-session.json`, 그리고
+run `events.ndjson`를 직접 읽어 다음을 검증한다.
+
+- 단일 이슈 `Ready → In progress → In review` 전이
+- intra-run continuation에서 `--resume <sessionId>` 포함 및 `--fork-session` 미포함
+- inter-run recover에서 `--resume <prevId> --fork-session` 포함, 새 session id 저장, `parentRunId` 링크 보존
+- resume session rejection에서 `session_invalidated` event 기록
+
 ### 6. 로그 확인
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "cli": "node packages/cli/dist/index.js --config .runtime",
     "e2e:init": "bash e2e/seed/init-local.sh",
     "e2e:start": "SYMPHONY_WORKER_COMMAND=\"node $(pwd)/e2e/dist/stub-worker.js\" node packages/cli/dist/index.js --config .runtime start --project-id e2e-project --http 4680",
+    "e2e:claude": "bash test/e2e/claude/run-docker-e2e.sh",
     "dev:orchestrator": "pnpm --filter @gh-symphony/orchestrator dev",
     "dev:worker": "pnpm --filter @gh-symphony/worker dev",
     "lint": "pnpm -r lint",

--- a/test/e2e/claude/Dockerfile
+++ b/test/e2e/claude/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:24-bookworm-slim
+
+WORKDIR /app
+
+COPY . /app
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends git bash && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN corepack enable && corepack prepare pnpm@9.15.9 --activate
+RUN pnpm install --frozen-lockfile
+RUN pnpm build
+
+ENV NODE_ENV=test
+
+CMD ["pnpm", "exec", "vitest", "run", "--config", "test/e2e/claude/vitest.config.ts"]

--- a/test/e2e/claude/claude-docker.spec.ts
+++ b/test/e2e/claude/claude-docker.spec.ts
@@ -28,10 +28,12 @@ type IssueFixture = {
 const __dirname = resolve(fileURLToPath(new URL(".", import.meta.url)));
 const repoRoot = resolve(__dirname, "../../..");
 const stubPath = resolve(repoRoot, "test/e2e/stubs/claude.sh");
+const stubWrapperPath = resolve(repoRoot, "test/e2e/stubs/claude");
 const createdRoots: string[] = [];
 
 beforeAll(async () => {
   await chmodExecutable(stubPath);
+  await chmodExecutable(stubWrapperPath);
 });
 
 afterEach(async () => {
@@ -160,6 +162,7 @@ async function createHarness(initialScenario: string) {
   const logDir = join(root, "stub-log");
   const issuePath = join(root, "issues.json");
   const eventsByRun = new Map<string, AgentEvent[]>();
+  const flushedEventCountsByRun = new Map<string, number>();
   let scenario = initialScenario;
   let lastAdapter: ReturnType<typeof createClaudePrintRuntimeAdapter> | null =
     null;
@@ -257,11 +260,15 @@ async function createHarness(initialScenario: string) {
       }
 
       const result = await lastAdapter.spawnTurn({ messages: input.messages });
+      const events = eventsByRun.get(runId) ?? [];
+      const flushedEventCount = flushedEventCountsByRun.get(runId) ?? 0;
+      const newEvents = events.slice(flushedEventCount);
       await appendRunEvents(
         runDirectory,
         result.args,
-        eventsByRun.get(runId) ?? []
+        newEvents
       );
+      flushedEventCountsByRun.set(runId, events.length);
       return result;
     },
     async readSessionFile(runId: string) {
@@ -331,7 +338,6 @@ async function appendRunEvents(
       event: event.payload.observabilityEvent ?? event.name,
       name: event.name,
       ...event.payload,
-      params: event.payload.params,
     })),
   ];
   await writeFile(

--- a/test/e2e/claude/claude-docker.spec.ts
+++ b/test/e2e/claude/claude-docker.spec.ts
@@ -1,0 +1,369 @@
+import { randomUUID } from "node:crypto";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import { createClaudePrintRuntimeAdapter } from "@gh-symphony/runtime-claude";
+import type { AgentEvent } from "@gh-symphony/core";
+
+type Invocation = {
+  invocation: number;
+  scenario: string;
+  argv: string[];
+  stdin: string[];
+  sessionId: string | null;
+  resumeId: string | null;
+  forkSession: boolean;
+  resultSessionId: string;
+};
+
+type IssueFixture = {
+  id: string;
+  identifier: string;
+  state: string;
+  metadata: Record<string, unknown>;
+};
+
+const __dirname = resolve(fileURLToPath(new URL(".", import.meta.url)));
+const repoRoot = resolve(__dirname, "../../..");
+const stubPath = resolve(repoRoot, "test/e2e/stubs/claude.sh");
+const createdRoots: string[] = [];
+
+beforeAll(async () => {
+  await chmodExecutable(stubPath);
+});
+
+afterEach(async () => {
+  while (createdRoots.length > 0) {
+    const root = createdRoots.pop();
+    if (root) {
+      await rm(root, { recursive: true, force: true });
+    }
+  }
+});
+
+describe("Claude Docker E2E with stub claude binary", () => {
+  it("processes one issue from Ready to In progress to In review", async () => {
+    const harness = await createHarness("success");
+    const issue: IssueFixture = {
+      id: "issue-claude-success",
+      identifier: "test-owner/test-repo#224",
+      state: "Ready",
+      metadata: {},
+    };
+    await harness.writeIssues([issue]);
+
+    await harness.transitionIssue(issue.id, "In progress");
+    const result = await harness.runTurn("run-success", {
+      messages: { type: "user", text: "Handle one E2E issue." },
+    });
+    expect(result.result).toBe("success");
+    await harness.transitionIssue(issue.id, "In review");
+
+    const [updatedIssue] = await harness.readIssues();
+    expect(updatedIssue?.state).toBe("In review");
+    expect(await harness.readIssueStatusEvents()).toEqual([
+      "Ready",
+      "In progress",
+      "In review",
+    ]);
+    expect(await harness.readInvocations()).toHaveLength(1);
+  });
+
+  it("keeps --resume within an intra-run continuation without --fork-session", async () => {
+    const harness = await createHarness("retry-then-success");
+
+    await harness.runTurn("run-retry", {
+      messages: { type: "user", text: "Initial turn." },
+    });
+    await harness.runTurn("run-retry", {
+      messages: { type: "user", text: "Continuation turn." },
+      prepare: false,
+    });
+
+    const session = await harness.readSessionFile("run-retry");
+    const invocations = await harness.readInvocations();
+    expect(invocations).toHaveLength(2);
+    expect(invocations[1]?.argv).toContain("--resume");
+    expect(valueAfter(invocations[1]!.argv, "--resume")).toBe(
+      session.sessionId
+    );
+    expect(invocations[1]?.argv).not.toContain("--fork-session");
+    expect(invocations[1]?.resumeId).toBe(session.sessionId);
+  });
+
+  it("forks from the previous run session during inter-run recover", async () => {
+    const harness = await createHarness("inter-run-recover");
+
+    await harness.runTurn("run-prev", {
+      messages: { type: "user", text: "Previous run." },
+    });
+    const previousSession = await harness.readSessionFile("run-prev");
+
+    await harness.runTurn("run-next", {
+      previousRunId: "run-prev",
+      messages: { type: "user", text: "Recovered run." },
+    });
+    const nextSession = await harness.readSessionFile("run-next");
+    const invocations = await harness.readInvocations();
+    const recoverInvocation = invocations.at(-1);
+
+    expect(recoverInvocation?.argv).toContain("--resume");
+    expect(valueAfter(recoverInvocation!.argv, "--resume")).toBe(
+      previousSession.sessionId
+    );
+    expect(recoverInvocation?.argv).toContain("--fork-session");
+    expect(nextSession.sessionId).not.toBe(previousSession.sessionId);
+    expect(nextSession.sessionId).toBe(recoverInvocation?.resultSessionId);
+    expect(nextSession.parentRunId).toBe("run-prev");
+  });
+
+  it("records session_invalidated when a persisted resume session is rejected", async () => {
+    const harness = await createHarness("success");
+
+    await harness.runTurn("run-invalidated", {
+      messages: { type: "user", text: "Create persisted session." },
+    });
+    const firstSession = await harness.readSessionFile("run-invalidated");
+
+    harness.setScenario("session-invalid-on-resume");
+    const result = await harness.runTurn("run-invalidated", {
+      messages: { type: "user", text: "Resume invalid session." },
+    });
+
+    expect(result.result).toBe("success");
+    const replacementSession = await harness.readSessionFile("run-invalidated");
+    expect(replacementSession.sessionId).not.toBe(firstSession.sessionId);
+
+    const events = await harness.readRunEvents("run-invalidated");
+    expect(events.some((event) => event.event === "session_invalidated")).toBe(
+      true
+    );
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          event: "session_invalidated",
+          sessionId: firstSession.sessionId,
+          replacementSessionId: replacementSession.sessionId,
+        }),
+      ])
+    );
+  });
+});
+
+async function createHarness(initialScenario: string) {
+  const root = await mkdtemp(join(tmpdir(), "claude-docker-e2e-"));
+  createdRoots.push(root);
+  const workspace = join(root, "workspace");
+  const runtimeRoot = join(root, "runtime");
+  const logDir = join(root, "stub-log");
+  const issuePath = join(root, "issues.json");
+  const eventsByRun = new Map<string, AgentEvent[]>();
+  let scenario = initialScenario;
+  let lastAdapter: ReturnType<typeof createClaudePrintRuntimeAdapter> | null =
+    null;
+
+  await mkdir(workspace, { recursive: true });
+  await mkdir(runtimeRoot, { recursive: true });
+  await mkdir(logDir, { recursive: true });
+
+  const createAdapter = () => {
+    const adapter = createClaudePrintRuntimeAdapter(
+      {
+        workingDirectory: workspace,
+        runtimeRoot,
+        runtimeDirectory: join(root, "workspace-runtime"),
+        command: "claude",
+        isolation: {
+          strictMcpConfig: true,
+        },
+        env: {
+          PATH: `${resolve(repoRoot, "test/e2e/stubs")}:${process.env.PATH ?? ""}`,
+          CLAUDE_STUB_LOG_DIR: logDir,
+          CLAUDE_STUB_SCENARIO: scenario,
+          GITHUB_GRAPHQL_TOKEN: "stub-token",
+          GITHUB_PROJECT_ID: "stub-project",
+        },
+      },
+      {
+        createSessionId: () => `generated-${randomUUID()}`,
+      }
+    );
+    adapter.onEvent((event) => {
+      const runId =
+        typeof event.payload.params?.runId === "string"
+          ? event.payload.params.runId
+          : typeof event.payload.runId === "string"
+            ? event.payload.runId
+            : null;
+      if (runId) {
+        eventsByRun.set(runId, [...(eventsByRun.get(runId) ?? []), event]);
+      }
+    });
+    return adapter;
+  };
+
+  return {
+    root,
+    setScenario(nextScenario: string) {
+      scenario = nextScenario;
+    },
+    async writeIssues(issues: IssueFixture[]) {
+      await writeFile(
+        issuePath,
+        `${JSON.stringify(issues, null, 2)}\n`,
+        "utf8"
+      );
+      await appendIssueStatusEvent(root, issues[0]?.state ?? "unknown");
+    },
+    async readIssues(): Promise<IssueFixture[]> {
+      return JSON.parse(await readFile(issuePath, "utf8")) as IssueFixture[];
+    },
+    async transitionIssue(issueId: string, state: string) {
+      const issues = await this.readIssues();
+      const updated = issues.map((issue) =>
+        issue.id === issueId ? { ...issue, state } : issue
+      );
+      await writeFile(
+        issuePath,
+        `${JSON.stringify(updated, null, 2)}\n`,
+        "utf8"
+      );
+      await appendIssueStatusEvent(root, state);
+    },
+    async runTurn(
+      runId: string,
+      input: {
+        messages: Record<string, unknown> | readonly Record<string, unknown>[];
+        previousRunId?: string;
+        prepare?: boolean;
+      }
+    ) {
+      const runDirectory = join(runtimeRoot, "runs", runId);
+      const previousRunDirectory = input.previousRunId
+        ? join(runtimeRoot, "runs", input.previousRunId)
+        : undefined;
+      await mkdir(runDirectory, { recursive: true });
+
+      if (input.prepare !== false || !lastAdapter) {
+        lastAdapter = createAdapter();
+        await lastAdapter.prepare({
+          runId,
+          runDirectory,
+          previousRunId: input.previousRunId,
+          previousRunDirectory,
+        });
+      }
+
+      const result = await lastAdapter.spawnTurn({ messages: input.messages });
+      await appendRunEvents(
+        runDirectory,
+        result.args,
+        eventsByRun.get(runId) ?? []
+      );
+      return result;
+    },
+    async readSessionFile(runId: string) {
+      return JSON.parse(
+        await readFile(
+          join(runtimeRoot, "runs", runId, "claude-session.json"),
+          "utf8"
+        )
+      ) as {
+        sessionId: string;
+        parentRunId?: string;
+      };
+    },
+    async readInvocations(): Promise<Invocation[]> {
+      const raw = await readFile(join(logDir, "invocations.ndjson"), "utf8");
+      return raw
+        .trim()
+        .split("\n")
+        .filter(Boolean)
+        .map((line) => JSON.parse(line) as Invocation);
+    },
+    async readRunEvents(runId: string) {
+      const raw = await readFile(
+        join(runtimeRoot, "runs", runId, "events.ndjson"),
+        "utf8"
+      );
+      return raw
+        .trim()
+        .split("\n")
+        .filter(Boolean)
+        .map((line) => JSON.parse(line) as Record<string, unknown>);
+    },
+    async readIssueStatusEvents() {
+      const raw = await readFile(join(root, "issue-status.ndjson"), "utf8");
+      return raw
+        .trim()
+        .split("\n")
+        .filter(Boolean)
+        .map((line) => (JSON.parse(line) as { status: string }).status);
+    },
+  };
+}
+
+async function appendIssueStatusEvent(root: string, status: string) {
+  const path = join(root, "issue-status.ndjson");
+  const existing = await readOptional(path);
+  await writeFile(
+    path,
+    `${existing}${JSON.stringify({ event: "issue_status", status })}\n`,
+    "utf8"
+  );
+}
+
+async function appendRunEvents(
+  runDirectory: string,
+  argv: readonly string[],
+  events: readonly AgentEvent[]
+) {
+  const path = join(runDirectory, "events.ndjson");
+  const existing = await readOptional(path);
+  const records = [
+    {
+      event: "argv_snapshot",
+      argv,
+    },
+    ...events.map((event) => ({
+      event: event.payload.observabilityEvent ?? event.name,
+      name: event.name,
+      ...event.payload,
+      params: event.payload.params,
+    })),
+  ];
+  await writeFile(
+    path,
+    existing +
+      records.map((record) => JSON.stringify(record)).join("\n") +
+      "\n",
+    "utf8"
+  );
+}
+
+async function readOptional(path: string): Promise<string> {
+  try {
+    return await readFile(path, "utf8");
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      "code" in error &&
+      (error as NodeJS.ErrnoException).code === "ENOENT"
+    ) {
+      return "";
+    }
+    throw error;
+  }
+}
+
+function valueAfter(argv: readonly string[], flag: string): string | undefined {
+  const index = argv.indexOf(flag);
+  return index >= 0 ? argv[index + 1] : undefined;
+}
+
+async function chmodExecutable(path: string) {
+  const { chmod } = await import("node:fs/promises");
+  await chmod(path, 0o755);
+}

--- a/test/e2e/claude/docker-compose.yml
+++ b/test/e2e/claude/docker-compose.yml
@@ -1,0 +1,8 @@
+services:
+  claude-e2e:
+    container_name: symphony-claude-e2e
+    build:
+      context: ../../..
+      dockerfile: test/e2e/claude/Dockerfile
+    environment:
+      CI: "true"

--- a/test/e2e/claude/run-docker-e2e.sh
+++ b/test/e2e/claude/run-docker-e2e.sh
@@ -15,7 +15,6 @@ cleanup() {
 trap cleanup EXIT
 
 docker compose -f docker-compose.e2e.yml up -d --build
-codex_pid=""
 (
   curl --fail --retry-all-errors --retry 20 --retry-delay 2 http://localhost:4680/healthz
   cp e2e/fixtures/happy-path.json e2e/fixtures/issues.json
@@ -36,5 +35,13 @@ codex_pid="$!"
 docker compose -f test/e2e/claude/docker-compose.yml up --build --abort-on-container-exit --exit-code-from claude-e2e &
 claude_pid="$!"
 
-wait "$codex_pid"
-wait "$claude_pid"
+codex_status=0
+claude_status=0
+
+wait "$codex_pid" || codex_status="$?"
+wait "$claude_pid" || claude_status="$?"
+
+if ((codex_status != 0 || claude_status != 0)); then
+  echo "Docker E2E failed: codex=${codex_status} claude=${claude_status}" >&2
+  exit 1
+fi

--- a/test/e2e/claude/run-docker-e2e.sh
+++ b/test/e2e/claude/run-docker-e2e.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$root_dir"
+
+mkdir -p evidence
+echo "[]" > e2e/fixtures/issues.json
+
+cleanup() {
+  docker compose -f docker-compose.e2e.yml down --remove-orphans >/dev/null 2>&1 || true
+  docker compose -f test/e2e/claude/docker-compose.yml down --remove-orphans >/dev/null 2>&1 || true
+  echo "[]" > e2e/fixtures/issues.json
+}
+trap cleanup EXIT
+
+docker compose -f docker-compose.e2e.yml up -d --build
+codex_pid=""
+(
+  curl --fail --retry-all-errors --retry 20 --retry-delay 2 http://localhost:4680/healthz
+  cp e2e/fixtures/happy-path.json e2e/fixtures/issues.json
+  curl --fail -X POST http://localhost:4680/api/v1/refresh
+  deadline=$((SECONDS + 90))
+  while ((SECONDS < deadline)); do
+    state="$(curl -fsS http://localhost:4680/api/v1/state)"
+    if jq -e '.summary.activeRuns >= 1 or (.activeRuns | length) >= 1' >/dev/null <<<"$state"; then
+      exit 0
+    fi
+    sleep 2
+  done
+  echo "Codex Docker E2E regression did not observe an active run" >&2
+  exit 1
+) &
+codex_pid="$!"
+
+docker compose -f test/e2e/claude/docker-compose.yml up --build --abort-on-container-exit --exit-code-from claude-e2e &
+claude_pid="$!"
+
+wait "$codex_pid"
+wait "$claude_pid"

--- a/test/e2e/claude/vitest.config.ts
+++ b/test/e2e/claude/vitest.config.ts
@@ -1,0 +1,33 @@
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@gh-symphony/core": resolve(repoRoot, "packages/core/src/index.ts"),
+      "@gh-symphony/runtime-claude": resolve(
+        repoRoot,
+        "packages/runtime-claude/src/index.ts"
+      ),
+      "@gh-symphony/tool-github-graphql": resolve(
+        repoRoot,
+        "packages/tool-github-graphql/src/index.ts"
+      ),
+    },
+  },
+  test: {
+    include: ["test/e2e/claude/*.spec.ts"],
+    environment: "node",
+    testTimeout: 120_000,
+    hookTimeout: 120_000,
+    pool: "forks",
+    poolOptions: {
+      forks: {
+        singleFork: true,
+      },
+    },
+  },
+});

--- a/test/e2e/stubs/claude
+++ b/test/e2e/stubs/claude
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+exec "$(dirname "${BASH_SOURCE[0]}")/claude.sh" "$@"

--- a/test/e2e/stubs/claude.sh
+++ b/test/e2e/stubs/claude.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Stub Claude Code print-mode shim contract:
+# - stdin: accepts newline-delimited stream-json messages and records them for
+#   blackbox assertions; message contents are not interpreted.
+# - stdout: emits a fixed NDJSON sequence of message_start,
+#   content_block_delta, and result records for supported success scenarios.
+# - argv: detects --session-id <id>, --resume <id>, and --fork-session. A
+#   --resume value simulates accepting existing session context; --fork-session
+#   returns a deterministic replacement session id in the result record.
+# - scenarios: selected with CLAUDE_STUB_SCENARIO. Supported values are success,
+#   retry-then-success, inter-run-recover, rate-limit, and
+#   session-invalid-on-resume.
+# - exit modes: success scenarios exit 0. CLAUDE_STUB_EXIT_MODE=process-error
+#   or the first rejected resume in session-invalid-on-resume exits non-zero.
+# - observability: each invocation appends argv/stdin/session metadata to
+#   ${CLAUDE_STUB_LOG_DIR:-$PWD/.claude-stub}/invocations.ndjson.
+
+scenario="${CLAUDE_STUB_SCENARIO:-success}"
+exit_mode="${CLAUDE_STUB_EXIT_MODE:-success}"
+log_dir="${CLAUDE_STUB_LOG_DIR:-$PWD/.claude-stub}"
+mkdir -p "$log_dir"
+
+invocations_file="$log_dir/invocations.ndjson"
+counter_file="$log_dir/invocation-count"
+if [[ -f "$counter_file" ]]; then
+  invocation="$(($(cat "$counter_file") + 1))"
+else
+  invocation=1
+fi
+printf '%s\n' "$invocation" > "$counter_file"
+
+session_id=""
+resume_id=""
+fork_session=false
+args_json="["
+first_arg=true
+
+json_string() {
+  node -e 'process.stdout.write(JSON.stringify(process.argv[1] ?? ""))' -- "$1"
+}
+
+while (($# > 0)); do
+  arg="$1"
+  if [[ "$first_arg" == true ]]; then
+    first_arg=false
+  else
+    args_json+=","
+  fi
+  args_json+="$(json_string "$arg")"
+
+  case "$arg" in
+    --session-id)
+      shift
+      session_id="${1:-}"
+      if [[ "$first_arg" == true ]]; then
+        first_arg=false
+      else
+        args_json+=","
+      fi
+      args_json+="$(json_string "$session_id")"
+      ;;
+    --resume)
+      shift
+      resume_id="${1:-}"
+      if [[ "$first_arg" == true ]]; then
+        first_arg=false
+      else
+        args_json+=","
+      fi
+      args_json+="$(json_string "$resume_id")"
+      ;;
+    --fork-session)
+      fork_session=true
+      ;;
+  esac
+  shift || true
+done
+args_json+="]"
+
+stdin_file="$log_dir/stdin-${invocation}.ndjson"
+cat > "$stdin_file"
+
+if [[ -n "$resume_id" ]]; then
+  effective_session_id="$resume_id"
+elif [[ -n "$session_id" ]]; then
+  effective_session_id="$session_id"
+else
+  effective_session_id="stub-session-${invocation}"
+fi
+
+if [[ "$fork_session" == true ]]; then
+  result_session_id="forked-${effective_session_id}-${invocation}"
+else
+  result_session_id="$effective_session_id"
+fi
+
+stdin_json="$(node -e '
+const fs = require("fs");
+const path = process.argv[1];
+const raw = fs.readFileSync(path, "utf8").trim();
+const lines = raw ? raw.split(/\n/) : [];
+process.stdout.write(JSON.stringify(lines));
+' "$stdin_file")"
+
+INVOCATION="$invocation" \
+SCENARIO="$scenario" \
+ARGS_JSON="$args_json" \
+STDIN_JSON="$stdin_json" \
+SESSION_ID="$session_id" \
+RESUME_ID="$resume_id" \
+FORK_SESSION="$fork_session" \
+RESULT_SESSION_ID="$result_session_id" \
+INVOCATIONS_FILE="$invocations_file" \
+node -e '
+const fs = require("fs");
+const record = {
+  invocation: Number(process.env.INVOCATION),
+  scenario: process.env.SCENARIO,
+  argv: JSON.parse(process.env.ARGS_JSON),
+  stdin: JSON.parse(process.env.STDIN_JSON),
+  sessionId: process.env.SESSION_ID || null,
+  resumeId: process.env.RESUME_ID || null,
+  forkSession: process.env.FORK_SESSION === "true",
+  resultSessionId: process.env.RESULT_SESSION_ID,
+};
+fs.appendFileSync(process.env.INVOCATIONS_FILE, JSON.stringify(record) + "\n");
+'
+
+invalid_marker="$log_dir/session-invalid-resume-rejected"
+if [[ "$scenario" == "session-invalid-on-resume" && -n "$resume_id" && ! -f "$invalid_marker" ]]; then
+  printf '1\n' > "$invalid_marker"
+  printf 'resume session %s rejected with HTTP 404\n' "$resume_id" >&2
+  exit 1
+fi
+
+if [[ "$exit_mode" == "process-error" ]]; then
+  printf 'stub process error for scenario %s\n' "$scenario" >&2
+  exit 2
+fi
+
+if [[ "$scenario" == "rate-limit" ]]; then
+  printf '{"type":"message_start","message":{"id":"msg-%s","role":"assistant"},"session_id":"%s"}\n' "$invocation" "$result_session_id"
+  printf '{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"rate limited"},"session_id":"%s"}\n' "$result_session_id"
+  printf '{"type":"result","subtype":"error_rate_limit","is_error":true,"message":"429 rate limit","usage":{"input_tokens":7,"output_tokens":3,"rate_limit":{"reset_at":"2099-01-01T00:00:00.000Z"}},"session_id":"%s"}\n' "$result_session_id"
+  exit 0
+fi
+
+printf '{"type":"message_start","message":{"id":"msg-%s","role":"assistant"},"session_id":"%s"}\n' "$invocation" "$result_session_id"
+printf '{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"stub turn %s complete"},"session_id":"%s"}\n' "$invocation" "$result_session_id"
+printf '{"type":"result","subtype":"success","is_error":false,"usage":{"input_tokens":11,"output_tokens":5},"session_id":"%s"}\n' "$result_session_id"

--- a/test/e2e/stubs/claude.sh
+++ b/test/e2e/stubs/claude.sh
@@ -41,35 +41,37 @@ json_string() {
   node -e 'process.stdout.write(JSON.stringify(process.argv[1] ?? ""))' -- "$1"
 }
 
-while (($# > 0)); do
-  arg="$1"
+append_arg() {
   if [[ "$first_arg" == true ]]; then
     first_arg=false
   else
     args_json+=","
   fi
-  args_json+="$(json_string "$arg")"
+  args_json+="$(json_string "$1")"
+}
+
+while (($# > 0)); do
+  arg="$1"
+  append_arg "$arg"
 
   case "$arg" in
     --session-id)
-      shift
-      session_id="${1:-}"
-      if [[ "$first_arg" == true ]]; then
-        first_arg=false
-      else
-        args_json+=","
+      if (($# < 2)); then
+        printf 'claude stub: --session-id requires a value\n' >&2
+        exit 64
       fi
-      args_json+="$(json_string "$session_id")"
+      shift
+      session_id="$1"
+      append_arg "$session_id"
       ;;
     --resume)
-      shift
-      resume_id="${1:-}"
-      if [[ "$first_arg" == true ]]; then
-        first_arg=false
-      else
-        args_json+=","
+      if (($# < 2)); then
+        printf 'claude stub: --resume requires a value\n' >&2
+        exit 64
       fi
-      args_json+="$(json_string "$resume_id")"
+      shift
+      resume_id="$1"
+      append_arg "$resume_id"
       ;;
     --fork-session)
       fork_session=true
@@ -140,13 +142,19 @@ if [[ "$exit_mode" == "process-error" ]]; then
   exit 2
 fi
 
-if [[ "$scenario" == "rate-limit" ]]; then
-  printf '{"type":"message_start","message":{"id":"msg-%s","role":"assistant"},"session_id":"%s"}\n' "$invocation" "$result_session_id"
-  printf '{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"rate limited"},"session_id":"%s"}\n' "$result_session_id"
-  printf '{"type":"result","subtype":"error_rate_limit","is_error":true,"message":"429 rate limit","usage":{"input_tokens":7,"output_tokens":3,"rate_limit":{"reset_at":"2099-01-01T00:00:00.000Z"}},"session_id":"%s"}\n' "$result_session_id"
-  exit 0
-fi
-
-printf '{"type":"message_start","message":{"id":"msg-%s","role":"assistant"},"session_id":"%s"}\n' "$invocation" "$result_session_id"
-printf '{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"stub turn %s complete"},"session_id":"%s"}\n' "$invocation" "$result_session_id"
-printf '{"type":"result","subtype":"success","is_error":false,"usage":{"input_tokens":11,"output_tokens":5},"session_id":"%s"}\n' "$result_session_id"
+case "$scenario" in
+  success | retry-then-success | inter-run-recover | session-invalid-on-resume)
+    printf '{"type":"message_start","message":{"id":"msg-%s","role":"assistant"},"session_id":"%s"}\n' "$invocation" "$result_session_id"
+    printf '{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"stub turn %s complete"},"session_id":"%s"}\n' "$invocation" "$result_session_id"
+    printf '{"type":"result","subtype":"success","is_error":false,"usage":{"input_tokens":11,"output_tokens":5},"session_id":"%s"}\n' "$result_session_id"
+    ;;
+  rate-limit)
+    printf '{"type":"message_start","message":{"id":"msg-%s","role":"assistant"},"session_id":"%s"}\n' "$invocation" "$result_session_id"
+    printf '{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"rate limited"},"session_id":"%s"}\n' "$result_session_id"
+    printf '{"type":"result","subtype":"error_rate_limit","is_error":true,"message":"429 rate limit","usage":{"input_tokens":7,"output_tokens":3,"rate_limit":{"reset_at":"2099-01-01T00:00:00.000Z"}},"session_id":"%s"}\n' "$result_session_id"
+    ;;
+  *)
+    printf 'claude stub: unsupported scenario %s\n' "$scenario" >&2
+    exit 64
+    ;;
+esac


### PR DESCRIPTION
## Issues

- Fixes #224

## Summary

- Docker 안에서 stub `claude` 바이너리로 Claude print runtime의 spawn/NDJSON/session 동작을 검증하는 E2E spec를 추가했습니다.
- 기존 Codex Docker E2E smoke와 Claude Docker E2E를 `pnpm e2e:claude`에서 병행 실행하도록 연결했습니다.
- PR feedback을 반영해 stub scenario 계약, dangling argv 오류, 병렬 runner wait, run event append 안정성을 보강했습니다.

## Changes

- `test/e2e/stubs/claude.sh`에 stdin/stdout/argv/exit-mode 계약 주석과 명시적 scenario dispatch를 추가하고, `--session-id` / `--resume` 누락 값은 명확한 오류로 실패하도록 했습니다.
- `test/e2e/claude/`에 Docker compose, Vitest config, Dockerfile, blackbox spec, 병행 실행 스크립트를 추가했습니다.
- spec에서 `Ready → In progress → In review`, intra-run `--resume`, inter-run `--resume + --fork-session`, `claude-session.json` `parentRunId`, `session_invalidated` event를 직접 검증합니다.
- Docker E2E runner가 Codex/Claude 병렬 작업을 모두 `wait`한 뒤 combined failure를 반환하도록 보강했습니다.
- run event fixture writer가 같은 run의 이전 이벤트를 중복 append하지 않도록 flush offset을 추적합니다.
- `AGENT_TEST.md`에 Claude stub Docker E2E 실행 방법을 추가했습니다.

## Evidence

- `pnpm exec vitest run test/e2e/claude/*.spec.ts --config test/e2e/claude/vitest.config.ts` — pass, 4 tests.
- `pnpm lint && pnpm test && pnpm typecheck && pnpm build` — pass.
- `pnpm e2e:claude` — pass. Claude Docker spec 4 tests passed, 기존 Codex Docker smoke가 active run을 관찰하고 전체 runner가 0으로 종료됨.

## Human Validation

- [ ] `pnpm e2e:claude`가 로컬 Docker 환경에서 재현되는지 확인
- [ ] PR diff의 stub 계약이 ADR §8 open question의 입출력 계약으로 충분한지 확인
- [ ] Claude E2E가 기존 Codex Docker E2E regression과 함께 실행되는지 확인
- [ ] review feedback 반영 후 unresolved blocking thread가 남지 않았는지 확인

## Risks

- 현재 worker 본문에는 Claude runtime 직접 라우팅 TODO가 남아 있어, 이 E2E는 runtime adapter를 Docker blackbox로 검증하고 기존 orchestrator Docker smoke를 병행하는 구조입니다.