### PR TITLE
chore(changeset): add cli release note for Claude runtime debut

### DIFF
--- a/.changeset/claude-runtime-debut.md
+++ b/.changeset/claude-runtime-debut.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Add Claude as a first-class agent runtime alongside Codex. The CLI now lets you pick a runtime during `init`, runs Claude preflight checks (auth, broker probe), and ships a `claude -p` spawn-loop adapter with session-id persistence, stream-json event mapping, prompt constraints, and a composed GitHub GraphQL MCP config. Worker agent events are normalized to runtime-neutral names and the workflow `runtime` block is parsed in core.


### PR DESCRIPTION
## Summary
- Adds a `@gh-symphony/cli` patch changeset summarizing the Claude runtime work merged since the last release (PRs #247–#258).
- Highlights `init` runtime selection, Claude preflight, `claude -p` adapter with session/stream-json/MCP support, runtime-neutral worker events, and core workflow `runtime` parsing.

## Test plan
- [ ] `pnpm changeset status` recognizes the new entry
- [ ] Release workflow picks it up on next `version-packages`

🤖 Generated with [Claude Code](https://claude.com/claude-code)