### PR TITLE
feat(core): collapse orchestrator repository contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,11 +82,17 @@ jobs:
             "projectId": "smoke",
             "slug": "smoke",
             "workspaceDir": "/var/lib/gh-symphony/workspaces/smoke",
+            "repository": {
+              "owner": "smoke-org",
+              "name": "smoke-repo",
+              "cloneUrl": "https://github.com/smoke-org/smoke-repo.git"
+            },
             "repositories": [],
             "tracker": {
               "adapter": "file",
               "bindingId": "smoke-file",
               "settings": {
+                "repository": "smoke-org/smoke-repo",
                 "issuesPath": "/var/lib/gh-symphony/issues.json"
               }
             }

--- a/e2e/seed/config.json
+++ b/e2e/seed/config.json
@@ -2,6 +2,11 @@
   "projectId": "e2e-project",
   "slug": "e2e-project",
   "workspaceDir": "/e2e/workspaces",
+  "repository": {
+    "owner": "test-owner",
+    "name": "test-repo",
+    "cloneUrl": "/e2e/repos/test-owner/test-repo"
+  },
   "repositories": [
     {
       "owner": "test-owner",
@@ -13,7 +18,8 @@
     "adapter": "file",
     "bindingId": "e2e-test",
     "settings": {
-      "issuesPath": "/e2e/fixtures/issues.json"
+      "issuesPath": "/e2e/fixtures/issues.json",
+      "repository": "test-owner/test-repo"
     }
   }
 }

--- a/e2e/seed/init-local.sh
+++ b/e2e/seed/init-local.sh
@@ -89,6 +89,11 @@ cat > "$CONFIG_DIR/project.json" << EOF
   "projectId": "$PROJECT_ID",
   "slug": "$PROJECT_ID",
   "workspaceDir": "$WORKSPACE_DIR",
+  "repository": {
+    "owner": "test-owner",
+    "name": "test-repo",
+    "cloneUrl": "$REPO_DIR"
+  },
   "repositories": [
     {
       "owner": "test-owner",
@@ -100,7 +105,8 @@ cat > "$CONFIG_DIR/project.json" << EOF
     "adapter": "file",
     "bindingId": "e2e-test",
     "settings": {
-      "issuesPath": "$ISSUES_PATH"
+      "issuesPath": "$ISSUES_PATH",
+      "repository": "test-owner/test-repo"
     }
   }
 }

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1280,11 +1280,22 @@ export async function writeConfig(
   configDir: string,
   input: WriteConfigInput
 ): Promise<void> {
+  const repository = input.repos[0] ?? {
+    owner: "",
+    name: "",
+    cloneUrl: "",
+  };
+
   await saveProjectConfig(configDir, input.projectId, {
     projectId: input.projectId,
     slug: input.projectId,
     displayName: input.project.title,
     workspaceDir: input.workspaceDir,
+    repository: {
+      owner: repository.owner,
+      name: repository.name,
+      cloneUrl: repository.cloneUrl,
+    },
     repositories: input.repos.map((r) => ({
       owner: r.owner,
       name: r.name,
@@ -1295,6 +1306,9 @@ export async function writeConfig(
       bindingId: input.project.id,
       settings: {
         projectId: input.project.id,
+        ...(input.repos[0]
+          ? { repository: `${repository.owner}/${repository.name}` }
+          : {}),
         ...(input.assignedOnly ? { assignedOnly: true } : {}),
       },
     },

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1280,22 +1280,22 @@ export async function writeConfig(
   configDir: string,
   input: WriteConfigInput
 ): Promise<void> {
-  const repository = input.repos[0] ?? {
-    owner: "",
-    name: "",
-    cloneUrl: "",
-  };
+  const repository = input.repos[0];
 
   await saveProjectConfig(configDir, input.projectId, {
     projectId: input.projectId,
     slug: input.projectId,
     displayName: input.project.title,
     workspaceDir: input.workspaceDir,
-    repository: {
-      owner: repository.owner,
-      name: repository.name,
-      cloneUrl: repository.cloneUrl,
-    },
+    ...(repository
+      ? {
+          repository: {
+            owner: repository.owner,
+            name: repository.name,
+            cloneUrl: repository.cloneUrl,
+          },
+        }
+      : {}),
     repositories: input.repos.map((r) => ({
       owner: r.owner,
       name: r.name,

--- a/packages/cli/src/commands/repo.test.ts
+++ b/packages/cli/src/commands/repo.test.ts
@@ -563,9 +563,9 @@ describe("repo add", () => {
     );
   });
 
-  it("removes a validated repository regardless of input casing", async () => {
+  it("rejects removing the last repository regardless of input casing", async () => {
     const configDir = await mkdtemp(join(tmpdir(), "repo-remove-casing-"));
-    const stdout = captureWrites(process.stdout);
+    const stderr = captureWrites(process.stderr);
     const repoCommand = await loadRepoCommand();
 
     await seedActiveProject(configDir, [
@@ -579,6 +579,47 @@ describe("repo add", () => {
     try {
       await repoCommand(["remove", "acmeorg/platform"], baseOptions(configDir));
     } finally {
+      stderr.restore();
+    }
+
+    const saved = JSON.parse(
+      await readFile(projectConfigPath(configDir, "managed-project"), "utf8")
+    ) as CliProjectConfig;
+
+    expect(saved.repositories).toEqual([
+      {
+        owner: "AcmeOrg",
+        name: "Platform",
+        cloneUrl: "https://github.com/AcmeOrg/Platform.git",
+      },
+    ]);
+    expect(process.exitCode).toBe(1);
+    expect(stderr.output()).toContain(
+      "Repository removal would leave the project without a repository"
+    );
+  });
+
+  it("removes one repository when another repository remains", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "repo-remove-one-"));
+    const stdout = captureWrites(process.stdout);
+    const repoCommand = await loadRepoCommand();
+
+    await seedActiveProject(configDir, [
+      {
+        owner: "AcmeOrg",
+        name: "Platform",
+        cloneUrl: "https://github.com/AcmeOrg/Platform.git",
+      },
+      {
+        owner: "AcmeOrg",
+        name: "Api",
+        cloneUrl: "https://github.com/AcmeOrg/Api.git",
+      },
+    ]);
+
+    try {
+      await repoCommand(["remove", "acmeorg/platform"], baseOptions(configDir));
+    } finally {
       stdout.restore();
     }
 
@@ -586,7 +627,19 @@ describe("repo add", () => {
       await readFile(projectConfigPath(configDir, "managed-project"), "utf8")
     ) as CliProjectConfig;
 
-    expect(saved.repositories).toEqual([]);
+    expect(saved.repository).toEqual({
+      owner: "AcmeOrg",
+      name: "Api",
+      cloneUrl: "https://github.com/AcmeOrg/Api.git",
+    });
+    expect(saved.repositories).toEqual([
+      {
+        owner: "AcmeOrg",
+        name: "Api",
+        cloneUrl: "https://github.com/AcmeOrg/Api.git",
+      },
+    ]);
+    expect(saved.tracker.settings?.repository).toBe("AcmeOrg/Api");
     expect(stdout.output()).toContain("Removed repository: acmeorg/platform");
   });
 

--- a/packages/cli/src/commands/repo.ts
+++ b/packages/cli/src/commands/repo.ts
@@ -86,9 +86,12 @@ function toRepoConfigEntry(repo: LinkedRepository): RepoConfigEntry {
 function configuredRepositories(
   config: Pick<CliProjectConfig, "repository" | "repositories">
 ): RepoConfigEntry[] {
-  return (
-    config.repositories ?? (config.repository.owner ? [config.repository] : [])
-  );
+  const repos = [
+    ...(config.repository ? [config.repository] : []),
+    ...(config.repositories ?? []),
+  ].filter(isConfiguredRepository);
+
+  return [...new Map(repos.map((repo) => [repoKey(repo), repo])).values()];
 }
 
 function withConfiguredRepository(
@@ -107,6 +110,12 @@ function withConfiguredRepository(
       },
     },
   };
+}
+
+function isConfiguredRepository(
+  repository: Partial<RepoConfigEntry> | undefined
+): repository is RepoConfigEntry {
+  return Boolean(repository?.owner && repository.name);
 }
 
 function parseRepoSyncFlags(args: string[]): RepoSyncFlags {
@@ -385,19 +394,23 @@ async function repoRemove(
   const nextRepositories = currentRepos.filter(
     (repo) => repoKey(repo) !== repoKey(requestedRepo)
   );
+  if (nextRepositories.length === 0) {
+    process.stderr.write(
+      "Repository removal would leave the project without a repository. Remove the project instead or add another repository first.\n"
+    );
+    process.exitCode = 1;
+    return;
+  }
+
   await saveProjectConfig(options.configDir, global.activeProject, {
     ...ws,
-    repository: nextRepositories[0] ?? { owner: "", name: "", cloneUrl: "" },
+    repository: nextRepositories[0],
     repositories: nextRepositories,
     tracker: {
       ...ws.tracker,
       settings: {
         ...ws.tracker.settings,
-        ...(nextRepositories[0]
-          ? {
-              repository: `${nextRepositories[0].owner}/${nextRepositories[0].name}`,
-            }
-          : {}),
+        repository: `${nextRepositories[0].owner}/${nextRepositories[0].name}`,
       },
     },
   });
@@ -518,18 +531,19 @@ async function repoSync(args: string[], options: GlobalOptions): Promise<void> {
   );
 
   if (!flags.dryRun) {
+    const repository = nextRepositories[0];
+    const { repository: _legacyRepository, ...trackerSettings } =
+      ws.tracker.settings ?? {};
     await saveProjectConfig(options.configDir, global.activeProject, {
       ...ws,
-      repository: nextRepositories[0] ?? { owner: "", name: "", cloneUrl: "" },
+      ...(repository ? { repository } : { repository: undefined }),
       repositories: nextRepositories,
       tracker: {
         ...ws.tracker,
         settings: {
-          ...ws.tracker.settings,
-          ...(nextRepositories[0]
-            ? {
-                repository: `${nextRepositories[0].owner}/${nextRepositories[0].name}`,
-              }
+          ...trackerSettings,
+          ...(repository
+            ? { repository: `${repository.owner}/${repository.name}` }
             : {}),
         },
       },

--- a/packages/cli/src/commands/repo.ts
+++ b/packages/cli/src/commands/repo.ts
@@ -3,6 +3,7 @@ import {
   loadActiveProjectConfig,
   loadGlobalConfig,
   saveProjectConfig,
+  type CliProjectConfig,
 } from "../config.js";
 import {
   checkRequiredScopes,
@@ -82,6 +83,32 @@ function toRepoConfigEntry(repo: LinkedRepository): RepoConfigEntry {
   };
 }
 
+function configuredRepositories(
+  config: Pick<CliProjectConfig, "repository" | "repositories">
+): RepoConfigEntry[] {
+  return (
+    config.repositories ?? (config.repository.owner ? [config.repository] : [])
+  );
+}
+
+function withConfiguredRepository(
+  config: CliProjectConfig,
+  repository: RepoConfigEntry
+): CliProjectConfig {
+  return {
+    ...config,
+    repository,
+    repositories: [repository],
+    tracker: {
+      ...config.tracker,
+      settings: {
+        ...config.tracker.settings,
+        repository: `${repository.owner}/${repository.name}`,
+      },
+    },
+  };
+}
+
 function parseRepoSyncFlags(args: string[]): RepoSyncFlags {
   const flags: RepoSyncFlags = { dryRun: false, prune: false };
 
@@ -102,7 +129,9 @@ function displayScopeError(error: GitHubScopeError): void {
     `Token is missing required scope${plural}: ${error.requiredScopes.join(", ")}\n`
   );
 
-  const currentSet = new Set(error.currentScopes.map((scope) => scope.toLowerCase()));
+  const currentSet = new Set(
+    error.currentScopes.map((scope) => scope.toLowerCase())
+  );
   const scopesToAdd = ["repo", "read:org", "project"].filter(
     (scope) => !currentSet.has(scope)
   );
@@ -134,7 +163,10 @@ function renderRepoGroup(label: string, repos: RepoConfigEntry[]): string[] {
     return [`${label}: none`];
   }
 
-  return [label, ...sortRepos(repos).map((repo) => `  ${formatRepoSpec(repo)}`)];
+  return [
+    label,
+    ...sortRepos(repos).map((repo) => `  ${formatRepoSpec(repo)}`),
+  ];
 }
 
 function buildSyncedRepositories(
@@ -159,7 +191,10 @@ function buildSyncedRepositories(
   return [...retained, ...additions];
 }
 
-function writeRepoSummary(summary: RepoSyncSummary, options: GlobalOptions): void {
+function writeRepoSummary(
+  summary: RepoSyncSummary,
+  options: GlobalOptions
+): void {
   if (options.json) {
     process.stdout.write(JSON.stringify(summary, null, 2) + "\n");
     return;
@@ -186,12 +221,14 @@ async function repoList(options: GlobalOptions): Promise<void> {
   }
 
   if (options.json) {
-    process.stdout.write(JSON.stringify(ws.repositories, null, 2) + "\n");
+    process.stdout.write(
+      JSON.stringify(configuredRepositories(ws), null, 2) + "\n"
+    );
     return;
   }
 
   process.stdout.write("Repositories:\n");
-  for (const repo of ws.repositories) {
+  for (const repo of configuredRepositories(ws)) {
     process.stdout.write(`  ${repo.owner}/${repo.name}\n`);
   }
 }
@@ -232,15 +269,22 @@ async function repoAdd(args: string[], options: GlobalOptions): Promise<void> {
     message: string,
     warning?: string
   ): Promise<void> => {
-    if (ws.repositories.some((entry: RepoConfigEntry) => repoKey(entry) === repoKey(repo))) {
+    if (
+      configuredRepositories(ws).some(
+        (entry) => repoKey(entry) === repoKey(repo)
+      )
+    ) {
       process.stdout.write(
         `Repository ${formatRepoSpec(repo)} is already configured.\n`
       );
       return;
     }
 
-    ws.repositories.push(repo);
-    await saveProjectConfig(options.configDir, activeProjectId, ws);
+    await saveProjectConfig(
+      options.configDir,
+      activeProjectId,
+      withConfiguredRepository(ws, repo)
+    );
 
     if (warning) {
       process.stderr.write(`${warning}\n`);
@@ -264,7 +308,11 @@ async function repoAdd(args: string[], options: GlobalOptions): Promise<void> {
   }
 
   try {
-    const repository = await getRepositoryMetadata(createClient(token), owner, name);
+    const repository = await getRepositoryMetadata(
+      createClient(token),
+      owner,
+      name
+    );
     await addRepository(
       {
         owner: repository.owner,
@@ -327,19 +375,35 @@ async function repoRemove(
 
   const [owner, name] = repoSpec.split("/");
   const requestedRepo = { owner, name };
-  const idx = ws.repositories.findIndex(
-    (r: RepoConfigEntry) => repoKey(r) === repoKey(requestedRepo)
-  );
-
-  if (idx === -1) {
+  const currentRepos = configuredRepositories(ws);
+  if (!currentRepos.some((repo) => repoKey(repo) === repoKey(requestedRepo))) {
     process.stderr.write(`Repository ${repoSpec} is not configured.\n`);
     process.exitCode = 1;
     return;
   }
 
-  ws.repositories.splice(idx, 1);
-  await saveProjectConfig(options.configDir, global.activeProject, ws);
-  process.stdout.write(`Removed repository: ${formatRepoSpec(requestedRepo)}\n`);
+  const nextRepositories = currentRepos.filter(
+    (repo) => repoKey(repo) !== repoKey(requestedRepo)
+  );
+  await saveProjectConfig(options.configDir, global.activeProject, {
+    ...ws,
+    repository: nextRepositories[0] ?? { owner: "", name: "", cloneUrl: "" },
+    repositories: nextRepositories,
+    tracker: {
+      ...ws.tracker,
+      settings: {
+        ...ws.tracker.settings,
+        ...(nextRepositories[0]
+          ? {
+              repository: `${nextRepositories[0].owner}/${nextRepositories[0].name}`,
+            }
+          : {}),
+      },
+    },
+  });
+  process.stdout.write(
+    `Removed repository: ${formatRepoSpec(requestedRepo)}\n`
+  );
 }
 
 async function repoSync(args: string[], options: GlobalOptions): Promise<void> {
@@ -415,7 +479,7 @@ async function repoSync(args: string[], options: GlobalOptions): Promise<void> {
     return;
   }
 
-  const currentRepos: RepoConfigEntry[] = ws.repositories;
+  const currentRepos: RepoConfigEntry[] = configuredRepositories(ws);
   const currentMap = new Map<string, RepoConfigEntry>(
     currentRepos.map((repo: RepoConfigEntry) => [repoKey(repo), repo])
   );
@@ -456,7 +520,19 @@ async function repoSync(args: string[], options: GlobalOptions): Promise<void> {
   if (!flags.dryRun) {
     await saveProjectConfig(options.configDir, global.activeProject, {
       ...ws,
+      repository: nextRepositories[0] ?? { owner: "", name: "", cloneUrl: "" },
       repositories: nextRepositories,
+      tracker: {
+        ...ws.tracker,
+        settings: {
+          ...ws.tracker.settings,
+          ...(nextRepositories[0]
+            ? {
+                repository: `${nextRepositories[0].owner}/${nextRepositories[0].name}`,
+              }
+            : {}),
+        },
+      },
     });
   }
 

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -84,16 +84,25 @@ const handler = async (
   const projectId = projectConfig.projectId;
   // Validate the issue identifier belongs to a configured repo
   const [repoSpec] = parsed.issue.split("#");
-  const repository = projectConfig.repository.owner
-    ? projectConfig.repository
-    : projectConfig.repositories?.[0];
-  const configuredRepo = repository
-    ? `${repository.owner}/${repository.name}`
-    : null;
-  if (repoSpec && configuredRepo !== repoSpec) {
+  const configuredRepos = [
+    ...(projectConfig.repository ? [projectConfig.repository] : []),
+    ...(projectConfig.repositories ?? []),
+  ]
+    .filter((repository) => repository.owner && repository.name)
+    .map((repository) => `${repository.owner}/${repository.name}`);
+  const configuredRepoSet = new Set(configuredRepos);
+  if (configuredRepoSet.size === 0) {
+    process.stderr.write(
+      "No repository is configured in this project. Run 'gh-symphony repo add owner/name' first.\n"
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  if (repoSpec && !configuredRepoSet.has(repoSpec)) {
     process.stderr.write(
       `Repository "${repoSpec}" is not configured in this project.\n` +
-        `Configured repo: ${configuredRepo ?? "(none)"}\n`
+        `Configured repo: ${configuredRepos.join(", ")}\n`
     );
     process.exitCode = 1;
     return;

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -1,8 +1,6 @@
 import type { GlobalOptions } from "../index.js";
 import { runCli as orchestratorRunCli } from "@gh-symphony/orchestrator";
-import {
-  resolveRuntimeRoot,
-} from "../orchestrator-runtime.js";
+import { resolveRuntimeRoot } from "../orchestrator-runtime.js";
 import {
   handleMissingManagedProjectConfig,
   resolveManagedProjectConfig,
@@ -86,13 +84,16 @@ const handler = async (
   const projectId = projectConfig.projectId;
   // Validate the issue identifier belongs to a configured repo
   const [repoSpec] = parsed.issue.split("#");
-  if (
-    repoSpec &&
-    !projectConfig.repositories.some((r) => `${r.owner}/${r.name}` === repoSpec)
-  ) {
+  const repository = projectConfig.repository.owner
+    ? projectConfig.repository
+    : projectConfig.repositories?.[0];
+  const configuredRepo = repository
+    ? `${repository.owner}/${repository.name}`
+    : null;
+  if (repoSpec && configuredRepo !== repoSpec) {
     process.stderr.write(
       `Repository "${repoSpec}" is not configured in this project.\n` +
-        `Configured repos: ${projectConfig.repositories.map((r) => `${r.owner}/${r.name}`).join(", ")}\n`
+        `Configured repo: ${configuredRepo ?? "(none)"}\n`
     );
     process.exitCode = 1;
     return;

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -18,7 +18,10 @@ import {
   type OrchestratorLogLevel,
   type ProjectLockHandle,
 } from "@gh-symphony/orchestrator";
-import type { ProjectStatusSnapshot } from "@gh-symphony/core";
+import type {
+  OrchestratorProjectConfig,
+  ProjectStatusSnapshot,
+} from "@gh-symphony/core";
 import {
   DashboardFsReader,
   resolveDashboardResponse,
@@ -461,6 +464,13 @@ const handler = async (
     handleMissingManagedProjectConfig();
     return;
   }
+  if (!hasConfiguredRepository(projectConfig)) {
+    process.stderr.write(
+      "No repository is configured in this project. Run 'gh-symphony repo add owner/name' first.\n"
+    );
+    process.exitCode = 1;
+    return;
+  }
 
   const runtimeRoot = resolveRuntimeRoot(options.configDir);
   const projectId = projectConfig.projectId;
@@ -758,6 +768,12 @@ export async function shutdownForegroundOrchestrator(
   }
 
   return (input.exit ?? process.exit)(0);
+}
+
+function hasConfiguredRepository(
+  config: { repository?: OrchestratorProjectConfig["repository"] }
+): config is OrchestratorProjectConfig {
+  return Boolean(config.repository?.owner && config.repository.name);
 }
 
 async function tailWorkerLog(

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1,7 +1,10 @@
 import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { homedir } from "node:os";
-import type { OrchestratorProjectConfig } from "@gh-symphony/core";
+import type {
+  OrchestratorProjectConfig,
+  RepositoryRef,
+} from "@gh-symphony/core";
 
 export const DEFAULT_CONFIG_DIR = join(homedir(), ".gh-symphony");
 export const CONFIG_FILE = "config.json";
@@ -19,12 +22,14 @@ export type CliProjectTrackerSettings = Record<
   string | number | boolean
 > & {
   projectId?: string;
+  repository?: string;
   assignedOnly?: boolean;
   timeoutMs?: number;
 };
 
 export type CliProjectConfig = Omit<OrchestratorProjectConfig, "tracker"> & {
   displayName?: string;
+  repositories?: RepositoryRef[];
   tracker: Omit<OrchestratorProjectConfig["tracker"], "settings"> & {
     settings?: CliProjectTrackerSettings;
   };
@@ -53,10 +58,7 @@ export function projectConfigPath(
   return join(projectConfigDir(configDir, projectId), "project.json");
 }
 
-export function daemonPidPath(
-  configDir: string,
-  projectId: string
-): string {
+export function daemonPidPath(configDir: string, projectId: string): string {
   return join(projectConfigDir(configDir, projectId), DAEMON_PID_FILE);
 }
 
@@ -113,9 +115,21 @@ export async function loadProjectConfig(
   configDir: string,
   projectId: string
 ): Promise<CliProjectConfig | null> {
-  return readJsonFile<CliProjectConfig>(
-    projectConfigPath(configDir, projectId)
-  );
+  const config = await readJsonFile<
+    CliProjectConfig & {
+      repository?: RepositoryRef;
+      repositories?: RepositoryRef[];
+    }
+  >(projectConfigPath(configDir, projectId));
+  if (!config) {
+    return null;
+  }
+
+  const repository = config.repository ?? config.repositories?.[0];
+  return {
+    ...config,
+    ...(repository ? { repository } : {}),
+  } as CliProjectConfig;
 }
 
 export async function saveProjectConfig(

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -27,8 +27,12 @@ export type CliProjectTrackerSettings = Record<
   timeoutMs?: number;
 };
 
-export type CliProjectConfig = Omit<OrchestratorProjectConfig, "tracker"> & {
+export type CliProjectConfig = Omit<
+  OrchestratorProjectConfig,
+  "repository" | "tracker"
+> & {
   displayName?: string;
+  repository?: RepositoryRef;
   repositories?: RepositoryRef[];
   tracker: Omit<OrchestratorProjectConfig["tracker"], "settings"> & {
     settings?: CliProjectTrackerSettings;
@@ -125,11 +129,13 @@ export async function loadProjectConfig(
     return null;
   }
 
-  const repository = config.repository ?? config.repositories?.[0];
+  // P1 compat: tolerate legacy `repositories[]` JSON written by older CLI;
+  // the first valid entry becomes the canonical `repository`.
+  const repository = config.repository ?? firstConfiguredRepository(config);
   return {
     ...config,
     ...(repository ? { repository } : {}),
-  } as CliProjectConfig;
+  };
 }
 
 export async function saveProjectConfig(
@@ -179,5 +185,17 @@ function isFileMissing(error: unknown): boolean {
     typeof error === "object" &&
     "code" in error &&
     (error.code === "ENOENT" || error.code === "ENOTDIR")
+  );
+}
+
+function firstConfiguredRepository(config: {
+  repositories?: RepositoryRef[];
+}): RepositoryRef | undefined {
+  return config.repositories?.find(
+    (repository) =>
+      typeof repository.owner === "string" &&
+      repository.owner.length > 0 &&
+      typeof repository.name === "string" &&
+      repository.name.length > 0
   );
 }

--- a/packages/core/src/contracts/state-store.ts
+++ b/packages/core/src/contracts/state-store.ts
@@ -2,24 +2,26 @@ import type {
   IssueStatusEvent,
   OrchestratorRunRecord,
   OrchestratorProjectConfig,
-  ProjectStatusSnapshot
+  ProjectStatusSnapshot,
 } from "./status-surface.js";
 import type { IssueOrchestrationRecord } from "./issue-orchestration.js";
 import type { IssueWorkspaceRecord } from "../domain/issue.js";
 import type { OrchestratorEvent } from "../observability/structured-events.js";
 
 export type OrchestratorStateStore = {
-  loadProjectConfig(projectId: string): Promise<OrchestratorProjectConfig | null>;
+  loadProjectConfig(
+    projectId?: string
+  ): Promise<OrchestratorProjectConfig | null>;
   saveProjectConfig(config: OrchestratorProjectConfig): Promise<void>;
   loadProjectIssueOrchestrations(
-    projectId: string
+    projectId?: string
   ): Promise<IssueOrchestrationRecord[]>;
   saveProjectIssueOrchestrations(
-    projectId: string,
+    projectId: string | undefined,
     issues: IssueOrchestrationRecord[]
   ): Promise<void>;
   saveProjectStatus(status: ProjectStatusSnapshot): Promise<void>;
-  loadProjectStatus(projectId: string): Promise<ProjectStatusSnapshot | null>;
+  loadProjectStatus(projectId?: string): Promise<ProjectStatusSnapshot | null>;
   loadRun(
     runId: string,
     projectId?: string
@@ -33,9 +35,15 @@ export type OrchestratorStateStore = {
     projectId?: string
   ): Promise<IssueStatusEvent[]>;
   runDir(runId: string, projectId?: string): string;
-  projectDir(projectId: string): string;
-  loadIssueWorkspace(projectId: string, workspaceKey: string): Promise<IssueWorkspaceRecord | null>;
-  loadIssueWorkspaces(projectId: string): Promise<IssueWorkspaceRecord[]>;
+  projectDir(projectId?: string): string;
+  loadIssueWorkspace(
+    projectId: string | undefined,
+    workspaceKey: string
+  ): Promise<IssueWorkspaceRecord | null>;
+  loadIssueWorkspaces(projectId?: string): Promise<IssueWorkspaceRecord[]>;
   saveIssueWorkspace(record: IssueWorkspaceRecord): Promise<void>;
-  removeIssueWorkspace(projectId: string, workspaceKey: string): Promise<void>;
+  removeIssueWorkspace(
+    projectId: string | undefined,
+    workspaceKey: string
+  ): Promise<void>;
 };

--- a/packages/core/src/contracts/state-store.ts
+++ b/packages/core/src/contracts/state-store.ts
@@ -9,6 +9,9 @@ import type { IssueWorkspaceRecord } from "../domain/issue.js";
 import type { OrchestratorEvent } from "../observability/structured-events.js";
 
 export type OrchestratorStateStore = {
+  // P1 single-repo transition: projectId is optional at the contract boundary
+  // so later phases can remove the legacy project namespace incrementally.
+  // Legacy layout implementations may still require it until migration ships.
   loadProjectConfig(
     projectId?: string
   ): Promise<OrchestratorProjectConfig | null>;

--- a/packages/core/src/contracts/status-surface.ts
+++ b/packages/core/src/contracts/status-surface.ts
@@ -16,7 +16,7 @@ export type OrchestratorProjectConfig = {
   projectId: string;
   slug: string;
   workspaceDir: string;
-  repositories: RepositoryRef[];
+  repository: RepositoryRef;
   tracker: OrchestratorTrackerConfig;
 };
 
@@ -30,8 +30,7 @@ export const WORKFLOW_EXECUTION_PHASES = [
   "completed",
 ] as const;
 
-export type WorkflowExecutionPhase =
-  (typeof WORKFLOW_EXECUTION_PHASES)[number];
+export type WorkflowExecutionPhase = (typeof WORKFLOW_EXECUTION_PHASES)[number];
 
 export function isWorkflowExecutionPhase(
   value: unknown

--- a/packages/core/src/core-conformance.test.ts
+++ b/packages/core/src/core-conformance.test.ts
@@ -7,6 +7,7 @@ import {
   DEFAULT_BASE_DELAY_MS,
   DEFAULT_WORKFLOW_AGENT,
   DEFAULT_WORKFLOW_LIFECYCLE,
+  deriveWorkspaceKey,
   deriveIssueWorkspaceKey,
   isStateActive,
   isStateTerminal,
@@ -17,59 +18,27 @@ import {
 } from "./index.js";
 import type { RunDispatchedEvent } from "./observability/structured-events.js";
 
-describe("deriveIssueWorkspaceKey", () => {
+describe("deriveWorkspaceKey", () => {
   it("produces a stable deterministic key", () => {
-    const identity = {
-      projectId: "ws-1",
-      adapter: "github-project",
-      issueSubjectId: "issue-abc",
-    };
-
-    const key1 = deriveIssueWorkspaceKey(identity, "acme/platform#42");
-    const key2 = deriveIssueWorkspaceKey(identity, "acme/platform#42");
+    const key1 = deriveWorkspaceKey("acme/platform#42");
+    const key2 = deriveWorkspaceKey("acme/platform#42");
 
     expect(key1).toBe(key2);
     expect(key1).toBe("acme_platform_42");
   });
 
   it("produces different keys for different identifiers", () => {
-    const keyA = deriveIssueWorkspaceKey({
-      projectId: "ws-1",
-      adapter: "github-project",
-      issueSubjectId: "issue-1",
-    }, "acme/platform#1");
-    const keyB = deriveIssueWorkspaceKey({
-      projectId: "ws-1",
-      adapter: "github-project",
-      issueSubjectId: "issue-2",
-    }, "acme/platform#2");
-    const keyC = deriveIssueWorkspaceKey({
-      projectId: "ws-2",
-      adapter: "github-project",
-      issueSubjectId: "issue-1",
-    }, "acme/api#1");
+    const keyA = deriveWorkspaceKey("acme/platform#1");
+    const keyB = deriveWorkspaceKey("acme/platform#2");
+    const keyC = deriveWorkspaceKey("acme/api#1");
 
     expect(keyA).not.toBe(keyB);
     expect(keyA).not.toBe(keyC);
   });
 
   it("distinguishes hyphens from underscores under spec 4.2 substitution", () => {
-    const keyA = deriveIssueWorkspaceKey(
-      {
-        projectId: "ws-1",
-        adapter: "github-project",
-        issueSubjectId: "issue-1",
-      },
-      "acme/foo-bar#1"
-    );
-    const keyB = deriveIssueWorkspaceKey(
-      {
-        projectId: "ws-1",
-        adapter: "github-project",
-        issueSubjectId: "issue-2",
-      },
-      "acme/foo_bar#1"
-    );
+    const keyA = deriveWorkspaceKey("acme/foo-bar#1");
+    const keyB = deriveWorkspaceKey("acme/foo_bar#1");
 
     expect(keyA).toBe("acme_foo-bar_1");
     expect(keyB).toBe("acme_foo_bar_1");
@@ -77,41 +46,27 @@ describe("deriveIssueWorkspaceKey", () => {
   });
 
   it("preserves uppercase letters, dots, and hyphens allowed by spec 4.2", () => {
-    const key = deriveIssueWorkspaceKey(
-      {
-        projectId: "ws-1",
-        adapter: "github-project",
-        issueSubjectId: "issue-1",
-      },
-      "My.Issue-1"
-    );
+    const key = deriveWorkspaceKey("My.Issue-1");
 
     expect(key).toBe("My.Issue-1");
   });
 
   it("falls back to 'issue' when sanitization strips everything", () => {
-    const key = deriveIssueWorkspaceKey(
-      {
-        projectId: "ws-1",
-        adapter: "github-project",
-        issueSubjectId: "issue-1",
-      },
-      "!!!"
-    );
+    const key = deriveWorkspaceKey("!!!");
 
     expect(key).toBe("issue");
   });
 
   it("falls back to 'issue' for dot-only sanitized keys", () => {
-    const identity = {
-      projectId: "ws-1",
-      adapter: "github-project",
-      issueSubjectId: "issue-1",
-    };
+    expect(deriveWorkspaceKey(".")).toBe("issue");
+    expect(deriveWorkspaceKey("..")).toBe("issue");
+    expect(deriveWorkspaceKey("...")).toBe("issue");
+  });
 
-    expect(deriveIssueWorkspaceKey(identity, ".")).toBe("issue");
-    expect(deriveIssueWorkspaceKey(identity, "..")).toBe("issue");
-    expect(deriveIssueWorkspaceKey(identity, "...")).toBe("issue");
+  it("keeps the legacy deriveIssueWorkspaceKey alias on identifier input", () => {
+    expect(deriveIssueWorkspaceKey("acme/platform#42")).toBe(
+      "acme_platform_42"
+    );
   });
 });
 
@@ -408,7 +363,10 @@ describe("renderPrompt", () => {
       renderPrompt("{% if unknown_var %}x{% endif %}", variables)
     ).toThrow("template_render_error");
     expect(() =>
-      renderPrompt("{% for item in unknown_list %}{{ item }}{% endfor %}", variables)
+      renderPrompt(
+        "{% for item in unknown_list %}{{ item }}{% endfor %}",
+        variables
+      )
     ).toThrow("template_render_error");
   });
 
@@ -526,7 +484,7 @@ describe("renderPrompt", () => {
         number: 76,
         title: "Replace template engine",
         description:
-          '현재 `renderPrompt()`는 `{{variable.path}}` 단순 치환만 지원한다.',
+          "현재 `renderPrompt()`는 `{{variable.path}}` 단순 치환만 지원한다.",
         priority: null,
         state: "Ready",
         branchName: null,
@@ -693,7 +651,7 @@ describe("buildProjectSnapshot", () => {
     slug: "ws-1",
     promptGuidelines: "",
     workspaceDir: "/runtime",
-    repositories: [],
+    repository: { owner: "acme", name: "platform", cloneUrl: "" },
     tracker: {
       adapter: "github-project" as const,
       bindingId: "project-123",
@@ -803,7 +761,11 @@ describe("token accounting - buildProjectSnapshot", () => {
         projectId: "ws-1",
         slug: "test",
         workspaceDir: "/tmp",
-        repositories: [],
+        repository: {
+          owner: "acme",
+          name: "repo",
+          cloneUrl: "https://github.com/acme/repo.git",
+        },
         tracker: { adapter: "github-project", bindingId: "proj-1" },
       },
       activeRuns: [],
@@ -855,7 +817,11 @@ describe("token accounting - buildProjectSnapshot", () => {
         projectId: "ws-1",
         slug: "test",
         workspaceDir: "/tmp",
-        repositories: [],
+        repository: {
+          owner: "acme",
+          name: "repo",
+          cloneUrl: "https://github.com/acme/repo.git",
+        },
         tracker: { adapter: "github-project", bindingId: "proj-1" },
       },
       activeRuns: [],

--- a/packages/core/src/domain/issue.ts
+++ b/packages/core/src/domain/issue.ts
@@ -9,7 +9,6 @@ import type { TrackerAdapterKind } from "../contracts/tracker-adapter.js";
  * metadata and do not participate in workspace identity derivation.
  */
 export type IssueSubjectIdentity = {
-  projectId: string;
   adapter: TrackerAdapterKind;
   /**
    * Stable subject identifier within the adapter scope.
@@ -26,10 +25,7 @@ export type IssueSubjectIdentity = {
  * - `cleanup_pending` — terminal state reached, cleanup scheduled
  * - `removed`         — workspace cleaned up
  */
-export type IssueWorkspaceStatus =
-  | "active"
-  | "cleanup_pending"
-  | "removed";
+export type IssueWorkspaceStatus = "active" | "cleanup_pending" | "removed";
 
 export type IssueWorkspaceRecord = {
   workspaceKey: string;

--- a/packages/core/src/observability/snapshot-builder.test.ts
+++ b/packages/core/src/observability/snapshot-builder.test.ts
@@ -18,13 +18,11 @@ function mockProject(
     projectId: "tenant-123",
     slug: "test-tenant",
     workspaceDir: "/tmp/runtime",
-    repositories: [
-      {
-        owner: "acme",
-        name: "platform",
-        cloneUrl: "https://github.com/acme/platform.git",
-      },
-    ],
+    repository: {
+      owner: "acme",
+      name: "platform",
+      cloneUrl: "https://github.com/acme/platform.git",
+    },
     tracker: {
       adapter: "github",
       bindingId: "binding-456",
@@ -554,7 +552,9 @@ describe("buildProjectSnapshot", () => {
     expect(snapshot.activeRuns[0].tokenUsage?.outputTokens).toBe(1200);
     expect(snapshot.activeRuns[0].tokenUsage?.totalTokens).toBe(3700);
     expect(snapshot.activeRuns[0].tokenUsage?.cumulativeInputTokens).toBe(2500);
-    expect(snapshot.activeRuns[0].tokenUsage?.cumulativeOutputTokens).toBe(1200);
+    expect(snapshot.activeRuns[0].tokenUsage?.cumulativeOutputTokens).toBe(
+      1200
+    );
     expect(snapshot.activeRuns[0].tokenUsage?.cumulativeTotalTokens).toBe(3700);
   });
 

--- a/packages/core/src/workspace/identity.ts
+++ b/packages/core/src/workspace/identity.ts
@@ -15,21 +15,8 @@ import type { IssueSubjectIdentity } from "../domain/issue.js";
  * `OrchestratorRunRecord.issueWorkspaceKey` is nullable to support older run
  * records created before the transition.
  */
-export function deriveIssueWorkspaceKey(
-  identity: IssueSubjectIdentity,
-  issueIdentifier?: string
-): string {
-  if (issueIdentifier) {
-    return deriveIssueWorkspaceKeyFromIdentifier(issueIdentifier);
-  }
-
-  return deriveLegacyIssueWorkspaceKey(identity);
-}
-
-export function deriveIssueWorkspaceKeyFromIdentifier(
-  issueIdentifier: string
-): string {
-  const sanitized = issueIdentifier
+export function deriveWorkspaceKey(identifier: string): string {
+  const sanitized = identifier
     .replace(/[^A-Za-z0-9._-]+/g, "_")
     .replace(/^_+|_+$/g, "");
 
@@ -40,14 +27,33 @@ export function deriveIssueWorkspaceKeyFromIdentifier(
   return sanitized;
 }
 
-export function deriveLegacyIssueWorkspaceKey(
-  identity: IssueSubjectIdentity
+export const deriveIssueWorkspaceKeyFromIdentifier = deriveWorkspaceKey;
+
+export function deriveIssueWorkspaceKey(identifier: string): string;
+export function deriveIssueWorkspaceKey(
+  identity: IssueSubjectIdentity,
+  issueIdentifier: string
+): string;
+export function deriveIssueWorkspaceKey(
+  identityOrIdentifier: IssueSubjectIdentity | string,
+  issueIdentifier?: string
 ): string {
-  const input = [
-    identity.projectId,
-    identity.adapter,
-    identity.issueSubjectId,
-  ].join(":");
+  if (typeof identityOrIdentifier === "string") {
+    return deriveWorkspaceKey(identityOrIdentifier);
+  }
+
+  return deriveWorkspaceKey(
+    issueIdentifier ?? identityOrIdentifier.issueSubjectId
+  );
+}
+
+export function deriveLegacyIssueWorkspaceKey(
+  identity: IssueSubjectIdentity,
+  projectId?: string
+): string {
+  const input = [projectId, identity.adapter, identity.issueSubjectId]
+    .filter((part): part is string => typeof part === "string")
+    .join(":");
   return createHash("sha256").update(input).digest("hex").slice(0, 16);
 }
 

--- a/packages/orchestrator/src/dispatch.test.ts
+++ b/packages/orchestrator/src/dispatch.test.ts
@@ -545,7 +545,9 @@ describe("codex policy propagation", () => {
 
   it("passes workflow codex policies through worker environment", async () => {
     process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
-    const tempRoot = await mkdtemp(join(tmpdir(), "orchestrator-codex-policy-"));
+    const tempRoot = await mkdtemp(
+      join(tmpdir(), "orchestrator-codex-policy-")
+    );
     const repository = await createRepositoryFixture(
       tempRoot,
       "acme",
@@ -716,18 +718,17 @@ function createProjectConfig(
     projectId: "tenant-1",
     slug: "tenant-1",
     workspaceDir: join(tempRoot, "workspaces", "tenant-1"),
-    repositories: [
-      {
-        owner,
-        name,
-        cloneUrl,
-      },
-    ],
+    repository: {
+      owner,
+      name,
+      cloneUrl,
+    },
     tracker: {
       adapter: "github-project" as const,
       bindingId: "project-123",
       settings: {
         projectId: "project-123",
+        repository: `${owner}/${name}`,
       },
     },
   };

--- a/packages/orchestrator/src/fs-store.ts
+++ b/packages/orchestrator/src/fs-store.ts
@@ -44,8 +44,8 @@ export class OrchestratorFsStore implements OrchestratorStateStore {
     return join(this.runtimeRoot, "projects");
   }
 
-  projectDir(projectId: string): string {
-    return join(this.projectsRoot(), projectId);
+  projectDir(projectId?: string): string {
+    return join(this.projectsRoot(), requireProjectId(projectId));
   }
 
   private projectRunsDir(projectId: string): string {
@@ -61,7 +61,7 @@ export class OrchestratorFsStore implements OrchestratorStateStore {
   }
 
   async loadProjectConfig(
-    projectId: string
+    projectId?: string
   ): Promise<OrchestratorProjectConfig | null> {
     return readJsonFile<OrchestratorProjectConfig>(
       join(this.projectDir(projectId), "project.json")
@@ -76,7 +76,7 @@ export class OrchestratorFsStore implements OrchestratorStateStore {
   }
 
   async loadProjectIssueOrchestrations(
-    projectId: string
+    projectId?: string
   ): Promise<IssueOrchestrationRecord[]> {
     const issuesPath = join(this.projectDir(projectId), "issues.json");
     const issues = await readJsonFile<IssueOrchestrationRecord[]>(issuesPath);
@@ -124,7 +124,7 @@ export class OrchestratorFsStore implements OrchestratorStateStore {
   }
 
   async saveProjectIssueOrchestrations(
-    projectId: string,
+    projectId: string | undefined,
     issues: IssueOrchestrationRecord[]
   ): Promise<void> {
     await writeJsonFile(
@@ -141,7 +141,7 @@ export class OrchestratorFsStore implements OrchestratorStateStore {
   }
 
   async loadProjectStatus(
-    projectId: string
+    projectId?: string
   ): Promise<ProjectStatusSnapshot | null> {
     return (
       (await readJsonFile<ProjectStatusSnapshot>(
@@ -294,12 +294,15 @@ export class OrchestratorFsStore implements OrchestratorStateStore {
     }
   }
 
-  issueWorkspaceDir(projectId: string, workspaceKey: string): string {
+  issueWorkspaceDir(
+    projectId: string | undefined,
+    workspaceKey: string
+  ): string {
     return join(this.projectDir(projectId), "issues", workspaceKey);
   }
 
   async loadIssueWorkspace(
-    projectId: string,
+    projectId: string | undefined,
     workspaceKey: string
   ): Promise<IssueWorkspaceRecord | null> {
     return (
@@ -310,7 +313,7 @@ export class OrchestratorFsStore implements OrchestratorStateStore {
   }
 
   async loadIssueWorkspaces(
-    projectId: string
+    projectId?: string
   ): Promise<IssueWorkspaceRecord[]> {
     const issuesDir = join(this.projectDir(projectId), "issues");
     const entries = await safeReadDir(issuesDir);
@@ -333,7 +336,7 @@ export class OrchestratorFsStore implements OrchestratorStateStore {
   }
 
   async removeIssueWorkspace(
-    projectId: string,
+    projectId: string | undefined,
     workspaceKey: string
   ): Promise<void> {
     const dir = this.issueWorkspaceDir(projectId, workspaceKey);
@@ -388,4 +391,14 @@ async function pathExists(path: string): Promise<boolean> {
 
     throw error;
   }
+}
+
+function requireProjectId(projectId: string | undefined): string {
+  if (!projectId) {
+    throw new Error(
+      "projectId is required for the legacy project directory layout."
+    );
+  }
+
+  return projectId;
 }

--- a/packages/orchestrator/src/headless-verification.test.ts
+++ b/packages/orchestrator/src/headless-verification.test.ts
@@ -24,12 +24,13 @@ describe("headless orchestration verification", () => {
         projectId: "tenant-1",
         slug: "tenant-1",
         workspaceDir: join(tempRoot, "workspaces", "tenant-1"),
-        repositories: [repository],
+        repository,
         tracker: {
           adapter: "github-project" as const,
           bindingId: "project-123",
           settings: {
             projectId: "project-123",
+            repository: `${repository.owner}/${repository.name}`,
           },
         },
       };
@@ -73,7 +74,6 @@ describe("headless orchestration verification", () => {
       }
     }
   });
-
 });
 
 async function createRepositoryFixture(
@@ -138,11 +138,14 @@ Prefer focused changes.
   };
 }
 
-function createTrackerResponse(repository: {
-  owner: string;
-  name: string;
-  cloneUrl: string;
-}, state = "Todo") {
+function createTrackerResponse(
+  repository: {
+    owner: string;
+    name: string;
+    cloneUrl: string;
+  },
+  state = "Todo"
+) {
   return {
     ok: true,
     json: async () => ({

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -930,11 +930,7 @@ describe("OrchestratorService", () => {
     const projectConfig = createProjectConfig(tempRoot, repository);
     await store.saveProjectConfig(projectConfig);
 
-    const workspaceKey = deriveIssueWorkspaceKey({
-      projectId: "tenant-1",
-      adapter: "github-project",
-      issueSubjectId: "issue-1",
-    });
+    const workspaceKey = deriveIssueWorkspaceKey("acme/platform#1");
     const workspacePath = resolveIssueWorkspaceDirectory(
       store.projectDir(projectConfig.projectId),
       workspaceKey
@@ -1042,11 +1038,7 @@ Prefer focused changes.
     const projectConfig = createProjectConfig(tempRoot, repository);
     await store.saveProjectConfig(projectConfig);
 
-    const workspaceKey = deriveIssueWorkspaceKey({
-      projectId: "tenant-1",
-      adapter: "github-project",
-      issueSubjectId: "issue-1",
-    });
+    const workspaceKey = deriveIssueWorkspaceKey("acme/platform#1");
     const workspacePath = resolveIssueWorkspaceDirectory(
       store.projectDir(projectConfig.projectId),
       workspaceKey
@@ -1133,11 +1125,7 @@ Prefer focused changes.
     const projectConfig = createProjectConfig(tempRoot, repository);
     await store.saveProjectConfig(projectConfig);
 
-    const workspaceKey = deriveIssueWorkspaceKey({
-      projectId: "tenant-1",
-      adapter: "github-project",
-      issueSubjectId: "issue-1",
-    });
+    const workspaceKey = deriveIssueWorkspaceKey("acme/platform#1");
     const workspacePath = resolveIssueWorkspaceDirectory(
       store.projectDir(projectConfig.projectId),
       workspaceKey
@@ -1195,11 +1183,7 @@ Prefer focused changes.
     const projectConfig = createProjectConfig(tempRoot, repository);
     await store.saveProjectConfig(projectConfig);
 
-    const workspaceKey = deriveIssueWorkspaceKey({
-      projectId: "tenant-1",
-      adapter: "github-project",
-      issueSubjectId: "issue-1",
-    });
+    const workspaceKey = deriveIssueWorkspaceKey("acme/platform#1");
     const workspacePath = resolveIssueWorkspaceDirectory(
       store.projectDir(projectConfig.projectId),
       workspaceKey
@@ -1334,11 +1318,7 @@ Prefer focused changes.
     const projectConfig = createProjectConfig(tempRoot, configuredRepository);
     await store.saveProjectConfig(projectConfig);
 
-    const workspaceKey = deriveIssueWorkspaceKey({
-      projectId: "tenant-1",
-      adapter: "github-project",
-      issueSubjectId: "issue-legacy-1",
-    });
+    const workspaceKey = deriveIssueWorkspaceKey("acme/legacy#1");
     const workspacePath = resolveIssueWorkspaceDirectory(
       store.projectDir(projectConfig.projectId),
       workspaceKey
@@ -1434,11 +1414,7 @@ Prefer focused changes.
     const projectConfig = createProjectConfig(tempRoot, repository);
     await store.saveProjectConfig(projectConfig);
 
-    const workspaceKey = deriveIssueWorkspaceKey({
-      projectId: "tenant-1",
-      adapter: "github-project",
-      issueSubjectId: "issue-1",
-    });
+    const workspaceKey = deriveIssueWorkspaceKey("acme/platform#1");
     const workspacePath = resolveIssueWorkspaceDirectory(
       store.projectDir(projectConfig.projectId),
       workspaceKey
@@ -1522,11 +1498,7 @@ Prefer focused changes.
     const projectConfig = createProjectConfig(tempRoot, repository);
     await store.saveProjectConfig(projectConfig);
 
-    const workspaceKey = deriveIssueWorkspaceKey({
-      projectId: "tenant-1",
-      adapter: "github-project",
-      issueSubjectId: "issue-1",
-    });
+    const workspaceKey = deriveIssueWorkspaceKey("acme/platform#1");
     const workspacePath = resolveIssueWorkspaceDirectory(
       store.projectDir(projectConfig.projectId),
       workspaceKey
@@ -2101,8 +2073,7 @@ Prefer focused changes.
                         fieldValues: {
                           nodes: [
                             {
-                              __typename:
-                                "ProjectV2ItemFieldSingleSelectValue",
+                              __typename: "ProjectV2ItemFieldSingleSelectValue",
                               name: "Todo",
                               field: { name: "Status" },
                             },
@@ -2716,7 +2687,9 @@ Prefer focused changes.
     const service = new OrchestratorService(store, projectConfig, {
       fetchImpl: vi
         .fn()
-        .mockResolvedValue(createTrackerResponseWithRateLimits(repository, 100, 5000)) as typeof fetch,
+        .mockResolvedValue(
+          createTrackerResponseWithRateLimits(repository, 100, 5000)
+        ) as typeof fetch,
       spawnImpl: vi.fn().mockReturnValue({
         pid: 4307,
         unref: vi.fn(),
@@ -3289,7 +3262,11 @@ Prefer focused changes.
       port: 4601,
       workingDirectory: join(tempRoot, "suppressed-run"),
       issueWorkspaceKey: null,
-      workspaceRuntimeDir: join(tempRoot, "suppressed-run", "workspace-runtime"),
+      workspaceRuntimeDir: join(
+        tempRoot,
+        "suppressed-run",
+        "workspace-runtime"
+      ),
       workflowPath: null,
       retryKind: null,
       createdAt: "2026-03-08T00:00:00.000Z",
@@ -3307,13 +3284,11 @@ Prefer focused changes.
       unref: vi.fn(),
     });
     const service = new OrchestratorService(store, projectConfig, {
-      fetchImpl: vi
-        .fn()
-        .mockResolvedValue(
-          createTrackerResponseWithState(repository, "Todo", {
-            updatedAt: "2026-03-08T00:04:00.000Z",
-          })
-        ) as never,
+      fetchImpl: vi.fn().mockResolvedValue(
+        createTrackerResponseWithState(repository, "Todo", {
+          updatedAt: "2026-03-08T00:04:00.000Z",
+        })
+      ) as never,
       spawnImpl: spawnImpl as never,
       now: () => new Date("2026-03-08T00:06:00.000Z"),
     });
@@ -3374,7 +3349,11 @@ Prefer focused changes.
       port: 4601,
       workingDirectory: join(tempRoot, "suppressed-run"),
       issueWorkspaceKey: null,
-      workspaceRuntimeDir: join(tempRoot, "suppressed-run", "workspace-runtime"),
+      workspaceRuntimeDir: join(
+        tempRoot,
+        "suppressed-run",
+        "workspace-runtime"
+      ),
       workflowPath: null,
       retryKind: null,
       createdAt: "2026-03-08T00:00:00.000Z",
@@ -3392,13 +3371,11 @@ Prefer focused changes.
       unref: vi.fn(),
     });
     const service = new OrchestratorService(store, projectConfig, {
-      fetchImpl: vi
-        .fn()
-        .mockResolvedValue(
-          createTrackerResponseWithState(repository, "Todo", {
-            updatedAt: "2026-03-08T00:06:00.000Z",
-          })
-        ) as never,
+      fetchImpl: vi.fn().mockResolvedValue(
+        createTrackerResponseWithState(repository, "Todo", {
+          updatedAt: "2026-03-08T00:06:00.000Z",
+        })
+      ) as never,
       spawnImpl: spawnImpl as never,
       now: () => new Date("2026-03-08T00:06:00.000Z"),
     });
@@ -3483,21 +3460,18 @@ Prefer focused changes.
         unref: vi.fn(),
       });
       const service = new OrchestratorService(store, projectConfig, {
-        fetchImpl: vi
-          .fn()
-          .mockResolvedValue(
-            createTrackerResponseWithState(repository, "Todo", {
-              updatedAt: "2026-03-08T00:06:00.000Z",
-            })
-          ) as never,
+        fetchImpl: vi.fn().mockResolvedValue(
+          createTrackerResponseWithState(repository, "Todo", {
+            updatedAt: "2026-03-08T00:06:00.000Z",
+          })
+        ) as never,
         spawnImpl: spawnImpl as never,
         now: () => new Date("2026-03-08T00:06:00.000Z"),
       });
 
       const result = await service.runOnce();
-      const issueRecords = await store.loadProjectIssueOrchestrations(
-        "tenant-1"
-      );
+      const issueRecords =
+        await store.loadProjectIssueOrchestrations("tenant-1");
 
       expect(result.summary.dispatched).toBe(1);
       expect(spawnImpl).toHaveBeenCalledTimes(1);
@@ -3579,21 +3553,18 @@ Prefer focused changes.
         unref: vi.fn(),
       });
       const service = new OrchestratorService(store, projectConfig, {
-        fetchImpl: vi
-          .fn()
-          .mockResolvedValue(
-            createTrackerResponseWithState(repository, "Todo", {
-              updatedAt: "2026-03-08T00:05:00.000Z",
-            })
-          ) as never,
+        fetchImpl: vi.fn().mockResolvedValue(
+          createTrackerResponseWithState(repository, "Todo", {
+            updatedAt: "2026-03-08T00:05:00.000Z",
+          })
+        ) as never,
         spawnImpl: spawnImpl as never,
         now: () => new Date("2026-03-08T00:06:00.000Z"),
       });
 
       const result = await service.runOnce();
-      const issueRecords = await store.loadProjectIssueOrchestrations(
-        "tenant-1"
-      );
+      const issueRecords =
+        await store.loadProjectIssueOrchestrations("tenant-1");
 
       expect(result.summary.dispatched).toBe(0);
       expect(spawnImpl).not.toHaveBeenCalled();
@@ -3675,21 +3646,18 @@ Prefer focused changes.
         unref: vi.fn(),
       });
       const service = new OrchestratorService(store, projectConfig, {
-        fetchImpl: vi
-          .fn()
-          .mockResolvedValue(
-            createTrackerResponseWithState(repository, "Todo", {
-              updatedAt: "2026-03-08T00:04:00.000Z",
-            })
-          ) as never,
+        fetchImpl: vi.fn().mockResolvedValue(
+          createTrackerResponseWithState(repository, "Todo", {
+            updatedAt: "2026-03-08T00:04:00.000Z",
+          })
+        ) as never,
         spawnImpl: spawnImpl as never,
         now: () => new Date("2026-03-08T00:06:00.000Z"),
       });
 
       const result = await service.runOnce();
-      const issueRecords = await store.loadProjectIssueOrchestrations(
-        "tenant-1"
-      );
+      const issueRecords =
+        await store.loadProjectIssueOrchestrations("tenant-1");
 
       expect(result.summary.dispatched).toBe(0);
       expect(spawnImpl).not.toHaveBeenCalled();
@@ -4036,23 +4004,21 @@ Prefer focused changes.
     });
 
     const service = new OrchestratorService(store, projectConfig, {
-      fetchImpl: vi
-        .fn()
-        .mockResolvedValue(
-          createTrackerResponseWithState(repository, "Todo", {
-            blockedBy: [
-              {
-                id: "issue-2",
-                number: 2,
-                state: "Todo",
-                repository: {
-                  owner: "acme",
-                  name: "platform",
-                },
+      fetchImpl: vi.fn().mockResolvedValue(
+        createTrackerResponseWithState(repository, "Todo", {
+          blockedBy: [
+            {
+              id: "issue-2",
+              number: 2,
+              state: "Todo",
+              repository: {
+                owner: "acme",
+                name: "platform",
               },
-            ],
-          })
-        ) as never,
+            },
+          ],
+        })
+      ) as never,
       spawnImpl: vi.fn().mockReturnValue({
         pid: 4105,
         unref: vi.fn(),
@@ -6468,11 +6434,7 @@ Prefer focused changes.
     );
     await store.saveProjectConfig(projectConfig);
 
-    const workspaceKey = deriveIssueWorkspaceKey({
-      projectId: "tenant-1",
-      adapter: "github-project",
-      issueSubjectId: "issue-1",
-    });
+    const workspaceKey = deriveIssueWorkspaceKey("acme/platform#1");
 
     await store.saveProjectIssueOrchestrations("tenant-1", [
       {
@@ -8023,11 +7985,7 @@ Prefer focused changes.
     );
     await store.saveProjectConfig(projectConfig);
 
-    const workspaceKey = deriveIssueWorkspaceKey({
-      projectId: "tenant-1",
-      adapter: "github-project",
-      issueSubjectId: "issue-1",
-    });
+    const workspaceKey = deriveIssueWorkspaceKey("acme/platform#1");
     const expectedWorkspacePath = resolveIssueWorkspaceDirectory(
       store.projectDir("tenant-1"),
       workspaceKey
@@ -8154,12 +8112,13 @@ function createProjectConfig(
     projectId: "tenant-1",
     slug: "tenant-1",
     workspaceDir,
-    repositories: [repository],
+    repository,
     tracker: {
       adapter: "github-project" as const,
       bindingId: "project-123",
       settings: {
         projectId: "project-123",
+        repository: `${repository.owner}/${repository.name}`,
       },
     },
   };

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -2517,16 +2517,11 @@ export class OrchestratorService {
       tenant,
       tenant.repository
     );
-    const intervals = [
-      isUsableWorkflowResolution(resolution)
-        ? resolution.workflow.polling.intervalMs
-        : NaN,
-    ];
-    const validIntervals = intervals.filter(
-      (value) => Number.isFinite(value) && value > 0
-    );
-    return validIntervals.length
-      ? Math.min(...validIntervals)
+    const interval = isUsableWorkflowResolution(resolution)
+      ? resolution.workflow.polling.intervalMs
+      : NaN;
+    return Number.isFinite(interval) && interval > 0
+      ? interval
       : DEFAULT_POLL_INTERVAL_MS;
   }
 
@@ -2534,23 +2529,17 @@ export class OrchestratorService {
     tenant: OrchestratorProjectConfig
   ): Promise<Record<string, number>> {
     const result: Record<string, number> = {};
-    const resolutions = [
-      await this.loadProjectWorkflow(tenant, tenant.repository).catch(
-        () => null
-      ),
-    ];
+    const resolution = await this.loadProjectWorkflow(
+      tenant,
+      tenant.repository
+    ).catch(() => null);
+    if (!resolution || !isUsableWorkflowResolution(resolution)) {
+      return result;
+    }
 
-    for (const resolution of resolutions) {
-      if (!resolution) continue;
-      if (!isUsableWorkflowResolution(resolution)) continue;
-      const stateLimits = resolution.workflow.agent.maxConcurrentAgentsByState;
-      for (const [state, limit] of Object.entries(stateLimits)) {
-        const existing = result[state];
-        const numLimit = typeof limit === "number" ? limit : Number(limit);
-        // Use the minimum limit across all repository workflows
-        result[state] =
-          existing === undefined ? numLimit : Math.min(existing, numLimit);
-      }
+    const stateLimits = resolution.workflow.agent.maxConcurrentAgentsByState;
+    for (const [state, limit] of Object.entries(stateLimits)) {
+      result[state] = typeof limit === "number" ? limit : Number(limit);
     }
 
     return result;
@@ -2599,19 +2588,16 @@ export class OrchestratorService {
       return this.dependencies.concurrency;
     }
 
-    const limits = [
-      await this.loadProjectWorkflow(project, project.repository)
-        .then((resolution) =>
-          isUsableWorkflowResolution(resolution)
-            ? resolution.workflow.agent.maxConcurrentAgents
-            : NaN
-        )
-        .catch(() => NaN),
-    ];
-    const validLimits = limits.filter(
-      (value) => Number.isFinite(value) && value >= 0
-    );
-    return validLimits.length ? Math.min(...validLimits) : DEFAULT_CONCURRENCY;
+    const limit = await this.loadProjectWorkflow(project, project.repository)
+      .then((resolution) =>
+        isUsableWorkflowResolution(resolution)
+          ? resolution.workflow.agent.maxConcurrentAgents
+          : NaN
+      )
+      .catch(() => NaN);
+    return Number.isFinite(limit) && limit >= 0
+      ? limit
+      : DEFAULT_CONCURRENCY;
   }
 
   private async resolveWorkflowResolution(

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -63,8 +63,7 @@ const CONTINUATION_RETRY_DELAY_MS = 1_000;
 const DEFAULT_WORKER_COMMAND = "node packages/worker/dist/index.js";
 const DEFAULT_MAX_NONPRODUCTIVE_TURNS = 3;
 const LOW_RATE_LIMIT_WARNING_THRESHOLD = 0.05;
-const MAX_FAILURE_RETRIES_EXCEEDED_REASON =
-  "max_failure_retries_exceeded";
+const MAX_FAILURE_RETRIES_EXCEEDED_REASON = "max_failure_retries_exceeded";
 
 type ProjectWorkflowResolution = Awaited<
   ReturnType<typeof loadRepositoryWorkflow>
@@ -557,7 +556,6 @@ export class OrchestratorService {
 
         const preferredWorkspaceKey = deriveIssueWorkspaceKey(
           {
-            projectId: tenant.projectId,
             adapter: issue.tracker.adapter,
             issueSubjectId: issue.id,
           },
@@ -871,12 +869,13 @@ export class OrchestratorService {
   ): RepositoryRef[] {
     const repositories = new Map<string, RepositoryRef>();
 
-    for (const repository of tenant.repositories) {
-      repositories.set(
-        this.startupCleanupRepositoryKey(repository.owner, repository.name),
-        repository
-      );
-    }
+    repositories.set(
+      this.startupCleanupRepositoryKey(
+        tenant.repository.owner,
+        tenant.repository.name
+      ),
+      tenant.repository
+    );
 
     for (const workspaceRecord of workspaceRecords) {
       const repository = this.parseWorkspaceRepositoryRef(workspaceRecord);
@@ -934,13 +933,11 @@ export class OrchestratorService {
       return cachedResolution;
     }
 
-    const resolutionPromise = tenant.repositories.some(
-      (candidate) =>
-        candidate.owner === repository.owner &&
-        candidate.name === repository.name
-    )
-      ? this.loadProjectWorkflow(tenant, repository)
-      : loadRepositoryWorkflow(repository.cloneUrl, repository);
+    const resolutionPromise =
+      tenant.repository.owner === repository.owner &&
+      tenant.repository.name === repository.name
+        ? this.loadProjectWorkflow(tenant, repository)
+        : loadRepositoryWorkflow(repository.cloneUrl, repository);
     workflowCache.set(cacheKey, resolutionPromise);
     return resolutionPromise;
   }
@@ -1032,20 +1029,18 @@ export class OrchestratorService {
         lifecycle = resolution.lifecycle;
       }
 
-      if (
-        !this.isIssueCandidateEligible(issue, resolution.lifecycle, issues)
-      ) {
+      if (!this.isIssueCandidateEligible(issue, resolution.lifecycle, issues)) {
         continue;
       }
 
       candidates.push(issue);
     }
 
-    // If no issues were processed, load lifecycle from first repo
-    if (!lifecycle && tenant.repositories.length > 0) {
+    // If no issues were processed, load lifecycle from the configured repo.
+    if (!lifecycle) {
       const resolution = await this.loadProjectWorkflow(
         tenant,
-        tenant.repositories[0]!
+        tenant.repository
       );
       if (isUsableWorkflowResolution(resolution)) {
         lifecycle = resolution.lifecycle;
@@ -1164,7 +1159,6 @@ export class OrchestratorService {
 
     const issueSubjectId = issue.id;
     const identity: IssueSubjectIdentity = {
-      projectId: tenant.projectId,
       adapter: issue.tracker.adapter,
       issueSubjectId,
     };
@@ -1172,7 +1166,10 @@ export class OrchestratorService {
       identity,
       issue.identifier
     );
-    const legacyWorkspaceKey = deriveLegacyIssueWorkspaceKey(identity);
+    const legacyWorkspaceKey = deriveLegacyIssueWorkspaceKey(
+      identity,
+      tenant.projectId
+    );
     const existingWorkspaceRecord =
       (await this.store.loadIssueWorkspace(
         tenant.projectId,
@@ -1358,12 +1355,8 @@ export class OrchestratorService {
           SYMPHONY_CUMULATIVE_TOTAL_TOKENS: "0",
           SYMPHONY_LAST_TURN_SUMMARY: "",
           SYMPHONY_SESSION_STARTED_AT: "",
-          SYMPHONY_READ_TIMEOUT_MS: String(
-            runtimeTimeouts.readTimeoutMs
-          ),
-          SYMPHONY_TURN_TIMEOUT_MS: String(
-            runtimeTimeouts.turnTimeoutMs
-          ),
+          SYMPHONY_READ_TIMEOUT_MS: String(runtimeTimeouts.readTimeoutMs),
+          SYMPHONY_TURN_TIMEOUT_MS: String(runtimeTimeouts.turnTimeoutMs),
         }),
         detached: true,
         stdio: ["ignore", "ignore", "pipe"],
@@ -1628,7 +1621,6 @@ export class OrchestratorService {
             run.issueWorkspaceKey ??
             deriveIssueWorkspaceKey(
               {
-                projectId: tenant.projectId,
                 adapter: tenant.tracker.adapter,
                 issueSubjectId: run.issueSubjectId,
               },
@@ -1780,10 +1772,7 @@ export class OrchestratorService {
       tenant,
       run.repository
     );
-    if (
-      retryKind === "failure" &&
-      failureRetryCount >= maxFailureRetries
-    ) {
+    if (retryKind === "failure" && failureRetryCount >= maxFailureRetries) {
       const lastError = [
         `Run suppressed: ${MAX_FAILURE_RETRIES_EXCEEDED_REASON}.`,
         `failureRetryCount=${failureRetryCount}.`,
@@ -1820,7 +1809,6 @@ export class OrchestratorService {
             run.issueWorkspaceKey ??
             deriveIssueWorkspaceKey(
               {
-                projectId: tenant.projectId,
                 adapter: tenant.tracker.adapter,
                 issueSubjectId: run.issueSubjectId,
               },
@@ -1891,7 +1879,6 @@ export class OrchestratorService {
         run.issueWorkspaceKey ??
         deriveIssueWorkspaceKey(
           {
-            projectId: tenant.projectId,
             adapter: tenant.tracker.adapter,
             issueSubjectId: run.issueSubjectId,
           },
@@ -2479,7 +2466,6 @@ export class OrchestratorService {
           recoveredRecord.issueWorkspaceKey ??
           deriveIssueWorkspaceKey(
             {
-              projectId: tenant.projectId,
               adapter: tenant.tracker.adapter,
               issueSubjectId: recoveredRecord.issueSubjectId,
             },
@@ -2527,14 +2513,15 @@ export class OrchestratorService {
   private async loadProjectPollInterval(
     tenant: OrchestratorProjectConfig
   ): Promise<number> {
-    const intervals = await Promise.all(
-      tenant.repositories.map(async (repository) => {
-        const resolution = await this.loadProjectWorkflow(tenant, repository);
-        return isUsableWorkflowResolution(resolution)
-          ? resolution.workflow.polling.intervalMs
-          : NaN;
-      })
+    const resolution = await this.loadProjectWorkflow(
+      tenant,
+      tenant.repository
     );
+    const intervals = [
+      isUsableWorkflowResolution(resolution)
+        ? resolution.workflow.polling.intervalMs
+        : NaN,
+    ];
     const validIntervals = intervals.filter(
       (value) => Number.isFinite(value) && value > 0
     );
@@ -2547,15 +2534,11 @@ export class OrchestratorService {
     tenant: OrchestratorProjectConfig
   ): Promise<Record<string, number>> {
     const result: Record<string, number> = {};
-    const resolutions = await Promise.all(
-      tenant.repositories.map(async (repository) => {
-        try {
-          return await this.loadProjectWorkflow(tenant, repository);
-        } catch {
-          return null;
-        }
-      })
-    );
+    const resolutions = [
+      await this.loadProjectWorkflow(tenant, tenant.repository).catch(
+        () => null
+      ),
+    ];
 
     for (const resolution of resolutions) {
       if (!resolution) continue;
@@ -2593,8 +2576,8 @@ export class OrchestratorService {
         maxDelayMs:
           this.dependencies.retryBackoffMs ??
           resolution.workflow.agent.maxRetryBackoffMs,
-        stallTimeoutMs:
-          resolveWorkflowRuntimeTimeouts(resolution.workflow).stallTimeoutMs,
+        stallTimeoutMs: resolveWorkflowRuntimeTimeouts(resolution.workflow)
+          .stallTimeoutMs,
       };
     } catch {
       if (!this.dependencies.retryBackoffMs) {
@@ -2616,21 +2599,15 @@ export class OrchestratorService {
       return this.dependencies.concurrency;
     }
 
-    const limits = await Promise.all(
-      project.repositories.map(async (repository) => {
-        try {
-          const resolution = await this.loadProjectWorkflow(
-            project,
-            repository
-          );
-          return isUsableWorkflowResolution(resolution)
+    const limits = [
+      await this.loadProjectWorkflow(project, project.repository)
+        .then((resolution) =>
+          isUsableWorkflowResolution(resolution)
             ? resolution.workflow.agent.maxConcurrentAgents
-            : NaN;
-        } catch {
-          return NaN;
-        }
-      })
-    );
+            : NaN
+        )
+        .catch(() => NaN),
+    ];
     const validLimits = limits.filter(
       (value) => Number.isFinite(value) && value >= 0
     );
@@ -2793,7 +2770,6 @@ export class OrchestratorService {
   ): Promise<void> {
     const issueSubjectId = issue.id;
     const identity: IssueSubjectIdentity = {
-      projectId: tenant.projectId,
       adapter: issue.tracker.adapter,
       issueSubjectId,
     };
@@ -2801,7 +2777,10 @@ export class OrchestratorService {
       identity,
       issue.identifier
     );
-    const legacyWorkspaceKey = deriveLegacyIssueWorkspaceKey(identity);
+    const legacyWorkspaceKey = deriveLegacyIssueWorkspaceKey(
+      identity,
+      tenant.projectId
+    );
     const orchestrationRecord = (
       await this.store.loadProjectIssueOrchestrations(tenant.projectId)
     ).find((record) => record.issueId === issue.id);

--- a/packages/tracker-file/src/file-tracker-adapter.test.ts
+++ b/packages/tracker-file/src/file-tracker-adapter.test.ts
@@ -14,13 +14,15 @@ function makeProject(issuesPath: string): OrchestratorProjectConfig {
     projectId: "test-project",
     slug: "test-project",
     workspaceDir: "/tmp/test",
-    repositories: [
-      { owner: "test-owner", name: "test-repo", cloneUrl: "/tmp/test-repo" },
-    ],
+    repository: {
+      owner: "test-owner",
+      name: "test-repo",
+      cloneUrl: "/tmp/test-repo",
+    },
     tracker: {
       adapter: "file",
       bindingId: "e2e-test",
-      settings: { issuesPath },
+      settings: { issuesPath, repository: "test-owner/test-repo" },
     },
   };
 }
@@ -125,7 +127,7 @@ describe("fileTrackerAdapter", () => {
         projectId: "test",
         slug: "test",
         workspaceDir: "/tmp",
-        repositories: [],
+        repository: { owner: "test-owner", name: "test-repo", cloneUrl: "" },
         tracker: {
           adapter: "file",
           bindingId: "e2e-test",
@@ -157,7 +159,9 @@ describe("fileTrackerAdapter", () => {
       );
 
       const project = makeProject(issuesPath);
-      const issues = await fileTrackerAdapter.listIssuesByStates(project, ["done"]);
+      const issues = await fileTrackerAdapter.listIssuesByStates(project, [
+        "done",
+      ]);
 
       expect(issues).toHaveLength(1);
       expect(issues[0]?.id).toBe("issue-2");

--- a/packages/tracker-github/src/tracker-github.test.ts
+++ b/packages/tracker-github/src/tracker-github.test.ts
@@ -319,7 +319,11 @@ describe("resolveTrackerAdapter", () => {
         projectId: "tenant-1",
         slug: "tenant-1",
         workspaceDir: "/tmp/workspaces/tenant-1",
-        repositories: [],
+        repository: {
+          owner: "acme",
+          name: "platform",
+          cloneUrl: "https://github.com/acme/platform.git",
+        },
         tracker: {
           adapter: "github-project",
           bindingId: "project-123",
@@ -412,7 +416,11 @@ describe("resolveTrackerAdapter", () => {
           projectId: "workspace-1",
           slug: "workspace-1",
           workspaceDir: "/tmp/workspace-1",
-          repositories: [],
+          repository: {
+            owner: "acme",
+            name: "platform",
+            cloneUrl: "https://github.com/acme/platform.git",
+          },
           tracker: {
             adapter: "github-project",
             bindingId: "project-123",
@@ -459,7 +467,11 @@ describe("resolveTrackerAdapter", () => {
           projectId: "workspace-1",
           slug: "workspace-1",
           workspaceDir: "/tmp/workspace-1",
-          repositories: [],
+          repository: {
+            owner: "acme",
+            name: "platform",
+            cloneUrl: "https://github.com/acme/platform.git",
+          },
           tracker: {
             adapter: "github-project",
             bindingId: "project-123",
@@ -549,7 +561,11 @@ describe("resolveTrackerAdapter", () => {
         projectId: "workspace-1",
         slug: "workspace-1",
         workspaceDir: "/tmp/workspace-1",
-        repositories: [],
+        repository: {
+          owner: "acme",
+          name: "platform",
+          cloneUrl: "https://github.com/acme/platform.git",
+        },
         tracker: {
           adapter: "github-project",
           bindingId: "project-123",
@@ -678,7 +694,11 @@ describe("resolveTrackerAdapter", () => {
         projectId: "workspace-1",
         slug: "workspace-1",
         workspaceDir: "/tmp/workspace-1",
-        repositories: [],
+        repository: {
+          owner: "acme",
+          name: "platform",
+          cloneUrl: "https://github.com/acme/platform.git",
+        },
         tracker: {
           adapter: "github-project",
           bindingId: "project-123",
@@ -698,7 +718,11 @@ describe("resolveTrackerAdapter", () => {
         projectId: "workspace-1",
         slug: "workspace-1",
         workspaceDir: "/tmp/workspace-1",
-        repositories: [],
+        repository: {
+          owner: "acme",
+          name: "platform",
+          cloneUrl: "https://github.com/acme/platform.git",
+        },
         tracker: {
           adapter: "github-project",
           bindingId: "project-123",
@@ -733,40 +757,42 @@ describe("resolveTrackerAdapter", () => {
       },
     });
 
-    const fetchImpl = vi
-      .fn()
-      .mockResolvedValueOnce(
-        new Response(
-          JSON.stringify({
-            data: {
-              node: {
-                __typename: "ProjectV2",
-                items: {
-                  nodes: [],
-                  pageInfo: { endCursor: null, hasNextPage: false },
-                },
+    const fetchImpl = vi.fn().mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          data: {
+            node: {
+              __typename: "ProjectV2",
+              items: {
+                nodes: [],
+                pageInfo: { endCursor: null, hasNextPage: false },
               },
             },
-          }),
-          {
-            status: 200,
-            headers: {
-              "content-type": "application/json",
-              "x-ratelimit-limit": "5000",
-              "x-ratelimit-remaining": "100",
-              "x-ratelimit-reset": "1773892920",
-              "x-ratelimit-resource": "graphql",
-            },
-          }
-        )
-      );
+          },
+        }),
+        {
+          status: 200,
+          headers: {
+            "content-type": "application/json",
+            "x-ratelimit-limit": "5000",
+            "x-ratelimit-remaining": "100",
+            "x-ratelimit-reset": "1773892920",
+            "x-ratelimit-resource": "graphql",
+          },
+        }
+      )
+    );
 
     await adapter.listIssues(
       {
         projectId: "workspace-1",
         slug: "workspace-1",
         workspaceDir: "/tmp/workspace-1",
-        repositories: [],
+        repository: {
+          owner: "acme",
+          name: "platform",
+          cloneUrl: "https://github.com/acme/platform.git",
+        },
         tracker: {
           adapter: "github-project",
           bindingId: "project-123",
@@ -787,7 +813,11 @@ describe("resolveTrackerAdapter", () => {
           projectId: "workspace-1",
           slug: "workspace-1",
           workspaceDir: "/tmp/workspace-1",
-          repositories: [],
+          repository: {
+            owner: "acme",
+            name: "platform",
+            cloneUrl: "https://github.com/acme/platform.git",
+          },
           tracker: {
             adapter: "github-project",
             bindingId: "project-123",
@@ -875,7 +905,11 @@ describe("resolveTrackerAdapter", () => {
         projectId: "workspace-1",
         slug: "workspace-1",
         workspaceDir: "/tmp/workspace-1",
-        repositories: [],
+        repository: {
+          owner: "acme",
+          name: "platform",
+          cloneUrl: "https://github.com/acme/platform.git",
+        },
         tracker: {
           adapter: "github-project",
           bindingId: "project-123",
@@ -896,7 +930,11 @@ describe("resolveTrackerAdapter", () => {
           projectId: "workspace-1",
           slug: "workspace-1",
           workspaceDir: "/tmp/workspace-1",
-          repositories: [],
+          repository: {
+            owner: "acme",
+            name: "platform",
+            cloneUrl: "https://github.com/acme/platform.git",
+          },
           tracker: {
             adapter: "github-project",
             bindingId: "project-123",
@@ -929,7 +967,11 @@ describe("resolveTrackerAdapter", () => {
         projectId: "workspace-1",
         slug: "workspace-1",
         workspaceDir: "/tmp/workspace-1",
-        repositories: [],
+        repository: {
+          owner: "acme",
+          name: "platform",
+          cloneUrl: "https://github.com/acme/platform.git",
+        },
         tracker: {
           adapter: "github-project",
           bindingId: "project-123",
@@ -945,47 +987,48 @@ describe("resolveTrackerAdapter", () => {
             variables?: { cursor?: string | null };
           };
           const cursor = body.variables?.cursor ?? null;
-          const page = cursor === null
-            ? {
-                nodes: [
-                  makeProjectItem({
-                    itemId: "item-1",
-                    issueId: "issue-1",
-                    number: 1,
-                    title: "First issue",
-                    assignees: [],
-                  }),
-                ],
-                pageInfo: { endCursor: "cursor-1", hasNextPage: true },
-                headers: {
-                  "content-type": "application/json",
-                  "x-ratelimit-limit": "5000",
-                  "x-ratelimit-remaining": "4999",
-                  "x-ratelimit-used": "1",
-                  "x-ratelimit-reset": "1773892800",
-                  "x-ratelimit-resource": "graphql",
-                },
-              }
-            : {
-                nodes: [
-                  makeProjectItem({
-                    itemId: "item-2",
-                    issueId: "issue-2",
-                    number: 2,
-                    title: "Second issue",
-                    assignees: [],
-                  }),
-                ],
-                pageInfo: { endCursor: null, hasNextPage: false },
-                headers: {
-                  "content-type": "application/json",
-                  "x-ratelimit-limit": "5000",
-                  "x-ratelimit-remaining": "4997",
-                  "x-ratelimit-used": "3",
-                  "x-ratelimit-reset": "1773892860",
-                  "x-ratelimit-resource": "graphql",
-                },
-              };
+          const page =
+            cursor === null
+              ? {
+                  nodes: [
+                    makeProjectItem({
+                      itemId: "item-1",
+                      issueId: "issue-1",
+                      number: 1,
+                      title: "First issue",
+                      assignees: [],
+                    }),
+                  ],
+                  pageInfo: { endCursor: "cursor-1", hasNextPage: true },
+                  headers: {
+                    "content-type": "application/json",
+                    "x-ratelimit-limit": "5000",
+                    "x-ratelimit-remaining": "4999",
+                    "x-ratelimit-used": "1",
+                    "x-ratelimit-reset": "1773892800",
+                    "x-ratelimit-resource": "graphql",
+                  },
+                }
+              : {
+                  nodes: [
+                    makeProjectItem({
+                      itemId: "item-2",
+                      issueId: "issue-2",
+                      number: 2,
+                      title: "Second issue",
+                      assignees: [],
+                    }),
+                  ],
+                  pageInfo: { endCursor: null, hasNextPage: false },
+                  headers: {
+                    "content-type": "application/json",
+                    "x-ratelimit-limit": "5000",
+                    "x-ratelimit-remaining": "4997",
+                    "x-ratelimit-used": "3",
+                    "x-ratelimit-reset": "1773892860",
+                    "x-ratelimit-resource": "graphql",
+                  },
+                };
 
           return new Response(
             JSON.stringify({
@@ -1051,7 +1094,11 @@ describe("resolveTrackerAdapter", () => {
           projectId: "workspace-1",
           slug: "workspace-1",
           workspaceDir: "/tmp/workspace-1",
-          repositories: [],
+          repository: {
+            owner: "acme",
+            name: "platform",
+            cloneUrl: "https://github.com/acme/platform.git",
+          },
           tracker: {
             adapter: "github-project",
             bindingId: "project-123",
@@ -1116,7 +1163,11 @@ describe("resolveTrackerAdapter", () => {
           projectId: "workspace-1",
           slug: "workspace-1",
           workspaceDir: "/tmp/workspace-1",
-          repositories: [],
+          repository: {
+            owner: "acme",
+            name: "platform",
+            cloneUrl: "https://github.com/acme/platform.git",
+          },
           tracker: {
             adapter: "github-project",
             bindingId: "project-123",
@@ -1189,7 +1240,11 @@ describe("resolveTrackerAdapter", () => {
           projectId: "workspace-1",
           slug: "workspace-1",
           workspaceDir: "/tmp/workspace-1",
-          repositories: [],
+          repository: {
+            owner: "acme",
+            name: "platform",
+            cloneUrl: "https://github.com/acme/platform.git",
+          },
           tracker: {
             adapter: "github-project",
             bindingId: "project-123",
@@ -1249,7 +1304,11 @@ describe("resolveTrackerAdapter", () => {
           projectId: "workspace-1",
           slug: "workspace-1",
           workspaceDir: "/tmp/workspace-1",
-          repositories: [],
+          repository: {
+            owner: "acme",
+            name: "platform",
+            cloneUrl: "https://github.com/acme/platform.git",
+          },
           tracker: {
             adapter: "github-project",
             bindingId: "project-123",
@@ -1283,7 +1342,11 @@ describe("resolveTrackerAdapter", () => {
         projectId: "workspace-1",
         slug: "workspace-1",
         workspaceDir: "/tmp/workspace-1",
-        repositories: [],
+        repository: {
+          owner: "acme",
+          name: "platform",
+          cloneUrl: "https://github.com/acme/platform.git",
+        },
         tracker: {
           adapter: "github-project",
           bindingId: "project-123",
@@ -1382,7 +1445,11 @@ describe("resolveTrackerAdapter", () => {
         projectId: "workspace-1",
         slug: "workspace-1",
         workspaceDir: "/tmp/workspace-1",
-        repositories: [],
+        repository: {
+          owner: "acme",
+          name: "platform",
+          cloneUrl: "https://github.com/acme/platform.git",
+        },
         tracker: {
           adapter: "github-project",
           bindingId: "project-123",
@@ -1510,7 +1577,11 @@ describe("resolveTrackerAdapter", () => {
         projectId: "workspace-1",
         slug: "workspace-1",
         workspaceDir: "/tmp/workspace-1",
-        repositories: [],
+        repository: {
+          owner: "acme",
+          name: "platform",
+          cloneUrl: "https://github.com/acme/platform.git",
+        },
         tracker: {
           adapter: "github-project",
           bindingId: "project-123",
@@ -1571,7 +1642,11 @@ describe("resolveTrackerAdapter", () => {
         projectId: "workspace-1",
         slug: "workspace-1",
         workspaceDir: "/tmp/workspace-1",
-        repositories: [],
+        repository: {
+          owner: "acme",
+          name: "platform",
+          cloneUrl: "https://github.com/acme/platform.git",
+        },
         tracker: {
           adapter: "github-project",
           bindingId: "project-123",
@@ -1648,40 +1723,45 @@ describe("resolveTrackerAdapter", () => {
         return pending;
       },
     };
-    const fetchImpl = vi.fn(async () =>
-      new Response(
-        JSON.stringify({
-          data: {
-            node: {
-              __typename: "ProjectV2",
-              items: {
-                nodes: [
-                  makeProjectItem({
-                    itemId: "item-1",
-                    issueId: "issue-1",
-                    number: 1,
-                    title: "Done issue",
-                    assignees: [],
-                    state: "Done",
-                  }),
-                ],
-                pageInfo: { endCursor: null, hasNextPage: false },
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            data: {
+              node: {
+                __typename: "ProjectV2",
+                items: {
+                  nodes: [
+                    makeProjectItem({
+                      itemId: "item-1",
+                      issueId: "issue-1",
+                      number: 1,
+                      title: "Done issue",
+                      assignees: [],
+                      state: "Done",
+                    }),
+                  ],
+                  pageInfo: { endCursor: null, hasNextPage: false },
+                },
               },
             },
-          },
-        }),
-        {
-          status: 200,
-          headers: { "content-type": "application/json" },
-        }
-      )
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }
+        )
     );
 
     const project = {
       projectId: "workspace-1",
       slug: "workspace-1",
       workspaceDir: "/tmp/workspace-1",
-      repositories: [],
+      repository: {
+        owner: "acme",
+        name: "platform",
+        cloneUrl: "https://github.com/acme/platform.git",
+      },
       tracker: {
         adapter: "github-project" as const,
         bindingId: "project-123",
@@ -1723,30 +1803,35 @@ describe("resolveTrackerAdapter", () => {
         return load();
       },
     };
-    const fetchImpl = vi.fn(async () =>
-      new Response(
-        JSON.stringify({
-          data: {
-            node: {
-              __typename: "ProjectV2",
-              items: {
-                nodes: [],
-                pageInfo: { endCursor: null, hasNextPage: false },
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            data: {
+              node: {
+                __typename: "ProjectV2",
+                items: {
+                  nodes: [],
+                  pageInfo: { endCursor: null, hasNextPage: false },
+                },
               },
             },
-          },
-        }),
-        {
-          status: 200,
-          headers: { "content-type": "application/json" },
-        }
-      )
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }
+        )
     );
     const project = {
       projectId: "workspace-1",
       slug: "workspace-1",
       workspaceDir: "/tmp/workspace-1",
-      repositories: [],
+      repository: {
+        owner: "acme",
+        name: "platform",
+        cloneUrl: "https://github.com/acme/platform.git",
+      },
       tracker: {
         adapter: "github-project" as const,
         bindingId: "project-123",
@@ -1828,7 +1913,11 @@ describe("resolveTrackerAdapter", () => {
       projectId: "workspace-1",
       slug: "workspace-1",
       workspaceDir: "/tmp/workspace-1",
-      repositories: [],
+      repository: {
+        owner: "acme",
+        name: "platform",
+        cloneUrl: "https://github.com/acme/platform.git",
+      },
       tracker: {
         adapter: "github-project" as const,
         bindingId: "project-123",
@@ -1882,7 +1971,11 @@ describe("resolveTrackerAdapter", () => {
         projectId: "workspace-1",
         slug: "workspace-1",
         workspaceDir: "/tmp/workspace-1",
-        repositories: [],
+        repository: {
+          owner: "acme",
+          name: "platform",
+          cloneUrl: "https://github.com/acme/platform.git",
+        },
         tracker: {
           adapter: "github-project",
           bindingId: "project-123",
@@ -1900,9 +1993,13 @@ describe("resolveTrackerAdapter", () => {
             variables: { issueIds: string[] };
           };
 
-          expect(body.query).toContain("query IssueStatesByIds($issueIds: [ID!]!)");
+          expect(body.query).toContain(
+            "query IssueStatesByIds($issueIds: [ID!]!)"
+          );
           expect(body.query).toContain("nodes(ids: $issueIds)");
-          expect(body.query).toContain("projectItems(first: 100, includeArchived: false)");
+          expect(body.query).toContain(
+            "projectItems(first: 100, includeArchived: false)"
+          );
           expect(body.query).not.toContain("blockedBy(");
           expect(body.query).not.toContain("labels(");
           expect(body.query).not.toContain("assignees(");
@@ -1945,10 +2042,7 @@ describe("resolveTrackerAdapter", () => {
       "acme/platform#1",
       "acme/platform#2",
     ]);
-    expect(issues.map((issue) => issue.state)).toEqual([
-      "In Progress",
-      "Done",
-    ]);
+    expect(issues.map((issue) => issue.state)).toEqual(["In Progress", "Done"]);
   });
 
   it("attaches GitHub API rate-limit headers to fetched issue state lookups", async () => {
@@ -1965,7 +2059,11 @@ describe("resolveTrackerAdapter", () => {
         projectId: "workspace-1",
         slug: "workspace-1",
         workspaceDir: "/tmp/workspace-1",
-        repositories: [],
+        repository: {
+          owner: "acme",
+          name: "platform",
+          cloneUrl: "https://github.com/acme/platform.git",
+        },
         tracker: {
           adapter: "github-project",
           bindingId: "project-123",
@@ -2032,7 +2130,11 @@ describe("resolveTrackerAdapter", () => {
     const fetchImpl = vi.fn(async (_url, init) => {
       const body = JSON.parse(String(init?.body)) as {
         query: string;
-        variables: { issueIds?: string[]; issueId?: string; cursor?: string | null };
+        variables: {
+          issueIds?: string[];
+          issueId?: string;
+          cursor?: string | null;
+        };
       };
 
       if (body.query.includes("query IssueStatesByIds")) {
@@ -2062,7 +2164,9 @@ describe("resolveTrackerAdapter", () => {
         );
       }
 
-      expect(body.query).toContain("query IssueProjectItemsPage($issueId: ID!, $cursor: String)");
+      expect(body.query).toContain(
+        "query IssueProjectItemsPage($issueId: ID!, $cursor: String)"
+      );
       expect(body.variables.issueId).toBe("issue-1");
       expect(body.variables.cursor).toBe("cursor-1");
 
@@ -2116,7 +2220,11 @@ describe("resolveTrackerAdapter", () => {
         projectId: "workspace-1",
         slug: "workspace-1",
         workspaceDir: "/tmp/workspace-1",
-        repositories: [],
+        repository: {
+          owner: "acme",
+          name: "platform",
+          cloneUrl: "https://github.com/acme/platform.git",
+        },
         tracker: {
           adapter: "github-project",
           bindingId: "project-123",


### PR DESCRIPTION
## Issues

- Fixes #262

## Summary

- `OrchestratorProjectConfig` 공개 계약을 `repositories[]`에서 단일 `repository`로 전환했습니다.
- `deriveWorkspaceKey(identifier)`를 도입하고 workspace identity의 public subject identity에서 `projectId`를 제거했습니다.
- 리뷰 피드백을 반영해 CLI zero-repository 관리 상태와 orchestrator 실행 진입점을 분리하고, 빈 repository sentinel 저장 경로를 제거했습니다.

## Changes

- core contract: `repository: RepositoryRef`, optional `projectId` state-store signatures, readable `deriveWorkspaceKey(identifier)` 테스트 추가.
- orchestrator: single-repo workflow polling/concurrency 경로의 array-of-one leftover를 단일 값 처리로 정리했습니다.
- CLI config: legacy `repositories[]` JSON은 첫 유효 entry를 canonical `repository`로 정규화하되, repository가 없는 관리 config는 CLI 단계에서 명확히 가드합니다.
- repo commands: 마지막 repo 제거를 거부하고, sync가 0개 repo 상태를 저장할 때 `tracker.settings.repository` stale 값을 제거합니다.

## Evidence

- `pnpm --filter @gh-symphony/core test` — passed, 13 files / 118 tests
- `pnpm --filter @gh-symphony/cli test -- src/commands/repo.test.ts src/commands/start.test.ts` — passed, 2 files / 27 tests
- `pnpm typecheck` — passed
- `pnpm lint && pnpm test && pnpm typecheck && pnpm build` — passed
- Docker E2E TC from initial P1 pass: `docker compose -f docker-compose.e2e.yml -f docker-compose.e2e.events.yml up -d --build`, happy-path issue injection, `POST /api/v1/refresh`, `/api/v1/state` 확인 — dispatch observed (`summary.dispatched=1`, `activeRuns=1`), completion continuation observed, issue removal led to failure retry queue, cleanup completed

## Human Validation

- [ ] 단일 repository config로 기존 GitHub Project workflow가 예상대로 시작되는지 확인
- [ ] 기존 `repositories`가 남은 CLI config가 전환 호환 정규화되는지 확인
- [ ] repository가 없는 관리 config에서 `start`/`run`이 명확한 오류를 내는지 확인
- [ ] 후속 phase에서 제거될 `projectId`/legacy 배열 사용처가 컴파일러로 잘 드러나는지 확인

## Risks

- CLI는 P1 호환을 위해 legacy `repositories[]`를 계속 읽고 저장할 수 있습니다. core/orchestrator 실행 계약은 `repository`로 전환됐고, legacy 배열 제거는 후속 CLI/migration phase에서 완료해야 합니다.