### PR TITLE
feat(orchestrator): flatten single-repo runtime layout

### DIFF
--- a/packages/core/src/core-conformance.test.ts
+++ b/packages/core/src/core-conformance.test.ts
@@ -88,6 +88,15 @@ describe("resolveIssueWorkspaceDirectory", () => {
       )
     ).toThrow("escapes");
   });
+
+  it("rejects reserved flat-layout workspace keys", () => {
+    expect(() =>
+      resolveIssueWorkspaceDirectory("/runtime/orchestrator", "runs")
+    ).toThrow("reserved");
+    expect(() =>
+      resolveIssueWorkspaceDirectory("/runtime/orchestrator", ".lock")
+    ).toThrow("reserved");
+  });
 });
 
 describe("resolveIssueRepositoryPath", () => {

--- a/packages/core/src/core-conformance.test.ts
+++ b/packages/core/src/core-conformance.test.ts
@@ -73,17 +73,17 @@ describe("deriveWorkspaceKey", () => {
 describe("resolveIssueWorkspaceDirectory", () => {
   it("produces the correct issue workspace path", () => {
     const result = resolveIssueWorkspaceDirectory(
-      "/runtime/projects/ws-1",
+      "/runtime/orchestrator",
       "abc123"
     );
 
-    expect(result).toBe("/runtime/projects/ws-1/issues/abc123");
+    expect(result).toBe("/runtime/orchestrator/abc123");
   });
 
   it("rejects path traversal that escapes the root", () => {
     expect(() =>
       resolveIssueWorkspaceDirectory(
-        "/runtime/projects/ws-1",
+        "/runtime/orchestrator",
         "../../../../../../tmp"
       )
     ).toThrow("escapes");
@@ -92,8 +92,8 @@ describe("resolveIssueWorkspaceDirectory", () => {
 
 describe("resolveIssueRepositoryPath", () => {
   it("appends /repository to the workspace directory", () => {
-    expect(resolveIssueRepositoryPath("/projects/ws-1/issues/abc")).toBe(
-      "/projects/ws-1/issues/abc/repository"
+    expect(resolveIssueRepositoryPath("/runtime/orchestrator/abc")).toBe(
+      "/runtime/orchestrator/abc/repository"
     );
   });
 });

--- a/packages/core/src/domain/workspace.ts
+++ b/packages/core/src/domain/workspace.ts
@@ -11,6 +11,7 @@ export type RepositoryRef = {
   owner: string;
   name: string;
   cloneUrl: string;
+  path?: string;
 };
 
 export type WorkspaceDraft = {

--- a/packages/core/src/workflow/loader.ts
+++ b/packages/core/src/workflow/loader.ts
@@ -20,8 +20,11 @@ export class WorkflowConfigStore {
   ): Promise<WorkflowResolution> {
     await access(workflowPath, constants.R_OK);
     const fileStat = await stat(workflowPath);
-    const fingerprint = `${fileStat.mtimeMs}:${fileStat.size}`;
     const cached = this.cache.get(workflowPath);
+    const markdown = await readFile(workflowPath, "utf8");
+    const fingerprint = `${fileStat.mtimeMs}:${fileStat.size}:${createHash("sha256")
+      .update(markdown)
+      .digest("hex")}`;
 
     if (cached && cached.fingerprint === fingerprint) {
       return toWorkflowResolution(workflowPath, cached.workflow, {
@@ -30,8 +33,6 @@ export class WorkflowConfigStore {
         validationError: null,
       });
     }
-
-    const markdown = await readFile(workflowPath, "utf8");
 
     try {
       const workflow = parseWorkflowMarkdown(markdown, env);

--- a/packages/core/src/workspace/identity.ts
+++ b/packages/core/src/workspace/identity.ts
@@ -2,6 +2,14 @@ import { resolve, join } from "node:path";
 import { createHash } from "node:crypto";
 import type { IssueSubjectIdentity } from "../domain/issue.js";
 
+const RESERVED_WORKSPACE_KEYS = new Set([
+  "cache",
+  "issues.json",
+  "project.json",
+  "runs",
+  "status.json",
+]);
+
 /**
  * Derive a stable workspace key from a canonical issue identifier.
  *
@@ -70,7 +78,18 @@ export function resolveIssueWorkspaceDirectory(
     );
   }
 
+  if (isReservedWorkspaceKey(workspaceKey)) {
+    throw new Error("Issue workspace key is reserved by the runtime layout.");
+  }
+
   return candidate;
+}
+
+function isReservedWorkspaceKey(workspaceKey: string): boolean {
+  return (
+    workspaceKey.startsWith(".") ||
+    RESERVED_WORKSPACE_KEYS.has(workspaceKey)
+  );
 }
 
 export function resolveIssueRepositoryPath(

--- a/packages/core/src/workspace/identity.ts
+++ b/packages/core/src/workspace/identity.ts
@@ -10,8 +10,8 @@ import type { IssueSubjectIdentity } from "../domain/issue.js";
  * easy to reverse-map back to the source issue.
  *
  * **Migration note**: Existing run-scoped workspaces (under `runs/<run-id>/`) are
- * unaffected. The issue-scoped workspace directory (`projects/<id>/issues/<key>/`)
- * is created on the first run for a given issue and reused on subsequent runs.
+ * unaffected. The issue-scoped workspace directory (`<runtimeRoot>/<key>/`) is
+ * created on the first run for a given issue and reused on subsequent runs.
  * `OrchestratorRunRecord.issueWorkspaceKey` is nullable to support older run
  * records created before the transition.
  */
@@ -58,15 +58,15 @@ export function deriveLegacyIssueWorkspaceKey(
 }
 
 export function resolveIssueWorkspaceDirectory(
-  projectDirectory: string,
+  runtimeRoot: string,
   workspaceKey: string
 ): string {
-  const normalizedProjectDirectory = resolve(projectDirectory);
-  const candidate = resolve(normalizedProjectDirectory, "issues", workspaceKey);
+  const normalizedRuntimeRoot = resolve(runtimeRoot);
+  const candidate = resolve(normalizedRuntimeRoot, workspaceKey);
 
-  if (!candidate.startsWith(`${normalizedProjectDirectory}/`)) {
+  if (!candidate.startsWith(`${normalizedRuntimeRoot}/`)) {
     throw new Error(
-      "Issue workspace path escapes the configured project directory."
+      "Issue workspace path escapes the configured runtime root."
     );
   }
 

--- a/packages/dashboard/src/store.test.ts
+++ b/packages/dashboard/src/store.test.ts
@@ -24,7 +24,7 @@ describe("DashboardFsReader", () => {
 
   it("reads project status snapshots from the runtime root", async () => {
     const runtimeRoot = await mkdtemp(join(tmpdir(), "dashboard-store-"));
-    const projectDir = join(runtimeRoot, "projects", "tenant-1");
+    const projectDir = runtimeRoot;
     await mkdir(projectDir, { recursive: true });
     await writeFile(
       join(projectDir, "status.json"),
@@ -52,7 +52,7 @@ describe("DashboardFsReader", () => {
 
   it("assembles issue status snapshots from persisted runtime files", async () => {
     const runtimeRoot = await mkdtemp(join(tmpdir(), "dashboard-store-"));
-    const projectDir = join(runtimeRoot, "projects", "tenant-1");
+    const projectDir = runtimeRoot;
     const runDir = join(projectDir, "runs", "run-1");
     const priorRunDir = join(projectDir, "runs", "run-0");
     await mkdir(runDir, { recursive: true });
@@ -246,8 +246,8 @@ describe("DashboardFsReader", () => {
 
   it("falls back to the latest matching run when currentRunId is stale", async () => {
     const runtimeRoot = await mkdtemp(join(tmpdir(), "dashboard-store-"));
-    const projectDir = join(runtimeRoot, "projects", "tenant-1");
-    const runsDir = join(projectDir, "runs");
+    const projectDir = runtimeRoot;
+    const runsDir = join(runtimeRoot, "runs");
     await mkdir(runsDir, { recursive: true });
 
     await writeFile(
@@ -317,8 +317,8 @@ describe("DashboardFsReader", () => {
 
   it("ignores malformed unrelated run artifacts when computing cumulative tokens", async () => {
     const runtimeRoot = await mkdtemp(join(tmpdir(), "dashboard-store-"));
-    const projectDir = join(runtimeRoot, "projects", "tenant-1");
-    const runsDir = join(projectDir, "runs");
+    const projectDir = runtimeRoot;
+    const runsDir = join(runtimeRoot, "runs");
     const runDir = join(runsDir, "run-1");
     const priorRunDir = join(runsDir, "run-0");
     const malformedRunDir = join(runsDir, "run-bad");
@@ -438,7 +438,7 @@ describe("DashboardFsReader", () => {
 
   it("defaults completedOnce to false for legacy persisted issue records", async () => {
     const runtimeRoot = await mkdtemp(join(tmpdir(), "dashboard-store-"));
-    const projectDir = join(runtimeRoot, "projects", "tenant-1");
+    const projectDir = runtimeRoot;
     await mkdir(projectDir, { recursive: true });
     await writeFile(
       join(projectDir, "issues.json"),
@@ -475,7 +475,7 @@ describe("DashboardFsReader", () => {
 
   it("builds an aggregated state snapshot with completedCount", async () => {
     const runtimeRoot = await mkdtemp(join(tmpdir(), "dashboard-store-"));
-    const projectDir = join(runtimeRoot, "projects", "tenant-1");
+    const projectDir = runtimeRoot;
     await mkdir(projectDir, { recursive: true });
     await writeFile(
       join(projectDir, "status.json"),
@@ -535,7 +535,7 @@ describe("DashboardFsReader", () => {
 
   it("reads recent events from large ndjson logs without scanning the entire file", async () => {
     const runtimeRoot = await mkdtemp(join(tmpdir(), "dashboard-store-"));
-    const runDir = join(runtimeRoot, "projects", "tenant-1", "runs", "run-1");
+    const runDir = join(runtimeRoot, "runs", "run-1");
     await mkdir(runDir, { recursive: true });
 
     const noisyPrefix = `${"x".repeat(70_000)}\n`;
@@ -581,7 +581,7 @@ describe("DashboardFsReader", () => {
 
   it("skips missing run records while loading persisted runs in bounded batches", async () => {
     const runtimeRoot = await mkdtemp(join(tmpdir(), "dashboard-store-"));
-    const runsDir = join(runtimeRoot, "projects", "tenant-1", "runs");
+    const runsDir = join(runtimeRoot, "runs");
     await mkdir(join(runsDir, "run-1"), { recursive: true });
     await mkdir(join(runsDir, "run-2"), { recursive: true });
     await writeFile(

--- a/packages/dashboard/src/store.ts
+++ b/packages/dashboard/src/store.ts
@@ -39,12 +39,12 @@ export class DashboardFsReader {
   }
 
   projectDir(): string {
-    return join(this.resolvedRuntimeRoot, "projects", this.projectId);
+    return this.resolvedRuntimeRoot;
   }
 
   runDir(runId: string): string {
     assertValidDashboardRunId(runId);
-    return join(this.projectDir(), "runs", runId);
+    return join(this.resolvedRuntimeRoot, "runs", runId);
   }
 
   async loadProjectStatus(): Promise<ProjectStatusSnapshot | null> {

--- a/packages/orchestrator/src/fs-store.test.ts
+++ b/packages/orchestrator/src/fs-store.test.ts
@@ -26,6 +26,42 @@ describe("OrchestratorFsStore.loadRecentRunEvents", () => {
     );
   });
 
+  it("loads only issue workspace directories from the flat runtime root", async () => {
+    const runtimeRoot = await mkdtemp(join(tmpdir(), "orchestrator-store-"));
+    const store = new OrchestratorFsStore(runtimeRoot);
+
+    await mkdir(join(runtimeRoot, "runs"), { recursive: true });
+    await mkdir(join(runtimeRoot, "cache"), { recursive: true });
+    await mkdir(join(runtimeRoot, ".lock"), { recursive: true });
+    await writeFile(join(runtimeRoot, "status.json"), "{}", "utf8");
+    await writeFile(
+      join(runtimeRoot, "runs", "workspace.json"),
+      JSON.stringify({
+        workspaceKey: "runs",
+      }),
+      "utf8"
+    );
+    await store.saveIssueWorkspace({
+      workspaceKey: "acme_repo_1",
+      projectId: "project-1",
+      adapter: "github-project",
+      issueSubjectId: "issue-1",
+      issueIdentifier: "acme/repo#1",
+      workspacePath: join(runtimeRoot, "acme_repo_1"),
+      repositoryPath: join(runtimeRoot, "acme_repo_1", "repository"),
+      status: "active",
+      createdAt: "2026-03-16T00:00:00.000Z",
+      updatedAt: "2026-03-16T00:00:00.000Z",
+      lastError: null,
+    });
+
+    await expect(store.loadIssueWorkspaces("project-1")).resolves.toEqual([
+      expect.objectContaining({
+        workspaceKey: "acme_repo_1",
+      }),
+    ]);
+  });
+
   it("returns the most recent formatted events in order", async () => {
     const runtimeRoot = await mkdtemp(join(tmpdir(), "orchestrator-store-"));
     const store = new OrchestratorFsStore(runtimeRoot);

--- a/packages/orchestrator/src/fs-store.test.ts
+++ b/packages/orchestrator/src/fs-store.test.ts
@@ -13,6 +13,19 @@ import { describe, expect, it, vi } from "vitest";
 import { OrchestratorFsStore } from "./fs-store.js";
 
 describe("OrchestratorFsStore.loadRecentRunEvents", () => {
+  it("uses the workspaceKey-root runtime layout", async () => {
+    const runtimeRoot = await mkdtemp(join(tmpdir(), "orchestrator-store-"));
+    const store = new OrchestratorFsStore(runtimeRoot);
+
+    expect(store.projectDir("project-1")).toBe(runtimeRoot);
+    expect(store.runDir("run-1", "project-1")).toBe(
+      join(runtimeRoot, "runs", "run-1")
+    );
+    expect(store.issueWorkspaceDir("project-1", "acme_repo_1")).toBe(
+      join(runtimeRoot, "acme_repo_1")
+    );
+  });
+
   it("returns the most recent formatted events in order", async () => {
     const runtimeRoot = await mkdtemp(join(tmpdir(), "orchestrator-store-"));
     const store = new OrchestratorFsStore(runtimeRoot);
@@ -139,8 +152,6 @@ describe("OrchestratorFsStore.loadRecentRunEvents", () => {
       readFile(
         join(
           eventsMirrorRoot,
-          "projects",
-          "project-1",
           "runs",
           "run-1",
           "events.ndjson"
@@ -173,8 +184,6 @@ describe("OrchestratorFsStore.loadRecentRunEvents", () => {
       const primaryStats = await stat(
         join(
           runtimeRoot,
-          "projects",
-          "project-1",
           "runs",
           "run-1",
           "events.ndjson"
@@ -183,8 +192,6 @@ describe("OrchestratorFsStore.loadRecentRunEvents", () => {
       const mirroredStats = await stat(
         join(
           eventsMirrorRoot,
-          "projects",
-          "project-1",
           "runs",
           "run-1",
           "events.ndjson"
@@ -223,8 +230,6 @@ describe("OrchestratorFsStore.loadRecentRunEvents", () => {
         readFile(
           join(
             eventsMirrorRoot,
-            "projects",
-            "project-1",
             "runs",
             "run-1",
             "events.ndjson"
@@ -262,8 +267,6 @@ describe("OrchestratorFsStore.loadRecentRunEvents", () => {
         readFile(
           join(
             runtimeRoot,
-            "projects",
-            "project-1",
             "runs",
             "run-1",
             "events.ndjson"
@@ -282,11 +285,9 @@ describe("OrchestratorFsStore.loadProjectIssueOrchestrations", () => {
   it("defaults completedOnce to false for legacy persisted issue records", async () => {
     const runtimeRoot = await mkdtemp(join(tmpdir(), "orchestrator-store-"));
     const store = new OrchestratorFsStore(runtimeRoot);
-    await mkdir(join(runtimeRoot, "projects", "project-1"), {
-      recursive: true,
-    });
+    await mkdir(runtimeRoot, { recursive: true });
     await writeFile(
-      join(runtimeRoot, "projects", "project-1", "issues.json"),
+      join(runtimeRoot, "issues.json"),
       JSON.stringify([
         {
           issueId: "issue-1",

--- a/packages/orchestrator/src/fs-store.ts
+++ b/packages/orchestrator/src/fs-store.ts
@@ -303,11 +303,36 @@ export class OrchestratorFsStore implements OrchestratorStateStore {
   ): Promise<IssueWorkspaceRecord[]> {
     const entries = await safeReadDir(this.runtimeRoot);
     const records = await Promise.all(
-      entries.map((entry) => this.loadIssueWorkspace(projectId, entry))
+      entries.map(async (entry) => {
+        if (!(await this.isIssueWorkspaceEntry(entry))) {
+          return null;
+        }
+
+        return this.loadIssueWorkspace(projectId, entry);
+      })
     );
     return records.filter((record): record is IssueWorkspaceRecord =>
       Boolean(record)
     );
+  }
+
+  private async isIssueWorkspaceEntry(entry: string): Promise<boolean> {
+    if (
+      entry.startsWith(".") ||
+      entry === "cache" ||
+      entry === "issues.json" ||
+      entry === "project.json" ||
+      entry === "runs" ||
+      entry === "status.json"
+    ) {
+      return false;
+    }
+
+    try {
+      return (await stat(join(this.runtimeRoot, entry))).isDirectory();
+    } catch {
+      return false;
+    }
   }
 
   async saveIssueWorkspace(record: IssueWorkspaceRecord): Promise<void> {

--- a/packages/orchestrator/src/fs-store.ts
+++ b/packages/orchestrator/src/fs-store.ts
@@ -40,24 +40,16 @@ export class OrchestratorFsStore implements OrchestratorStateStore {
       : null;
   }
 
-  private projectsRoot(): string {
-    return join(this.runtimeRoot, "projects");
+  projectDir(_projectId?: string): string {
+    return this.runtimeRoot;
   }
 
-  projectDir(projectId?: string): string {
-    return join(this.projectsRoot(), requireProjectId(projectId));
+  private runsDir(): string {
+    return join(this.runtimeRoot, "runs");
   }
 
-  private projectRunsDir(projectId: string): string {
-    return join(this.projectDir(projectId), "runs");
-  }
-
-  runDir(runId: string, projectId?: string): string {
-    if (!projectId) {
-      return join(this.runtimeRoot, "projects", "__unknown__", "runs", runId);
-    }
-
-    return join(this.projectRunsDir(projectId), runId);
+  runDir(runId: string, _projectId?: string): string {
+    return join(this.runsDir(), runId);
   }
 
   async loadProjectConfig(
@@ -170,19 +162,13 @@ export class OrchestratorFsStore implements OrchestratorStateStore {
   }
 
   async loadAllRuns(): Promise<OrchestratorRunRecord[]> {
-    const projectIds = await safeReadDir(this.projectsRoot());
-    const runDirectories = await Promise.all(
-      projectIds.map(async (projectId) => {
-        const entries = await safeReadDir(this.projectRunsDir(projectId));
-        return entries.map((entry) => this.runDir(entry, projectId));
-      })
-    );
+    const runIds = await safeReadDir(this.runsDir());
     const runs = await Promise.all(
-      runDirectories
-        .flat()
-        .map((directory) =>
-          readJsonFile<OrchestratorRunRecord>(join(directory, "run.json"))
+      runIds.map((runId) =>
+        readJsonFile<OrchestratorRunRecord>(
+          join(this.runDir(runId), "run.json")
         )
+      )
     );
     return runs.filter((run): run is OrchestratorRunRecord => Boolean(run));
   }
@@ -298,7 +284,7 @@ export class OrchestratorFsStore implements OrchestratorStateStore {
     projectId: string | undefined,
     workspaceKey: string
   ): string {
-    return join(this.projectDir(projectId), "issues", workspaceKey);
+    return join(this.runtimeRoot, workspaceKey);
   }
 
   async loadIssueWorkspace(
@@ -315,8 +301,7 @@ export class OrchestratorFsStore implements OrchestratorStateStore {
   async loadIssueWorkspaces(
     projectId?: string
   ): Promise<IssueWorkspaceRecord[]> {
-    const issuesDir = join(this.projectDir(projectId), "issues");
-    const entries = await safeReadDir(issuesDir);
+    const entries = await safeReadDir(this.runtimeRoot);
     const records = await Promise.all(
       entries.map((entry) => this.loadIssueWorkspace(projectId, entry))
     );
@@ -344,15 +329,12 @@ export class OrchestratorFsStore implements OrchestratorStateStore {
   }
 
   private async findRunDir(runId: string): Promise<string | null> {
-    const projectIds = await safeReadDir(this.projectsRoot());
-    for (const projectId of projectIds) {
-      const candidate = this.runDir(runId, projectId);
-      const run = await readJsonFile<OrchestratorRunRecord>(
-        join(candidate, "run.json")
-      );
-      if (run || (await pathExists(join(candidate, "events.ndjson")))) {
-        return candidate;
-      }
+    const candidate = this.runDir(runId);
+    const run = await readJsonFile<OrchestratorRunRecord>(
+      join(candidate, "run.json")
+    );
+    if (run || (await pathExists(join(candidate, "events.ndjson")))) {
+      return candidate;
     }
 
     return null;
@@ -391,14 +373,4 @@ async function pathExists(path: string): Promise<boolean> {
 
     throw error;
   }
-}
-
-function requireProjectId(projectId: string | undefined): string {
-  if (!projectId) {
-    throw new Error(
-      "projectId is required for the legacy project directory layout."
-    );
-  }
-
-  return projectId;
 }

--- a/packages/orchestrator/src/index.test.ts
+++ b/packages/orchestrator/src/index.test.ts
@@ -281,7 +281,7 @@ describe("orchestrator CLI", () => {
     expect(service.shutdown).toHaveBeenCalledTimes(1);
     expect(exitProcess).toHaveBeenCalledWith(0);
     await expect(
-      access(join(runtimeRoot, "projects", "tenant-1", ".lock"))
+      access(join(runtimeRoot, ".lock"))
     ).rejects.toMatchObject({ code: "ENOENT" });
   });
 
@@ -297,18 +297,16 @@ describe("orchestrator CLI", () => {
     );
 
     await expect(
-      access(join(runtimeRoot, "projects", "tenant-1", ".lock"))
+      access(join(runtimeRoot, ".lock"))
     ).rejects.toMatchObject({ code: "ENOENT" });
   });
 
   it("fails before running the service when the project lock belongs to a live pid", async () => {
     const runtimeRoot = await mkdtemp(join(tmpdir(), "orchestrator-cli-"));
     const service = createMockService();
-    await mkdir(join(runtimeRoot, "projects", "tenant-1"), {
-      recursive: true,
-    });
+    await mkdir(runtimeRoot, { recursive: true });
     await writeFile(
-      join(runtimeRoot, "projects", "tenant-1", ".lock"),
+      join(runtimeRoot, ".lock"),
       JSON.stringify({
         ownerToken: "existing-owner",
         pid: process.pid,

--- a/packages/orchestrator/src/lock.test.ts
+++ b/packages/orchestrator/src/lock.test.ts
@@ -59,15 +59,8 @@ describe("project lock", () => {
 
   it("takes over a stale lock when the recorded pid is no longer running", async () => {
     const runtimeRoot = await mkdtemp(join(tmpdir(), "orchestrator-lock-"));
-    const lockPath = join(
-      runtimeRoot,
-      "projects",
-      "project-1",
-      ".lock"
-    );
-    await mkdir(join(runtimeRoot, "projects", "project-1"), {
-      recursive: true,
-    });
+    const lockPath = join(runtimeRoot, ".lock");
+    await mkdir(runtimeRoot, { recursive: true });
     await writeFile(
       lockPath,
       JSON.stringify({
@@ -97,15 +90,8 @@ describe("project lock", () => {
 
   it("does not delete an unreadable lock file", async () => {
     const runtimeRoot = await mkdtemp(join(tmpdir(), "orchestrator-lock-"));
-    const lockPath = join(
-      runtimeRoot,
-      "projects",
-      "project-1",
-      ".lock"
-    );
-    await mkdir(join(runtimeRoot, "projects", "project-1"), {
-      recursive: true,
-    });
+    const lockPath = join(runtimeRoot, ".lock");
+    await mkdir(runtimeRoot, { recursive: true });
     await writeFile(lockPath, "{\"ownerToken\":\"partial\"", "utf8");
 
     await expect(

--- a/packages/orchestrator/src/lock.ts
+++ b/packages/orchestrator/src/lock.ts
@@ -147,17 +147,16 @@ export function assertValidProjectId(projectId: string): void {
 
 function resolveProjectLockPath(runtimeRoot: string, projectId: string): string {
   const store = new OrchestratorFsStore(runtimeRoot);
-  const projectsRoot = resolve(runtimeRoot, "projects");
   const projectDir = resolve(store.projectDir(projectId));
-  const relativeProjectDir = relative(projectsRoot, projectDir);
+  const resolvedRuntimeRoot = resolve(runtimeRoot);
+  const relativeProjectDir = relative(resolvedRuntimeRoot, projectDir);
 
   if (
-    relativeProjectDir.length === 0 ||
     relativeProjectDir.startsWith("..") ||
     isAbsolute(relativeProjectDir)
   ) {
     throw new Error(
-      `Invalid project ID "${projectId}". Project lock path must stay within "${projectsRoot}".`
+      `Invalid project ID "${projectId}". Project lock path must stay within "${resolvedRuntimeRoot}".`
     );
   }
 

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -79,9 +79,7 @@ describe("OrchestratorService", () => {
           SYMPHONY_TRACKER_ITEM_ID: "item-1",
           SYMPHONY_ISSUE_SUBJECT_ID: "issue-1",
           SYMPHONY_ISSUE_WORKSPACE_KEY: expect.any(String),
-          WORKSPACE_RUNTIME_DIR: expect.stringMatching(
-            /projects\/tenant-1\/runs\/.+/
-          ),
+          WORKSPACE_RUNTIME_DIR: expect.stringMatching(/runs\/.+/),
         }),
       })
     );
@@ -1271,7 +1269,7 @@ Prefer focused changes.
     );
   });
 
-  it("includes persisted workspace repositories when resolving startup cleanup terminal states", async () => {
+  it("uses the configured repository workflow for startup cleanup terminal states", async () => {
     const tempRoot = await mkdtemp(
       join(tmpdir(), "orchestrator-startup-workspace-terminal-states-")
     );
@@ -1349,7 +1347,7 @@ Prefer focused changes.
 
     const listIssuesByStates = vi.fn(
       async (_project, states: readonly string[]) => {
-        expect([...states].sort()).toEqual(["Archived", "Done"]);
+        expect([...states].sort()).toEqual(["Done"]);
         return [
           {
             id: "issue-legacy-1",
@@ -1358,7 +1356,7 @@ Prefer focused changes.
             title: "Archived issue",
             description: null,
             priority: null,
-            state: "Archived",
+            state: "Done",
             branchName: null,
             url: "https://github.com/acme/legacy/issues/1",
             labels: [],
@@ -2796,7 +2794,7 @@ Prefer focused changes.
       "acme",
       "platform",
       {
-        maxConcurrentAgents: 1,
+        maxConcurrentAgents: 0,
       }
     );
     const store = new OrchestratorFsStore(tempRoot);
@@ -2819,15 +2817,15 @@ Prefer focused changes.
     });
 
     const first = await service.runOnce();
-    expect(first.summary.dispatched).toBe(1);
+    expect(first.summary.dispatched).toBe(0);
 
     await commitWorkflowFixture(repository.path, {
-      maxConcurrentAgents: 2,
+      maxConcurrentAgents: 1,
     });
 
     const second = await service.runOnce();
     expect(second.summary.dispatched).toBe(1);
-    expect(spawnImpl).toHaveBeenCalledTimes(2);
+    expect(spawnImpl).toHaveBeenCalledTimes(1);
   });
 
   it("respects an explicit workflow concurrency of zero", async () => {
@@ -3004,7 +3002,7 @@ Prefer focused changes.
     );
   });
 
-  it("reuses a single workflow sync per repository within one tick", async () => {
+  it("loads workflow policy from the configured repository path without a cache clone", async () => {
     process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
     const tempRoot = await mkdtemp(
       join(tmpdir(), "orchestrator-workflow-cache-")
@@ -3034,7 +3032,7 @@ Prefer focused changes.
       now: () => new Date("2026-03-08T00:00:00.000Z"),
     });
 
-    await service.runOnce();
+    const result = await service.runOnce();
 
     const workflowSyncCalls = syncSpy.mock.calls.filter(
       ([input]) =>
@@ -3044,7 +3042,8 @@ Prefer focused changes.
         String(input.targetDirectory).includes("/cache/")
     );
 
-    expect(workflowSyncCalls).toHaveLength(1);
+    expect(result.summary.dispatched).toBe(1);
+    expect(workflowSyncCalls).toHaveLength(0);
   });
 
   it("uses the latest workflow retry policy for future retries", async () => {

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -15,6 +15,9 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   deriveIssueWorkspaceKey,
   resolveIssueWorkspaceDirectory,
+  type OrchestratorProjectConfig,
+  type RepositoryRef,
+  type WorkflowResolution,
 } from "@gh-symphony/core";
 import { OrchestratorFsStore } from "./fs-store.js";
 import * as gitModule from "./git.js";
@@ -3044,6 +3047,50 @@ Prefer focused changes.
 
     expect(result.summary.dispatched).toBe(1);
     expect(workflowSyncCalls).toHaveLength(0);
+  });
+
+  it("loads workflow policy from explicit local path when cloneUrl is remote", async () => {
+    process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
+    const tempRoot = await mkdtemp(
+      join(tmpdir(), "orchestrator-workflow-local-path-")
+    );
+    const repository = await createRepositoryFixture(
+      tempRoot,
+      "acme",
+      "platform",
+      {
+        codexCommand: "codex --model gpt-5",
+      }
+    );
+    const configuredRepository = {
+      ...repository,
+      cloneUrl: "https://github.com/acme/platform.git",
+    };
+    const store = new OrchestratorFsStore(tempRoot);
+    const projectConfig = createProjectConfig(tempRoot, configuredRepository);
+    await store.saveProjectConfig(projectConfig);
+
+    const service = new OrchestratorService(store, projectConfig, {
+      fetchImpl: vi.fn(),
+      spawnImpl: vi.fn().mockReturnValue({
+        pid: 4308,
+        unref: vi.fn(),
+      }) as never,
+      now: () => new Date("2026-03-08T00:00:00.000Z"),
+    });
+
+    const resolution = await (
+      service as unknown as {
+        loadProjectWorkflow: (
+          tenant: OrchestratorProjectConfig,
+          repository: RepositoryRef
+        ) => Promise<WorkflowResolution>;
+      }
+    ).loadProjectWorkflow(projectConfig, configuredRepository);
+
+    expect(resolution.isValid).toBe(true);
+    expect(resolution.workflowPath).toBe(join(repository.path, "WORKFLOW.md"));
+    expect(resolution.agentCommand).toBe("codex --model gpt-5");
   });
 
   it("uses the latest workflow retry policy for future retries", async () => {

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -51,7 +51,6 @@ import {
 import {
   ensureIssueWorkspaceRepository,
   loadRepositoryWorkflow,
-  syncRepositoryForRun,
 } from "./git.js";
 import { OrchestratorFsStore } from "./fs-store.js";
 import { resolveTrackerAdapter } from "./tracker-adapters.js";
@@ -769,7 +768,6 @@ export class OrchestratorService {
       try {
         const resolution = await this.loadStartupCleanupWorkflow(
           tenant,
-          issue.repository,
           workflowCache
         );
 
@@ -822,36 +820,26 @@ export class OrchestratorService {
 
   private async resolveStartupCleanupTerminalStates(
     tenant: OrchestratorProjectConfig,
-    workspaceRecords: readonly IssueWorkspaceRecord[],
+    _workspaceRecords: readonly IssueWorkspaceRecord[],
     workflowCache: Map<string, Promise<ProjectWorkflowResolution>>
   ): Promise<string[]> {
     const terminalStates = new Map<string, string>();
-    const repositories = this.resolveStartupCleanupRepositories(
-      tenant,
-      workspaceRecords
-    );
 
-    for (const repository of repositories) {
-      let resolution: ProjectWorkflowResolution;
-      try {
-        resolution = await this.loadStartupCleanupWorkflow(
-          tenant,
-          repository,
-          workflowCache
-        );
-      } catch {
-        continue;
-      }
-      if (!isUsableWorkflowResolution(resolution)) {
-        continue;
-      }
-
-      for (const state of resolution.lifecycle.terminalStates) {
-        const normalizedState = state.trim().toLowerCase();
-        if (!terminalStates.has(normalizedState)) {
-          terminalStates.set(normalizedState, state);
+    try {
+      const resolution = await this.loadStartupCleanupWorkflow(
+        tenant,
+        workflowCache
+      );
+      if (isUsableWorkflowResolution(resolution)) {
+        for (const state of resolution.lifecycle.terminalStates) {
+          const normalizedState = state.trim().toLowerCase();
+          if (!terminalStates.has(normalizedState)) {
+            terminalStates.set(normalizedState, state);
+          }
         }
       }
+    } catch {
+      // Fall back to the default lifecycle below when startup workflow loading fails.
     }
 
     if (terminalStates.size === 0) {
@@ -863,81 +851,20 @@ export class OrchestratorService {
     return [...terminalStates.values()];
   }
 
-  private resolveStartupCleanupRepositories(
-    tenant: OrchestratorProjectConfig,
-    workspaceRecords: readonly IssueWorkspaceRecord[]
-  ): RepositoryRef[] {
-    const repositories = new Map<string, RepositoryRef>();
-
-    repositories.set(
-      this.startupCleanupRepositoryKey(
-        tenant.repository.owner,
-        tenant.repository.name
-      ),
-      tenant.repository
-    );
-
-    for (const workspaceRecord of workspaceRecords) {
-      const repository = this.parseWorkspaceRepositoryRef(workspaceRecord);
-      if (!repository) {
-        continue;
-      }
-
-      const key = this.startupCleanupRepositoryKey(
-        repository.owner,
-        repository.name
-      );
-      if (!repositories.has(key)) {
-        repositories.set(key, repository);
-      }
-    }
-
-    return [...repositories.values()];
-  }
-
-  private parseWorkspaceRepositoryRef(
-    workspaceRecord: IssueWorkspaceRecord
-  ): RepositoryRef | null {
-    const match = workspaceRecord.issueIdentifier.match(
-      /^([^/]+)\/([^#]+)#\d+$/
-    );
-    if (!match) {
-      return null;
-    }
-
-    const owner = match[1];
-    const name = match[2];
-    if (!owner || !name) {
-      return null;
-    }
-
-    return {
-      owner,
-      name,
-      cloneUrl: workspaceRecord.repositoryPath,
-    };
-  }
-
-  private startupCleanupRepositoryKey(owner: string, name: string): string {
-    return `${owner}/${name}`;
-  }
-
   private async loadStartupCleanupWorkflow(
     tenant: OrchestratorProjectConfig,
-    repository: RepositoryRef,
     workflowCache: Map<string, Promise<ProjectWorkflowResolution>>
   ): Promise<ProjectWorkflowResolution> {
-    const cacheKey = this.workflowCacheKey(repository);
+    const cacheKey = this.workflowCacheKey(tenant.repository);
     const cachedResolution = workflowCache.get(cacheKey);
     if (cachedResolution) {
       return cachedResolution;
     }
 
-    const resolutionPromise =
-      tenant.repository.owner === repository.owner &&
-      tenant.repository.name === repository.name
-        ? this.loadProjectWorkflow(tenant, repository)
-        : loadRepositoryWorkflow(repository.cloneUrl, repository);
+    const resolutionPromise = this.loadProjectWorkflow(
+      tenant,
+      tenant.repository
+    );
     workflowCache.set(cacheKey, resolutionPromise);
     return resolutionPromise;
   }
@@ -1125,19 +1052,12 @@ export class OrchestratorService {
       repository.owner,
       repository.name
     );
-    const { repositoryDirectory, changed } = await syncRepositoryForRun({
-      repository,
-      targetDirectory: cacheRoot,
-    });
-    const resolution = await loadRepositoryWorkflow(
-      repositoryDirectory,
-      repository
-    );
+    const resolution = await loadRepositoryWorkflow(repository.cloneUrl, repository);
     return this.resolveWorkflowResolution(
       repository,
       cacheRoot,
       resolution,
-      changed
+      true
     );
   }
 

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -2,7 +2,7 @@ import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { createWriteStream, mkdirSync } from "node:fs";
 import { spawn } from "node:child_process";
 import type { ChildProcess, SpawnOptions } from "node:child_process";
-import { join } from "node:path";
+import { isAbsolute, join } from "node:path";
 import { StringDecoder } from "node:string_decoder";
 import { fileURLToPath } from "node:url";
 import {
@@ -1052,7 +1052,12 @@ export class OrchestratorService {
       repository.owner,
       repository.name
     );
-    const resolution = await loadRepositoryWorkflow(repository.cloneUrl, repository);
+    const repositoryDirectory =
+      this.resolveWorkflowRepositoryDirectory(repository);
+    const resolution = await loadRepositoryWorkflow(
+      repositoryDirectory,
+      repository
+    );
     return this.resolveWorkflowResolution(
       repository,
       cacheRoot,
@@ -2598,6 +2603,32 @@ export class OrchestratorService {
 
   private workflowCacheKey(repository: RepositoryRef): string {
     return `${repository.owner}/${repository.name}:${this.normalizeRepositoryCloneUrl(repository.cloneUrl)}`;
+  }
+
+  private resolveWorkflowRepositoryDirectory(repository: RepositoryRef): string {
+    if (repository.path) {
+      return repository.path;
+    }
+
+    const localCloneUrlPath = this.resolveLocalCloneUrlPath(
+      repository.cloneUrl
+    );
+    if (localCloneUrlPath) {
+      return localCloneUrlPath;
+    }
+
+    return process.cwd();
+  }
+
+  private resolveLocalCloneUrlPath(cloneUrl: string): string | null {
+    try {
+      const url = new URL(cloneUrl);
+      return url.protocol === "file:" ? fileURLToPath(url) : null;
+    } catch {
+      return isAbsolute(cloneUrl) || cloneUrl.startsWith(".")
+        ? cloneUrl
+        : null;
+    }
   }
 
   private normalizeRepositoryCloneUrl(cloneUrl: string): string {


### PR DESCRIPTION
## Issues

- Fixes #263

## Summary

- 단일 repository 기준으로 orchestrator 정책 로딩과 startup cleanup workflow 해석을 단순화했습니다.
- 런타임 저장소 레이아웃을 `projects/<projectId>` 중심에서 `<runtimeRoot>/<workspaceKey>` 및 `<runtimeRoot>/runs/<runId>` 중심으로 평탄화했습니다.
- 리뷰에서 확인된 P1 회귀를 수정해 remote `cloneUrl`을 filesystem path로 취급하지 않고, 명시 local repository path 또는 cwd에서 `WORKFLOW.md`를 로드합니다.

## Changes

- `OrchestratorFsStore`의 project/run/workspace 경로를 runtime root 기준으로 변경하고, 새 layout 단위 테스트를 추가했습니다.
- `resolveStartupCleanupTerminalStates`/`loadStartupCleanupWorkflow`에서 persisted workspace repository 병합을 제거하고 configured repository workflow만 사용하도록 변경했습니다.
- `loadProjectWorkflow`가 HTTPS/scp-style `cloneUrl`을 local path로 오인하지 않고 `repository.path`, local `file://`/path, cwd 순서로 workflow source를 결정하도록 변경했습니다.
- flat runtime root의 reserved sibling(`runs`, `cache`, dot-prefixed entry 등)을 issue workspace로 스캔하지 않도록 방어하고, reserved workspace key를 core resolver에서 거부합니다.
- dashboard fs reader도 동일한 물리 레이아웃을 읽도록 맞추고, service/fs-store/dashboard fixture를 갱신했습니다.
- 빠른 연속 workflow rewrite에서도 변경을 감지하도록 workflow loader fingerprint에 content hash를 포함했습니다.

## Evidence

- `pnpm --filter @gh-symphony/orchestrator test -- service.test.ts -t "loads workflow policy"` — 2 tests passed
- `pnpm --filter @gh-symphony/orchestrator test -- fs-store.test.ts service.test.ts -t "loads workflow policy|flat runtime root|workspaceKey-root"` — 4 tests passed
- `pnpm --filter @gh-symphony/core test -- core-conformance.test.ts -t "resolveIssueWorkspaceDirectory"` — 3 tests passed
- `pnpm --filter @gh-symphony/orchestrator test` — 8 files / 146 tests passed
- `rg "tenant\\.repositories\\." packages/orchestrator || true` — 결과 0건
- `pnpm lint && pnpm test && pnpm typecheck && pnpm build` — 통과
- Docker E2E TC: `docker compose -f docker-compose.e2e.yml -f docker-compose.e2e.events.yml up -d --build`, happy-path issue 주입, `/api/v1/state` running/dispatched 확인, `/app/.runtime/test-owner_test-repo_1/repository` 및 `/app/.runtime/runs/*/events.ndjson` 확인 — 통과

## Human Validation

- [ ] 새 runtime layout에서 기존 project namespace가 필요한 운영 스크립트가 없는지 확인
- [ ] Phase 3 CLI migration 전 stable 채널 릴리즈 금지 위험을 재확인
- [ ] Dashboard/API에서 단일 repo 상태 조회가 기대한 경로를 읽는지 확인
- [ ] production 실행 cwd 또는 명시 repository path가 실제 `WORKFLOW.md`가 있는 checkout을 가리키는지 확인

## Risks

- 기존 `.runtime/orchestrator/projects/<projectId>/...` 데이터와 호환되지 않습니다. 이슈 본문에 명시된 대로 마이그레이션은 다음 phase에서 처리해야 하며, Phase 3 전 stable 릴리즈는 피해야 합니다.
- CLI의 완전한 cwd 기반 전환은 ADR상 Phase 3 범위입니다. 이번 PR은 service core에서 remote `cloneUrl`을 workflow filesystem path로 사용하지 않도록 막고, 명시 local path/cwd 모델에 맞춥니다.