### PR TITLE
feat(cli): switch repo workflow to cwd

### DIFF
--- a/.changeset/cwd-repo-cli-migration.md
+++ b/.changeset/cwd-repo-cli-migration.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": minor
+---
+
+BREAKING: switch repository orchestration commands to the cwd-based single-repo workflow. `gh-symphony repo init/start/status/stop` now use repo-local `.runtime/orchestrator` state, `--project-id` is rejected with a removal error, and `repo init` migrates a single legacy `.runtime/orchestrator/projects/<projectId>` directory while failing with manual cleanup guidance for multiple legacy project directories.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,4 +106,4 @@ jobs:
           docker run --rm \
             -v "${TMPDIR}/config:/var/lib/gh-symphony" \
             gh-symphony:test \
-            gh-symphony start --once --project-id smoke
+            gh-symphony start --once

--- a/e2e/seed/entrypoint.sh
+++ b/e2e/seed/entrypoint.sh
@@ -28,7 +28,6 @@ fi
 echo "[entrypoint] Starting CLI orchestrator with HTTP composition..."
 GH_SYMPHONY_CONFIG_DIR="$RUNTIME_DIR" \
 node /app/packages/cli/dist/index.js start \
-  --project-id "$PROJECT_ID" \
   --http 4680 &
 CLI_PID=$!
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build:cli": "pnpm --filter @gh-symphony/cli... build",
     "cli": "node packages/cli/dist/index.js --config .runtime",
     "e2e:init": "bash e2e/seed/init-local.sh",
-    "e2e:start": "SYMPHONY_WORKER_COMMAND=\"node $(pwd)/e2e/dist/stub-worker.js\" node packages/cli/dist/index.js --config .runtime start --project-id e2e-project --http 4680",
+    "e2e:start": "SYMPHONY_WORKER_COMMAND=\"node $(pwd)/e2e/dist/stub-worker.js\" node packages/cli/dist/index.js --config .runtime start --http 4680",
     "e2e:claude": "bash test/e2e/claude/run-docker-e2e.sh",
     "dev:orchestrator": "pnpm --filter @gh-symphony/orchestrator dev",
     "dev:worker": "pnpm --filter @gh-symphony/worker dev",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @gh-symphony/cli
 
+## Unreleased
+
+### Minor Changes
+
+- BREAKING: switch repository orchestration commands to the cwd-based single-repo workflow. `gh-symphony repo init/start/status/stop` now use repo-local `.runtime/orchestrator` state, `--project-id` is rejected with a removal error, and `repo init` migrates a single legacy `.runtime/orchestrator/projects/<projectId>` directory while failing with manual cleanup guidance for multiple legacy project directories.
+
 ## 0.0.21
 
 ### Patch Changes

--- a/packages/cli/src/commands/lifecycle.test.ts
+++ b/packages/cli/src/commands/lifecycle.test.ts
@@ -163,7 +163,7 @@ describe("lifecycle command integration", () => {
 
     expect(spawnMock).toHaveBeenCalledWith(
       process.execPath,
-      [process.argv[1], "start", "--project", "tenant-a"],
+      [process.argv[1], "start"],
       expect.any(Object)
     );
   });
@@ -240,7 +240,7 @@ describe("lifecycle command integration", () => {
     expect(process.exitCode).toBe(1);
   });
 
-  it("starts the requested project in daemon mode", async () => {
+  it("rejects removed project selection flags in daemon mode", async () => {
     const configDir = await createConfigFixture({
       activeProject: "tenant-a",
       projects: [
@@ -249,43 +249,26 @@ describe("lifecycle command integration", () => {
       ],
     });
 
-    spawnMock.mockReturnValue({
-      pid: 4321,
-      stdout: { pipe: vi.fn() },
-      stderr: { pipe: vi.fn() },
-      unref: vi.fn(),
-    });
+    const stderr = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
 
     await startModule.default(
       ["--project", "tenant-b", "--daemon"],
       baseOptions(configDir)
     );
 
-    expect(spawnMock).toHaveBeenCalledWith(
-      process.execPath,
-      [process.argv[1], "start", "--project", "tenant-b"],
-      expect.objectContaining({
-        env: expect.objectContaining({
-          GH_SYMPHONY_CONFIG_DIR: configDir,
-        }),
-      })
+    expect(spawnMock).not.toHaveBeenCalled();
+    expect(stderr.mock.calls.map((call) => String(call[0])).join("")).toContain(
+      "--project-id has been removed"
     );
-
-    expect(
-      await readFile(
-        join(configDir, "projects", "tenant-b", "daemon.pid"),
-        "utf8"
-      )
-    ).toBe("4321");
+    expect(process.exitCode).toBe(2);
   });
 
-  it("supports project start subcommand for explicit project orchestration", async () => {
+  it("supports project start subcommand for the active repository", async () => {
     const configDir = await createConfigFixture({
       activeProject: "tenant-a",
-      projects: [
-        createTenant("tenant-a", "acme", "platform"),
-        createTenant("tenant-b", "beta", "api"),
-      ],
+      projects: [createTenant("tenant-a", "acme", "platform")],
     });
 
     spawnMock.mockReturnValue({
@@ -295,35 +278,22 @@ describe("lifecycle command integration", () => {
       unref: vi.fn(),
     });
 
-    await projectModule.default(
-      ["start", "--project-id", "tenant-b", "--daemon", "--log-level", "verbose"],
-      baseOptions(configDir)
-    );
+    await projectModule.default(["start", "--daemon", "--log-level", "verbose"], baseOptions(configDir));
 
     expect(spawnMock).toHaveBeenCalledWith(
       process.execPath,
-      [
-        process.argv[1],
-        "start",
-        "--project",
-        "tenant-b",
-        "--log-level",
-        "verbose",
-      ],
+      [process.argv[1], "start", "--log-level", "verbose"],
       expect.any(Object)
     );
   });
 
-  it("routes project status to the requested project's orchestrator snapshot", async () => {
+  it("routes project status to the active repository orchestrator snapshot", async () => {
     const configDir = await createConfigFixture({
       activeProject: "tenant-a",
-      projects: [
-        createTenant("tenant-a", "acme", "platform"),
-        createTenant("tenant-b", "beta", "api"),
-      ],
+      projects: [createTenant("tenant-a", "acme", "platform")],
     });
-    await writeStatusSnapshot(configDir, "tenant-b", {
-      slug: "tenant-b",
+    await writeStatusSnapshot(configDir, "tenant-a", {
+      slug: "tenant-a",
       health: "running",
     });
 
@@ -331,15 +301,12 @@ describe("lifecycle command integration", () => {
       .spyOn(process.stdout, "write")
       .mockImplementation(() => true);
 
-    await projectModule.default(
-      ["status", "--project-id", "tenant-b"],
-      baseOptions(configDir)
-    );
+    await projectModule.default(["status"], baseOptions(configDir));
 
     const output = stdout.mock.calls.map((call) => String(call[0])).join("");
     expect(output).toContain("gh-symphony");
-    expect(output).toContain("tenant-b");
-    expect(output).not.toContain("tenant-a");
+    expect(output).toContain("tenant-a");
+    expect(output).not.toContain("tenant-b");
   });
 
   it("rejects unknown project status flags instead of falling back to the active project", async () => {
@@ -363,23 +330,18 @@ describe("lifecycle command integration", () => {
     const output = stderr.mock.calls.map((call) => String(call[0])).join("");
     expect(output).toContain("Unknown option '--proejct-id'");
     expect(output).toContain(
-      "Usage: gh-symphony status [--project-id <project-id>] [--watch]"
+      "Usage: gh-symphony status [--watch]"
     );
     expect(process.exitCode).toBe(2);
   });
 
-  it("stops only the requested project's daemon files", async () => {
+  it("stops the active repository daemon files", async () => {
     const configDir = await createConfigFixture({
       activeProject: "tenant-a",
-      projects: [
-        createTenant("tenant-a", "acme", "platform"),
-        createTenant("tenant-b", "beta", "api"),
-      ],
+      projects: [createTenant("tenant-a", "acme", "platform")],
     });
     await writeFile(join(configDir, "projects", "tenant-a", "daemon.pid"), "111\n");
     await writeFile(join(configDir, "projects", "tenant-a", "port"), "41001\n");
-    await writeFile(join(configDir, "projects", "tenant-b", "daemon.pid"), "222\n");
-    await writeFile(join(configDir, "projects", "tenant-b", "port"), "41002\n");
 
     const killSpy = vi
       .spyOn(process, "kill")
@@ -393,19 +355,13 @@ describe("lifecycle command integration", () => {
         return true;
       }) as typeof process.kill);
 
-    await stopModule.default(["--project-id", "tenant-a"], baseOptions(configDir));
+    await stopModule.default([], baseOptions(configDir));
 
     expect(killSpy).toHaveBeenCalledWith(111, 0);
     expect(killSpy).toHaveBeenCalledWith(111, "SIGTERM");
     await expect(
       readFile(join(configDir, "projects", "tenant-a", "daemon.pid"), "utf8")
     ).rejects.toMatchObject({ code: "ENOENT" });
-    await expect(
-      readFile(join(configDir, "projects", "tenant-b", "daemon.pid"), "utf8")
-    ).resolves.toContain("222");
-    await expect(
-      readFile(join(configDir, "projects", "tenant-b", "port"), "utf8")
-    ).resolves.toContain("41002");
   });
 
   it("rejects unknown project stop flags before touching daemon state", async () => {
@@ -428,7 +384,7 @@ describe("lifecycle command integration", () => {
     const output = stderr.mock.calls.map((call) => String(call[0])).join("");
     expect(output).toContain("Unknown option '--proejct-id'");
     expect(output).toContain(
-      "Usage: gh-symphony stop --project-id <project-id> [--force]"
+      "Usage: gh-symphony stop [--force]"
     );
     expect(killSpy).not.toHaveBeenCalled();
     await expect(
@@ -547,13 +503,11 @@ async function createConfigFixture(input: {
 
 async function writeStatusSnapshot(
   configDir: string,
-  projectId: string,
+  _projectId: string,
   input: { slug: string; health: "idle" | "running" | "degraded" }
 ): Promise<void> {
-  const statusDir = join(configDir, "projects", projectId);
-  await mkdir(statusDir, { recursive: true });
   await writeFile(
-    join(statusDir, "status.json"),
+    join(configDir, "status.json"),
     JSON.stringify(
       {
         slug: input.slug,

--- a/packages/cli/src/commands/repo.test.ts
+++ b/packages/cli/src/commands/repo.test.ts
@@ -1,4 +1,5 @@
-import { mkdtemp, readFile } from "node:fs/promises";
+import { execFileSync } from "node:child_process";
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -89,6 +90,29 @@ function createProjectConfig(repositories: CliProjectConfig["repositories"]): Cl
     },
   };
 }
+
+const VALID_WORKFLOW = `---
+tracker:
+  kind: github-project
+  project_id: PVT_project_123
+  state_field: Status
+  active_states:
+    - Ready
+  terminal_states:
+    - Done
+polling:
+  interval_ms: 30000
+workspace:
+  root: .runtime/symphony-workspaces
+hooks:
+  timeout_ms: 60000
+agent:
+  max_concurrent_agents: 1
+codex:
+  command: codex app-server
+---
+Handle {{issue.identifier}}.
+`;
 
 async function seedActiveProject(
   configDir: string,
@@ -508,6 +532,127 @@ describe("repo sync", () => {
 
     expect(process.exitCode).toBe(1);
     expect(stderr.output()).toContain("Active project is missing its GitHub Project binding");
+  });
+});
+
+describe("repo init runtime migration", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.exitCode = undefined;
+  });
+
+  it("promotes a single legacy project directory and strips projectId from run records", async () => {
+    const repoDir = await mkdtemp(join(tmpdir(), "repo-init-single-"));
+    const stdout = captureWrites(process.stdout);
+    const repoCommand = await loadRepoCommand();
+    execFileSync("git", ["-C", repoDir, "init"]);
+    execFileSync("git", [
+      "-C",
+      repoDir,
+      "remote",
+      "add",
+      "origin",
+      "https://github.com/acme/platform.git",
+    ]);
+    await writeFile(join(repoDir, "WORKFLOW.md"), VALID_WORKFLOW, "utf8");
+
+    const runDir = join(
+      repoDir,
+      ".runtime",
+      "orchestrator",
+      "projects",
+      "tenant-a",
+      "runs",
+      "run-1"
+    );
+    await mkdir(runDir, { recursive: true });
+    await writeFile(
+      join(runDir, "run.json"),
+      JSON.stringify({ runId: "run-1", projectId: "tenant-a", status: "running" }),
+      "utf8"
+    );
+
+    try {
+      await repoCommand(["init", "--repo-dir", repoDir], baseOptions(join(repoDir, "unused")));
+    } finally {
+      stdout.restore();
+    }
+
+    const migratedRun = JSON.parse(
+      await readFile(
+        join(repoDir, ".runtime", "orchestrator", "runs", "run-1", "run.json"),
+        "utf8"
+      )
+    ) as Record<string, unknown>;
+    const projectConfig = JSON.parse(
+      await readFile(
+        join(
+          repoDir,
+          ".runtime",
+          "orchestrator",
+          "projects",
+          "repository",
+          "project.json"
+        ),
+        "utf8"
+      )
+    ) as CliProjectConfig;
+
+    expect(migratedRun).not.toHaveProperty("projectId");
+    expect(projectConfig.repository).toMatchObject({
+      owner: "acme",
+      name: "platform",
+    });
+    expect(stdout.output()).toContain("Repository initialized: acme/platform");
+  });
+
+  it("fails with manual cleanup guidance when multiple legacy project directories exist", async () => {
+    const repoDir = await mkdtemp(join(tmpdir(), "repo-init-multi-"));
+    const stderr = captureWrites(process.stderr);
+    const repoCommand = await loadRepoCommand();
+    execFileSync("git", ["-C", repoDir, "init"]);
+    execFileSync("git", [
+      "-C",
+      repoDir,
+      "remote",
+      "add",
+      "origin",
+      "https://github.com/acme/platform.git",
+    ]);
+    await writeFile(join(repoDir, "WORKFLOW.md"), VALID_WORKFLOW, "utf8");
+    await mkdir(
+      join(repoDir, ".runtime", "orchestrator", "projects", "tenant-a"),
+      { recursive: true }
+    );
+    await mkdir(
+      join(repoDir, ".runtime", "orchestrator", "projects", "tenant-b"),
+      { recursive: true }
+    );
+
+    try {
+      await repoCommand(["init", "--repo-dir", repoDir], baseOptions(join(repoDir, "unused")));
+    } finally {
+      stderr.restore();
+    }
+
+    expect(process.exitCode).toBe(1);
+    expect(stderr.output()).toContain("Multiple legacy project runtime directories");
+    expect(stderr.output()).toContain("Manually keep the project directory");
+  });
+
+  it("reports a clear error when --project-id is used", async () => {
+    const stderr = captureWrites(process.stderr);
+    const repoCommand = await loadRepoCommand();
+
+    try {
+      await repoCommand(["init", "--project-id", "tenant-a"], baseOptions(tmpdir()));
+    } finally {
+      stderr.restore();
+    }
+
+    expect(process.exitCode).toBe(2);
+    expect(stderr.output()).toContain("--project-id has been removed");
+    expect(stderr.output()).toContain("current repository directory");
   });
 });
 

--- a/packages/cli/src/commands/repo.test.ts
+++ b/packages/cli/src/commands/repo.test.ts
@@ -74,7 +74,9 @@ function baseOptions(configDir: string) {
   };
 }
 
-function createProjectConfig(repositories: CliProjectConfig["repositories"]): CliProjectConfig {
+function createProjectConfig(
+  repositories: CliProjectConfig["repositories"]
+): CliProjectConfig {
   return {
     projectId: "managed-project",
     slug: "managed-project",
@@ -216,7 +218,9 @@ describe("repo sync", () => {
         cloneUrl: "https://github.com/acme/api.git",
       },
     ]);
-    expect(stdout.output()).toContain("Repository sync complete for managed-project");
+    expect(stdout.output()).toContain(
+      "Repository sync complete for managed-project"
+    );
     expect(stdout.output()).toContain("Mode: additive");
     expect(stdout.output()).toContain("Added");
     expect(stdout.output()).toContain("acme/api");
@@ -288,7 +292,9 @@ describe("repo sync", () => {
         cloneUrl: "https://github.com/acme/platform.git",
       },
     ]);
-    expect(stdout.output()).toContain("Repository sync preview for managed-project");
+    expect(stdout.output()).toContain(
+      "Repository sync preview for managed-project"
+    );
     expect(stdout.output()).toContain("No config changes written.");
   });
 
@@ -507,7 +513,9 @@ describe("repo sync", () => {
   });
 
   it("fails when the active project has no GitHub Project binding", async () => {
-    const configDir = await mkdtemp(join(tmpdir(), "repo-sync-missing-binding-"));
+    const configDir = await mkdtemp(
+      join(tmpdir(), "repo-sync-missing-binding-")
+    );
     const stderr = captureWrites(process.stderr);
     const repoCommand = await loadRepoCommand();
 
@@ -531,7 +539,9 @@ describe("repo sync", () => {
     }
 
     expect(process.exitCode).toBe(1);
-    expect(stderr.output()).toContain("Active project is missing its GitHub Project binding");
+    expect(stderr.output()).toContain(
+      "Active project is missing its GitHub Project binding"
+    );
   });
 });
 
@@ -568,12 +578,19 @@ describe("repo init runtime migration", () => {
     await mkdir(runDir, { recursive: true });
     await writeFile(
       join(runDir, "run.json"),
-      JSON.stringify({ runId: "run-1", projectId: "tenant-a", status: "running" }),
+      JSON.stringify({
+        runId: "run-1",
+        projectId: "tenant-a",
+        status: "running",
+      }),
       "utf8"
     );
 
     try {
-      await repoCommand(["init", "--repo-dir", repoDir], baseOptions(join(repoDir, "unused")));
+      await repoCommand(
+        ["init", "--repo-dir", repoDir],
+        baseOptions(join(repoDir, "unused"))
+      );
     } finally {
       stdout.restore();
     }
@@ -606,6 +623,126 @@ describe("repo init runtime migration", () => {
     expect(stdout.output()).toContain("Repository initialized: acme/platform");
   });
 
+  it("can run repo init again after the repository layout exists", async () => {
+    const repoDir = await mkdtemp(join(tmpdir(), "repo-init-idempotent-"));
+    const stdout = captureWrites(process.stdout);
+    const repoCommand = await loadRepoCommand();
+    execFileSync("git", ["-C", repoDir, "init"]);
+    execFileSync("git", [
+      "-C",
+      repoDir,
+      "remote",
+      "add",
+      "origin",
+      "https://github.com/acme/platform.git",
+    ]);
+    await writeFile(join(repoDir, "WORKFLOW.md"), VALID_WORKFLOW, "utf8");
+
+    try {
+      await repoCommand(
+        ["init", "--repo-dir", repoDir],
+        baseOptions(join(repoDir, "unused"))
+      );
+      process.exitCode = undefined;
+      await repoCommand(
+        ["init", "--repo-dir", repoDir],
+        baseOptions(join(repoDir, "unused"))
+      );
+    } finally {
+      stdout.restore();
+    }
+
+    expect(process.exitCode).toBeUndefined();
+    expect(stdout.output()).toContain("Repository initialized: acme/platform");
+  });
+
+  it("resolves a relative --workflow-file against --repo-dir", async () => {
+    const repoDir = await mkdtemp(join(tmpdir(), "repo-init-workflow-file-"));
+    const elsewhere = await mkdtemp(join(tmpdir(), "repo-init-elsewhere-"));
+    const stdout = captureWrites(process.stdout);
+    const repoCommand = await loadRepoCommand();
+    const originalCwd = process.cwd();
+    execFileSync("git", ["-C", repoDir, "init"]);
+    execFileSync("git", [
+      "-C",
+      repoDir,
+      "remote",
+      "add",
+      "origin",
+      "https://github.com/acme/platform.git",
+    ]);
+    await writeFile(join(repoDir, "CUSTOM.md"), VALID_WORKFLOW, "utf8");
+
+    try {
+      process.chdir(elsewhere);
+      await repoCommand(
+        ["init", "--repo-dir", repoDir, "--workflow-file", "CUSTOM.md"],
+        baseOptions(join(repoDir, "unused"))
+      );
+    } finally {
+      process.chdir(originalCwd);
+      stdout.restore();
+    }
+
+    expect(process.exitCode).toBeUndefined();
+    expect(stdout.output()).toContain(
+      `Workflow: ${join(repoDir, "CUSTOM.md")}`
+    );
+  });
+
+  it.each([
+    ["name.with.dots", "name.with.dots"],
+    [".github", ".github"],
+  ])(
+    "infers GitHub repository names containing dots: %s",
+    async (remoteName, expectedName) => {
+      const repoDir = await mkdtemp(join(tmpdir(), "repo-init-dotted-"));
+      const stdout = captureWrites(process.stdout);
+      const repoCommand = await loadRepoCommand();
+      execFileSync("git", ["-C", repoDir, "init"]);
+      execFileSync("git", [
+        "-C",
+        repoDir,
+        "remote",
+        "add",
+        "origin",
+        `https://github.com/acme/${remoteName}.git`,
+      ]);
+      await writeFile(join(repoDir, "WORKFLOW.md"), VALID_WORKFLOW, "utf8");
+
+      try {
+        await repoCommand(
+          ["init", "--repo-dir", repoDir],
+          baseOptions(join(repoDir, "unused"))
+        );
+      } finally {
+        stdout.restore();
+      }
+
+      const projectConfig = JSON.parse(
+        await readFile(
+          join(
+            repoDir,
+            ".runtime",
+            "orchestrator",
+            "projects",
+            "repository",
+            "project.json"
+          ),
+          "utf8"
+        )
+      ) as CliProjectConfig;
+
+      expect(projectConfig.repository).toMatchObject({
+        owner: "acme",
+        name: expectedName,
+      });
+      expect(stdout.output()).toContain(
+        `Repository initialized: acme/${expectedName}`
+      );
+    }
+  );
+
   it("fails with manual cleanup guidance when multiple legacy project directories exist", async () => {
     const repoDir = await mkdtemp(join(tmpdir(), "repo-init-multi-"));
     const stderr = captureWrites(process.stderr);
@@ -630,13 +767,18 @@ describe("repo init runtime migration", () => {
     );
 
     try {
-      await repoCommand(["init", "--repo-dir", repoDir], baseOptions(join(repoDir, "unused")));
+      await repoCommand(
+        ["init", "--repo-dir", repoDir],
+        baseOptions(join(repoDir, "unused"))
+      );
     } finally {
       stderr.restore();
     }
 
     expect(process.exitCode).toBe(1);
-    expect(stderr.output()).toContain("Multiple legacy project runtime directories");
+    expect(stderr.output()).toContain(
+      "Multiple legacy project runtime directories"
+    );
     expect(stderr.output()).toContain("Manually keep the project directory");
   });
 
@@ -645,7 +787,10 @@ describe("repo init runtime migration", () => {
     const repoCommand = await loadRepoCommand();
 
     try {
-      await repoCommand(["init", "--project-id", "tenant-a"], baseOptions(tmpdir()));
+      await repoCommand(
+        ["init", "--project-id", "tenant-a"],
+        baseOptions(tmpdir())
+      );
     } finally {
       stderr.restore();
     }
@@ -935,6 +1080,8 @@ describe("repo add", () => {
     expect(stderr.output()).toContain(
       "GitHub API rate limit blocked repository validation."
     );
-    expect(stderr.output()).toContain("Wait for the rate limit window to reset");
+    expect(stderr.output()).toContain(
+      "Wait for the rate limit window to reset"
+    );
   });
 });

--- a/packages/cli/src/commands/repo.ts
+++ b/packages/cli/src/commands/repo.ts
@@ -123,7 +123,7 @@ async function repoInit(args: string[], options: GlobalOptions): Promise<void> {
     process.stderr.write(
       `${error instanceof Error ? error.message : "Repository initialization failed."}\n`
     );
-    process.exitCode = error instanceof RepoRuntimeMigrationError ? 1 : 1;
+    process.exitCode = 1;
   }
 }
 

--- a/packages/cli/src/commands/repo.ts
+++ b/packages/cli/src/commands/repo.ts
@@ -11,7 +11,6 @@ import {
 import {
   initRepoRuntime,
   parseRepoRuntimeFlags,
-  RepoRuntimeMigrationError,
 } from "../repo-runtime.js";
 import { resolveRepoRuntimeRoot } from "../orchestrator-runtime.js";
 import { rejectRemovedProjectId } from "../removed-project-id.js";

--- a/packages/cli/src/commands/repo.ts
+++ b/packages/cli/src/commands/repo.ts
@@ -1,10 +1,20 @@
 import type { GlobalOptions } from "../index.js";
+import startCommand from "./start.js";
+import statusCommand from "./status.js";
+import stopCommand from "./stop.js";
 import {
   loadActiveProjectConfig,
   loadGlobalConfig,
   saveProjectConfig,
   type CliProjectConfig,
 } from "../config.js";
+import {
+  initRepoRuntime,
+  parseRepoRuntimeFlags,
+  RepoRuntimeMigrationError,
+} from "../repo-runtime.js";
+import { resolveRepoRuntimeRoot } from "../orchestrator-runtime.js";
+import { rejectRemovedProjectId } from "../removed-project-id.js";
 import {
   checkRequiredScopes,
   createClient,
@@ -28,6 +38,21 @@ const handler = async (
     case "list":
       await repoList(options);
       break;
+    case "init":
+      await repoInit(rest, options);
+      break;
+    case "start":
+      if (rejectRemovedProjectId(rest)) return;
+      await startCommand(rest, repoOptions(options));
+      break;
+    case "status":
+      if (rejectRemovedProjectId(rest)) return;
+      await statusCommand(rest, repoOptions(options));
+      break;
+    case "stop":
+      if (rejectRemovedProjectId(rest)) return;
+      await stopCommand(rest, repoOptions(options));
+      break;
     case "add":
       await repoAdd(rest, options);
       break;
@@ -39,7 +64,7 @@ const handler = async (
       break;
     default:
       process.stderr.write(
-        "Usage: gh-symphony repo <list|add|remove|sync> [repo]\n"
+        "Usage: gh-symphony repo <init|start|status|stop|list|add|remove|sync> [repo]\n"
       );
       process.exitCode = 2;
   }
@@ -54,6 +79,56 @@ type RepoConfigEntry = {
   name: string;
   cloneUrl: string;
 };
+
+function repoOptions(options: GlobalOptions): GlobalOptions {
+  return {
+    ...options,
+    configDir: resolveRepoRuntimeRoot(),
+  };
+}
+
+async function repoInit(
+  args: string[],
+  options: GlobalOptions
+): Promise<void> {
+  if (rejectRemovedProjectId(args)) {
+    return;
+  }
+
+  let flags: ReturnType<typeof parseRepoRuntimeFlags>;
+  try {
+    flags = parseRepoRuntimeFlags(args);
+  } catch (error) {
+    process.stderr.write(
+      `${error instanceof Error ? error.message : "Invalid arguments"}\n`
+    );
+    process.stderr.write(
+      "Usage: gh-symphony repo init [--repo-dir <path>] [--workflow-file <path>]\n"
+    );
+    process.exitCode = 2;
+    return;
+  }
+
+  try {
+    const result = await initRepoRuntime(flags);
+    if (options.json) {
+      process.stdout.write(JSON.stringify(result, null, 2) + "\n");
+      return;
+    }
+    process.stdout.write(
+      [
+        `Repository initialized: ${formatRepoSpec(result.repository)}`,
+        `Runtime: ${result.configDir}`,
+        `Workflow: ${result.workflowPath}`,
+      ].join("\n") + "\n"
+    );
+  } catch (error) {
+    process.stderr.write(
+      `${error instanceof Error ? error.message : "Repository initialization failed."}\n`
+    );
+    process.exitCode = error instanceof RepoRuntimeMigrationError ? 1 : 1;
+  }
+}
 
 type RepoSyncFlags = {
   dryRun: boolean;

--- a/packages/cli/src/commands/repo.ts
+++ b/packages/cli/src/commands/repo.ts
@@ -87,10 +87,7 @@ function repoOptions(options: GlobalOptions): GlobalOptions {
   };
 }
 
-async function repoInit(
-  args: string[],
-  options: GlobalOptions
-): Promise<void> {
+async function repoInit(args: string[], options: GlobalOptions): Promise<void> {
   if (rejectRemovedProjectId(args)) {
     return;
   }

--- a/packages/cli/src/commands/start.test.ts
+++ b/packages/cli/src/commands/start.test.ts
@@ -155,7 +155,7 @@ describe("start command foreground locking", () => {
       .mockImplementation(((_code?: number) => undefined) as (code?: number) => never);
 
     await startModule.default(
-      ["--project-id", "tenant-a", "--once"],
+      ["--once"],
       baseOptions(configDir)
     );
 
@@ -174,7 +174,7 @@ describe("start command foreground locking", () => {
 
     try {
       await startModule.default(
-        ["--project-id", "tenant-a", "--daemon", "--once"],
+        ["--daemon", "--once"],
         baseOptions(configDir)
       );
     } finally {
@@ -198,7 +198,7 @@ describe("start command foreground locking", () => {
 
     try {
       await startModule.default(
-        ["--project-id", "tenant-a", "--http", "--web"],
+        ["--http", "--web"],
         baseOptions(configDir)
       );
     } finally {
@@ -253,7 +253,7 @@ describe("start command foreground locking", () => {
       .spyOn(process, "exit")
       .mockImplementation(((_code?: number) => undefined) as (code?: number) => never);
 
-    await startModule.default(["--project-id", "tenant-a"], baseOptions(configDir));
+    await startModule.default([], baseOptions(configDir));
 
     expect(acquireProjectLock).toHaveBeenCalledWith({
       runtimeRoot: configDir,
@@ -310,7 +310,7 @@ describe("start command foreground locking", () => {
       .spyOn(process, "exit")
       .mockImplementation(((_code?: number) => undefined) as (code?: number) => never);
 
-    await startModule.default(["--project-id", "tenant-a"], baseOptions(configDir));
+    await startModule.default([], baseOptions(configDir));
 
     expect(run).toHaveBeenCalledTimes(2);
     expect(releaseProjectLock).toHaveBeenCalledWith(lock);
@@ -348,7 +348,7 @@ describe("start command foreground locking", () => {
 
     try {
       const startPromise = startModule.default(
-        ["--project-id", "tenant-a", "--http"],
+        ["--http"],
         baseOptions(configDir)
       );
 
@@ -447,7 +447,7 @@ describe("start command foreground locking", () => {
 
     try {
       const startPromise = startModule.default(
-        ["--project-id", "tenant-a", "--web"],
+        ["--web"],
         baseOptions(configDir)
       );
 
@@ -541,7 +541,7 @@ describe("start command foreground locking", () => {
       .mockImplementation(((_code?: number) => undefined) as (code?: number) => never);
 
     const startPromise = startModule.default(
-      ["--project-id", "tenant-a", "--web", "4900"],
+      ["--web", "4900"],
       baseOptions(configDir)
     );
 
@@ -604,7 +604,7 @@ describe("start command foreground locking", () => {
 
     try {
       const startPromise = startModule.default(
-        ["--project-id", "tenant-a", "--once", "--http"],
+        ["--once", "--http"],
         baseOptions(configDir)
       );
 
@@ -672,7 +672,7 @@ describe("start command foreground locking", () => {
 
     try {
       const startPromise = startModule.default(
-        ["--project-id", "tenant-a", "--http"],
+        ["--http"],
         baseOptions(configDir)
       );
 
@@ -735,7 +735,7 @@ describe("start command foreground locking", () => {
 
     try {
       const startPromise = startModule.default(
-        ["--project-id", "tenant-a", "--http", String(address.port)],
+        ["--http", String(address.port)],
         baseOptions(configDir)
       );
 
@@ -785,7 +785,7 @@ describe("start command foreground locking", () => {
     acquireProjectLock.mockRejectedValue(new Error("lock busy"));
 
     await expect(
-      startModule.default(["--project-id", "tenant-a"], baseOptions(configDir))
+      startModule.default([], baseOptions(configDir))
     ).rejects.toThrow("lock busy");
 
     await expect(readFile(statePath, "utf8")).resolves.toContain(
@@ -826,7 +826,7 @@ describe("start command foreground locking", () => {
 
     try {
       const startPromise = startModule.default(
-        ["--project-id", "tenant-a", "--http"],
+        ["--http"],
         baseOptions(configDir)
       );
 

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -32,6 +32,7 @@ import {
   handleMissingManagedProjectConfig,
   resolveManagedProjectConfig,
 } from "../project-selection.js";
+import { rejectRemovedProjectId } from "../removed-project-id.js";
 import { bold, dim, green, red, yellow, cyan, setNoColor } from "../ansi.js";
 import { getGhToken } from "../github/gh-auth.js";
 
@@ -435,6 +436,9 @@ const handler = async (
   setNoColor(options.noColor);
   let parsed: ReturnType<typeof parseStartArgs>;
   try {
+    if (rejectRemovedProjectId(args)) {
+      return;
+    }
     parsed = parseStartArgs(args);
   } catch (error) {
     process.stderr.write(
@@ -446,7 +450,7 @@ const handler = async (
   if (parsed.error) {
     process.stderr.write(`${parsed.error}\n`);
     process.stderr.write(
-      "Usage: gh-symphony start --project-id <project-id> [--daemon] [--once] [--http [port]] [--web [port]]\n"
+      "Usage: gh-symphony start [--daemon] [--once] [--http [port]] [--web [port]]\n"
     );
     process.exitCode = 2;
     return;
@@ -458,7 +462,7 @@ const handler = async (
   }
   const projectConfig = await resolveManagedProjectConfig({
     configDir: options.configDir,
-    requestedProjectId: parsed.projectId,
+      requestedProjectId: undefined,
   });
   if (!projectConfig) {
     handleMissingManagedProjectConfig();
@@ -783,7 +787,7 @@ async function tailWorkerLog(
   issueIdentifier: string
 ): Promise<void> {
   try {
-    const logPath = join(runtimeRoot, "projects", projectId, "runs", runId, "worker.log");
+    const logPath = join(runtimeRoot, "runs", runId, "worker.log");
     const content = await readFile(logPath, "utf8");
     const lines = content.split("\n").filter((l) => l.trim());
     if (lines.length === 0) return;
@@ -814,13 +818,11 @@ async function startDaemon(
   const { openSync } = await import("node:fs");
   const logFd = openSync(logPath, "a");
 
-  const child = spawn(
+    const child = spawn(
     process.execPath,
     [
       process.argv[1]!,
       "start",
-      "--project",
-      projectId,
       ...(httpPort !== undefined ? ["--http", String(httpPort)] : []),
       ...(webPort !== undefined ? ["--web", String(webPort)] : []),
       ...(logLevel ? ["--log-level", logLevel] : []),
@@ -846,8 +848,8 @@ async function startDaemon(
   closeSync(logFd);
 
   process.stdout.write(
-    `Orchestrator started in background (PID: ${child.pid}).\n` +
+      `Orchestrator started in background (PID: ${child.pid}).\n` +
       `Logs: ${logPath}\n` +
-      `Stop with: gh-symphony project stop --project-id ${projectId}\n`
+      "Stop with: gh-symphony repo stop\n"
   );
 }

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -74,7 +74,6 @@ function parseStartArgs(args: string[]): {
   once: boolean;
   httpPort?: number;
   webPort?: number;
-  projectId?: string;
   logLevel?: string;
   error?: string;
 } {
@@ -83,7 +82,6 @@ function parseStartArgs(args: string[]): {
     once: boolean;
     httpPort?: number;
     webPort?: number;
-    projectId?: string;
     logLevel?: string;
     error?: string;
   } = {
@@ -118,16 +116,6 @@ function parseStartArgs(args: string[]): {
         continue;
       }
       parsed.webPort = parsePort(value, arg);
-      i += 1;
-      continue;
-    }
-    if (arg === "--project" || arg === "--project-id") {
-      const value = args[i + 1];
-      if (!value || value.startsWith("-")) {
-        parsed.error = `Option '${arg}' argument missing`;
-        return parsed;
-      }
-      parsed.projectId = value;
       i += 1;
       continue;
     }
@@ -311,7 +299,7 @@ function formatBoundUrl(server: Server): string {
 
 function logHttpRequestError(error: unknown): void {
   const message =
-    error instanceof Error ? error.stack ?? error.message : String(error);
+    error instanceof Error ? (error.stack ?? error.message) : String(error);
   process.stderr.write(`[start] HTTP request failed: ${message}\n`);
 }
 
@@ -359,10 +347,7 @@ async function startHttpServer(input: {
       void (async () => {
         try {
           const url = new URL(request.url ?? "/", `http://${HTTP_HOST}`);
-          if (
-            request.method === "POST" &&
-            url.pathname === "/api/v1/refresh"
-          ) {
+          if (request.method === "POST" && url.pathname === "/api/v1/refresh") {
             request.resume();
             input.service.requestReconcile();
             respondJson(response, 202, { ok: true });
@@ -456,13 +441,15 @@ const handler = async (
     return;
   }
   if (parsed.daemon && parsed.once) {
-    process.stderr.write("Options '--daemon' and '--once' cannot be used together\n");
+    process.stderr.write(
+      "Options '--daemon' and '--once' cannot be used together\n"
+    );
     process.exitCode = 2;
     return;
   }
   const projectConfig = await resolveManagedProjectConfig({
     configDir: options.configDir,
-      requestedProjectId: undefined,
+    requestedProjectId: undefined,
   });
   if (!projectConfig) {
     handleMissingManagedProjectConfig();
@@ -601,13 +588,13 @@ const handler = async (
               onRefreshRequest: () => service.requestReconcile(),
             })
           : parsed.httpPort !== undefined
-          ? await startHttpServer({
-              runtimeRoot,
-              projectId,
-              initialPort: parsed.httpPort,
-              service,
-            })
-          : null;
+            ? await startHttpServer({
+                runtimeRoot,
+                projectId,
+                initialPort: parsed.httpPort,
+                service,
+              })
+            : null;
       if (httpServer) {
         try {
           await writeHttpBindingState(options.configDir, projectId, {
@@ -642,7 +629,9 @@ const handler = async (
       logLine(
         dim("\u00B7"),
         dim(
-          parsed.once ? "Running one orchestration tick" : "Press Ctrl+C to stop"
+          parsed.once
+            ? "Running one orchestration tick"
+            : "Press Ctrl+C to stop"
         )
       );
 
@@ -774,9 +763,9 @@ export async function shutdownForegroundOrchestrator(
   return (input.exit ?? process.exit)(0);
 }
 
-function hasConfiguredRepository(
-  config: { repository?: OrchestratorProjectConfig["repository"] }
-): config is OrchestratorProjectConfig {
+function hasConfiguredRepository(config: {
+  repository?: OrchestratorProjectConfig["repository"];
+}): config is OrchestratorProjectConfig {
   return Boolean(config.repository?.owner && config.repository.name);
 }
 
@@ -818,7 +807,7 @@ async function startDaemon(
   const { openSync } = await import("node:fs");
   const logFd = openSync(logPath, "a");
 
-    const child = spawn(
+  const child = spawn(
     process.execPath,
     [
       process.argv[1]!,
@@ -848,7 +837,7 @@ async function startDaemon(
   closeSync(logFd);
 
   process.stdout.write(
-      `Orchestrator started in background (PID: ${child.pid}).\n` +
+    `Orchestrator started in background (PID: ${child.pid}).\n` +
       `Logs: ${logPath}\n` +
       "Stop with: gh-symphony repo stop\n"
   );

--- a/packages/cli/src/commands/status.test.ts
+++ b/packages/cli/src/commands/status.test.ts
@@ -63,10 +63,8 @@ async function createConfigFixture(): Promise<string> {
     "utf8"
   );
 
-  const runtimeProjectDir = join(configDir, "projects", projectId);
-  await mkdir(runtimeProjectDir, { recursive: true });
   await writeFile(
-    join(runtimeProjectDir, "status.json"),
+    join(configDir, "status.json"),
     JSON.stringify(
       {
         projectId,

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -2,9 +2,7 @@ import type { GlobalOptions } from "../index.js";
 import type { ProjectStatusSnapshot } from "@gh-symphony/core";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
-import {
-  resolveRuntimeRoot,
-} from "../orchestrator-runtime.js";
+import { resolveRuntimeRoot } from "../orchestrator-runtime.js";
 import {
   handleMissingManagedProjectConfig,
   resolveManagedProjectConfig,
@@ -161,10 +159,9 @@ function renderLegacyStatus(
 
 function parseStatusArgs(args: string[]): {
   watch: boolean;
-  projectId?: string;
   error?: string;
 } {
-  const parsed: { watch: boolean; projectId?: string; error?: string } = {
+  const parsed: { watch: boolean; error?: string } = {
     watch: false,
   };
 
@@ -172,16 +169,6 @@ function parseStatusArgs(args: string[]): {
     const arg = args[i];
     if (arg === "--watch" || arg === "-w") {
       parsed.watch = true;
-      continue;
-    }
-    if (arg === "--project" || arg === "--project-id") {
-      const value = args[i + 1];
-      if (!value || value.startsWith("-")) {
-        parsed.error = `Option '${arg}' argument missing`;
-        return parsed;
-      }
-      parsed.projectId = value;
-      i += 1;
       continue;
     }
     if (arg?.startsWith("-")) {
@@ -210,15 +197,13 @@ const handler = async (
   args: string[],
   options: GlobalOptions
 ): Promise<void> => {
-  const parsed = parseStatusArgs(args);
   if (rejectRemovedProjectId(args)) {
     return;
   }
+  const parsed = parseStatusArgs(args);
   if (parsed.error) {
     process.stderr.write(`${parsed.error}\n`);
-    process.stderr.write(
-      "Usage: gh-symphony status [--watch]\n"
-    );
+    process.stderr.write("Usage: gh-symphony status [--watch]\n");
     process.exitCode = 2;
     return;
   }

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -9,6 +9,7 @@ import {
   handleMissingManagedProjectConfig,
   resolveManagedProjectConfig,
 } from "../project-selection.js";
+import { rejectRemovedProjectId } from "../removed-project-id.js";
 import { bold, dim, green, red, yellow, cyan, stripAnsi } from "../ansi.js";
 import { clearScreen, showCursor, hideCursor } from "../ansi.js";
 import { renderDashboard } from "../dashboard/renderer.js";
@@ -194,15 +195,10 @@ function parseStatusArgs(args: string[]): {
 
 async function readStatusSnapshot(
   runtimeRoot: string,
-  projectId: string
+  _projectId: string
 ): Promise<ProjectStatusSnapshot | null> {
   try {
-    const statusPath = join(
-      runtimeRoot,
-      "projects",
-      projectId,
-      "status.json"
-    );
+    const statusPath = join(runtimeRoot, "status.json");
     const content = await readFile(statusPath, "utf-8");
     return JSON.parse(content) as ProjectStatusSnapshot;
   } catch {
@@ -215,10 +211,13 @@ const handler = async (
   options: GlobalOptions
 ): Promise<void> => {
   const parsed = parseStatusArgs(args);
+  if (rejectRemovedProjectId(args)) {
+    return;
+  }
   if (parsed.error) {
     process.stderr.write(`${parsed.error}\n`);
     process.stderr.write(
-      "Usage: gh-symphony status [--project-id <project-id>] [--watch]\n"
+      "Usage: gh-symphony status [--watch]\n"
     );
     process.exitCode = 2;
     return;
@@ -226,7 +225,7 @@ const handler = async (
 
   const projectConfig = await resolveManagedProjectConfig({
     configDir: options.configDir,
-    requestedProjectId: parsed.projectId,
+    requestedProjectId: undefined,
   });
   if (!projectConfig) {
     handleMissingManagedProjectConfig();

--- a/packages/cli/src/commands/stop.ts
+++ b/packages/cli/src/commands/stop.ts
@@ -5,6 +5,7 @@ import {
   handleMissingManagedProjectConfig,
   resolveManagedProjectConfig,
 } from "../project-selection.js";
+import { rejectRemovedProjectId } from "../removed-project-id.js";
 
 function parseStopArgs(args: string[]): {
   force: boolean;
@@ -45,10 +46,13 @@ const handler = async (
   options: GlobalOptions
 ): Promise<void> => {
   const parsed = parseStopArgs(args);
+  if (rejectRemovedProjectId(args)) {
+    return;
+  }
   if (parsed.error) {
     process.stderr.write(`${parsed.error}\n`);
     process.stderr.write(
-      "Usage: gh-symphony stop --project-id <project-id> [--force]\n"
+      "Usage: gh-symphony stop [--force]\n"
     );
     process.exitCode = 2;
     return;
@@ -56,7 +60,7 @@ const handler = async (
   const resolvedForce = parsed.force;
   const projectConfig = await resolveManagedProjectConfig({
     configDir: options.configDir,
-    requestedProjectId: parsed.projectId,
+    requestedProjectId: undefined,
   });
   if (!projectConfig) {
     handleMissingManagedProjectConfig();

--- a/packages/cli/src/commands/stop.ts
+++ b/packages/cli/src/commands/stop.ts
@@ -9,10 +9,9 @@ import { rejectRemovedProjectId } from "../removed-project-id.js";
 
 function parseStopArgs(args: string[]): {
   force: boolean;
-  projectId?: string;
   error?: string;
 } {
-  const parsed: { force: boolean; projectId?: string; error?: string } = {
+  const parsed: { force: boolean; error?: string } = {
     force: false,
   };
 
@@ -20,16 +19,6 @@ function parseStopArgs(args: string[]): {
     const arg = args[i];
     if (arg === "--force") {
       parsed.force = true;
-      continue;
-    }
-    if (arg === "--project" || arg === "--project-id") {
-      const value = args[i + 1];
-      if (!value || value.startsWith("-")) {
-        parsed.error = `Option '${arg}' argument missing`;
-        return parsed;
-      }
-      parsed.projectId = value;
-      i += 1;
       continue;
     }
     if (arg?.startsWith("-")) {
@@ -45,15 +34,13 @@ const handler = async (
   args: string[],
   options: GlobalOptions
 ): Promise<void> => {
-  const parsed = parseStopArgs(args);
   if (rejectRemovedProjectId(args)) {
     return;
   }
+  const parsed = parseStopArgs(args);
   if (parsed.error) {
     process.stderr.write(`${parsed.error}\n`);
-    process.stderr.write(
-      "Usage: gh-symphony stop [--force]\n"
-    );
+    process.stderr.write("Usage: gh-symphony stop [--force]\n");
     process.exitCode = 2;
     return;
   }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -64,6 +64,8 @@ type CliOptionValues = Partial<
     skipSkills?: boolean;
     version?: boolean;
     web?: string | boolean;
+    repoDir?: string;
+    workflowFile?: string;
     workspaceDir?: string;
     watch?: boolean;
     sample?: string;
@@ -621,6 +623,84 @@ function createProgram(): { program: Command; wasInvoked: () => boolean } {
       ["list"],
       this.optsWithGlobals<CliOptionValues>()
     );
+  });
+
+  addGlobalOptions(
+    repo
+      .command("init")
+      .description("Initialize gh-symphony for the current repository")
+      .option("--repo-dir <path>", "Repository directory")
+      .option("--workflow-file <path>", "Use a custom WORKFLOW.md path")
+      .addOption(new Option("--project-id <projectId>").hideHelp())
+      .addOption(new Option("--project <projectId>").hideHelp())
+      .allowExcessArguments(false)
+  ).action(async function (this: Command) {
+    markInvoked();
+    const values = this.optsWithGlobals<CliOptionValues>();
+    const args: string[] = ["init"];
+    pushOption(args, "--repo-dir", values.repoDir);
+    pushOption(args, "--workflow-file", values.workflowFile);
+    pushOption(args, "--project-id", resolveProjectId(values));
+    await invokeHandler("repo", args, values);
+  });
+
+  addGlobalOptions(
+    repo
+      .command("start")
+      .description("Start the orchestrator for the current repository")
+      .option("-d, --daemon", "Start in daemon mode")
+      .option("--once", "Run a single orchestration tick and exit")
+      .option("--http [port]", "Expose dashboard and refresh endpoints over HTTP")
+      .option("--web [port]", "Expose the control plane web dashboard and API over HTTP")
+      .option("--log-level <level>", "Orchestrator lifecycle log level")
+      .addOption(new Option("--project-id <projectId>").hideHelp())
+      .addOption(new Option("--project <projectId>").hideHelp())
+      .allowExcessArguments(false)
+  ).action(async function (this: Command) {
+    markInvoked();
+    const values = this.optsWithGlobals<CliOptionValues>();
+    const args: string[] = ["start"];
+    pushOption(args, "--project-id", resolveProjectId(values));
+    pushOption(args, "--daemon", values.daemon);
+    pushOption(args, "--once", values.once);
+    pushOption(args, "--http", values.http);
+    pushOption(args, "--web", values.web);
+    pushOption(args, "--log-level", values.logLevel);
+    await invokeHandler("repo", args, values);
+  });
+
+  addGlobalOptions(
+    repo
+      .command("status")
+      .description("Show current repository orchestrator status")
+      .option("-w, --watch", "Watch status continuously")
+      .addOption(new Option("--project-id <projectId>").hideHelp())
+      .addOption(new Option("--project <projectId>").hideHelp())
+      .allowExcessArguments(false)
+  ).action(async function (this: Command) {
+    markInvoked();
+    const values = this.optsWithGlobals<CliOptionValues>();
+    const args: string[] = ["status"];
+    pushOption(args, "--project-id", resolveProjectId(values));
+    pushOption(args, "--watch", values.watch);
+    await invokeHandler("repo", args, values);
+  });
+
+  addGlobalOptions(
+    repo
+      .command("stop")
+      .description("Stop the current repository background orchestrator")
+      .option("--force", "Force stop with SIGKILL")
+      .addOption(new Option("--project-id <projectId>").hideHelp())
+      .addOption(new Option("--project <projectId>").hideHelp())
+      .allowExcessArguments(false)
+  ).action(async function (this: Command) {
+    markInvoked();
+    const values = this.optsWithGlobals<CliOptionValues>();
+    const args: string[] = ["stop"];
+    pushOption(args, "--project-id", resolveProjectId(values));
+    pushOption(args, "--force", values.force);
+    await invokeHandler("repo", args, values);
   });
 
   addGlobalOptions(

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -199,7 +199,10 @@ function createProgram(): { program: Command; wasInvoked: () => boolean } {
       .option("--non-interactive", "Run without prompts")
       .option("--project <id>", "GitHub Project ID or URL")
       .option("--output <path>", "Write WORKFLOW.md to a custom path")
-      .option("--runtime <kind>", "Runtime preset: codex-app-server or claude-print")
+      .option(
+        "--runtime <kind>",
+        "Runtime preset: codex-app-server or claude-print"
+      )
       .option("--skip-skills", "Skip runtime skill generation")
       .option("--skip-context", "Skip .gh-symphony/context.yaml generation")
       .option("--dry-run", "Preview generated files without writing them")
@@ -238,7 +241,10 @@ function createProgram(): { program: Command; wasInvoked: () => boolean } {
       .option("--non-interactive", "Run without prompts")
       .option("--project <id>", "GitHub Project ID or URL")
       .option("--output <path>", "Write WORKFLOW.md to a custom path")
-      .option("--runtime <kind>", "Runtime preset: codex-app-server or claude-print")
+      .option(
+        "--runtime <kind>",
+        "Runtime preset: codex-app-server or claude-print"
+      )
       .option("--skip-skills", "Skip runtime skill generation")
       .option("--skip-context", "Skip .gh-symphony/context.yaml generation")
       .option("--dry-run", "Preview generated files without writing them")
@@ -365,7 +371,7 @@ function createProgram(): { program: Command; wasInvoked: () => boolean } {
         "Expose the control plane web dashboard and API over HTTP"
       )
       .option("--log-level <level>", "Orchestrator lifecycle log level")
-      .option("--project-id <projectId>", "Project identifier")
+      .addOption(new Option("--project-id <projectId>").hideHelp())
       .addOption(new Option("--project <projectId>").hideHelp())
       .allowExcessArguments(false)
   ).action(async function (this: Command) {
@@ -386,7 +392,7 @@ function createProgram(): { program: Command; wasInvoked: () => boolean } {
       .command("stop")
       .description("Stop the background orchestrator")
       .option("--force", "Force stop with SIGKILL")
-      .option("--project-id <projectId>", "Project identifier")
+      .addOption(new Option("--project-id <projectId>").hideHelp())
       .addOption(new Option("--project <projectId>").hideHelp())
       .allowExcessArguments(false)
   ).action(async function (this: Command) {
@@ -403,7 +409,7 @@ function createProgram(): { program: Command; wasInvoked: () => boolean } {
       .command("status")
       .description("Show orchestrator status")
       .option("-w, --watch", "Watch status continuously")
-      .option("--project-id <projectId>", "Project identifier")
+      .addOption(new Option("--project-id <projectId>").hideHelp())
       .addOption(new Option("--project <projectId>").hideHelp())
       .allowExcessArguments(false)
   ).action(async function (this: Command) {
@@ -650,8 +656,14 @@ function createProgram(): { program: Command; wasInvoked: () => boolean } {
       .description("Start the orchestrator for the current repository")
       .option("-d, --daemon", "Start in daemon mode")
       .option("--once", "Run a single orchestration tick and exit")
-      .option("--http [port]", "Expose dashboard and refresh endpoints over HTTP")
-      .option("--web [port]", "Expose the control plane web dashboard and API over HTTP")
+      .option(
+        "--http [port]",
+        "Expose dashboard and refresh endpoints over HTTP"
+      )
+      .option(
+        "--web [port]",
+        "Expose the control plane web dashboard and API over HTTP"
+      )
       .option("--log-level <level>", "Orchestrator lifecycle log level")
       .addOption(new Option("--project-id <projectId>").hideHelp())
       .addOption(new Option("--project <projectId>").hideHelp())

--- a/packages/cli/src/orchestrator-runtime.ts
+++ b/packages/cli/src/orchestrator-runtime.ts
@@ -3,3 +3,7 @@ import { resolve } from "node:path";
 export function resolveRuntimeRoot(configDir: string): string {
   return resolve(configDir);
 }
+
+export function resolveRepoRuntimeRoot(repoDir = process.cwd()): string {
+  return resolve(repoDir, ".runtime", "orchestrator");
+}

--- a/packages/cli/src/removed-project-id.ts
+++ b/packages/cli/src/removed-project-id.ts
@@ -1,0 +1,29 @@
+export const REMOVED_PROJECT_ID_MESSAGE =
+  "--project-id has been removed. gh-symphony now uses the current repository directory; run the command from the target repo or pass --repo-dir where supported.";
+
+export function rejectRemovedProjectId(
+  args: readonly string[],
+  options: { rejectProjectAlias?: boolean } = { rejectProjectAlias: true }
+): boolean {
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (
+      arg === "--project-id" ||
+      (options.rejectProjectAlias !== false && arg === "--project")
+    ) {
+      process.stderr.write(`${REMOVED_PROJECT_ID_MESSAGE}\n`);
+      process.exitCode = 2;
+      return true;
+    }
+    if (
+      arg?.startsWith("--project-id=") ||
+      (options.rejectProjectAlias !== false && arg?.startsWith("--project="))
+    ) {
+      process.stderr.write(`${REMOVED_PROJECT_ID_MESSAGE}\n`);
+      process.exitCode = 2;
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/packages/cli/src/repo-runtime.ts
+++ b/packages/cli/src/repo-runtime.ts
@@ -48,7 +48,7 @@ export function parseRepoRuntimeFlags(args: readonly string[]): RepoInitFlags {
       if (!value || value.startsWith("-")) {
         throw new Error("Option '--workflow-file' argument missing");
       }
-      flags.workflowFile = resolve(value);
+      flags.workflowFile = value;
       i += 1;
       continue;
     }
@@ -81,9 +81,9 @@ export async function initRepoRuntime(flags: RepoInitFlags): Promise<{
     repository,
     repositories: [repository],
     tracker: {
-      adapter:
-        workflow.tracker.kind === "linear" ? "linear" : "github-project",
-      bindingId: workflow.tracker.projectId ?? workflow.tracker.projectSlug ?? "",
+      adapter: workflow.tracker.kind === "linear" ? "linear" : "github-project",
+      bindingId:
+        workflow.tracker.projectId ?? workflow.tracker.projectSlug ?? "",
       settings: {
         ...(workflow.tracker.projectId
           ? { projectId: workflow.tracker.projectId }
@@ -121,6 +121,14 @@ export async function migrateLegacyRuntime(runtimeRoot: string): Promise<void> {
   const projectsDir = join(runtimeRoot, "projects");
   const projectIds = await readDirectoryNames(projectsDir);
   if (projectIds.length === 0) {
+    return;
+  }
+
+  if (
+    projectIds.length === 1 &&
+    projectIds[0] === INTERNAL_PROJECT_ID &&
+    (await pathExists(join(runtimeRoot, "project.json")))
+  ) {
     return;
   }
 
@@ -180,9 +188,10 @@ async function readDirectoryNames(path: string): Promise<string[]> {
 
 function resolveRepository(repoDir: string): RepositoryRef {
   const remote = readGitOrigin(repoDir);
+  const cleanedRemote = remote.replace(/\.git$/, "");
   const match =
-    remote.match(/github\.com[:/]([^/]+)\/([^/.]+)(?:\.git)?$/) ??
-    remote.match(/^([^/]+)\/([^/]+)$/);
+    cleanedRemote.match(/github\.com[:/]([^/]+)\/([^/]+)$/) ??
+    cleanedRemote.match(/^([^/]+)\/([^/]+)$/);
   if (!match) {
     throw new Error(
       "Unable to infer GitHub repository from git remote 'origin'. Run from a cloned GitHub repository or set origin to owner/name."
@@ -201,10 +210,14 @@ function resolveRepository(repoDir: string): RepositoryRef {
 
 function readGitOrigin(repoDir: string): string {
   try {
-    return execFileSync("git", ["-C", repoDir, "config", "--get", "remote.origin.url"], {
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"],
-    }).trim();
+    return execFileSync(
+      "git",
+      ["-C", repoDir, "config", "--get", "remote.origin.url"],
+      {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+      }
+    ).trim();
   } catch {
     throw new Error(
       "Unable to read git remote 'origin'. Run 'gh-symphony repo init' inside a cloned repository."
@@ -245,8 +258,8 @@ async function pathExists(path: string): Promise<boolean> {
 function isMissing(error: unknown): boolean {
   return Boolean(
     error &&
-      typeof error === "object" &&
-      "code" in error &&
-      (error.code === "ENOENT" || error.code === "ENOTDIR")
+    typeof error === "object" &&
+    "code" in error &&
+    (error.code === "ENOENT" || error.code === "ENOTDIR")
   );
 }

--- a/packages/cli/src/repo-runtime.ts
+++ b/packages/cli/src/repo-runtime.ts
@@ -1,0 +1,252 @@
+import { execFileSync } from "node:child_process";
+import {
+  mkdir,
+  readdir,
+  readFile,
+  rename,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import { basename, dirname, join, resolve } from "node:path";
+import {
+  parseWorkflowMarkdown,
+  type OrchestratorProjectConfig,
+  type RepositoryRef,
+} from "@gh-symphony/core";
+import {
+  saveGlobalConfig,
+  saveProjectConfig,
+  type CliProjectConfig,
+} from "./config.js";
+import { resolveRepoRuntimeRoot } from "./orchestrator-runtime.js";
+
+export type RepoInitFlags = {
+  repoDir: string;
+  workflowFile?: string;
+};
+
+const INTERNAL_PROJECT_ID = "repository";
+
+export class RepoRuntimeMigrationError extends Error {}
+
+export function parseRepoRuntimeFlags(args: readonly string[]): RepoInitFlags {
+  const flags: RepoInitFlags = { repoDir: process.cwd() };
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    const value = args[i + 1];
+    if (arg === "--repo-dir") {
+      if (!value || value.startsWith("-")) {
+        throw new Error("Option '--repo-dir' argument missing");
+      }
+      flags.repoDir = resolve(value);
+      i += 1;
+      continue;
+    }
+    if (arg === "--workflow-file") {
+      if (!value || value.startsWith("-")) {
+        throw new Error("Option '--workflow-file' argument missing");
+      }
+      flags.workflowFile = resolve(value);
+      i += 1;
+      continue;
+    }
+    if (arg?.startsWith("-")) {
+      throw new Error(`Unknown option '${arg}'`);
+    }
+  }
+
+  return flags;
+}
+
+export async function initRepoRuntime(flags: RepoInitFlags): Promise<{
+  configDir: string;
+  projectId: string;
+  workflowPath: string;
+  repository: RepositoryRef;
+}> {
+  const repoDir = resolve(flags.repoDir);
+  const runtimeRoot = resolveRepoRuntimeRoot(repoDir);
+  await migrateLegacyRuntime(runtimeRoot);
+
+  const workflowPath = resolve(repoDir, flags.workflowFile ?? "WORKFLOW.md");
+  const workflow = parseWorkflowMarkdown(await readFile(workflowPath, "utf8"));
+  const repository = resolveRepository(repoDir);
+  const projectConfig: CliProjectConfig = {
+    projectId: INTERNAL_PROJECT_ID,
+    slug: basename(repoDir) || INTERNAL_PROJECT_ID,
+    displayName: `${repository.owner}/${repository.name}`,
+    workspaceDir: repoDir,
+    repository,
+    repositories: [repository],
+    tracker: {
+      adapter:
+        workflow.tracker.kind === "linear" ? "linear" : "github-project",
+      bindingId: workflow.tracker.projectId ?? workflow.tracker.projectSlug ?? "",
+      settings: {
+        ...(workflow.tracker.projectId
+          ? { projectId: workflow.tracker.projectId }
+          : {}),
+        repository: `${repository.owner}/${repository.name}`,
+      },
+    },
+  };
+
+  await mkdir(runtimeRoot, { recursive: true });
+  await saveProjectConfig(runtimeRoot, INTERNAL_PROJECT_ID, projectConfig);
+  await saveGlobalConfig(runtimeRoot, {
+    activeProject: INTERNAL_PROJECT_ID,
+    projects: [INTERNAL_PROJECT_ID],
+  });
+
+  const orchestratorConfig: OrchestratorProjectConfig = {
+    projectId: INTERNAL_PROJECT_ID,
+    slug: projectConfig.slug,
+    workspaceDir: repoDir,
+    repository,
+    tracker: projectConfig.tracker,
+  };
+  await writeJsonFile(join(runtimeRoot, "project.json"), orchestratorConfig);
+
+  return {
+    configDir: runtimeRoot,
+    projectId: INTERNAL_PROJECT_ID,
+    workflowPath,
+    repository,
+  };
+}
+
+export async function migrateLegacyRuntime(runtimeRoot: string): Promise<void> {
+  const projectsDir = join(runtimeRoot, "projects");
+  const projectIds = await readDirectoryNames(projectsDir);
+  if (projectIds.length === 0) {
+    return;
+  }
+
+  if (projectIds.length > 1) {
+    throw new RepoRuntimeMigrationError(
+      [
+        "Multiple legacy project runtime directories were found under .runtime/orchestrator/projects.",
+        `Found: ${projectIds.join(", ")}`,
+        "Automatic migration is only supported when exactly one project directory exists.",
+        "Manually keep the project directory you want to promote, archive or remove the others, then re-run 'gh-symphony repo init'.",
+      ].join("\n")
+    );
+  }
+
+  const sourceDir = join(projectsDir, projectIds[0]!);
+  const entries = await readdir(sourceDir);
+  for (const entry of entries) {
+    const target = join(runtimeRoot, entry);
+    if (await pathExists(target)) {
+      throw new RepoRuntimeMigrationError(
+        `Cannot promote legacy runtime data because '${entry}' already exists in .runtime/orchestrator. Move or remove it, then re-run 'gh-symphony repo init'.`
+      );
+    }
+    await rename(join(sourceDir, entry), target);
+  }
+
+  await stripProjectIdFromRunRecords(join(runtimeRoot, "runs"));
+  await rm(projectsDir, { recursive: true, force: true });
+}
+
+async function stripProjectIdFromRunRecords(runsDir: string): Promise<void> {
+  for (const runId of await readDirectoryNames(runsDir)) {
+    const runPath = join(runsDir, runId, "run.json");
+    const run = await readJsonFile<Record<string, unknown>>(runPath);
+    if (!run || !("projectId" in run)) {
+      continue;
+    }
+    delete run.projectId;
+    await writeJsonFile(runPath, run);
+  }
+}
+
+async function readDirectoryNames(path: string): Promise<string[]> {
+  try {
+    const entries = await readdir(path, { withFileTypes: true });
+    return entries
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name)
+      .sort();
+  } catch (error) {
+    if (isMissing(error)) {
+      return [];
+    }
+    throw error;
+  }
+}
+
+function resolveRepository(repoDir: string): RepositoryRef {
+  const remote = readGitOrigin(repoDir);
+  const match =
+    remote.match(/github\.com[:/]([^/]+)\/([^/.]+)(?:\.git)?$/) ??
+    remote.match(/^([^/]+)\/([^/]+)$/);
+  if (!match) {
+    throw new Error(
+      "Unable to infer GitHub repository from git remote 'origin'. Run from a cloned GitHub repository or set origin to owner/name."
+    );
+  }
+
+  return {
+    owner: match[1]!,
+    name: match[2]!,
+    cloneUrl: remote.startsWith("http")
+      ? remote
+      : `https://github.com/${match[1]}/${match[2]}.git`,
+    path: repoDir,
+  };
+}
+
+function readGitOrigin(repoDir: string): string {
+  try {
+    return execFileSync("git", ["-C", repoDir, "config", "--get", "remote.origin.url"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    throw new Error(
+      "Unable to read git remote 'origin'. Run 'gh-symphony repo init' inside a cloned repository."
+    );
+  }
+}
+
+async function readJsonFile<T>(path: string): Promise<T | null> {
+  try {
+    return JSON.parse(await readFile(path, "utf8")) as T;
+  } catch (error) {
+    if (isMissing(error)) {
+      return null;
+    }
+    throw error;
+  }
+}
+
+async function writeJsonFile(path: string, value: unknown): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  const temporaryPath = `${path}.tmp`;
+  await writeFile(temporaryPath, JSON.stringify(value, null, 2) + "\n", "utf8");
+  await rename(temporaryPath, path);
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch (error) {
+    if (isMissing(error)) {
+      return false;
+    }
+    throw error;
+  }
+}
+
+function isMissing(error: unknown): boolean {
+  return Boolean(
+    error &&
+      typeof error === "object" &&
+      "code" in error &&
+      (error.code === "ENOENT" || error.code === "ENOTDIR")
+  );
+}


### PR DESCRIPTION
## Issues

- Fixes #264

## Summary

- Switches repository orchestration to the cwd-based `gh-symphony repo init/start/status/stop` path.
- Adds legacy `.runtime/orchestrator/projects/<projectId>` promotion during `repo init` with multi-project manual cleanup failure.
- Rejects removed `--project-id` / legacy project alias usage with a clear breaking-change message.
- Refreshes the branch on latest `main` after PR #270/#272 merges while preserving the approved CLI behavior.

## Changes

- Added repo-local runtime resolution at `.runtime/orchestrator` and repo initialization from cwd or `--repo-dir`.
- Added run-record migration that promotes a single legacy project directory and removes `projectId` from migrated `run.json` records.
- Skips legacy migration for an already initialized repo runtime so repeated `repo init` remains safe.
- Resolves relative `--workflow-file` values against `--repo-dir` and accepts GitHub repository names containing dots.
- Updated CLI command wiring, start/status/stop behavior, Docker E2E entrypoint, CI smoke command, and CLI tests for the single-repo workflow.
- Preserved latest `main` status-surface/runtime fallback changes during conflict resolution.
- Added a changeset and CHANGELOG entry marking the CLI breaking change.

## Evidence

- `pnpm --filter @gh-symphony/cli test` — 32 files / 347 tests passed on merge commit `8b54bdd`.
- `pnpm lint && pnpm test && pnpm typecheck && pnpm build` — passed on merge commit `8b54bdd`.
- Previous Docker E2E TC: `docker compose -f docker-compose.e2e.yml -f docker-compose.e2e.events.yml up -d --build`, `curl /healthz`, inject `e2e/fixtures/happy-path.json`, `POST /api/v1/refresh`, poll `/api/v1/state`; observed `dispatched: 1`, `activeRuns: 1`, `test-owner/test-repo#1` running.
- GitHub PR state after push: `mergeable: MERGEABLE`, `reviewDecision: APPROVED`; CI `Test` and `Container Smoke` started for `8b54bdd`.

## Human Validation

- [ ] Confirm `git clone → cd → gh-symphony repo init → gh-symphony repo start` works in a real repository.
- [ ] Confirm legacy single-project `.runtime/orchestrator/projects/<projectId>` data is promoted as expected.
- [ ] Confirm multiple legacy project directories produce actionable manual cleanup guidance.

## Risks

- Existing scripts that still pass `--project-id` must be updated to run from the target repository directory.
- The orchestrator service still carries internal `projectId` compatibility fields from earlier phases; this PR removes the user-facing CLI dependency only.
