### PR TITLE
feat(control-plane): reshape state status surface

### DIFF
--- a/.changeset/drop-project-routing-state-api.md
+++ b/.changeset/drop-project-routing-state-api.md
@@ -1,0 +1,10 @@
+---
+"@gh-symphony/core": minor
+"@gh-symphony/dashboard": minor
+"@gh-symphony/control-plane": minor
+---
+
+Breaking API change: `/api/v1/state` no longer exposes orchestrator-side
+`projectId` or `slug`. Consumers should use the top-level
+`repository: { owner, name }` identifier, while tracker-side GitHub Project
+metadata is exposed under `tracker.settings.projectId` when configured.

--- a/packages/cli/src/commands/start.test.ts
+++ b/packages/cli/src/commands/start.test.ts
@@ -128,7 +128,7 @@ describe("start command foreground locking", () => {
       projects: [createProject("tenant-a", "acme", "platform")],
     });
     const lock = {
-      lockPath: join(configDir, "projects", "tenant-a", ".lock"),
+      lockPath: join(configDir, ".lock"),
       ownerToken: "owner",
       pid: 1234,
       startedAt: "2026-03-17T00:00:00.000Z",
@@ -223,7 +223,7 @@ describe("start command foreground locking", () => {
       projects: [createProject("tenant-a", "acme", "platform")],
     });
     const lock = {
-      lockPath: join(configDir, "projects", "tenant-a", ".lock"),
+      lockPath: join(configDir, ".lock"),
       ownerToken: "owner",
       pid: 1234,
       startedAt: "2026-03-17T00:00:00.000Z",
@@ -268,13 +268,87 @@ describe("start command foreground locking", () => {
     expect(exitSpy).toHaveBeenCalledWith(0);
   });
 
+  it("tails completed worker logs from the flat runtime run path", async () => {
+    const configDir = await createConfigFixture({
+      activeProject: "tenant-a",
+      projects: [createProject("tenant-a", "acme", "platform")],
+    });
+    await mkdir(join(configDir, "runs", "run-1"), { recursive: true });
+    await writeFile(
+      join(configDir, "runs", "run-1", "worker.log"),
+      "first line\nlast failure\n",
+      "utf8"
+    );
+    const lock = {
+      lockPath: join(configDir, ".lock"),
+      ownerToken: "owner",
+      pid: 1234,
+      startedAt: "2026-03-17T00:00:00.000Z",
+    };
+    acquireProjectLock.mockResolvedValue(lock);
+    status.mockResolvedValue(null);
+    run.mockImplementation(async () => {
+      const onTick = serviceDependencies.at(-1)?.onTick as
+        | ((snapshot: Record<string, unknown>) => Promise<void>)
+        | undefined;
+      await onTick?.({
+        repository: { owner: "acme", name: "platform" },
+        tracker: { adapter: "github-project", bindingId: "project-1" },
+        health: "running",
+        lastTickAt: "2026-03-17T00:00:00.000Z",
+        summary: { dispatched: 1, suppressed: 0, recovered: 0, activeRuns: 1 },
+        activeRuns: [
+          {
+            runId: "run-1",
+            issueIdentifier: "acme/platform#1",
+            issueState: "In Progress",
+            status: "running",
+          },
+        ],
+        retryQueue: [],
+        lastError: null,
+      });
+      await onTick?.({
+        repository: { owner: "acme", name: "platform" },
+        tracker: { adapter: "github-project", bindingId: "project-1" },
+        health: "idle",
+        lastTickAt: "2026-03-17T00:01:00.000Z",
+        summary: { dispatched: 1, suppressed: 0, recovered: 0, activeRuns: 0 },
+        activeRuns: [],
+        retryQueue: [],
+        lastError: null,
+      });
+      process.emit("SIGINT");
+    });
+
+    const exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation(
+        ((_code?: number) => undefined) as (code?: number) => never
+      );
+    const stdout = captureWrites(process.stdout);
+
+    try {
+      await startModule.default(
+        ["--project-id", "tenant-a"],
+        baseOptions(configDir)
+      );
+    } finally {
+      stdout.restore();
+    }
+
+    expect(stdout.output()).toContain("Worker stderr (acme/platform#1):");
+    expect(stdout.output()).toContain("last failure");
+    expect(exitSpy).toHaveBeenCalledWith(0);
+  });
+
   it("retries the foreground run loop after a service.run error", async () => {
     const configDir = await createConfigFixture({
       activeProject: "tenant-a",
       projects: [createProject("tenant-a", "acme", "platform")],
     });
     const lock = {
-      lockPath: join(configDir, "projects", "tenant-a", ".lock"),
+      lockPath: join(configDir, ".lock"),
       ownerToken: "owner",
       pid: 1234,
       startedAt: "2026-03-17T00:00:00.000Z",
@@ -327,7 +401,7 @@ describe("start command foreground locking", () => {
       projects: [createProject("tenant-a", "acme", "platform")],
     });
     const lock = {
-      lockPath: join(configDir, "projects", "tenant-a", ".lock"),
+      lockPath: join(configDir, ".lock"),
       ownerToken: "owner",
       pid: 1234,
       startedAt: "2026-03-17T00:00:00.000Z",
@@ -428,7 +502,7 @@ describe("start command foreground locking", () => {
       projects: [createProject("tenant-a", "acme", "platform")],
     });
     const lock = {
-      lockPath: join(configDir, "projects", "tenant-a", ".lock"),
+      lockPath: join(configDir, ".lock"),
       ownerToken: "owner",
       pid: 1234,
       startedAt: "2026-03-17T00:00:00.000Z",
@@ -525,7 +599,7 @@ describe("start command foreground locking", () => {
       projects: [createProject("tenant-a", "acme", "platform")],
     });
     const lock = {
-      lockPath: join(configDir, "projects", "tenant-a", ".lock"),
+      lockPath: join(configDir, ".lock"),
       ownerToken: "owner",
       pid: 1234,
       startedAt: "2026-03-17T00:00:00.000Z",
@@ -574,7 +648,7 @@ describe("start command foreground locking", () => {
       projects: [createProject("tenant-a", "acme", "platform")],
     });
     const lock = {
-      lockPath: join(configDir, "projects", "tenant-a", ".lock"),
+      lockPath: join(configDir, ".lock"),
       ownerToken: "owner",
       pid: 1234,
       startedAt: "2026-03-17T00:00:00.000Z",
@@ -653,7 +727,7 @@ describe("start command foreground locking", () => {
       projects: [createProject("tenant-a", "acme", "platform")],
     });
     const lock = {
-      lockPath: join(configDir, "projects", "tenant-a", ".lock"),
+      lockPath: join(configDir, ".lock"),
       ownerToken: "owner",
       pid: 1234,
       startedAt: "2026-03-17T00:00:00.000Z",
@@ -710,7 +784,7 @@ describe("start command foreground locking", () => {
       projects: [createProject("tenant-a", "acme", "platform")],
     });
     const lock = {
-      lockPath: join(configDir, "projects", "tenant-a", ".lock"),
+      lockPath: join(configDir, ".lock"),
       ownerToken: "owner",
       pid: 1234,
       startedAt: "2026-03-17T00:00:00.000Z",
@@ -810,7 +884,7 @@ describe("start command foreground locking", () => {
       projects: [createProject("tenant-a", "acme", "platform")],
     });
     const lock = {
-      lockPath: join(configDir, "projects", "tenant-a", ".lock"),
+      lockPath: join(configDir, ".lock"),
       ownerToken: "owner",
       pid: 1234,
       startedAt: "2026-03-17T00:00:00.000Z",

--- a/packages/cli/src/commands/start.test.ts
+++ b/packages/cli/src/commands/start.test.ts
@@ -69,8 +69,9 @@ beforeEach(() => {
       payload: { pathname, method: method ?? "GET" },
     })
   );
-  startControlPlaneServer.mockImplementation(async ({ port }: { port: number }) =>
-    createMockControlPlaneStartResult(port)
+  startControlPlaneServer.mockImplementation(
+    async ({ port }: { port: number }) =>
+      createMockControlPlaneStartResult(port)
   );
   serviceDependencies.length = 0;
 });
@@ -152,7 +153,9 @@ describe("start command foreground locking", () => {
 
     const exitSpy = vi
       .spyOn(process, "exit")
-      .mockImplementation(((_code?: number) => undefined) as (code?: number) => never);
+      .mockImplementation(
+        ((_code?: number) => undefined) as (code?: number) => never
+      );
 
     await startModule.default(
       ["--project-id", "tenant-a", "--once"],
@@ -220,12 +223,7 @@ describe("start command foreground locking", () => {
       projects: [createProject("tenant-a", "acme", "platform")],
     });
     const lock = {
-      lockPath: join(
-        configDir,
-        "projects",
-        "tenant-a",
-        ".lock"
-      ),
+      lockPath: join(configDir, "projects", "tenant-a", ".lock"),
       ownerToken: "owner",
       pid: 1234,
       startedAt: "2026-03-17T00:00:00.000Z",
@@ -251,9 +249,14 @@ describe("start command foreground locking", () => {
 
     const exitSpy = vi
       .spyOn(process, "exit")
-      .mockImplementation(((_code?: number) => undefined) as (code?: number) => never);
+      .mockImplementation(
+        ((_code?: number) => undefined) as (code?: number) => never
+      );
 
-    await startModule.default(["--project-id", "tenant-a"], baseOptions(configDir));
+    await startModule.default(
+      ["--project-id", "tenant-a"],
+      baseOptions(configDir)
+    );
 
     expect(acquireProjectLock).toHaveBeenCalledWith({
       runtimeRoot: configDir,
@@ -271,12 +274,7 @@ describe("start command foreground locking", () => {
       projects: [createProject("tenant-a", "acme", "platform")],
     });
     const lock = {
-      lockPath: join(
-        configDir,
-        "projects",
-        "tenant-a",
-        ".lock"
-      ),
+      lockPath: join(configDir, "projects", "tenant-a", ".lock"),
       ownerToken: "owner",
       pid: 1234,
       startedAt: "2026-03-17T00:00:00.000Z",
@@ -308,9 +306,14 @@ describe("start command foreground locking", () => {
 
     const exitSpy = vi
       .spyOn(process, "exit")
-      .mockImplementation(((_code?: number) => undefined) as (code?: number) => never);
+      .mockImplementation(
+        ((_code?: number) => undefined) as (code?: number) => never
+      );
 
-    await startModule.default(["--project-id", "tenant-a"], baseOptions(configDir));
+    await startModule.default(
+      ["--project-id", "tenant-a"],
+      baseOptions(configDir)
+    );
 
     expect(run).toHaveBeenCalledTimes(2);
     expect(releaseProjectLock).toHaveBeenCalledWith(lock);
@@ -343,7 +346,9 @@ describe("start command foreground locking", () => {
 
     const exitSpy = vi
       .spyOn(process, "exit")
-      .mockImplementation(((_code?: number) => undefined) as (code?: number) => never);
+      .mockImplementation(
+        ((_code?: number) => undefined) as (code?: number) => never
+      );
     const stdout = captureWrites(process.stdout);
 
     try {
@@ -442,7 +447,9 @@ describe("start command foreground locking", () => {
 
     const exitSpy = vi
       .spyOn(process, "exit")
-      .mockImplementation(((_code?: number) => undefined) as (code?: number) => never);
+      .mockImplementation(
+        ((_code?: number) => undefined) as (code?: number) => never
+      );
     const stdout = captureWrites(process.stdout);
 
     try {
@@ -456,7 +463,6 @@ describe("start command foreground locking", () => {
         host: "0.0.0.0",
         port: 4680,
         runtimeRoot: configDir,
-        projectId: "tenant-a",
         onRefreshRequest: expect.any(Function),
       });
 
@@ -538,7 +544,9 @@ describe("start command foreground locking", () => {
 
     const exitSpy = vi
       .spyOn(process, "exit")
-      .mockImplementation(((_code?: number) => undefined) as (code?: number) => never);
+      .mockImplementation(
+        ((_code?: number) => undefined) as (code?: number) => never
+      );
 
     const startPromise = startModule.default(
       ["--project-id", "tenant-a", "--web", "4900"],
@@ -550,7 +558,6 @@ describe("start command foreground locking", () => {
         host: "0.0.0.0",
         port: 4900,
         runtimeRoot: configDir,
-        projectId: "tenant-a",
         onRefreshRequest: expect.any(Function),
       });
     });
@@ -573,33 +580,33 @@ describe("start command foreground locking", () => {
       startedAt: "2026-03-17T00:00:00.000Z",
     };
     acquireProjectLock.mockResolvedValue(lock);
-    run.mockImplementation(
-      async (options?: { once?: boolean }) => {
-        expect(options).toEqual({ once: true });
-        const onTick = serviceDependencies.at(-1)?.onTick as
-          | ((snapshot: Record<string, unknown>) => Promise<void>)
-          | undefined;
-        await onTick?.({
-          projectId: "tenant-a",
-          slug: "tenant-a",
-          health: "idle",
-          lastTickAt: "2026-03-17T00:00:00.000Z",
-          summary: {
-            dispatched: 0,
-            suppressed: 0,
-            recovered: 0,
-            activeRuns: 0,
-          },
-          activeRuns: [],
-          retryQueue: [],
-          lastError: null,
-        });
-      }
-    );
+    run.mockImplementation(async (options?: { once?: boolean }) => {
+      expect(options).toEqual({ once: true });
+      const onTick = serviceDependencies.at(-1)?.onTick as
+        | ((snapshot: Record<string, unknown>) => Promise<void>)
+        | undefined;
+      await onTick?.({
+        projectId: "tenant-a",
+        slug: "tenant-a",
+        health: "idle",
+        lastTickAt: "2026-03-17T00:00:00.000Z",
+        summary: {
+          dispatched: 0,
+          suppressed: 0,
+          recovered: 0,
+          activeRuns: 0,
+        },
+        activeRuns: [],
+        retryQueue: [],
+        lastError: null,
+      });
+    });
 
     const exitSpy = vi
       .spyOn(process, "exit")
-      .mockImplementation(((_code?: number) => undefined) as (code?: number) => never);
+      .mockImplementation(
+        ((_code?: number) => undefined) as (code?: number) => never
+      );
     const stdout = captureWrites(process.stdout);
 
     try {
@@ -666,7 +673,9 @@ describe("start command foreground locking", () => {
 
     const exitSpy = vi
       .spyOn(process, "exit")
-      .mockImplementation(((_code?: number) => undefined) as (code?: number) => never);
+      .mockImplementation(
+        ((_code?: number) => undefined) as (code?: number) => never
+      );
     const stdout = captureWrites(process.stdout);
     const stderr = captureWrites(process.stderr);
 
@@ -730,7 +739,9 @@ describe("start command foreground locking", () => {
 
     const exitSpy = vi
       .spyOn(process, "exit")
-      .mockImplementation(((_code?: number) => undefined) as (code?: number) => never);
+      .mockImplementation(
+        ((_code?: number) => undefined) as (code?: number) => never
+      );
     const stdout = captureWrites(process.stdout);
 
     try {
@@ -789,7 +800,7 @@ describe("start command foreground locking", () => {
     ).rejects.toThrow("lock busy");
 
     await expect(readFile(statePath, "utf8")).resolves.toContain(
-      "\"endpoint\": \"http://localhost:4680\""
+      '"endpoint": "http://localhost:4680"'
     );
   });
 
@@ -821,7 +832,9 @@ describe("start command foreground locking", () => {
 
     const exitSpy = vi
       .spyOn(process, "exit")
-      .mockImplementation(((_code?: number) => undefined) as (code?: number) => never);
+      .mockImplementation(
+        ((_code?: number) => undefined) as (code?: number) => never
+      );
     const stdout = captureWrites(process.stdout);
 
     try {
@@ -874,9 +887,7 @@ async function waitForHttpUrl(
   while (Date.now() - startedAt < timeoutMs) {
     const match = output()
       .replace(ansiPattern, "")
-      .match(
-      /(HTTP|Web) dashboard listening on .*?(http:\/\/[^\s]+)/
-    );
+      .match(/(HTTP|Web) dashboard listening on .*?(http:\/\/[^\s]+)/);
     if (match?.[2]) {
       return match[2];
     }

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -34,6 +34,7 @@ import {
 } from "../project-selection.js";
 import { bold, dim, green, red, yellow, cyan, setNoColor } from "../ansi.js";
 import { getGhToken } from "../github/gh-auth.js";
+import { formatRepositoryDisplay } from "../format/repository.js";
 
 function timestamp(): string {
   const now = new Date();
@@ -41,13 +42,6 @@ function timestamp(): string {
   const mm = String(now.getMinutes()).padStart(2, "0");
   const ss = String(now.getSeconds()).padStart(2, "0");
   return dim(`${hh}:${mm}:${ss}`);
-}
-
-function formatRepository(
-  repository: ProjectStatusSnapshot["repository"] | undefined,
-  fallback: string
-): string {
-  return repository ? `${repository.owner}/${repository.name}` : fallback;
 }
 
 function logLine(icon: string, msg: string): void {
@@ -176,13 +170,9 @@ function logTickResult(
           : cyan;
     logLine(
       green("\u25CF"),
-      `Repository ${bold(
-        formatRepository(
-          snapshot.repository,
-          (snapshot as ProjectStatusSnapshot & { slug?: string }).slug ??
-            "repository"
-        )
-      )} connected ${dim("(")}${healthColor(snapshot.health)}${dim(")")}`
+      `Repository ${bold(formatRepositoryDisplay(snapshot))} connected ${dim(
+        "("
+      )}${healthColor(snapshot.health)}${dim(")")}`
     );
     if (snapshot.summary.activeRuns > 0) {
       logLine(cyan("\u25B8"), `${snapshot.summary.activeRuns} active run(s)`);
@@ -795,25 +785,23 @@ async function tailWorkerLog(
   runId: string,
   issueIdentifier: string
 ): Promise<void> {
-  try {
-    const logPath = join(
-      runtimeRoot,
-      "projects",
-      projectId,
-      "runs",
-      runId,
-      "worker.log"
-    );
-    const content = await readFile(logPath, "utf8");
-    const lines = content.split("\n").filter((l) => l.trim());
-    if (lines.length === 0) return;
-    const tail = lines.slice(-30);
-    logLine(red("\u2717"), red(`Worker stderr (${issueIdentifier}):`));
-    for (const line of tail) {
-      process.stdout.write(`  ${dim(line)}\n`);
+  for (const logPath of [
+    join(runtimeRoot, "runs", runId, "worker.log"),
+    join(runtimeRoot, "projects", projectId, "runs", runId, "worker.log"),
+  ]) {
+    try {
+      const content = await readFile(logPath, "utf8");
+      const lines = content.split("\n").filter((l) => l.trim());
+      if (lines.length === 0) return;
+      const tail = lines.slice(-30);
+      logLine(red("\u2717"), red(`Worker stderr (${issueIdentifier}):`));
+      for (const line of tail) {
+        process.stdout.write(`  ${dim(line)}\n`);
+      }
+      return;
+    } catch {
+      // Try the next known runtime layout.
     }
-  } catch {
-    // worker.log 없거나 읽기 실패 시 무시
   }
 }
 

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -43,6 +43,13 @@ function timestamp(): string {
   return dim(`${hh}:${mm}:${ss}`);
 }
 
+function formatRepository(
+  repository: ProjectStatusSnapshot["repository"] | undefined,
+  fallback: string
+): string {
+  return repository ? `${repository.owner}/${repository.name}` : fallback;
+}
+
 function logLine(icon: string, msg: string): void {
   process.stdout.write(`${timestamp()} ${icon} ${msg}\n`);
 }
@@ -169,7 +176,13 @@ function logTickResult(
           : cyan;
     logLine(
       green("\u25CF"),
-      `Project ${bold(snapshot.slug)} connected ${dim("(")}${healthColor(snapshot.health)}${dim(")")}`
+      `Repository ${bold(
+        formatRepository(
+          snapshot.repository,
+          (snapshot as ProjectStatusSnapshot & { slug?: string }).slug ??
+            "repository"
+        )
+      )} connected ${dim("(")}${healthColor(snapshot.health)}${dim(")")}`
     );
     if (snapshot.summary.activeRuns > 0) {
       logLine(cyan("\u25B8"), `${snapshot.summary.activeRuns} active run(s)`);
@@ -310,7 +323,7 @@ function formatBoundUrl(server: Server): string {
 
 function logHttpRequestError(error: unknown): void {
   const message =
-    error instanceof Error ? error.stack ?? error.message : String(error);
+    error instanceof Error ? (error.stack ?? error.message) : String(error);
   process.stderr.write(`[start] HTTP request failed: ${message}\n`);
 }
 
@@ -351,17 +364,14 @@ async function startHttpServer(input: {
   initialPort: number;
   service: { requestReconcile(): void };
 }): Promise<{ server: Server; port: number; url: string }> {
-  const reader = new DashboardFsReader(input.runtimeRoot, input.projectId);
+  const reader = new DashboardFsReader(input.runtimeRoot);
 
   for (let port = input.initialPort; port <= 65_535; port += 1) {
     const server = createServer((request, response) => {
       void (async () => {
         try {
           const url = new URL(request.url ?? "/", `http://${HTTP_HOST}`);
-          if (
-            request.method === "POST" &&
-            url.pathname === "/api/v1/refresh"
-          ) {
+          if (request.method === "POST" && url.pathname === "/api/v1/refresh") {
             request.resume();
             input.service.requestReconcile();
             respondJson(response, 202, { ok: true });
@@ -452,7 +462,9 @@ const handler = async (
     return;
   }
   if (parsed.daemon && parsed.once) {
-    process.stderr.write("Options '--daemon' and '--once' cannot be used together\n");
+    process.stderr.write(
+      "Options '--daemon' and '--once' cannot be used together\n"
+    );
     process.exitCode = 2;
     return;
   }
@@ -593,17 +605,16 @@ const handler = async (
               host: HTTP_HOST,
               port: parsed.webPort,
               runtimeRoot,
-              projectId,
               onRefreshRequest: () => service.requestReconcile(),
             })
           : parsed.httpPort !== undefined
-          ? await startHttpServer({
-              runtimeRoot,
-              projectId,
-              initialPort: parsed.httpPort,
-              service,
-            })
-          : null;
+            ? await startHttpServer({
+                runtimeRoot,
+                projectId,
+                initialPort: parsed.httpPort,
+                service,
+              })
+            : null;
       if (httpServer) {
         try {
           await writeHttpBindingState(options.configDir, projectId, {
@@ -638,7 +649,9 @@ const handler = async (
       logLine(
         dim("\u00B7"),
         dim(
-          parsed.once ? "Running one orchestration tick" : "Press Ctrl+C to stop"
+          parsed.once
+            ? "Running one orchestration tick"
+            : "Press Ctrl+C to stop"
         )
       );
 
@@ -770,9 +783,9 @@ export async function shutdownForegroundOrchestrator(
   return (input.exit ?? process.exit)(0);
 }
 
-function hasConfiguredRepository(
-  config: { repository?: OrchestratorProjectConfig["repository"] }
-): config is OrchestratorProjectConfig {
+function hasConfiguredRepository(config: {
+  repository?: OrchestratorProjectConfig["repository"];
+}): config is OrchestratorProjectConfig {
   return Boolean(config.repository?.owner && config.repository.name);
 }
 
@@ -783,7 +796,14 @@ async function tailWorkerLog(
   issueIdentifier: string
 ): Promise<void> {
   try {
-    const logPath = join(runtimeRoot, "projects", projectId, "runs", runId, "worker.log");
+    const logPath = join(
+      runtimeRoot,
+      "projects",
+      projectId,
+      "runs",
+      runId,
+      "worker.log"
+    );
     const content = await readFile(logPath, "utf8");
     const lines = content.split("\n").filter((l) => l.trim());
     if (lines.length === 0) return;

--- a/packages/cli/src/commands/status.test.ts
+++ b/packages/cli/src/commands/status.test.ts
@@ -38,7 +38,9 @@ function createProject(projectId: string): CliProjectConfig {
   };
 }
 
-async function createConfigFixture(): Promise<string> {
+async function createConfigFixture(
+  statusLayout: "flat" | "legacy" = "flat"
+): Promise<string> {
   const configDir = await mkdtemp(join(tmpdir(), "cli-status-"));
   const projectId = "tenant-a";
 
@@ -63,10 +65,11 @@ async function createConfigFixture(): Promise<string> {
     "utf8"
   );
 
-  const runtimeProjectDir = join(configDir, "projects", projectId);
-  await mkdir(runtimeProjectDir, { recursive: true });
+  const statusDir =
+    statusLayout === "flat" ? configDir : join(configDir, "projects", projectId);
+  await mkdir(statusDir, { recursive: true });
   await writeFile(
-    join(runtimeProjectDir, "status.json"),
+    join(statusDir, "status.json"),
     JSON.stringify(
       {
         projectId,
@@ -122,8 +125,26 @@ afterEach(() => {
 });
 
 describe("status command", () => {
-  it("renders project tokens as delta over cumulative total", async () => {
+  it("renders project tokens from the flat runtime status snapshot", async () => {
     const configDir = await createConfigFixture();
+    const stdout = captureWrites(process.stdout);
+
+    try {
+      await statusCommand([], {
+        configDir,
+        verbose: false,
+        json: false,
+        noColor: true,
+      });
+    } finally {
+      stdout.restore();
+    }
+
+    expect(stdout.output()).toContain("Tokens: 600 / 1,700 total");
+  });
+
+  it("falls back to the legacy per-project status snapshot path", async () => {
+    const configDir = await createConfigFixture("legacy");
     const stdout = captureWrites(process.stdout);
 
     try {

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -2,9 +2,7 @@ import type { GlobalOptions } from "../index.js";
 import type { ProjectStatusSnapshot } from "@gh-symphony/core";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
-import {
-  resolveRuntimeRoot,
-} from "../orchestrator-runtime.js";
+import { resolveRuntimeRoot } from "../orchestrator-runtime.js";
 import {
   handleMissingManagedProjectConfig,
   resolveManagedProjectConfig,
@@ -52,6 +50,13 @@ function resolveProjectTokenDelta(snapshot: ProjectStatusSnapshot): number {
   );
 }
 
+function formatRepository(
+  repository: ProjectStatusSnapshot["repository"] | undefined,
+  fallback: string
+): string {
+  return repository ? `${repository.owner}/${repository.name}` : fallback;
+}
+
 function renderLegacyStatus(
   snapshot: ProjectStatusSnapshot,
   noColor: boolean
@@ -61,7 +66,10 @@ function renderLegacyStatus(
   const lines: string[] = [];
 
   // Header
-  const headerTitle = `gh-symphony ∙ ${snapshot.slug}`;
+  const headerTitle = `gh-symphony ∙ ${formatRepository(
+    snapshot.repository,
+    (snapshot as ProjectStatusSnapshot & { slug?: string }).slug ?? "repository"
+  )}`;
   const headerWidth = 45;
   const headerPadding = Math.max(
     0,
@@ -197,12 +205,7 @@ async function readStatusSnapshot(
   projectId: string
 ): Promise<ProjectStatusSnapshot | null> {
   try {
-    const statusPath = join(
-      runtimeRoot,
-      "projects",
-      projectId,
-      "status.json"
-    );
+    const statusPath = join(runtimeRoot, "projects", projectId, "status.json");
     const content = await readFile(statusPath, "utf-8");
     return JSON.parse(content) as ProjectStatusSnapshot;
   } catch {

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -10,6 +10,7 @@ import {
 import { bold, dim, green, red, yellow, cyan, stripAnsi } from "../ansi.js";
 import { clearScreen, showCursor, hideCursor } from "../ansi.js";
 import { renderDashboard } from "../dashboard/renderer.js";
+import { formatRepositoryDisplay } from "../format/repository.js";
 
 function healthIcon(health: "idle" | "running" | "degraded"): string {
   switch (health) {
@@ -50,13 +51,6 @@ function resolveProjectTokenDelta(snapshot: ProjectStatusSnapshot): number {
   );
 }
 
-function formatRepository(
-  repository: ProjectStatusSnapshot["repository"] | undefined,
-  fallback: string
-): string {
-  return repository ? `${repository.owner}/${repository.name}` : fallback;
-}
-
 function renderLegacyStatus(
   snapshot: ProjectStatusSnapshot,
   noColor: boolean
@@ -66,10 +60,7 @@ function renderLegacyStatus(
   const lines: string[] = [];
 
   // Header
-  const headerTitle = `gh-symphony ∙ ${formatRepository(
-    snapshot.repository,
-    (snapshot as ProjectStatusSnapshot & { slug?: string }).slug ?? "repository"
-  )}`;
+  const headerTitle = `gh-symphony ∙ ${formatRepositoryDisplay(snapshot)}`;
   const headerWidth = 45;
   const headerPadding = Math.max(
     0,
@@ -204,13 +195,18 @@ async function readStatusSnapshot(
   runtimeRoot: string,
   projectId: string
 ): Promise<ProjectStatusSnapshot | null> {
-  try {
-    const statusPath = join(runtimeRoot, "projects", projectId, "status.json");
-    const content = await readFile(statusPath, "utf-8");
-    return JSON.parse(content) as ProjectStatusSnapshot;
-  } catch {
-    return null;
+  for (const statusPath of [
+    join(runtimeRoot, "status.json"),
+    join(runtimeRoot, "projects", projectId, "status.json"),
+  ]) {
+    try {
+      const content = await readFile(statusPath, "utf-8");
+      return JSON.parse(content) as ProjectStatusSnapshot;
+    } catch {
+      // Try the next known runtime layout.
+    }
   }
+  return null;
 }
 
 const handler = async (

--- a/packages/cli/src/dashboard/renderer.ts
+++ b/packages/cli/src/dashboard/renderer.ts
@@ -12,6 +12,7 @@ import {
   stripAnsi,
 } from "../ansi.js";
 import type { ProjectStatusSnapshot } from "@gh-symphony/core";
+import { formatRepositoryDisplay } from "../format/repository.js";
 
 // ── Public types ─────────────────────────────────────────────────────────────
 
@@ -91,13 +92,6 @@ function compactSessionId(id: string | null | undefined): string {
   if (!id) return "\u2014";
   if (id.length <= 10) return id;
   return `${id.slice(0, 4)}...${id.slice(-6)}`;
-}
-
-function formatRepository(
-  repository: ProjectStatusSnapshot["repository"] | undefined,
-  fallback: string
-): string {
-  return repository ? `${repository.owner}/${repository.name}` : fallback;
 }
 
 function fmtTokens(n: number): string {
@@ -324,15 +318,7 @@ export function renderDashboard(
     if (!hasActiveRuns && !hasRetries) continue;
 
     lines.push(
-      sectionDivider(
-        formatRepository(
-          snap.repository,
-          (snap as ProjectStatusSnapshot & { slug?: string }).slug ??
-            "repository"
-        ),
-        width,
-        c
-      )
+      sectionDivider(formatRepositoryDisplay(snap), width, c)
     );
     if (hasActiveRuns) {
       lines.push(tableHeaderRow(c));

--- a/packages/cli/src/dashboard/renderer.ts
+++ b/packages/cli/src/dashboard/renderer.ts
@@ -93,6 +93,13 @@ function compactSessionId(id: string | null | undefined): string {
   return `${id.slice(0, 4)}...${id.slice(-6)}`;
 }
 
+function formatRepository(
+  repository: ProjectStatusSnapshot["repository"] | undefined,
+  fallback: string
+): string {
+  return repository ? `${repository.owner}/${repository.name}` : fallback;
+}
+
 function fmtTokens(n: number): string {
   return n.toLocaleString("en-US");
 }
@@ -316,7 +323,17 @@ export function renderDashboard(
     const hasRetries = snap.retryQueue.length > 0;
     if (!hasActiveRuns && !hasRetries) continue;
 
-    lines.push(sectionDivider(snap.slug, width, c));
+    lines.push(
+      sectionDivider(
+        formatRepository(
+          snap.repository,
+          (snap as ProjectStatusSnapshot & { slug?: string }).slug ??
+            "repository"
+        ),
+        width,
+        c
+      )
+    );
     if (hasActiveRuns) {
       lines.push(tableHeaderRow(c));
       for (const rawRun of snap.activeRuns) {

--- a/packages/cli/src/format/repository.test.ts
+++ b/packages/cli/src/format/repository.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { formatRepositoryDisplay } from "./repository.js";
+
+describe("formatRepositoryDisplay", () => {
+  it("prefers repository owner/name when present", () => {
+    expect(
+      formatRepositoryDisplay({
+        repository: { owner: "acme", name: "platform", cloneUrl: "" },
+      } as never)
+    ).toBe("acme/platform");
+  });
+
+  it("falls back to legacy slug when repository is absent", () => {
+    expect(formatRepositoryDisplay({ slug: "tenant-a" } as never)).toBe(
+      "tenant-a"
+    );
+  });
+
+  it("uses the default fallback when both repository and slug are absent", () => {
+    expect(formatRepositoryDisplay({} as never)).toBe("repository");
+  });
+});

--- a/packages/cli/src/format/repository.ts
+++ b/packages/cli/src/format/repository.ts
@@ -1,0 +1,16 @@
+import type { ProjectStatusSnapshot } from "@gh-symphony/core";
+
+type LegacyStatusSnapshot = ProjectStatusSnapshot & {
+  slug?: string;
+};
+
+export function formatRepositoryDisplay(
+  snapshot: ProjectStatusSnapshot,
+  fallback = "repository"
+): string {
+  if (snapshot.repository) {
+    return `${snapshot.repository.owner}/${snapshot.repository.name}`;
+  }
+
+  return (snapshot as LegacyStatusSnapshot).slug ?? fallback;
+}

--- a/packages/control-plane/client/src/routes/-index.test.tsx
+++ b/packages/control-plane/client/src/routes/-index.test.tsx
@@ -134,7 +134,7 @@ describe("Project overview helpers", () => {
       </Theme>
     );
 
-    expect(markup).toContain("Repository repository unavailable");
+    expect(markup).toContain("Repository unavailable");
     expect(markup).toContain("Tracker binding-1");
   });
 });

--- a/packages/control-plane/client/src/routes/-index.test.tsx
+++ b/packages/control-plane/client/src/routes/-index.test.tsx
@@ -1,20 +1,29 @@
 import { describe, expect, it } from "vitest";
 import {
+  DataStatus,
   formatRelativeTime,
   mapRunStatusToBadgeVariant,
   resolveRetryError,
 } from "./index.js";
+import { renderToStaticMarkup } from "react-dom/server";
+import { Theme } from "@radix-ui/themes";
 
 describe("Project overview helpers", () => {
   it("formats past timestamps as compact relative time", () => {
     expect(
-      formatRelativeTime("2026-04-10T05:00:00.000Z", new Date("2026-04-10T05:02:34.000Z"))
+      formatRelativeTime(
+        "2026-04-10T05:00:00.000Z",
+        new Date("2026-04-10T05:02:34.000Z")
+      )
     ).toBe("2m 34s ago");
   });
 
   it("formats future timestamps for retry queue rows", () => {
     expect(
-      formatRelativeTime("2026-04-10T05:18:44.000Z", new Date("2026-04-10T05:00:00.000Z"))
+      formatRelativeTime(
+        "2026-04-10T05:18:44.000Z",
+        new Date("2026-04-10T05:00:00.000Z")
+      )
     ).toBe("in 18m 44s");
   });
 
@@ -51,5 +60,47 @@ describe("Project overview helpers", () => {
         "gh-symphony#163"
       )
     ).toBe("GitHub API rate limit exceeded");
+  });
+
+  it("renders repository and tracker-side project identifiers", () => {
+    const markup = renderToStaticMarkup(
+      <Theme appearance="dark">
+        <DataStatus
+          projectState={{
+            repository: {
+              owner: "acme",
+              name: "platform",
+              cloneUrl: "https://github.com/acme/platform.git",
+            },
+            tracker: {
+              adapter: "github",
+              bindingId: "binding-1",
+              settings: {
+                projectId: "PVT_project_123",
+              },
+            },
+            lastTickAt: "2026-04-10T05:00:00.000Z",
+            health: "idle",
+            summary: {
+              dispatched: 0,
+              suppressed: 0,
+              recovered: 0,
+              activeRuns: 0,
+            },
+            activeRuns: [],
+            retryQueue: [],
+            rateLimits: null,
+            lastError: null,
+            completedCount: 0,
+            issues: [],
+          }}
+        />
+      </Theme>
+    );
+
+    expect(markup).toContain("Repository acme/platform");
+    expect(markup).toContain("Tracker binding-1");
+    expect(markup).toContain("GitHub Project PVT_project_123");
+    expect(markup).not.toContain("tenant-");
   });
 });

--- a/packages/control-plane/client/src/routes/-index.test.tsx
+++ b/packages/control-plane/client/src/routes/-index.test.tsx
@@ -103,4 +103,38 @@ describe("Project overview helpers", () => {
     expect(markup).toContain("GitHub Project PVT_project_123");
     expect(markup).not.toContain("tenant-");
   });
+
+  it("renders a repository fallback for legacy cached project state", () => {
+    const markup = renderToStaticMarkup(
+      <Theme appearance="dark">
+        <DataStatus
+          projectState={
+            {
+              tracker: {
+                adapter: "github",
+                bindingId: "binding-1",
+              },
+              lastTickAt: "2026-04-10T05:00:00.000Z",
+              health: "idle",
+              summary: {
+                dispatched: 0,
+                suppressed: 0,
+                recovered: 0,
+                activeRuns: 0,
+              },
+              activeRuns: [],
+              retryQueue: [],
+              rateLimits: null,
+              lastError: null,
+              completedCount: 0,
+              issues: [],
+            } as never
+          }
+        />
+      </Theme>
+    );
+
+    expect(markup).toContain("Repository repository unavailable");
+    expect(markup).toContain("Tracker binding-1");
+  });
 });

--- a/packages/control-plane/client/src/routes/__root.tsx
+++ b/packages/control-plane/client/src/routes/__root.tsx
@@ -52,7 +52,9 @@ function RootErrorBoundary(props: { error: Error; reset: () => void }) {
 function RootLayout() {
   const projectState = useProjectState();
   const refresh = useRefresh();
-  const projectName = projectState.data?.slug ?? "project";
+  const repositoryName = projectState.data?.repository
+    ? `${projectState.data.repository.owner}/${projectState.data.repository.name}`
+    : "repository";
 
   return (
     <Shell>
@@ -70,12 +72,14 @@ function RootLayout() {
               className="h-5 w-px shrink-0 bg-border-subtle"
             />
             <span className="truncate font-mono text-sm text-text-muted">
-              {projectName}
+              {repositoryName}
             </span>
           </div>
 
           <div className="flex items-center gap-3">
-            <Badge variant={mapHealthToBadgeVariant(projectState.data?.health)} />
+            <Badge
+              variant={mapHealthToBadgeVariant(projectState.data?.health)}
+            />
             <Button
               size="sm"
               variant="ghost"

--- a/packages/control-plane/client/src/routes/index.tsx
+++ b/packages/control-plane/client/src/routes/index.tsx
@@ -321,7 +321,7 @@ function RetryQueueTable(props: { projectState: ProjectState }) {
 export function DataStatus(props: { projectState: ProjectState }) {
   const repository = props.projectState.repository
     ? `${props.projectState.repository.owner}/${props.projectState.repository.name}`
-    : "repository unavailable";
+    : "unavailable";
   const trackerProjectId = props.projectState.tracker.settings?.projectId;
 
   return (

--- a/packages/control-plane/client/src/routes/index.tsx
+++ b/packages/control-plane/client/src/routes/index.tsx
@@ -319,7 +319,9 @@ function RetryQueueTable(props: { projectState: ProjectState }) {
 }
 
 export function DataStatus(props: { projectState: ProjectState }) {
-  const repository = `${props.projectState.repository.owner}/${props.projectState.repository.name}`;
+  const repository = props.projectState.repository
+    ? `${props.projectState.repository.owner}/${props.projectState.repository.name}`
+    : "repository unavailable";
   const trackerProjectId = props.projectState.tracker.settings?.projectId;
 
   return (

--- a/packages/control-plane/client/src/routes/index.tsx
+++ b/packages/control-plane/client/src/routes/index.tsx
@@ -108,7 +108,11 @@ function getSummaryCards(projectState: ProjectState): SummaryCardDefinition[] {
   ];
 }
 
-function Section(props: { title: string; count?: number; children: ReactNode }) {
+function Section(props: {
+  title: string;
+  count?: number;
+  children: ReactNode;
+}) {
   return (
     <section className="overflow-hidden rounded-xl border border-border-default bg-bg-surface shadow-[0_20px_80px_rgb(0_0_0_/_0.24)]">
       <div className="flex items-center gap-2 px-5 py-4">
@@ -145,7 +149,9 @@ function SummaryCards(props: { projectState: ProjectState | undefined }) {
               <div className="text-4xl font-semibold tracking-tight text-text-primary">
                 {card.value}
               </div>
-              <div className="mt-1 text-sm text-text-secondary">{card.label}</div>
+              <div className="mt-1 text-sm text-text-secondary">
+                {card.label}
+              </div>
             </>
           ) : (
             <div className="space-y-2">
@@ -209,7 +215,9 @@ function LoadingTable(props: { columns: string[] }) {
 function ActiveRunsTable(props: { projectState: ProjectState }) {
   if (props.projectState.activeRuns.length === 0) {
     return (
-      <div className="px-5 pb-5 text-sm text-text-secondary">No active runs</div>
+      <div className="px-5 pb-5 text-sm text-text-secondary">
+        No active runs
+      </div>
     );
   }
 
@@ -310,11 +318,16 @@ function RetryQueueTable(props: { projectState: ProjectState }) {
   );
 }
 
-function DataStatus(props: { projectState: ProjectState }) {
+export function DataStatus(props: { projectState: ProjectState }) {
+  const repository = `${props.projectState.repository.owner}/${props.projectState.repository.name}`;
+  const trackerProjectId = props.projectState.tracker.settings?.projectId;
+
   return (
     <div className="flex flex-wrap gap-x-6 gap-y-2 text-sm text-text-secondary">
       <span>Last tick {formatRelativeTime(props.projectState.lastTickAt)}</span>
+      <span>Repository {repository}</span>
       <span>Tracker {props.projectState.tracker.bindingId}</span>
+      {trackerProjectId ? <span>GitHub Project {trackerProjectId}</span> : null}
       {props.projectState.lastError ? (
         <span className="text-status-failed-text">
           Last error: {props.projectState.lastError}
@@ -341,7 +354,9 @@ function ProjectOverviewRoute() {
 
       <SummaryCards projectState={projectState.data} />
 
-      {projectState.data ? <DataStatus projectState={projectState.data} /> : null}
+      {projectState.data ? (
+        <DataStatus projectState={projectState.data} />
+      ) : null}
 
       <Section
         title="Active Runs"

--- a/packages/control-plane/src/server.test.ts
+++ b/packages/control-plane/src/server.test.ts
@@ -21,7 +21,6 @@ function createReader() {
     loadAllRuns: vi.fn(),
     loadRunsForIssue: vi.fn(),
     loadRecentRunEvents: vi.fn(),
-    projectId: "tenant-1",
     runtimeRoot: "/tmp/runtime",
     projectDir: vi.fn(),
     runDir: vi.fn(),
@@ -54,11 +53,17 @@ describe("createControlPlaneHandler", () => {
   it("delegates GET /api/v1/state to the dashboard resolver", async () => {
     const reader = createReader();
     reader.loadProjectState.mockResolvedValue({
-      projectId: "tenant-1",
-      slug: "tenant-1",
+      repository: {
+        owner: "acme",
+        name: "platform",
+        cloneUrl: "https://github.com/acme/platform.git",
+      },
       tracker: {
         adapter: "github-project",
         bindingId: "project-1",
+        settings: {
+          projectId: "PVT_project_1",
+        },
       },
       lastTickAt: "2026-04-09T00:00:00.000Z",
       health: "idle",
@@ -81,15 +86,21 @@ describe("createControlPlaneHandler", () => {
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toMatchObject({
-      projectId: "tenant-1",
+      repository: { owner: "acme", name: "platform" },
+      tracker: { settings: { projectId: "PVT_project_1" } },
       health: "idle",
     });
   });
 
   it("serves static assets from client/dist", async () => {
     await mkdir(join(CLIENT_DIST_DIR, "assets"), { recursive: true });
-    await writeFile(join(CLIENT_DIST_DIR, "assets", "app.js"), "console.log(1);");
-    const handler = createControlPlaneHandler({ reader: createReader() as never });
+    await writeFile(
+      join(CLIENT_DIST_DIR, "assets", "app.js"),
+      "console.log(1);"
+    );
+    const handler = createControlPlaneHandler({
+      reader: createReader() as never,
+    });
 
     const response = await fetchWithHandler(handler, "/assets/app.js");
 
@@ -104,9 +115,11 @@ describe("createControlPlaneHandler", () => {
     await mkdir(CLIENT_DIST_DIR, { recursive: true });
     await writeFile(
       join(CLIENT_DIST_DIR, "index.html"),
-      "<!doctype html><div id=\"root\"></div>"
+      '<!doctype html><div id="root"></div>'
     );
-    const handler = createControlPlaneHandler({ reader: createReader() as never });
+    const handler = createControlPlaneHandler({
+      reader: createReader() as never,
+    });
 
     const response = await fetchWithHandler(handler, "/assets/app%2Ejs");
 
@@ -118,9 +131,11 @@ describe("createControlPlaneHandler", () => {
     await mkdir(CLIENT_DIST_DIR, { recursive: true });
     await writeFile(
       join(CLIENT_DIST_DIR, "index.html"),
-      "<!doctype html><div id=\"root\"></div>"
+      '<!doctype html><div id="root"></div>'
     );
-    const handler = createControlPlaneHandler({ reader: createReader() as never });
+    const handler = createControlPlaneHandler({
+      reader: createReader() as never,
+    });
 
     const response = await fetchWithHandler(handler, "/%E0%A4%A");
 
@@ -132,24 +147,31 @@ describe("createControlPlaneHandler", () => {
     await mkdir(CLIENT_DIST_DIR, { recursive: true });
     await writeFile(
       join(CLIENT_DIST_DIR, "index.html"),
-      "<!doctype html><div id=\"root\"></div>"
+      '<!doctype html><div id="root"></div>'
     );
-    const handler = createControlPlaneHandler({ reader: createReader() as never });
+    const handler = createControlPlaneHandler({
+      reader: createReader() as never,
+    });
 
-    const response = await fetchWithHandler(handler, "/issues/acme%2Frepo%23123");
+    const response = await fetchWithHandler(
+      handler,
+      "/issues/acme%2Frepo%23123"
+    );
 
     expect(response.status).toBe(200);
     expect(response.headers.get("content-type")).toContain("text/html");
-    await expect(response.text()).resolves.toContain("<div id=\"root\"></div>");
+    await expect(response.text()).resolves.toContain('<div id="root"></div>');
   });
 
   it("serves index.html with no-cache even when requested directly", async () => {
     await mkdir(CLIENT_DIST_DIR, { recursive: true });
     await writeFile(
       join(CLIENT_DIST_DIR, "index.html"),
-      "<!doctype html><div id=\"root\"></div>"
+      '<!doctype html><div id="root"></div>'
     );
-    const handler = createControlPlaneHandler({ reader: createReader() as never });
+    const handler = createControlPlaneHandler({
+      reader: createReader() as never,
+    });
 
     const response = await fetchWithHandler(handler, "/index.html");
 
@@ -163,16 +185,23 @@ describe("startControlPlaneServer", () => {
     await mkdir(CLIENT_DIST_DIR, { recursive: true });
     await writeFile(
       join(CLIENT_DIST_DIR, "index.html"),
-      "<!doctype html><div id=\"root\"></div>"
+      '<!doctype html><div id="root"></div>'
     );
     const runtimeRoot = await mkdtemp(join(tmpdir(), "control-plane-runtime-"));
-    await mkdir(join(runtimeRoot, "projects", "tenant-1"), { recursive: true });
+    await mkdir(runtimeRoot, { recursive: true });
     await writeFile(
-      join(runtimeRoot, "projects", "tenant-1", "status.json"),
+      join(runtimeRoot, "status.json"),
       JSON.stringify({
-        projectId: "tenant-1",
-        slug: "tenant-1",
-        tracker: { adapter: "github-project", bindingId: "project-1" },
+        repository: {
+          owner: "acme",
+          name: "platform",
+          cloneUrl: "https://github.com/acme/platform.git",
+        },
+        tracker: {
+          adapter: "github-project",
+          bindingId: "project-1",
+          settings: { projectId: "PVT_project_1" },
+        },
         lastTickAt: "2026-04-09T00:00:00.000Z",
         health: "idle",
         summary: {
@@ -187,16 +216,12 @@ describe("startControlPlaneServer", () => {
         lastError: null,
       })
     );
-    await writeFile(
-      join(runtimeRoot, "projects", "tenant-1", "issues.json"),
-      "[]"
-    );
+    await writeFile(join(runtimeRoot, "issues.json"), "[]");
 
     const started = await startControlPlaneServer({
       host: "127.0.0.1",
       port: 0,
       runtimeRoot,
-      projectId: "tenant-1",
     });
 
     try {

--- a/packages/control-plane/src/server.ts
+++ b/packages/control-plane/src/server.ts
@@ -65,7 +65,6 @@ export interface ControlPlaneServerOptions {
   host: string;
   port: number;
   runtimeRoot: string;
-  projectId: string;
   onRefreshRequest?: () => void;
 }
 
@@ -80,10 +79,9 @@ export interface ControlPlaneServerStartResult {
   port: number;
 }
 
-export function createControlPlaneHandler(options: ControlPlaneHandlerOptions): (
-  req: IncomingMessage,
-  res: ServerResponse
-) => Promise<void> {
+export function createControlPlaneHandler(
+  options: ControlPlaneHandlerOptions
+): (req: IncomingMessage, res: ServerResponse) => Promise<void> {
   return async (request, response) => {
     try {
       const method = request.method ?? "GET";
@@ -135,7 +133,7 @@ export function createControlPlaneHandler(options: ControlPlaneHandlerOptions): 
 export async function startControlPlaneServer(
   options: ControlPlaneServerOptions
 ): Promise<ControlPlaneServerStartResult> {
-  const reader = new DashboardFsReader(options.runtimeRoot, options.projectId);
+  const reader = new DashboardFsReader(options.runtimeRoot);
   const handler = createControlPlaneHandler({
     reader,
     onRefreshRequest: options.onRefreshRequest,

--- a/packages/core/src/contracts/status-surface.ts
+++ b/packages/core/src/contracts/status-surface.ts
@@ -157,11 +157,11 @@ export type LiveWorkerState = {
 };
 
 export type ProjectStatusSnapshot = {
-  projectId: string;
-  slug: string;
+  repository: RepositoryRef;
   tracker: {
     adapter: TrackerAdapterKind;
     bindingId: string;
+    settings?: Record<string, string | number | boolean>;
   };
   lastTickAt: string;
   health: "idle" | "running" | "degraded";

--- a/packages/core/src/contracts/status-surface.ts
+++ b/packages/core/src/contracts/status-surface.ts
@@ -161,6 +161,7 @@ export type ProjectStatusSnapshot = {
   tracker: {
     adapter: TrackerAdapterKind;
     bindingId: string;
+    /** Public, non-secret tracker identifiers safe to expose on status APIs. */
     settings?: Record<string, string | number | boolean>;
   };
   lastTickAt: string;

--- a/packages/core/src/observability/snapshot-builder.test.ts
+++ b/packages/core/src/observability/snapshot-builder.test.ts
@@ -274,13 +274,19 @@ describe("buildProjectSnapshot", () => {
     expect(snapshot.activeRuns).toHaveLength(2);
   });
 
-  it("preserves project metadata in snapshot", () => {
+  it("exposes repository and tracker metadata in snapshot", () => {
     const project = mockProject({
-      projectId: "custom-project-id",
-      slug: "custom-slug",
+      repository: {
+        owner: "octo",
+        name: "repo",
+        cloneUrl: "https://github.com/octo/repo.git",
+      },
       tracker: {
         adapter: "github",
         bindingId: "custom-binding",
+        settings: {
+          projectId: "PVT_project_123",
+        },
       },
     });
 
@@ -294,10 +300,18 @@ describe("buildProjectSnapshot", () => {
 
     const snapshot = buildProjectSnapshot(input);
 
-    expect(snapshot.projectId).toBe("custom-project-id");
-    expect(snapshot.slug).toBe("custom-slug");
+    expect(snapshot).not.toHaveProperty("projectId");
+    expect(snapshot).not.toHaveProperty("slug");
+    expect(snapshot.repository).toEqual({
+      owner: "octo",
+      name: "repo",
+      cloneUrl: "https://github.com/octo/repo.git",
+    });
     expect(snapshot.tracker.adapter).toBe("github");
     expect(snapshot.tracker.bindingId).toBe("custom-binding");
+    expect(snapshot.tracker.settings).toEqual({
+      projectId: "PVT_project_123",
+    });
   });
 
   it("includes summary counts in snapshot", () => {

--- a/packages/core/src/observability/snapshot-builder.ts
+++ b/packages/core/src/observability/snapshot-builder.ts
@@ -49,11 +49,13 @@ export function buildProjectSnapshot(
   );
 
   return {
-    projectId: project.projectId,
-    slug: project.slug,
+    repository: project.repository,
     tracker: {
       adapter: project.tracker.adapter,
       bindingId: project.tracker.bindingId,
+      ...(project.tracker.settings
+        ? { settings: project.tracker.settings }
+        : {}),
     },
     lastTickAt,
     health: lastError ? "degraded" : activeRuns.length > 0 ? "running" : "idle",
@@ -101,7 +103,10 @@ export function buildProjectSnapshot(
 function aggregateTokenUsageByIssue(
   runs: OrchestratorRunRecord[]
 ): Map<string, NonNullable<OrchestratorRunRecord["tokenUsage"]>> {
-  const totals = new Map<string, NonNullable<OrchestratorRunRecord["tokenUsage"]>>();
+  const totals = new Map<
+    string,
+    NonNullable<OrchestratorRunRecord["tokenUsage"]>
+  >();
 
   for (const run of runs) {
     if (!run.tokenUsage) {
@@ -133,8 +138,7 @@ function attachCumulativeTokenUsage(
   return {
     ...tokenUsage,
     cumulativeInputTokens: cumulative?.inputTokens ?? tokenUsage.inputTokens,
-    cumulativeOutputTokens:
-      cumulative?.outputTokens ?? tokenUsage.outputTokens,
+    cumulativeOutputTokens: cumulative?.outputTokens ?? tokenUsage.outputTokens,
     cumulativeTotalTokens: cumulative?.totalTokens ?? tokenUsage.totalTokens,
   };
 }

--- a/packages/core/src/observability/snapshot-builder.ts
+++ b/packages/core/src/observability/snapshot-builder.ts
@@ -53,9 +53,7 @@ export function buildProjectSnapshot(
     tracker: {
       adapter: project.tracker.adapter,
       bindingId: project.tracker.bindingId,
-      ...(project.tracker.settings
-        ? { settings: project.tracker.settings }
-        : {}),
+      settings: project.tracker.settings,
     },
     lastTickAt,
     health: lastError ? "degraded" : activeRuns.length > 0 ? "running" : "idle",

--- a/packages/core/src/observability/status-assembler.test.ts
+++ b/packages/core/src/observability/status-assembler.test.ts
@@ -41,29 +41,18 @@ function createRun(
 }
 
 describe("status-assembler", () => {
-  it("matches runs by project and either issue id or identifier", () => {
+  it("matches runs by either issue id or identifier", () => {
     const run = createRun();
 
-    expect(
-      isMatchingIssueRun(run, "project-1", "issue-1", "other/repo#2")
-    ).toBe(true);
-    expect(
-      isMatchingIssueRun(run, "project-1", "other-issue", "acme/repo#1")
-    ).toBe(true);
-    expect(
-      isMatchingIssueRun(run, "project-2", "issue-1", "acme/repo#1")
-    ).toBe(false);
-    expect(
-      isMatchingIssueRun(null, "project-1", "issue-1", "acme/repo#1")
-    ).toBe(false);
+    expect(isMatchingIssueRun(run, "issue-1", "other/repo#2")).toBe(true);
+    expect(isMatchingIssueRun(run, "other-issue", "acme/repo#1")).toBe(true);
+    expect(isMatchingIssueRun(null, "issue-1", "acme/repo#1")).toBe(false);
   });
 
   it("maps orchestration states to status surface values", () => {
     expect(mapIssueOrchestrationStateToStatus("claimed")).toBe("starting");
     expect(mapIssueOrchestrationStateToStatus("running")).toBe("running");
-    expect(mapIssueOrchestrationStateToStatus("retry_queued")).toBe(
-      "retrying"
-    );
+    expect(mapIssueOrchestrationStateToStatus("retry_queued")).toBe("retrying");
     expect(mapIssueOrchestrationStateToStatus("released")).toBe("released");
     expect(mapIssueOrchestrationStateToStatus("unclaimed")).toBe("pending");
   });

--- a/packages/core/src/observability/status-assembler.ts
+++ b/packages/core/src/observability/status-assembler.ts
@@ -3,14 +3,11 @@ import type { OrchestratorRunRecord } from "../contracts/status-surface.js";
 
 export function isMatchingIssueRun(
   run: OrchestratorRunRecord | null,
-  projectId: string,
   issueId: string,
   issueIdentifier: string
 ): run is OrchestratorRunRecord {
   return Boolean(
-    run &&
-      run.projectId === projectId &&
-      (run.issueId === issueId || run.issueIdentifier === issueIdentifier)
+    run && (run.issueId === issueId || run.issueIdentifier === issueIdentifier)
   );
 }
 

--- a/packages/dashboard/src/server.test.ts
+++ b/packages/dashboard/src/server.test.ts
@@ -10,7 +10,6 @@ function createReader() {
     loadAllRuns: vi.fn(),
     loadRunsForIssue: vi.fn(),
     loadRecentRunEvents: vi.fn(),
-    projectId: "tenant-1",
     runtimeRoot: "/tmp/runtime",
     projectDir: vi.fn(),
     runDir: vi.fn(),
@@ -24,11 +23,17 @@ afterEach(() => {
 describe("GET /api/v1/state", () => {
   it("returns a single project snapshot", async () => {
     const snapshot = {
-      projectId: "tenant-1",
-      slug: "tenant-1",
+      repository: {
+        owner: "acme",
+        name: "repo",
+        cloneUrl: "https://github.com/acme/repo.git",
+      },
       tracker: {
         adapter: "github-project",
         bindingId: "project-1",
+        settings: {
+          projectId: "PVT_project_1",
+        },
       },
       lastTickAt: new Date().toISOString(),
       health: "idle",
@@ -70,6 +75,8 @@ describe("GET /api/v1/state", () => {
 
     expect(result.status).toBe(200);
     expect(result.payload).toEqual(snapshot);
+    expect(result.payload).not.toHaveProperty("projectId");
+    expect(result.payload).not.toHaveProperty("slug");
     expect(reader.loadProjectState).toHaveBeenCalledOnce();
   });
 

--- a/packages/dashboard/src/store.test.ts
+++ b/packages/dashboard/src/store.test.ts
@@ -53,6 +53,30 @@ describe("DashboardFsReader", () => {
     expect(snapshot).not.toHaveProperty("slug");
   });
 
+  it("treats legacy status snapshots without repository identity as unavailable", async () => {
+    const runtimeRoot = await mkdtemp(join(tmpdir(), "dashboard-store-"));
+    await writeFile(
+      join(runtimeRoot, "status.json"),
+      JSON.stringify({
+        projectId: "tenant-1",
+        slug: "tenant-1",
+        tracker: { adapter: "github-project", bindingId: "project-1" },
+        lastTickAt: "2026-03-20T00:00:00.000Z",
+        health: "idle",
+        summary: { dispatched: 0, suppressed: 0, recovered: 0, activeRuns: 0 },
+        activeRuns: [],
+        retryQueue: [],
+        lastError: null,
+      }) + "\n",
+      "utf8"
+    );
+
+    const reader = new DashboardFsReader(runtimeRoot);
+
+    await expect(reader.loadProjectStatus()).resolves.toBeNull();
+    await expect(reader.loadProjectState()).resolves.toBeNull();
+  });
+
   it("assembles issue status snapshots from persisted runtime files", async () => {
     const runtimeRoot = await mkdtemp(join(tmpdir(), "dashboard-store-"));
     const projectDir = runtimeRoot;

--- a/packages/dashboard/src/store.test.ts
+++ b/packages/dashboard/src/store.test.ts
@@ -5,14 +5,8 @@ import { describe, expect, it } from "vitest";
 import { DashboardFsReader, statusForIssue } from "./store.js";
 
 describe("DashboardFsReader", () => {
-  it("rejects project IDs that would escape the runtime root", () => {
-    expect(() => new DashboardFsReader("/tmp/runtime", "../tenant-1")).toThrow(
-      'Invalid project ID "../tenant-1"'
-    );
-  });
-
   it("rejects run IDs that would escape the runtime root", async () => {
-    const reader = new DashboardFsReader("/tmp/runtime", "tenant-1");
+    const reader = new DashboardFsReader("/tmp/runtime");
 
     await expect(reader.loadRun("../run-1")).rejects.toThrow(
       'Invalid run ID "../run-1"'
@@ -31,6 +25,11 @@ describe("DashboardFsReader", () => {
       JSON.stringify({
         projectId: "tenant-1",
         slug: "tenant-1",
+        repository: {
+          owner: "acme",
+          name: "platform",
+          cloneUrl: "https://github.com/acme/platform.git",
+        },
         tracker: { adapter: "github-project", bindingId: "project-1" },
         lastTickAt: "2026-03-20T00:00:00.000Z",
         health: "idle",
@@ -42,12 +41,16 @@ describe("DashboardFsReader", () => {
       "utf8"
     );
 
-    const reader = new DashboardFsReader(runtimeRoot, "tenant-1");
+    const reader = new DashboardFsReader(runtimeRoot);
 
-    await expect(reader.loadProjectStatus()).resolves.toMatchObject({
-      projectId: "tenant-1",
+    const snapshot = await reader.loadProjectStatus();
+
+    expect(snapshot).toMatchObject({
+      repository: { owner: "acme", name: "platform" },
       health: "idle",
     });
+    expect(snapshot).not.toHaveProperty("projectId");
+    expect(snapshot).not.toHaveProperty("slug");
   });
 
   it("assembles issue status snapshots from persisted runtime files", async () => {
@@ -181,7 +184,7 @@ describe("DashboardFsReader", () => {
       "utf8"
     );
 
-    const reader = new DashboardFsReader(runtimeRoot, "tenant-1");
+    const reader = new DashboardFsReader(runtimeRoot);
 
     await expect(statusForIssue(reader, "acme/platform#1")).resolves.toEqual({
       issue_identifier: "acme/platform#1",
@@ -302,7 +305,7 @@ describe("DashboardFsReader", () => {
       "utf8"
     );
 
-    const reader = new DashboardFsReader(runtimeRoot, "tenant-1");
+    const reader = new DashboardFsReader(runtimeRoot);
 
     await expect(
       statusForIssue(reader, "acme/platform#1")
@@ -421,7 +424,7 @@ describe("DashboardFsReader", () => {
     );
     await writeFile(join(malformedRunDir, "run.json"), "{not-json\n", "utf8");
 
-    const reader = new DashboardFsReader(runtimeRoot, "tenant-1");
+    const reader = new DashboardFsReader(runtimeRoot);
 
     await expect(
       statusForIssue(reader, "acme/platform#1")
@@ -456,7 +459,7 @@ describe("DashboardFsReader", () => {
       "utf8"
     );
 
-    const reader = new DashboardFsReader(runtimeRoot, "tenant-1");
+    const reader = new DashboardFsReader(runtimeRoot);
 
     await expect(reader.loadProjectIssueOrchestrations()).resolves.toEqual([
       {
@@ -480,8 +483,11 @@ describe("DashboardFsReader", () => {
     await writeFile(
       join(projectDir, "status.json"),
       JSON.stringify({
-        projectId: "tenant-1",
-        slug: "tenant-1",
+        repository: {
+          owner: "acme",
+          name: "platform",
+          cloneUrl: "https://github.com/acme/platform.git",
+        },
         tracker: { adapter: "github-project", bindingId: "project-1" },
         lastTickAt: "2026-03-20T00:00:00.000Z",
         health: "idle",
@@ -521,10 +527,10 @@ describe("DashboardFsReader", () => {
       "utf8"
     );
 
-    const reader = new DashboardFsReader(runtimeRoot, "tenant-1");
+    const reader = new DashboardFsReader(runtimeRoot);
 
     await expect(reader.loadProjectState()).resolves.toMatchObject({
-      projectId: "tenant-1",
+      repository: { owner: "acme", name: "platform" },
       completedCount: 1,
       issues: [
         { issueId: "issue-1", completedOnce: true },
@@ -563,7 +569,7 @@ describe("DashboardFsReader", () => {
       "utf8"
     );
 
-    const reader = new DashboardFsReader(runtimeRoot, "tenant-1");
+    const reader = new DashboardFsReader(runtimeRoot);
 
     await expect(reader.loadRecentRunEvents("run-1", 2)).resolves.toEqual([
       {
@@ -618,7 +624,7 @@ describe("DashboardFsReader", () => {
       "utf8"
     );
 
-    const reader = new DashboardFsReader(runtimeRoot, "tenant-1");
+    const reader = new DashboardFsReader(runtimeRoot);
 
     await expect(reader.loadAllRuns()).resolves.toMatchObject([
       {

--- a/packages/dashboard/src/store.ts
+++ b/packages/dashboard/src/store.ts
@@ -30,11 +30,7 @@ export type DashboardProjectStateSnapshot = ProjectStatusSnapshot & {
 export class DashboardFsReader {
   private readonly resolvedRuntimeRoot: string;
 
-  constructor(
-    readonly runtimeRoot: string,
-    readonly projectId: string
-  ) {
-    assertValidDashboardProjectId(projectId);
+  constructor(readonly runtimeRoot: string) {
     this.resolvedRuntimeRoot = resolve(runtimeRoot);
   }
 
@@ -48,9 +44,20 @@ export class DashboardFsReader {
   }
 
   async loadProjectStatus(): Promise<ProjectStatusSnapshot | null> {
-    return readJsonFile<ProjectStatusSnapshot>(
-      join(this.projectDir(), "status.json")
-    );
+    const snapshot = await readJsonFile<
+      ProjectStatusSnapshot & { projectId?: string; slug?: string }
+    >(join(this.projectDir(), "status.json"));
+    if (!snapshot) {
+      return null;
+    }
+
+    const status: ProjectStatusSnapshot & {
+      projectId?: string;
+      slug?: string;
+    } = { ...snapshot };
+    delete status.projectId;
+    delete status.slug;
+    return status;
   }
 
   async loadProjectState(): Promise<DashboardProjectStateSnapshot | null> {
@@ -136,7 +143,8 @@ export class DashboardFsReader {
             return null;
           }
 
-          return run.issueId === issueId || run.issueIdentifier === issueIdentifier
+          return run.issueId === issueId ||
+            run.issueIdentifier === issueIdentifier
             ? run
             : null;
         } catch (error) {
@@ -241,7 +249,6 @@ export async function statusForIssue(
     : null;
   const currentRun = isMatchingIssueRun(
     currentRunCandidate,
-    reader.projectId,
     issueRecord.issueId,
     issueIdentifier
   )
@@ -253,8 +260,7 @@ export async function statusForIssue(
       : currentRun.tokenUsage
         ? await reader.loadRunsForIssue(issueRecord.issueId, issueIdentifier)
         : null;
-  const resolvedRun =
-    currentRun ?? findLatestRunForIssue(issueRuns ?? []);
+  const resolvedRun = currentRun ?? findLatestRunForIssue(issueRuns ?? []);
 
   const recentEvents =
     resolvedRun === null
@@ -360,27 +366,12 @@ function findLatestRunForIssue(
 ): OrchestratorRunRecord | null {
   // If the tracked currentRunId is stale, fall back to a bounded-concurrency scan
   // across persisted runs rather than opening every run.json at once.
-  const sortedRuns = [...matchingRuns]
-    .sort(
-      (left, right) =>
-        new Date(right.updatedAt).getTime() - new Date(left.updatedAt).getTime()
-    );
+  const sortedRuns = [...matchingRuns].sort(
+    (left, right) =>
+      new Date(right.updatedAt).getTime() - new Date(left.updatedAt).getTime()
+  );
 
   return sortedRuns[0] ?? null;
-}
-
-export function assertValidDashboardProjectId(projectId: string): void {
-  if (
-    projectId.length === 0 ||
-    projectId === "." ||
-    projectId === ".." ||
-    projectId.includes("/") ||
-    projectId.includes("\\")
-  ) {
-    throw new Error(
-      `Invalid project ID "${projectId}". Project IDs must not contain path separators or traversal segments.`
-    );
-  }
 }
 
 export function assertValidDashboardRunId(runId: string): void {

--- a/packages/dashboard/src/store.ts
+++ b/packages/dashboard/src/store.ts
@@ -1,6 +1,7 @@
 import { open } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import {
+  type RepositoryRef,
   deriveIssueWorkspaceKeyFromIdentifier,
   isFileMissing,
   isMatchingIssueRun,
@@ -57,6 +58,9 @@ export class DashboardFsReader {
     } = { ...snapshot };
     delete status.projectId;
     delete status.slug;
+    if (!isRepositoryRef(status.repository)) {
+      return null;
+    }
     return status;
   }
 
@@ -386,6 +390,19 @@ export function assertValidDashboardRunId(runId: string): void {
       `Invalid run ID "${runId}". Run IDs must not contain path separators or traversal segments.`
     );
   }
+}
+
+function isRepositoryRef(value: unknown): value is RepositoryRef {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const repository = value as Partial<RepositoryRef>;
+  return (
+    typeof repository.owner === "string" &&
+    repository.owner.length > 0 &&
+    typeof repository.name === "string" &&
+    repository.name.length > 0
+  );
 }
 
 async function mapWithConcurrency<T, R>(

--- a/packages/dashboard/src/store.ts
+++ b/packages/dashboard/src/store.ts
@@ -401,7 +401,8 @@ function isRepositoryRef(value: unknown): value is RepositoryRef {
     typeof repository.owner === "string" &&
     repository.owner.length > 0 &&
     typeof repository.name === "string" &&
-    repository.name.length > 0
+    repository.name.length > 0 &&
+    typeof repository.cloneUrl === "string"
   );
 }
 

--- a/packages/orchestrator/src/fs-store.ts
+++ b/packages/orchestrator/src/fs-store.ts
@@ -127,7 +127,7 @@ export class OrchestratorFsStore implements OrchestratorStateStore {
 
   async saveProjectStatus(status: ProjectStatusSnapshot): Promise<void> {
     await writeJsonFile(
-      join(this.projectDir(status.projectId), "status.json"),
+      join(this.projectDir(), "status.json"),
       status
     );
   }

--- a/packages/orchestrator/src/headless-verification.test.ts
+++ b/packages/orchestrator/src/headless-verification.test.ts
@@ -58,12 +58,27 @@ describe("headless orchestration verification", () => {
       });
 
       const cliStatus = JSON.parse(stdout) as {
-        projectId: string;
+        repository: {
+          owner: string;
+          name: string;
+        };
+        tracker: {
+          settings?: {
+            projectId?: string;
+          };
+        };
         summary: {
           dispatched: number;
         };
       };
-      expect(cliStatus.projectId).toBe("tenant-1");
+      expect(cliStatus).not.toHaveProperty("projectId");
+      expect(cliStatus).not.toHaveProperty("slug");
+      expect(cliStatus.repository).toEqual({
+        owner: "acme",
+        name: "platform",
+        cloneUrl: repository.cloneUrl,
+      });
+      expect(cliStatus.tracker.settings?.projectId).toBe("project-123");
       expect(cliStatus.summary.dispatched).toBe(1);
       expect(spawnImpl).toHaveBeenCalledTimes(1);
     } finally {

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -66,6 +66,16 @@ describe("OrchestratorService", () => {
     expect(first.tracker).toEqual({
       adapter: "github-project",
       bindingId: "project-123",
+      settings: {
+        projectId: "project-123",
+        repository: "acme/platform",
+      },
+    });
+    expect(first).not.toHaveProperty("projectId");
+    expect(first).not.toHaveProperty("slug");
+    expect(first.repository).toMatchObject({
+      owner: "acme",
+      name: "platform",
     });
     expect(second.summary.dispatched).toBe(0);
     expect(issueRecords).toHaveLength(1);
@@ -693,8 +703,15 @@ describe("OrchestratorService", () => {
       expect(onTick).toHaveBeenCalledTimes(1);
       expect(onTick).toHaveBeenCalledWith(
         expect.objectContaining({
-          projectId: "tenant-1",
-          slug: "tenant-1",
+          repository: expect.objectContaining({
+            owner: "acme",
+            name: "platform",
+          }),
+          tracker: expect.objectContaining({
+            settings: expect.objectContaining({
+              projectId: "project-123",
+            }),
+          }),
           health: "idle",
           lastTickAt: "2026-03-08T00:00:00.000Z",
           summary: expect.objectContaining({

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -231,7 +231,6 @@ export class OrchestratorService {
       : null;
     const currentRun = isMatchingIssueRun(
       currentRunCandidate,
-      this.projectConfig.projectId,
       issueRecord.issueId,
       issueIdentifier
     )
@@ -623,7 +622,6 @@ export class OrchestratorService {
           syncedActiveRuns.find((run) =>
             isMatchingIssueRun(
               run,
-              tenant.projectId,
               issueRecord.issueId,
               issueRecord.identifier
             )


### PR DESCRIPTION
## Issues

- Fixes #265

## Summary

- Drops orchestrator-side `projectId` routing from the control-plane/dashboard status path.
- Reshapes `/api/v1/state` to expose `repository: { owner, name }` as the first-class runtime identifier and removes top-level `projectId`/`slug` from the status surface.
- Preserves tracker-side project metadata under `tracker.settings` when configured, and hardens upgrade handling for legacy persisted status files.

## Changes

- Removed `ControlPlaneServerOptions.projectId` and made `DashboardFsReader` read the single-repo runtime root directly.
- Updated `ProjectStatusSnapshot` assembly, persisted status writes, dashboard API normalization, and issue run matching to avoid control-plane project namespace routing.
- Updated the React dashboard header/status row to render repository and tracker identifiers, with a non-crashing fallback for legacy cached state.
- Updated CLI status/log readers to prefer flat runtime paths (`runtimeRoot/status.json`, `runtimeRoot/runs/...`) while retaining legacy per-project fallbacks.
- Consolidated CLI repository display fallback formatting and documented `tracker.settings` as public non-secret status metadata.
- Updated control-plane, dashboard, core/orchestrator, and CLI regression tests for the new status response shape and review feedback.
- Added a changeset documenting the breaking `/api/v1/state` API change.

## Evidence

- `pnpm --filter @gh-symphony/control-plane test`
- `pnpm --filter @gh-symphony/dashboard test`
- `pnpm --filter @gh-symphony/cli test`
- `pnpm --filter @gh-symphony/core test`
- `pnpm --filter @gh-symphony/cli typecheck`
- `pnpm --filter @gh-symphony/control-plane typecheck && pnpm --filter @gh-symphony/dashboard typecheck`
- `pnpm lint && pnpm test && pnpm typecheck && pnpm build`
- Docker E2E TC: `docker compose -f docker-compose.e2e.yml -f docker-compose.e2e.events.yml up -d --build`, inject `e2e/fixtures/happy-path.json`, trigger `/api/v1/refresh`, then verify `/api/v1/state` exposes `repository.owner/name`, `tracker.settings.repository`, and has no top-level `projectId`/`slug`.

## Human Validation

- [ ] Confirm the dashboard overview shows the watched repository identity.
- [ ] Confirm `/api/v1/state` clients have migrated from top-level `projectId`/`slug` to `repository`.
- [ ] Confirm tracker-side GitHub Project identifiers remain visible through `tracker.settings.projectId` for GitHub-backed configs.
- [ ] Confirm `gh-symphony status` reads status from the flat runtime root after upgrade.

## Risks

- This is a breaking API change for consumers that still read top-level `projectId` or `slug` from `/api/v1/state`.
- Legacy persisted status files without `repository` are treated as unavailable by the dashboard reader until the orchestrator writes a fresh status snapshot.
