### PR TITLE
fix(orchestrator): preserve dirty issue workspaces

### DIFF
--- a/docs/adr/2026-05-06_issue-workspace-sync-policy.md
+++ b/docs/adr/2026-05-06_issue-workspace-sync-policy.md
@@ -25,6 +25,12 @@ Repository synchronization uses two policies:
   checkout is dirty, or if a clean checkout cannot be fast-forwarded, the
   workspace is preserved and run preparation fails with an explicit recovery
   error.
+- If a persisted workspace record exists but `repository/` is missing entirely,
+  the orchestrator creates a fresh clone in that path. This is not treated as
+  destructive because there is no checkout state at `repository/` to preserve.
+- If `repository/` exists but is not a git checkout, the directory is preserved
+  and run preparation fails. Operators or hooks must decide whether that debris
+  is recoverable before retrying.
 
 New issue workspaces may still remove partial clone debris during first
 creation, because no prior issue workspace state exists to preserve.

--- a/docs/adr/2026-05-06_issue-workspace-sync-policy.md
+++ b/docs/adr/2026-05-06_issue-workspace-sync-policy.md
@@ -1,0 +1,39 @@
+# ADR: Issue Workspace Repository Sync Policy
+
+## Status
+
+Accepted
+
+## Context
+
+Symphony requires deterministic per-issue workspaces to be reused and preserved
+across runs. In this implementation, issue workspaces contain a `repository/`
+checkout used as the coding-agent working directory. Failed or interrupted agent
+runs can leave that checkout dirty, and that dirty state is recovery context.
+
+The workflow cache clone is different: it is an implementation cache used to
+load repository policy and can be rebuilt if a pull fails.
+
+## Decision
+
+Repository synchronization uses two policies:
+
+- Workflow-cache clones may be destructively recloned after `git pull --ff-only`
+  fails.
+- Persisted issue workspaces are synchronized non-destructively. Existing
+  `repository/` checkouts are checked for local changes before pulling. If the
+  checkout is dirty, or if a clean checkout cannot be fast-forwarded, the
+  workspace is preserved and run preparation fails with an explicit recovery
+  error.
+
+New issue workspaces may still remove partial clone debris during first
+creation, because no prior issue workspace state exists to preserve.
+
+## Consequences
+
+Retries no longer silently discard uncommitted agent work from per-issue
+workspaces. Operators or configured recovery hooks must resolve local changes or
+divergence before another run can reuse that workspace.
+
+This aligns the implementation with `docs/symphony-spec.md` workspace reuse and
+population-failure guidance without changing the upstream specification.

--- a/packages/orchestrator/src/git.test.ts
+++ b/packages/orchestrator/src/git.test.ts
@@ -127,7 +127,9 @@ describe("cloneRepositoryForRun", () => {
         issueWorkspacePath,
         existingWorkspace: true,
       })
-    ).rejects.toThrow(/was preserved because it has uncommitted changes/);
+    ).rejects.toThrow(
+      /was preserved because it has uncommitted changes: M WORKFLOW.md/
+    );
 
     expect(
       await readFile(join(repositoryDirectory, "WORKFLOW.md"), "utf8")
@@ -168,6 +170,35 @@ describe("cloneRepositoryForRun", () => {
     await expect(
       access(join(repositoryDirectory, ".git"))
     ).resolves.toBeUndefined();
+  });
+
+  it("preserves existing issue workspace repository debris without git metadata", async () => {
+    const tempRoot = await mkdtemp(join(tmpdir(), "orchestrator-git-issue-"));
+    const repository = await createRepositoryFixture(tempRoot);
+    const issueWorkspacePath = join(tempRoot, "workspaces", "acme_platform_1");
+    const repositoryDirectory = join(issueWorkspacePath, "repository");
+
+    await mkdir(repositoryDirectory, { recursive: true });
+    await writeFile(join(repositoryDirectory, "artifact.log"), "keep me");
+
+    await expect(
+      ensureIssueWorkspaceRepository({
+        repository,
+        issueWorkspacePath,
+        existingWorkspace: true,
+      })
+    ).rejects.toThrow(
+      /was preserved because it exists but is not a git checkout/
+    );
+
+    expect(
+      await readFile(join(repositoryDirectory, "artifact.log"), "utf8")
+    ).toBe("keep me");
+    await expect(
+      access(join(repositoryDirectory, ".git"))
+    ).rejects.toMatchObject({
+      code: "ENOENT",
+    });
   });
 
   it("only releases repository locks owned by the current caller", async () => {

--- a/packages/orchestrator/src/git.test.ts
+++ b/packages/orchestrator/src/git.test.ts
@@ -13,6 +13,7 @@ import { describe, expect, it } from "vitest";
 import {
   acquireRepositoryLock,
   cloneRepositoryForRun,
+  ensureIssueWorkspaceRepository,
   releaseRepositoryLock,
   syncRepositoryForRun,
 } from "./git.js";
@@ -56,9 +57,9 @@ describe("cloneRepositoryForRun", () => {
     });
 
     expect(clonedDirectory).toBe(repositoryDirectory);
-    expect(await readFile(join(clonedDirectory, "WORKFLOW.md"), "utf8")).toContain(
-      'project_id: "PVT_test"'
-    );
+    expect(
+      await readFile(join(clonedDirectory, "WORKFLOW.md"), "utf8")
+    ).toContain('project_id: "PVT_test"');
   });
 
   it("reports whether a cached repository pull changed HEAD", async () => {
@@ -75,7 +76,11 @@ describe("cloneRepositoryForRun", () => {
       targetDirectory,
     });
 
-    await writeFile(join(repository.path, "WORKFLOW.md"), "# updated\n", "utf8");
+    await writeFile(
+      join(repository.path, "WORKFLOW.md"),
+      "# updated\n",
+      "utf8"
+    );
     execSync(`git -C "${repository.path}" add WORKFLOW.md`);
     execSync(`git -C "${repository.path}" commit -m "Update workflow"`);
     execSync(`git -C "${repository.path}" push origin HEAD`);
@@ -88,6 +93,81 @@ describe("cloneRepositoryForRun", () => {
     expect(first.changed).toBe(true);
     expect(second.changed).toBe(false);
     expect(third.changed).toBe(true);
+  });
+
+  it("preserves dirty existing issue workspaces instead of recloning", async () => {
+    const tempRoot = await mkdtemp(join(tmpdir(), "orchestrator-git-issue-"));
+    const repository = await createRepositoryFixture(tempRoot);
+    const issueWorkspacePath = join(tempRoot, "workspaces", "acme_platform_1");
+    const repositoryDirectory = join(issueWorkspacePath, "repository");
+
+    await ensureIssueWorkspaceRepository({
+      repository,
+      issueWorkspacePath,
+      existingWorkspace: false,
+    });
+    await writeFile(
+      join(repositoryDirectory, "WORKFLOW.md"),
+      "# local dirty edit\n",
+      "utf8"
+    );
+    await writeFile(
+      join(repository.path, "WORKFLOW.md"),
+      "# remote edit\n",
+      "utf8"
+    );
+    execSync(`git -C "${repository.path}" add WORKFLOW.md`);
+    execSync(
+      `git -C "${repository.path}" commit -m "Update workflow remotely"`
+    );
+
+    await expect(
+      ensureIssueWorkspaceRepository({
+        repository,
+        issueWorkspacePath,
+        existingWorkspace: true,
+      })
+    ).rejects.toThrow(/was preserved because it has uncommitted changes/);
+
+    expect(
+      await readFile(join(repositoryDirectory, "WORKFLOW.md"), "utf8")
+    ).toBe("# local dirty edit\n");
+    expect(
+      execSync(`git -C "${repositoryDirectory}" status --porcelain`, {
+        encoding: "utf8",
+      })
+    ).toContain("M WORKFLOW.md");
+  });
+
+  it("pull failures in existing issue workspaces do not delete the checkout", async () => {
+    const tempRoot = await mkdtemp(join(tmpdir(), "orchestrator-git-issue-"));
+    const repository = await createRepositoryFixture(tempRoot);
+    const issueWorkspacePath = join(tempRoot, "workspaces", "acme_platform_1");
+    const repositoryDirectory = join(issueWorkspacePath, "repository");
+
+    await ensureIssueWorkspaceRepository({
+      repository,
+      issueWorkspacePath,
+      existingWorkspace: false,
+    });
+    execSync(
+      `git -C "${repositoryDirectory}" remote set-url origin "${join(tempRoot, "missing-origin.git")}"`
+    );
+
+    await expect(
+      ensureIssueWorkspaceRepository({
+        repository,
+        issueWorkspacePath,
+        existingWorkspace: true,
+      })
+    ).rejects.toThrow(/was preserved because it could not be fast-forwarded/);
+
+    expect(
+      await readFile(join(repositoryDirectory, "WORKFLOW.md"), "utf8")
+    ).toContain("# Test workflow");
+    await expect(
+      access(join(repositoryDirectory, ".git"))
+    ).resolves.toBeUndefined();
   });
 
   it("only releases repository locks owned by the current caller", async () => {
@@ -103,7 +183,9 @@ describe("cloneRepositoryForRun", () => {
     await expect(access(join(lockDirectory, "owner"))).resolves.toBeUndefined();
 
     await releaseRepositoryLock(lockDirectory, secondOwner);
-    await expect(access(lockDirectory)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(access(lockDirectory)).rejects.toMatchObject({
+      code: "ENOENT",
+    });
   });
 });
 
@@ -120,8 +202,8 @@ async function createRepositoryFixture(tempRoot: string) {
     join(workingPath, "WORKFLOW.md"),
     [
       "---",
-      'tracker:',
-      '  kind: github-project',
+      "tracker:",
+      "  kind: github-project",
       '  project_id: "PVT_test"',
       '  state_field: "Status"',
       '  active_states: ["Todo"]',

--- a/packages/orchestrator/src/git.ts
+++ b/packages/orchestrator/src/git.ts
@@ -106,11 +106,16 @@ export async function syncRepositoryForRun(input: {
 export async function ensureIssueWorkspaceRepository(input: {
   repository: RepositoryRef;
   issueWorkspacePath: string;
+  existingWorkspace: boolean;
 }): Promise<string> {
-  return cloneRepositoryForRun({
-    repository: input.repository,
-    targetDirectory: input.issueWorkspacePath,
-  });
+  if (!input.existingWorkspace) {
+    return cloneRepositoryForRun({
+      repository: input.repository,
+      targetDirectory: input.issueWorkspacePath,
+    });
+  }
+
+  return syncExistingIssueWorkspaceRepository(input);
 }
 
 export async function loadRepositoryWorkflow(
@@ -158,7 +163,9 @@ function runCommand(command: string, args: string[]): Promise<void> {
   });
 }
 
-async function readGitHead(repositoryDirectory: string): Promise<string | null> {
+async function readGitHead(
+  repositoryDirectory: string
+): Promise<string | null> {
   try {
     return await runCommandCapture("git", [
       "-C",
@@ -168,6 +175,107 @@ async function readGitHead(repositoryDirectory: string): Promise<string | null> 
     ]);
   } catch {
     return null;
+  }
+}
+
+async function syncExistingIssueWorkspaceRepository(input: {
+  repository: RepositoryRef;
+  issueWorkspacePath: string;
+}): Promise<string> {
+  await mkdir(input.issueWorkspacePath, { recursive: true });
+  const repositoryDirectory = join(input.issueWorkspacePath, "repository");
+  const lockDirectory = join(input.issueWorkspacePath, "repository.lock");
+
+  return withRepositoryLock(lockDirectory, async () => {
+    const repositoryExists = await pathExists(repositoryDirectory);
+    const hasGit = await pathExists(join(repositoryDirectory, ".git"));
+
+    if (hasGit) {
+      const dirtyStatus = await readGitStatusPorcelain(repositoryDirectory);
+      if (dirtyStatus.trim()) {
+        throw createIssueWorkspacePreservedError(
+          repositoryDirectory,
+          "has uncommitted changes"
+        );
+      }
+
+      try {
+        await runCommand("git", [
+          "-C",
+          repositoryDirectory,
+          "pull",
+          "--ff-only",
+        ]);
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : "git pull --ff-only failed";
+        throw createIssueWorkspacePreservedError(
+          repositoryDirectory,
+          `could not be fast-forwarded: ${message}`
+        );
+      }
+
+      return repositoryDirectory;
+    }
+
+    if (repositoryExists) {
+      throw createIssueWorkspacePreservedError(
+        repositoryDirectory,
+        "exists but is not a git checkout"
+      );
+    }
+
+    const tempRepositoryDirectory = join(
+      input.issueWorkspacePath,
+      `repository.tmp-${process.pid}-${Date.now()}`
+    );
+    await rm(tempRepositoryDirectory, { recursive: true, force: true });
+
+    try {
+      await runCommand("git", [
+        "clone",
+        "--depth",
+        "1",
+        input.repository.cloneUrl,
+        tempRepositoryDirectory,
+      ]);
+      await rename(tempRepositoryDirectory, repositoryDirectory);
+      return repositoryDirectory;
+    } finally {
+      await rm(tempRepositoryDirectory, { recursive: true, force: true });
+    }
+  });
+}
+
+function createIssueWorkspacePreservedError(
+  repositoryDirectory: string,
+  reason: string
+): Error {
+  return new Error(
+    [
+      `Issue workspace repository at ${repositoryDirectory} was preserved because it ${reason}.`,
+      "Resolve or commit the local workspace changes, or run a configured recovery hook, before retrying.",
+    ].join(" ")
+  );
+}
+
+async function readGitStatusPorcelain(
+  repositoryDirectory: string
+): Promise<string> {
+  return runCommandCapture("git", [
+    "-C",
+    repositoryDirectory,
+    "status",
+    "--porcelain",
+  ]);
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await access(path, constants.F_OK);
+    return true;
+  } catch {
+    return false;
   }
 }
 
@@ -283,9 +391,9 @@ async function isStaleLock(lockDirectory: string): Promise<boolean> {
 function isAlreadyExistsError(error: unknown): boolean {
   return Boolean(
     error &&
-      typeof error === "object" &&
-      "code" in error &&
-      error.code === "EEXIST"
+    typeof error === "object" &&
+    "code" in error &&
+    error.code === "EEXIST"
   );
 }
 

--- a/packages/orchestrator/src/git.ts
+++ b/packages/orchestrator/src/git.ts
@@ -191,11 +191,20 @@ async function syncExistingIssueWorkspaceRepository(input: {
     const hasGit = await pathExists(join(repositoryDirectory, ".git"));
 
     if (hasGit) {
-      const dirtyStatus = await readGitStatusPorcelain(repositoryDirectory);
+      let dirtyStatus: string;
+      try {
+        dirtyStatus = await readGitStatusPorcelain(repositoryDirectory);
+      } catch (error) {
+        throw createIssueWorkspacePreservedError(
+          repositoryDirectory,
+          `could not be inspected: ${formatCommandError(error, "git status --porcelain failed")}`
+        );
+      }
+
       if (dirtyStatus.trim()) {
         throw createIssueWorkspacePreservedError(
           repositoryDirectory,
-          "has uncommitted changes"
+          `has uncommitted changes: ${summarizeGitStatus(dirtyStatus)}`
         );
       }
 
@@ -207,8 +216,7 @@ async function syncExistingIssueWorkspaceRepository(input: {
           "--ff-only",
         ]);
       } catch (error) {
-        const message =
-          error instanceof Error ? error.message : "git pull --ff-only failed";
+        const message = formatCommandError(error, "git pull --ff-only failed");
         throw createIssueWorkspacePreservedError(
           repositoryDirectory,
           `could not be fast-forwarded: ${message}`
@@ -257,6 +265,25 @@ function createIssueWorkspacePreservedError(
       "Resolve or commit the local workspace changes, or run a configured recovery hook, before retrying.",
     ].join(" ")
   );
+}
+
+function formatCommandError(error: unknown, fallback: string): string {
+  const message = error instanceof Error ? error.message : fallback;
+  return normalizeWhitespace(message) || fallback;
+}
+
+function summarizeGitStatus(status: string): string {
+  const lines = status
+    .trim()
+    .split(/\r?\n/)
+    .map(normalizeWhitespace)
+    .filter(Boolean);
+  const summary = lines.slice(0, 5).join("; ");
+  return lines.length > 5 ? `${summary}; ...` : summary;
+}
+
+function normalizeWhitespace(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
 }
 
 async function readGitStatusPorcelain(

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -88,6 +88,79 @@ describe("OrchestratorService", () => {
     );
   });
 
+  it("preserves dirty persisted issue workspaces when dispatching a retry", async () => {
+    process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
+    const tempRoot = await mkdtemp(
+      join(tmpdir(), "orchestrator-dirty-workspace-")
+    );
+    const repository = await createRepositoryFixture(
+      tempRoot,
+      "acme",
+      "platform"
+    );
+    const store = new OrchestratorFsStore(tempRoot);
+    const projectConfig = createProjectConfig(tempRoot, repository);
+    await store.saveProjectConfig(projectConfig);
+
+    const workspaceKey = deriveIssueWorkspaceKey("acme/platform#1");
+    const issueWorkspacePath = resolveIssueWorkspaceDirectory(
+      store.projectDir(projectConfig.projectId),
+      workspaceKey
+    );
+    const repositoryDirectory = await gitModule.ensureIssueWorkspaceRepository({
+      repository,
+      issueWorkspacePath,
+      existingWorkspace: false,
+    });
+    await store.saveIssueWorkspace({
+      workspaceKey,
+      projectId: projectConfig.projectId,
+      adapter: "github-project",
+      issueSubjectId: "issue-1",
+      issueIdentifier: "acme/platform#1",
+      workspacePath: issueWorkspacePath,
+      repositoryPath: repositoryDirectory,
+      status: "active",
+      createdAt: "2026-03-07T23:59:00.000Z",
+      updatedAt: "2026-03-07T23:59:00.000Z",
+      lastError: null,
+    });
+    await writeFile(
+      join(repositoryDirectory, "WORKFLOW.md"),
+      "# local dirty retry edit\n",
+      "utf8"
+    );
+    await commitWorkflowFixture(repository.path, {
+      codexCommand: "codex app-server --remote-update",
+    });
+
+    const spawnImpl = vi.fn().mockReturnValue({
+      pid: 4102,
+      unref: vi.fn(),
+    });
+    const service = new OrchestratorService(store, projectConfig, {
+      fetchImpl: vi.fn().mockResolvedValue(createTrackerResponse(repository)),
+      spawnImpl: spawnImpl as never,
+      now: () => new Date("2026-03-08T00:00:00.000Z"),
+    });
+
+    const result = await service.runOnce();
+
+    expect(result.summary.dispatched).toBe(0);
+    expect(result.lastError).toContain(
+      "was preserved because it has uncommitted changes"
+    );
+    expect(spawnImpl).not.toHaveBeenCalled();
+    expect(
+      await readFile(join(repositoryDirectory, "WORKFLOW.md"), "utf8")
+    ).toBe("# local dirty retry edit\n");
+    expect(
+      execSync(`git -C ${shell(repositoryDirectory)} status --porcelain`, {
+        encoding: "utf8",
+      })
+    ).toContain("M WORKFLOW.md");
+  });
+
   it("clears legacy issue-budget and cross-session resume env before spawning a worker", async () => {
     process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
     process.env.SYMPHONY_GLOBAL_MAX_TURNS = "12";
@@ -931,7 +1004,13 @@ describe("OrchestratorService", () => {
     const projectConfig = createProjectConfig(tempRoot, repository);
     await store.saveProjectConfig(projectConfig);
 
-    const workspaceKey = deriveIssueWorkspaceKey("acme/platform#1");
+    const workspaceKey = deriveIssueWorkspaceKey(
+      {
+        adapter: "github-project",
+        issueSubjectId: "issue-1",
+      },
+      "acme/platform#1"
+    );
     const workspacePath = resolveIssueWorkspaceDirectory(
       store.projectDir(projectConfig.projectId),
       workspaceKey
@@ -1126,14 +1205,24 @@ Prefer focused changes.
     const projectConfig = createProjectConfig(tempRoot, repository);
     await store.saveProjectConfig(projectConfig);
 
-    const workspaceKey = deriveIssueWorkspaceKey("acme/platform#1");
+    const workspaceKey = deriveIssueWorkspaceKey(
+      {
+        adapter: "github-project",
+        issueSubjectId: "issue-1",
+      },
+      "acme/platform#1"
+    );
     const workspacePath = resolveIssueWorkspaceDirectory(
       store.projectDir(projectConfig.projectId),
       workspaceKey
     );
     const repositoryPath = join(workspacePath, "repository");
 
-    await mkdir(repositoryPath, { recursive: true });
+    await gitModule.ensureIssueWorkspaceRepository({
+      repository,
+      issueWorkspacePath: workspacePath,
+      existingWorkspace: false,
+    });
     await store.saveIssueWorkspace({
       workspaceKey,
       projectId: "tenant-1",

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -1117,6 +1117,7 @@ export class OrchestratorService {
     const repositoryDirectory = await ensureIssueWorkspaceRepository({
       repository: issue.repository,
       issueWorkspacePath,
+      existingWorkspace: Boolean(existingWorkspaceRecord),
     });
 
     if (!existingWorkspaceRecord) {
@@ -2520,9 +2521,7 @@ export class OrchestratorService {
           : NaN
       )
       .catch(() => NaN);
-    return Number.isFinite(limit) && limit >= 0
-      ? limit
-      : DEFAULT_CONCURRENCY;
+    return Number.isFinite(limit) && limit >= 0 ? limit : DEFAULT_CONCURRENCY;
   }
 
   private async resolveWorkflowResolution(
@@ -2605,7 +2604,9 @@ export class OrchestratorService {
     return `${repository.owner}/${repository.name}:${this.normalizeRepositoryCloneUrl(repository.cloneUrl)}`;
   }
 
-  private resolveWorkflowRepositoryDirectory(repository: RepositoryRef): string {
+  private resolveWorkflowRepositoryDirectory(
+    repository: RepositoryRef
+  ): string {
     if (repository.path) {
       return repository.path;
     }
@@ -2625,9 +2626,7 @@ export class OrchestratorService {
       const url = new URL(cloneUrl);
       return url.protocol === "file:" ? fileURLToPath(url) : null;
     } catch {
-      return isAbsolute(cloneUrl) || cloneUrl.startsWith(".")
-        ? cloneUrl
-        : null;
+      return isAbsolute(cloneUrl) || cloneUrl.startsWith(".") ? cloneUrl : null;
     }
   }
 


### PR DESCRIPTION
## Issues

- Fixes #243

## Summary

- Preserves persisted per-issue workspaces during retry preparation instead of deleting dirty checkouts.
- Keeps destructive reclone behavior limited to workflow/cache clones and brand-new issue workspace creation.
- Tightens preserved-workspace recovery messages so operators get concise, actionable reasons.

## Changes

- Added a non-destructive issue-workspace sync path that checks `git status --porcelain` before pulling existing workspaces.
- Fails retry preparation with an explicit recovery error when an existing issue workspace is dirty, non-git debris exists, cannot be inspected, or `git pull --ff-only` cannot fast-forward.
- Normalizes embedded git error output to a single line and includes a short dirty-status excerpt for diagnosis.
- Updated `OrchestratorService.startRun()` to distinguish new issue workspaces from persisted workspace records.
- Added dirty workspace, pull-failure, and non-git debris preservation regressions in orchestrator git/service tests.
- Documented the repository-local workspace sync policy in `docs/adr/2026-05-06_issue-workspace-sync-policy.md`, including the missing-`repository/` fresh-clone case.

## Evidence

- `pnpm --filter @gh-symphony/orchestrator test -- git.test.ts`
- `pnpm --filter @gh-symphony/orchestrator test`
- `pnpm lint && pnpm test && pnpm typecheck && pnpm build`
- Previous Docker E2E blackbox TC on this PR: `STUB_SCENARIO=happy docker compose -f docker-compose.e2e.yml -f docker-compose.e2e.events.yml up -d --build`; injected `e2e/fixtures/happy-path.json`, triggered `/api/v1/refresh`, observed one dispatched run move to `retrying` with `retryKind: "continuation"`, then removed the fixture and shut the stack down.
- Docker E2E was not rerun for commit `3c4e070` because the follow-up changed only preserved error formatting, one unit regression, and ADR wording, without changing dispatch or worker lifecycle behavior.

## Human Validation

- [ ] Confirm dirty per-issue workspaces are preserved across retry attempts.
- [ ] Confirm malformed existing `repository/` directories are preserved instead of deleted.
- [ ] Confirm clean existing issue workspaces still fast-forward when possible.
- [ ] Confirm workflow cache clone refresh behavior remains acceptable for policy loading.

## Risks

- Existing workspace records whose `repository/` path contains non-git debris now fail run preparation instead of being silently replaced. This is intentional to avoid destructive cleanup of persisted issue workspace state.
- `git status --porcelain` includes untracked files, so generated artifacts inside a persisted issue workspace can intentionally block retry until an operator or recovery hook resolves them.