### PR TITLE
feat(cli): explain project dispatch skips

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,7 @@ when a GitHub Project issue stays idle:
 ```bash
 gh-symphony project explain owner/repo#123
 gh-symphony project explain owner/repo#123 --json
+gh-symphony project explain owner/repo#123 --workflow ./WORKFLOW.md
 ```
 
 The report checks whether the repository is linked to the active managed
@@ -339,6 +340,10 @@ project, the issue is present in the GitHub Project item set, the current
 project status maps to active / wait / terminal in `WORKFLOW.md`, blockers are
 resolved, an existing run / retry / convergence state already owns the issue,
 and project or per-state concurrency limits still have capacity.
+
+If the project has no previous local run snapshot and the repository path is
+not stored in the managed project config, pass `--workflow` so the command
+evaluates the same `WORKFLOW.md` that orchestration will use.
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ gh-symphony project list             # List all configured projects
 gh-symphony project remove <id>      # Remove a project
 gh-symphony project switch           # Switch the active project
 gh-symphony project status           # Show status for a specific project
+gh-symphony project explain owner/repo#123  # Explain why one issue is not dispatching
 gh-symphony project start            # Start a specific project
 gh-symphony project start --once     # Run one orchestration tick for a specific project
 gh-symphony project stop             # Stop a specific project
@@ -322,6 +323,38 @@ Dispatch a single issue:
 gh-symphony run org/repo#123
 gh-symphony run org/repo#123 --watch  # Watch status after dispatch
 ```
+
+### Why Is My Issue Not Running?
+
+Use `gh-symphony project explain <owner/repo#number>` as the first diagnostic
+when a GitHub Project issue stays idle:
+
+```bash
+gh-symphony project explain owner/repo#123
+gh-symphony project explain owner/repo#123 --json
+```
+
+The report checks whether the repository is linked to the active managed
+project, the issue is present in the GitHub Project item set, the current
+project status maps to active / wait / terminal in `WORKFLOW.md`, blockers are
+resolved, an existing run / retry / convergence state already owns the issue,
+and project or per-state concurrency limits still have capacity.
+
+Example:
+
+```text
+Issue dispatch explanation: owner/repo#123
+Not dispatchable: Project state "Backlog" maps to wait, not active, in WORKFLOW.md.
+
+Checks:
+  ✓ Repository owner/repo is linked to the active managed project.
+  ✓ Issue is present in the bound GitHub Project item set.
+  ✗ Project state "Backlog" maps to wait, not active, in WORKFLOW.md.
+    Hint: Move the GitHub Project item to an active state or run 'gh-symphony workflow preview' to inspect WORKFLOW.md state mappings.
+```
+
+Hints point back to existing troubleshooting commands such as `workflow
+preview`, `doctor`, `project status`, and `logs --issue`.
 
 Recover stalled runs:
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -181,6 +181,7 @@ gh-symphony doctor                   # Validate local prerequisites, auth, confi
 gh-symphony doctor --fix             # Apply safe fixes and guide/launch follow-up recovery commands
 gh-symphony project list             # List all configured projects
 gh-symphony project remove <id>      # Remove a project
+gh-symphony project explain owner/repo#123  # Explain why one issue is not dispatching
 gh-symphony repo add owner/name      # Validate and save a repo target manually
 gh-symphony repo sync                # Add newly linked repositories from the GitHub Project
 gh-symphony repo sync --dry-run      # Preview linked repository drift
@@ -200,6 +201,36 @@ additive; `--prune` switches to strict alignment, and `--json` prints the added,
 removed, unchanged, and final repository sets.
 
 For empty projects, use `gh-symphony repo add owner/name` after setup to seed the local repository list without re-running the whole wizard.
+
+### Why Is My Issue Not Running?
+
+Use `gh-symphony project explain <owner/repo#number>` before digging through
+logs manually:
+
+```bash
+gh-symphony project explain owner/repo#123
+gh-symphony project explain owner/repo#123 --json
+```
+
+The command checks project repository linkage, GitHub Project item presence,
+`WORKFLOW.md` active / wait / terminal state mapping, blocker state, existing
+run / retry / convergence ownership, and project or per-state concurrency
+limits.
+
+```text
+Issue dispatch explanation: owner/repo#123
+Not dispatchable: Issue has 1 unresolved blocker.
+
+Checks:
+  ✓ Repository owner/repo is linked to the active managed project.
+  ✓ Issue is present in the bound GitHub Project item set.
+  ✓ Project state "Todo" maps to an active state in WORKFLOW.md.
+  ✗ Issue has 1 unresolved blocker.
+    Hint: Move blocker issues to a terminal state or update the blocker relationship in GitHub.
+```
+
+The remediation hints point to existing commands such as `workflow preview`,
+`doctor`, `project status`, and `logs --issue`.
 
 ## 4. Run the Orchestrator
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -210,12 +210,17 @@ logs manually:
 ```bash
 gh-symphony project explain owner/repo#123
 gh-symphony project explain owner/repo#123 --json
+gh-symphony project explain owner/repo#123 --workflow ./WORKFLOW.md
 ```
 
 The command checks project repository linkage, GitHub Project item presence,
 `WORKFLOW.md` active / wait / terminal state mapping, blocker state, existing
 run / retry / convergence ownership, and project or per-state concurrency
 limits.
+
+If the project has no previous local run snapshot and the repository path is
+not stored in the managed project config, pass `--workflow` so the command
+does not guess from the current shell directory.
 
 ```text
 Issue dispatch explanation: owner/repo#123

--- a/packages/cli/src/commands/help.ts
+++ b/packages/cli/src/commands/help.ts
@@ -35,6 +35,7 @@ Project / Repo:
   project list    List projects
   project switch  Switch active project
   project status  Show orchestrator status for a project
+  project explain Explain why a project issue is not dispatching
   repo list       List configured repositories
   repo add        Validate and add a repository
   repo remove     Remove a repository
@@ -59,6 +60,7 @@ Examples:
   gh-symphony project add --non-interactive --project <id> --workspace-dir <path>
   gh-symphony project list             # List all projects
   gh-symphony project remove <id>      # Remove a project
+  gh-symphony project explain owner/repo#123
   gh-symphony repo add owner/name      # Validate a repo target before saving it
   gh-symphony repo sync --dry-run      # Preview linked repository drift
   gh-symphony start                   # Start orchestrator

--- a/packages/cli/src/commands/help.ts
+++ b/packages/cli/src/commands/help.ts
@@ -61,6 +61,7 @@ Examples:
   gh-symphony project list             # List all projects
   gh-symphony project remove <id>      # Remove a project
   gh-symphony project explain owner/repo#123
+  gh-symphony project explain owner/repo#123 --workflow ./WORKFLOW.md
   gh-symphony repo add owner/name      # Validate a repo target before saving it
   gh-symphony repo sync --dry-run      # Preview linked repository drift
   gh-symphony start                   # Start orchestrator

--- a/packages/cli/src/commands/project.test.ts
+++ b/packages/cli/src/commands/project.test.ts
@@ -47,12 +47,13 @@ function captureWrites(stream: NodeJS.WriteStream): {
   restore: () => void;
 } {
   let buffer = "";
-  const spy = vi
-    .spyOn(stream, "write")
-    .mockImplementation(((chunk: string | Uint8Array) => {
-      buffer += typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8");
-      return true;
-    }) as typeof stream.write);
+  const spy = vi.spyOn(stream, "write").mockImplementation(((
+    chunk: string | Uint8Array
+  ) => {
+    buffer +=
+      typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8");
+    return true;
+  }) as typeof stream.write);
 
   return {
     output: () => buffer,
@@ -93,11 +94,7 @@ async function seedProject(
   }
 
   if (input.snapshot) {
-    const runtimeDir = join(
-      configDir,
-      "projects",
-      input.projectId
-    );
+    const runtimeDir = join(configDir, "projects", input.projectId);
     await mkdir(runtimeDir, { recursive: true });
     await writeFile(
       join(runtimeDir, "status.json"),
@@ -237,7 +234,9 @@ describe("project list", () => {
       stdout.restore();
     }
 
-    const output = JSON.parse(stdout.output()) as Array<Record<string, unknown>>;
+    const output = JSON.parse(stdout.output()) as Array<
+      Record<string, unknown>
+    >;
     expect(output).toEqual([
       expect.objectContaining({
         id: "infra-e5f6",
@@ -254,7 +253,9 @@ describe("project list", () => {
   });
 
   it("emits nulls for unknown runtime fields in JSON mode", async () => {
-    const configDir = await mkdtemp(join(tmpdir(), "project-list-json-stopped-"));
+    const configDir = await mkdtemp(
+      join(tmpdir(), "project-list-json-stopped-")
+    );
     const stdout = captureWrites(process.stdout);
 
     await saveGlobalConfig(configDir, {
@@ -279,7 +280,9 @@ describe("project list", () => {
       stdout.restore();
     }
 
-    const output = JSON.parse(stdout.output()) as Array<Record<string, unknown>>;
+    const output = JSON.parse(stdout.output()) as Array<
+      Record<string, unknown>
+    >;
     expect(output).toEqual([
       {
         id: "front-c3d4",
@@ -326,6 +329,11 @@ describe("project list", () => {
 });
 
 describe("project explain", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    process.exitCode = undefined;
+  });
+
   it("rejects malformed issue identifiers before loading project state", async () => {
     const configDir = await mkdtemp(join(tmpdir(), "project-explain-invalid-"));
     const stderr = captureWrites(process.stderr);
@@ -346,7 +354,207 @@ describe("project explain", () => {
       "Issue identifier must use the form <owner>/<repo>#<number>"
     );
   });
+
+  it("prints a friendly authentication error when gh auth is unavailable", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "project-explain-auth-"));
+    const stderr = captureWrites(process.stderr);
+    await seedExplainProject(configDir);
+    vi.spyOn(ghAuth, "getGhToken").mockImplementation(() => {
+      throw new ghAuth.GhAuthError(
+        "not_authenticated",
+        "gh is not authenticated."
+      );
+    });
+
+    try {
+      await projectCommand(["explain", "acme/widgets#42"], {
+        configDir,
+        verbose: false,
+        json: false,
+        noColor: true,
+      });
+    } finally {
+      stderr.restore();
+    }
+
+    expect(process.exitCode).toBe(2);
+    expect(stderr.output()).toContain(
+      "GitHub authentication is required for project explain"
+    );
+    expect(stderr.output()).toContain(
+      "gh auth login --scopes repo,read:org,project"
+    );
+  });
+
+  it("fails clearly instead of silently using default workflow settings", async () => {
+    const configDir = await mkdtemp(
+      join(tmpdir(), "project-explain-workflow-")
+    );
+    const stderr = captureWrites(process.stderr);
+    await seedExplainProject(configDir);
+    vi.spyOn(ghAuth, "getGhToken").mockReturnValue("gho_test");
+    vi.stubGlobal("fetch", vi.fn(mockProjectItemsFetch));
+
+    try {
+      await projectCommand(["explain", "acme/widgets#42"], {
+        configDir,
+        verbose: false,
+        json: false,
+        noColor: true,
+      });
+    } finally {
+      stderr.restore();
+      vi.unstubAllGlobals();
+    }
+
+    expect(process.exitCode).toBe(2);
+    expect(stderr.output()).toContain("No WORKFLOW.md path could be resolved");
+    expect(stderr.output()).toContain("--workflow <path-to-WORKFLOW.md>");
+  });
+
+  it("uses an explicit workflow path for the explanation report", async () => {
+    const configDir = await mkdtemp(
+      join(tmpdir(), "project-explain-explicit-")
+    );
+    const workflowDir = await mkdtemp(
+      join(tmpdir(), "project-explain-workflow-file-")
+    );
+    const workflowPath = join(workflowDir, "WORKFLOW.md");
+    const stdout = captureWrites(process.stdout);
+    await writeFile(
+      workflowPath,
+      `---
+tracker:
+  kind: github-project
+  project_id: PVT_test
+  state_field: Status
+  active_states:
+    - Ready
+  terminal_states:
+    - Done
+agent:
+  max_concurrent_agents: 2
+codex:
+  command: codex app-server
+---
+Follow the issue instructions.
+`,
+      "utf8"
+    );
+    await seedExplainProject(configDir);
+    vi.spyOn(ghAuth, "getGhToken").mockReturnValue("gho_test");
+    vi.stubGlobal("fetch", vi.fn(mockProjectItemsFetch));
+
+    try {
+      await projectCommand(
+        ["explain", "acme/widgets#42", "--workflow", workflowPath],
+        {
+          configDir,
+          verbose: false,
+          json: false,
+          noColor: true,
+        }
+      );
+    } finally {
+      stdout.restore();
+      vi.unstubAllGlobals();
+    }
+
+    expect(process.exitCode).toBeUndefined();
+    expect(stdout.output()).toContain(
+      "Dispatchable: no blocking project, workflow, runtime, or budget condition was found."
+    );
+    expect(stdout.output()).toContain(
+      'Project state "Ready" maps to an active state in WORKFLOW.md.'
+    );
+  });
 });
+
+async function seedExplainProject(configDir: string): Promise<void> {
+  const projectId = "explain-project";
+  await saveGlobalConfig(configDir, {
+    activeProject: projectId,
+    projects: [projectId],
+  });
+  await saveProjectConfig(configDir, projectId, {
+    projectId,
+    slug: projectId,
+    displayName: "Explain Project",
+    workspaceDir: join(configDir, "workspaces"),
+    repository: {
+      owner: "acme",
+      name: "widgets",
+      cloneUrl: "https://github.com/acme/widgets.git",
+    },
+    tracker: {
+      adapter: "github-project",
+      bindingId: "PVT_test",
+      settings: {
+        projectId: "PVT_test",
+      },
+    },
+  });
+}
+
+async function mockProjectItemsFetch(): Promise<Response> {
+  return new Response(
+    JSON.stringify({
+      data: {
+        node: {
+          __typename: "ProjectV2",
+          items: {
+            nodes: [
+              {
+                id: "PVTI_item_42",
+                updatedAt: "2026-05-07T00:00:00.000Z",
+                fieldValues: {
+                  nodes: [
+                    {
+                      __typename: "ProjectV2ItemFieldSingleSelectValue",
+                      name: "Ready",
+                      optionId: "ready",
+                      field: {
+                        name: "Status",
+                      },
+                    },
+                  ],
+                },
+                content: {
+                  __typename: "Issue",
+                  id: "I_42",
+                  number: 42,
+                  title: "Make widgets responsive",
+                  body: "Issue body",
+                  url: "https://github.com/acme/widgets/issues/42",
+                  createdAt: "2026-05-06T00:00:00.000Z",
+                  updatedAt: "2026-05-07T00:00:00.000Z",
+                  labels: { nodes: [] },
+                  assignees: { nodes: [] },
+                  repository: {
+                    name: "widgets",
+                    url: "https://github.com/acme/widgets",
+                    owner: { login: "acme" },
+                  },
+                  blockedBy: { nodes: [] },
+                },
+              },
+            ],
+            pageInfo: {
+              endCursor: null,
+              hasNextPage: false,
+            },
+          },
+        },
+      },
+    }),
+    {
+      status: 200,
+      headers: {
+        "content-type": "application/json",
+      },
+    }
+  );
+}
 
 const MOCK_PROJECT_SUMMARY = {
   id: "PVT_project_1",
@@ -453,12 +661,7 @@ describe("project add interactive", () => {
 
     const project = JSON.parse(
       await readFile(
-        join(
-          configDir,
-          "projects",
-          projectId,
-          "project.json"
-        ),
+        join(configDir, "projects", projectId, "project.json"),
         "utf8"
       )
     ) as CliProjectConfig;
@@ -553,12 +756,7 @@ describe("project add interactive", () => {
 
     const project = JSON.parse(
       await readFile(
-        join(
-          configDir,
-          "projects",
-          projectId,
-          "project.json"
-        ),
+        join(configDir, "projects", projectId, "project.json"),
         "utf8"
       )
     ) as CliProjectConfig;
@@ -650,7 +848,9 @@ describe("project add interactive", () => {
   });
 
   it("uses --assigned-only as the interactive prompt default", async () => {
-    const configDir = await mkdtemp(join(tmpdir(), "project-add-assigned-only-"));
+    const configDir = await mkdtemp(
+      join(tmpdir(), "project-add-assigned-only-")
+    );
     const projectId = generateProjectId(
       MOCK_PROJECT_DETAIL.title,
       MOCK_PROJECT_DETAIL.id
@@ -669,7 +869,10 @@ describe("project add interactive", () => {
     });
 
     const project = JSON.parse(
-      await readFile(join(configDir, "projects", projectId, "project.json"), "utf8")
+      await readFile(
+        join(configDir, "projects", projectId, "project.json"),
+        "utf8"
+      )
     ) as CliProjectConfig;
 
     expect(project.tracker.settings?.assignedOnly).toBe(true);
@@ -704,7 +907,10 @@ describe("project add interactive", () => {
     });
 
     const project = JSON.parse(
-      await readFile(join(configDir, "projects", projectId, "project.json"), "utf8")
+      await readFile(
+        join(configDir, "projects", projectId, "project.json"),
+        "utf8"
+      )
     ) as CliProjectConfig;
 
     expect(confirmSpy).toHaveBeenNthCalledWith(
@@ -722,7 +928,9 @@ describe("project add interactive", () => {
       "Configuration Summary"
     );
     expect(p.outro).toHaveBeenCalledWith(
-      expect.stringContaining(`Project "${projectId}" created with 0 repositories.`)
+      expect.stringContaining(
+        `Project "${projectId}" created with 0 repositories.`
+      )
     );
     expect(p.outro).toHaveBeenCalledWith(
       expect.stringContaining("gh-symphony repo add <owner/name>")
@@ -766,7 +974,9 @@ describe("project add interactive", () => {
   });
 
   it("guides empty projects toward repo add validation", async () => {
-    const configDir = await mkdtemp(join(tmpdir(), "project-add-empty-project-"));
+    const configDir = await mkdtemp(
+      join(tmpdir(), "project-add-empty-project-")
+    );
     vi.spyOn(githubClient, "getProjectDetail").mockResolvedValue({
       ...MOCK_PROJECT_DETAIL,
       linkedRepositories: [],
@@ -814,7 +1024,9 @@ describe("project add non-interactive", () => {
   });
 
   it("prints zero-repository completion guidance in non-interactive mode", async () => {
-    const configDir = await mkdtemp(join(tmpdir(), "project-add-non-interactive-empty-"));
+    const configDir = await mkdtemp(
+      join(tmpdir(), "project-add-non-interactive-empty-")
+    );
     const stdout = captureWrites(process.stdout);
     const projectId = generateProjectId(
       EMPTY_PROJECT_DETAIL.title,
@@ -839,7 +1051,10 @@ describe("project add non-interactive", () => {
     }
 
     const project = JSON.parse(
-      await readFile(join(configDir, "projects", projectId, "project.json"), "utf8")
+      await readFile(
+        join(configDir, "projects", projectId, "project.json"),
+        "utf8"
+      )
     ) as CliProjectConfig;
 
     expect(project.repositories).toEqual([]);
@@ -854,7 +1069,9 @@ describe("project add non-interactive", () => {
   });
 
   it("prints repository count without zero-repository follow-up when linked repositories exist", async () => {
-    const configDir = await mkdtemp(join(tmpdir(), "project-add-non-interactive-linked-"));
+    const configDir = await mkdtemp(
+      join(tmpdir(), "project-add-non-interactive-linked-")
+    );
     const stdout = captureWrites(process.stdout);
     const projectId = generateProjectId(
       MOCK_PROJECT_DETAIL.title,
@@ -879,7 +1096,10 @@ describe("project add non-interactive", () => {
     }
 
     const project = JSON.parse(
-      await readFile(join(configDir, "projects", projectId, "project.json"), "utf8")
+      await readFile(
+        join(configDir, "projects", projectId, "project.json"),
+        "utf8"
+      )
     ) as CliProjectConfig;
 
     expect(project.repositories).toHaveLength(3);

--- a/packages/cli/src/commands/project.test.ts
+++ b/packages/cli/src/commands/project.test.ts
@@ -325,6 +325,29 @@ describe("project list", () => {
   });
 });
 
+describe("project explain", () => {
+  it("rejects malformed issue identifiers before loading project state", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "project-explain-invalid-"));
+    const stderr = captureWrites(process.stderr);
+
+    try {
+      await projectCommand(["explain", "not-an-issue"], {
+        configDir,
+        verbose: false,
+        json: false,
+        noColor: true,
+      });
+    } finally {
+      stderr.restore();
+    }
+
+    expect(process.exitCode).toBe(2);
+    expect(stderr.output()).toContain(
+      "Issue identifier must use the form <owner>/<repo>#<number>"
+    );
+  });
+});
+
 const MOCK_PROJECT_SUMMARY = {
   id: "PVT_project_1",
   title: "My Project",

--- a/packages/cli/src/commands/project.test.ts
+++ b/packages/cli/src/commands/project.test.ts
@@ -496,64 +496,105 @@ async function seedExplainProject(configDir: string): Promise<void> {
   });
 }
 
-async function mockProjectItemsFetch(): Promise<Response> {
-  return new Response(
-    JSON.stringify({
+async function mockProjectItemsFetch(
+  _input: RequestInfo | URL,
+  init?: RequestInit
+): Promise<Response> {
+  const body =
+    typeof init?.body === "string"
+      ? (JSON.parse(init.body) as { query?: string })
+      : {};
+  const query = body.query ?? "";
+  if (query.includes("RepositoryIssue")) {
+    return jsonResponse({
       data: {
-        node: {
-          __typename: "ProjectV2",
-          items: {
-            nodes: [
-              {
-                id: "PVTI_item_42",
-                updatedAt: "2026-05-07T00:00:00.000Z",
-                fieldValues: {
-                  nodes: [
-                    {
-                      __typename: "ProjectV2ItemFieldSingleSelectValue",
-                      name: "Ready",
-                      optionId: "ready",
-                      field: {
-                        name: "Status",
-                      },
-                    },
-                  ],
-                },
-                content: {
-                  __typename: "Issue",
-                  id: "I_42",
-                  number: 42,
-                  title: "Make widgets responsive",
-                  body: "Issue body",
-                  url: "https://github.com/acme/widgets/issues/42",
-                  createdAt: "2026-05-06T00:00:00.000Z",
-                  updatedAt: "2026-05-07T00:00:00.000Z",
-                  labels: { nodes: [] },
-                  assignees: { nodes: [] },
-                  repository: {
-                    name: "widgets",
-                    url: "https://github.com/acme/widgets",
-                    owner: { login: "acme" },
-                  },
-                  blockedBy: { nodes: [] },
-                },
+        repository: {
+          issue: {
+            ...mockIssueContent(),
+            projectItems: {
+              nodes: [mockIssueProjectItem()],
+              pageInfo: {
+                endCursor: null,
+                hasNextPage: false,
               },
-            ],
-            pageInfo: {
-              endCursor: null,
-              hasNextPage: false,
             },
           },
         },
       },
-    }),
-    {
-      status: 200,
-      headers: {
-        "content-type": "application/json",
+    });
+  }
+
+  return jsonResponse({
+    data: {
+      node: {
+        __typename: "ProjectV2",
+        items: {
+          nodes: [
+            {
+              ...mockIssueProjectItem(),
+              content: mockIssueContent(),
+            },
+          ],
+          pageInfo: {
+            endCursor: null,
+            hasNextPage: false,
+          },
+        },
       },
-    }
-  );
+    },
+  });
+}
+
+function mockIssueProjectItem() {
+  return {
+    id: "PVTI_item_42",
+    updatedAt: "2026-05-07T00:00:00.000Z",
+    project: {
+      id: "PVT_test",
+    },
+    fieldValues: {
+      nodes: [
+        {
+          __typename: "ProjectV2ItemFieldSingleSelectValue",
+          name: "Ready",
+          optionId: "ready",
+          field: {
+            name: "Status",
+          },
+        },
+      ],
+    },
+  };
+}
+
+function mockIssueContent() {
+  return {
+    __typename: "Issue",
+    id: "I_42",
+    number: 42,
+    title: "Make widgets responsive",
+    body: "Issue body",
+    url: "https://github.com/acme/widgets/issues/42",
+    createdAt: "2026-05-06T00:00:00.000Z",
+    updatedAt: "2026-05-07T00:00:00.000Z",
+    labels: { nodes: [] },
+    assignees: { nodes: [] },
+    repository: {
+      name: "widgets",
+      url: "https://github.com/acme/widgets",
+      owner: { login: "acme" },
+    },
+    blockedBy: { nodes: [] },
+  };
+}
+
+function jsonResponse(payload: unknown): Response {
+  return new Response(JSON.stringify(payload), {
+    status: 200,
+    headers: {
+      "content-type": "application/json",
+    },
+  });
 }
 
 const MOCK_PROJECT_SUMMARY = {

--- a/packages/cli/src/commands/project.ts
+++ b/packages/cli/src/commands/project.ts
@@ -7,17 +7,19 @@ import { resolve } from "node:path";
 import type { GlobalOptions } from "../index.js";
 import {
   WorkflowConfigStore,
-  DEFAULT_WORKFLOW_LIFECYCLE,
   type IssueOrchestrationRecord,
   type OrchestratorProjectConfig,
   type OrchestratorRunRecord,
+  type ProjectItemsCache,
   type ProjectStatusSnapshot,
   type RepositoryRef,
   type WorkflowLifecycleConfig,
 } from "@gh-symphony/core";
 import {
   explainIssueDispatch,
+  findGithubProjectIssue,
   isActiveRunRecordStatus,
+  parseIssueIdentifier,
   resolveTrackerAdapter,
   type DispatchExplainReport,
 } from "@gh-symphony/orchestrator";
@@ -117,7 +119,10 @@ function formatProjectRepoSummary(
   return `${selectedRepos.map((repo) => `${repo.owner}/${repo.name}`).join(", ")}  (${selectedRepos.length} of ${totalLinked} linked)`;
 }
 
-function projectCreatedMessage(projectId: string, repositoryCount: number): string {
+function projectCreatedMessage(
+  projectId: string,
+  repositoryCount: number
+): string {
   const lines = [
     `Project "${projectId}" created with ${repositoryCount} repositor${repositoryCount === 1 ? "y" : "ies"}.`,
     "Run 'gh-symphony start' to begin orchestration.",
@@ -183,6 +188,7 @@ function parseProjectAddFlags(args: string[]): ProjectAddFlags {
 type ProjectExplainFlags = {
   identifier?: string;
   projectId?: string;
+  workflowPath?: string;
   error?: string;
 };
 
@@ -201,6 +207,16 @@ function parseProjectExplainFlags(args: string[]): ProjectExplainFlags {
       i += 1;
       continue;
     }
+    if (arg === "--workflow" || arg === "--workflow-path") {
+      const value = args[i + 1];
+      if (!value || value.startsWith("-")) {
+        parsed.error = `Option '${arg}' argument missing`;
+        return parsed;
+      }
+      parsed.workflowPath = value;
+      i += 1;
+      continue;
+    }
     if (arg?.startsWith("-")) {
       parsed.error = `Unknown option '${arg}'`;
       return parsed;
@@ -215,25 +231,10 @@ function parseProjectExplainFlags(args: string[]): ProjectExplainFlags {
   if (!parsed.identifier) {
     parsed.error = "Issue identifier argument missing";
   } else if (!parseIssueIdentifier(parsed.identifier)) {
-    parsed.error =
-      "Issue identifier must use the form <owner>/<repo>#<number>";
+    parsed.error = "Issue identifier must use the form <owner>/<repo>#<number>";
   }
 
   return parsed;
-}
-
-function parseIssueIdentifier(
-  identifier: string
-): { owner: string; name: string; number: number } | null {
-  const match = identifier.match(/^([^/\s#]+)\/([^/\s#]+)#(\d+)$/);
-  if (!match) {
-    return null;
-  }
-  return {
-    owner: match[1]!,
-    name: match[2]!,
-    number: Number.parseInt(match[3]!, 10),
-  };
 }
 
 const handler = async (
@@ -366,11 +367,7 @@ function isProcessRunning(pid: number): boolean {
     process.kill(pid, 0);
     return true;
   } catch (error) {
-    if (
-      error instanceof Error &&
-      "code" in error &&
-      error.code === "EPERM"
-    ) {
+    if (error instanceof Error && "code" in error && error.code === "EPERM") {
       return true;
     }
     return false;
@@ -408,7 +405,7 @@ async function projectExplain(
   if (parsed.error) {
     process.stderr.write(`${parsed.error}\n`);
     process.stderr.write(
-      "Usage: gh-symphony project explain <owner/repo#number> [--project-id <project-id>]\n"
+      "Usage: gh-symphony project explain <owner/repo#number> [--project-id <project-id>] [--workflow <path>]\n"
     );
     process.exitCode = 2;
     return;
@@ -431,33 +428,80 @@ async function projectExplain(
     cloneUrl: `https://github.com/${parsedIdentifier.owner}/${parsedIdentifier.name}.git`,
   };
   const workflowRepository = projectConfig.repository ?? fallbackRepository;
-  const token = getGhToken();
+  let token: string;
+  try {
+    token = getGhToken();
+  } catch (error) {
+    if (error instanceof GhAuthError) {
+      process.stderr.write(
+        `Error: GitHub authentication is required for project explain. ${error.message}\n`
+      );
+      process.stderr.write(
+        "Run 'gh auth login --scopes repo,read:org,project' or set GITHUB_GRAPHQL_TOKEN, then re-run this command.\n"
+      );
+      process.exitCode = 2;
+      return;
+    }
+    throw error;
+  }
   const trackerAdapter = resolveTrackerAdapter(projectConfig.tracker);
   const orchestratorProject = {
     ...projectConfig,
     repository: workflowRepository,
   } as OrchestratorProjectConfig;
-  const issues = await trackerAdapter.listIssues(orchestratorProject, {
+  const trackerDependencies = {
     token,
-  });
-  const issue =
-    issues.find(
-      (candidate) =>
-        candidate.identifier.trim().toLowerCase() ===
-        identifier.trim().toLowerCase()
-    ) ?? null;
-
-  const workflow = await loadExplainWorkflow(workflowRepository);
+    projectItemsCache: createProjectItemsCache(),
+  };
   const runtimeRoot = join(
     resolveRuntimeRoot(options.configDir),
     "projects",
     projectConfig.projectId
   );
-  const [issueRecords, runs, snapshot] = await Promise.all([
+  const issuesPromise = trackerAdapter.listIssues(
+    orchestratorProject,
+    trackerDependencies
+  );
+  const issuePromise =
+    projectConfig.tracker.adapter === "github-project"
+      ? findGithubProjectIssue(
+          orchestratorProject,
+          identifier,
+          trackerDependencies
+        )
+      : issuesPromise.then(
+          (issues) =>
+            issues.find(
+              (candidate) =>
+                candidate.identifier.trim().toLowerCase() ===
+                identifier.trim().toLowerCase()
+            ) ?? null
+        );
+  const [issues, issue, issueRecords, runs, snapshot] = await Promise.all([
+    issuesPromise,
+    issuePromise,
     readJsonFile<IssueOrchestrationRecord[]>(join(runtimeRoot, "issues.json")),
     readRuns(runtimeRoot, projectConfig.projectId),
     readPersistedSnapshot(options.configDir, projectConfig.projectId),
   ]);
+  let workflow: ExplainWorkflowSettings;
+  try {
+    workflow = await loadExplainWorkflow({
+      explicitWorkflowPath: parsed.workflowPath,
+      repository: workflowRepository,
+      runs,
+    });
+  } catch (error) {
+    if (error instanceof ProjectExplainWorkflowError) {
+      process.stderr.write(`Error: ${error.message}\n`);
+      process.stderr.write(
+        "Hint: pass --workflow <path-to-WORKFLOW.md> or run 'gh-symphony workflow preview --file <path>' to verify the workflow file.\n"
+      );
+      process.exitCode = 2;
+      return;
+    }
+    throw error;
+  }
   const activeRunCount = runs.filter((run) =>
     isActiveRunRecordStatus(run.status)
   ).length;
@@ -492,27 +536,97 @@ async function projectExplain(
   process.stdout.write(renderProjectExplainReport(report, options.noColor));
 }
 
-async function loadExplainWorkflow(repository: RepositoryRef): Promise<{
+type ExplainWorkflowSettings = {
   lifecycle: WorkflowLifecycleConfig;
   maxConcurrentAgents: number;
   maxConcurrentAgentsByState: Record<string, number>;
-}> {
-  const workflowPath = join(resolve(repository.path ?? process.cwd()), "WORKFLOW.md");
-  try {
-    const resolution = await new WorkflowConfigStore().load(workflowPath);
-    return {
-      lifecycle: resolution.lifecycle,
-      maxConcurrentAgents: resolution.workflow.agent.maxConcurrentAgents,
-      maxConcurrentAgentsByState:
-        resolution.workflow.agent.maxConcurrentAgentsByState,
-    };
-  } catch {
-    return {
-      lifecycle: DEFAULT_WORKFLOW_LIFECYCLE,
-      maxConcurrentAgents: 3,
-      maxConcurrentAgentsByState: {},
-    };
+};
+
+class ProjectExplainWorkflowError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ProjectExplainWorkflowError";
   }
+}
+
+async function loadExplainWorkflow(input: {
+  explicitWorkflowPath?: string;
+  repository: RepositoryRef;
+  runs: readonly OrchestratorRunRecord[];
+}): Promise<ExplainWorkflowSettings> {
+  const workflowPaths = resolveExplainWorkflowCandidates(input);
+  if (workflowPaths.length === 0) {
+    throw new ProjectExplainWorkflowError(
+      "No WORKFLOW.md path could be resolved from --workflow, the configured repository path, or previous run records."
+    );
+  }
+
+  const failures: string[] = [];
+  for (const workflowPath of workflowPaths) {
+    try {
+      const resolution = await new WorkflowConfigStore().load(workflowPath);
+      return {
+        lifecycle: resolution.lifecycle,
+        maxConcurrentAgents: resolution.workflow.agent.maxConcurrentAgents,
+        maxConcurrentAgentsByState:
+          resolution.workflow.agent.maxConcurrentAgentsByState,
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      failures.push(`${workflowPath}: ${message}`);
+    }
+  }
+
+  throw new ProjectExplainWorkflowError(
+    `Unable to load WORKFLOW.md for project explain. Checked: ${failures.join("; ")}`
+  );
+}
+
+function resolveExplainWorkflowCandidates(input: {
+  explicitWorkflowPath?: string;
+  repository: RepositoryRef;
+  runs: readonly OrchestratorRunRecord[];
+}): string[] {
+  const paths: string[] = [];
+  if (input.explicitWorkflowPath) {
+    paths.push(resolve(input.explicitWorkflowPath));
+  }
+  if (input.repository.path) {
+    paths.push(join(resolve(input.repository.path), "WORKFLOW.md"));
+  }
+
+  const newestRuns = [...input.runs].sort(
+    (left, right) =>
+      (Date.parse(right.updatedAt) || 0) - (Date.parse(left.updatedAt) || 0)
+  );
+  for (const run of newestRuns) {
+    if (run.workflowPath) {
+      paths.push(resolve(run.workflowPath));
+    }
+    if (run.workingDirectory) {
+      paths.push(join(resolve(run.workingDirectory), "WORKFLOW.md"));
+    }
+  }
+
+  return [...new Set(paths)];
+}
+
+function createProjectItemsCache(): ProjectItemsCache {
+  const entries = new Map<string, ReturnType<ProjectItemsCache["getOrLoad"]>>();
+  return {
+    getOrLoad(key, load) {
+      const cached = entries.get(key);
+      if (cached) {
+        return cached;
+      }
+      const pending = load().catch((error) => {
+        entries.delete(key);
+        throw error;
+      });
+      entries.set(key, pending);
+      return pending;
+    },
+  };
 }
 
 async function readRuns(
@@ -528,7 +642,9 @@ async function readRuns(
 
   const runs = await Promise.all(
     runIds.map((runId) =>
-      readJsonFile<OrchestratorRunRecord>(join(runtimeRoot, "runs", runId, "run.json"))
+      readJsonFile<OrchestratorRunRecord>(
+        join(runtimeRoot, "runs", runId, "run.json")
+      )
     )
   );
   return runs.filter(
@@ -549,7 +665,9 @@ function renderProjectExplainReport(
   report: DispatchExplainReport,
   noColor: boolean
 ): string {
-  const apply = noColor ? (value: string) => stripAnsi(value) : (value: string) => value;
+  const apply = noColor
+    ? (value: string) => stripAnsi(value)
+    : (value: string) => value;
   const lines = [
     apply(bold(`Issue dispatch explanation: ${report.issue.identifier}`)),
     report.summary,
@@ -562,7 +680,11 @@ function renderProjectExplainReport(
 
   for (const check of report.checks) {
     const marker =
-      check.status === "pass" ? green("✓") : check.status === "warn" ? yellow("!") : red("✗");
+      check.status === "pass"
+        ? green("✓")
+        : check.status === "warn"
+          ? yellow("!")
+          : red("✗");
     lines.push(`  ${apply(marker)} ${check.message}`);
     if (check.hint) {
       lines.push(`    Hint: ${check.hint}`);
@@ -583,7 +705,10 @@ async function readHttpEndpoint(
   projectId: string
 ): Promise<string | null> {
   try {
-    const content = await readFile(httpStatusPath(configDir, projectId), "utf8");
+    const content = await readFile(
+      httpStatusPath(configDir, projectId),
+      "utf8"
+    );
     const state = JSON.parse(content) as HttpBindingState;
     return typeof state.endpoint === "string" && state.endpoint.length > 0
       ? state.endpoint
@@ -599,7 +724,12 @@ async function readProcessUptime(pid: number): Promise<string> {
   }
 
   try {
-    const { stdout } = await execFile("ps", ["-o", "etime=", "-p", String(pid)]);
+    const { stdout } = await execFile("ps", [
+      "-o",
+      "etime=",
+      "-p",
+      String(pid),
+    ]);
     const seconds = parsePsElapsedTime(stdout);
     return seconds === null ? "-" : formatDuration(seconds);
   } catch {
@@ -803,7 +933,8 @@ async function projectAddNonInteractive(
   }
 
   const projectId = generateProjectId(project.title, project.id);
-  const workspaceDir = flags.workspaceDir ?? join(options.configDir, "workspaces");
+  const workspaceDir =
+    flags.workspaceDir ?? join(options.configDir, "workspaces");
 
   await writeConfig(options.configDir, {
     projectId,
@@ -935,14 +1066,13 @@ async function projectAddInteractive(
     assignedOnly: promptAssignedOnly,
     selectedRepos,
     workspaceDir,
-  } =
-    await promptProjectRegistrationOptions({
-      projectDetail,
-      defaultWorkspaceDir,
-      assignedOnlyMessage:
-        "Step 2/2 - Only process issues assigned to the authenticated GitHub user?",
-      assignedOnlyInitialValue: flags.assignedOnly,
-    });
+  } = await promptProjectRegistrationOptions({
+    projectDetail,
+    defaultWorkspaceDir,
+    assignedOnlyMessage:
+      "Step 2/2 - Only process issues assigned to the authenticated GitHub user?",
+    assignedOnlyInitialValue: flags.assignedOnly,
+  });
   const assignedOnly = flags.assignedOnly || promptAssignedOnly;
 
   const repoSummary = formatProjectRepoSummary(
@@ -1139,7 +1269,9 @@ async function projectRemove(
     return;
   }
 
-  const updatedProjects = global.projects.filter((entry) => entry !== projectId);
+  const updatedProjects = global.projects.filter(
+    (entry) => entry !== projectId
+  );
   if (updatedProjects.length === global.projects.length) {
     process.stderr.write(`Project "${projectId}" not found.\n`);
     process.exitCode = 1;

--- a/packages/cli/src/commands/project.ts
+++ b/packages/cli/src/commands/project.ts
@@ -1,11 +1,27 @@
 import * as p from "@clack/prompts";
 import { execFile as execFileCallback } from "node:child_process";
 import { promisify } from "node:util";
-import { readFile } from "node:fs/promises";
+import { readdir, readFile } from "node:fs/promises";
 import { join } from "node:path";
+import { resolve } from "node:path";
 import type { GlobalOptions } from "../index.js";
-import type { ProjectStatusSnapshot } from "@gh-symphony/core";
-import { stripAnsi } from "../ansi.js";
+import {
+  WorkflowConfigStore,
+  DEFAULT_WORKFLOW_LIFECYCLE,
+  type IssueOrchestrationRecord,
+  type OrchestratorProjectConfig,
+  type OrchestratorRunRecord,
+  type ProjectStatusSnapshot,
+  type RepositoryRef,
+  type WorkflowLifecycleConfig,
+} from "@gh-symphony/core";
+import {
+  explainIssueDispatch,
+  isActiveRunRecordStatus,
+  resolveTrackerAdapter,
+  type DispatchExplainReport,
+} from "@gh-symphony/orchestrator";
+import { bold, green, red, stripAnsi, yellow } from "../ansi.js";
 import {
   createClient,
   validateToken,
@@ -20,6 +36,7 @@ import {
   type LinkedRepository,
 } from "../github/client.js";
 import { getGhTokenWithSource, GhAuthError } from "../github/gh-auth.js";
+import { getGhToken } from "../github/gh-auth.js";
 import { resolveGitHubAuth } from "../github/gh-auth.js";
 import {
   loadGlobalConfig,
@@ -41,6 +58,10 @@ import startCommand from "./start.js";
 import statusCommand from "./status.js";
 import stopCommand from "./stop.js";
 import { resolveRuntimeRoot } from "../orchestrator-runtime.js";
+import {
+  handleMissingManagedProjectConfig,
+  resolveManagedProjectConfig,
+} from "../project-selection.js";
 
 const execFile = promisify(execFileCallback);
 
@@ -159,6 +180,62 @@ function parseProjectAddFlags(args: string[]): ProjectAddFlags {
   return flags;
 }
 
+type ProjectExplainFlags = {
+  identifier?: string;
+  projectId?: string;
+  error?: string;
+};
+
+function parseProjectExplainFlags(args: string[]): ProjectExplainFlags {
+  const parsed: ProjectExplainFlags = {};
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === "--project" || arg === "--project-id") {
+      const value = args[i + 1];
+      if (!value || value.startsWith("-")) {
+        parsed.error = `Option '${arg}' argument missing`;
+        return parsed;
+      }
+      parsed.projectId = value;
+      i += 1;
+      continue;
+    }
+    if (arg?.startsWith("-")) {
+      parsed.error = `Unknown option '${arg}'`;
+      return parsed;
+    }
+    if (parsed.identifier) {
+      parsed.error = "Only one issue identifier can be explained at a time";
+      return parsed;
+    }
+    parsed.identifier = arg;
+  }
+
+  if (!parsed.identifier) {
+    parsed.error = "Issue identifier argument missing";
+  } else if (!parseIssueIdentifier(parsed.identifier)) {
+    parsed.error =
+      "Issue identifier must use the form <owner>/<repo>#<number>";
+  }
+
+  return parsed;
+}
+
+function parseIssueIdentifier(
+  identifier: string
+): { owner: string; name: string; number: number } | null {
+  const match = identifier.match(/^([^/\s#]+)\/([^/\s#]+)#(\d+)$/);
+  if (!match) {
+    return null;
+  }
+  return {
+    owner: match[1]!,
+    name: match[2]!,
+    number: Number.parseInt(match[3]!, 10),
+  };
+}
+
 const handler = async (
   args: string[],
   options: GlobalOptions
@@ -187,9 +264,12 @@ const handler = async (
     case "status":
       await statusCommand(rest, options);
       return;
+    case "explain":
+      await projectExplain(rest, options);
+      return;
     default:
       process.stdout.write(
-        "Usage: gh-symphony project <add|list|remove|start|stop|switch|status>\n"
+        "Usage: gh-symphony project <add|list|remove|start|stop|switch|status|explain>\n"
       );
   }
 };
@@ -318,6 +398,184 @@ async function fetchProjectSnapshot(
   projectId: string
 ): Promise<ProjectStatusSnapshot | null> {
   return readPersistedSnapshot(configDir, projectId);
+}
+
+async function projectExplain(
+  args: string[],
+  options: GlobalOptions
+): Promise<void> {
+  const parsed = parseProjectExplainFlags(args);
+  if (parsed.error) {
+    process.stderr.write(`${parsed.error}\n`);
+    process.stderr.write(
+      "Usage: gh-symphony project explain <owner/repo#number> [--project-id <project-id>]\n"
+    );
+    process.exitCode = 2;
+    return;
+  }
+
+  const projectConfig = await resolveManagedProjectConfig({
+    configDir: options.configDir,
+    requestedProjectId: parsed.projectId,
+  });
+  if (!projectConfig) {
+    handleMissingManagedProjectConfig();
+    return;
+  }
+
+  const identifier = parsed.identifier!;
+  const parsedIdentifier = parseIssueIdentifier(identifier)!;
+  const fallbackRepository: RepositoryRef = {
+    owner: parsedIdentifier.owner,
+    name: parsedIdentifier.name,
+    cloneUrl: `https://github.com/${parsedIdentifier.owner}/${parsedIdentifier.name}.git`,
+  };
+  const workflowRepository = projectConfig.repository ?? fallbackRepository;
+  const token = getGhToken();
+  const trackerAdapter = resolveTrackerAdapter(projectConfig.tracker);
+  const orchestratorProject = {
+    ...projectConfig,
+    repository: workflowRepository,
+  } as OrchestratorProjectConfig;
+  const issues = await trackerAdapter.listIssues(orchestratorProject, {
+    token,
+  });
+  const issue =
+    issues.find(
+      (candidate) =>
+        candidate.identifier.trim().toLowerCase() ===
+        identifier.trim().toLowerCase()
+    ) ?? null;
+
+  const workflow = await loadExplainWorkflow(workflowRepository);
+  const runtimeRoot = join(
+    resolveRuntimeRoot(options.configDir),
+    "projects",
+    projectConfig.projectId
+  );
+  const [issueRecords, runs, snapshot] = await Promise.all([
+    readJsonFile<IssueOrchestrationRecord[]>(join(runtimeRoot, "issues.json")),
+    readRuns(runtimeRoot, projectConfig.projectId),
+    readPersistedSnapshot(options.configDir, projectConfig.projectId),
+  ]);
+  const activeRunCount = runs.filter((run) =>
+    isActiveRunRecordStatus(run.status)
+  ).length;
+  const report = explainIssueDispatch({
+    identifier,
+    issue,
+    projectRepository: projectConfig.repository ?? null,
+    allIssues: issues,
+    lifecycle: workflow.lifecycle,
+    issueRecords: issueRecords ?? [],
+    runs,
+    activeRunCount,
+    maxConcurrentAgents: workflow.maxConcurrentAgents,
+    maxConcurrentAgentsByState: workflow.maxConcurrentAgentsByState,
+  });
+  const enrichedReport = {
+    ...report,
+    project: {
+      id: projectConfig.projectId,
+      slug: projectConfig.slug,
+      tracker: projectConfig.tracker,
+      lastTickAt: snapshot?.lastTickAt ?? null,
+      health: snapshot?.health ?? null,
+    },
+  };
+
+  if (options.json) {
+    process.stdout.write(JSON.stringify(enrichedReport, null, 2) + "\n");
+    return;
+  }
+
+  process.stdout.write(renderProjectExplainReport(report, options.noColor));
+}
+
+async function loadExplainWorkflow(repository: RepositoryRef): Promise<{
+  lifecycle: WorkflowLifecycleConfig;
+  maxConcurrentAgents: number;
+  maxConcurrentAgentsByState: Record<string, number>;
+}> {
+  const workflowPath = join(resolve(repository.path ?? process.cwd()), "WORKFLOW.md");
+  try {
+    const resolution = await new WorkflowConfigStore().load(workflowPath);
+    return {
+      lifecycle: resolution.lifecycle,
+      maxConcurrentAgents: resolution.workflow.agent.maxConcurrentAgents,
+      maxConcurrentAgentsByState:
+        resolution.workflow.agent.maxConcurrentAgentsByState,
+    };
+  } catch {
+    return {
+      lifecycle: DEFAULT_WORKFLOW_LIFECYCLE,
+      maxConcurrentAgents: 3,
+      maxConcurrentAgentsByState: {},
+    };
+  }
+}
+
+async function readRuns(
+  runtimeRoot: string,
+  projectId: string
+): Promise<OrchestratorRunRecord[]> {
+  let runIds: string[];
+  try {
+    runIds = await readdir(join(runtimeRoot, "runs"));
+  } catch {
+    return [];
+  }
+
+  const runs = await Promise.all(
+    runIds.map((runId) =>
+      readJsonFile<OrchestratorRunRecord>(join(runtimeRoot, "runs", runId, "run.json"))
+    )
+  );
+  return runs.filter(
+    (run): run is OrchestratorRunRecord =>
+      run !== null && run.projectId === projectId
+  );
+}
+
+async function readJsonFile<T>(path: string): Promise<T | null> {
+  try {
+    return JSON.parse(await readFile(path, "utf8")) as T;
+  } catch {
+    return null;
+  }
+}
+
+function renderProjectExplainReport(
+  report: DispatchExplainReport,
+  noColor: boolean
+): string {
+  const apply = noColor ? (value: string) => stripAnsi(value) : (value: string) => value;
+  const lines = [
+    apply(bold(`Issue dispatch explanation: ${report.issue.identifier}`)),
+    report.summary,
+    "",
+    `State: ${report.issue.state ?? "unknown"}`,
+    `Repository: ${report.issue.repository}`,
+    "",
+    "Checks:",
+  ];
+
+  for (const check of report.checks) {
+    const marker =
+      check.status === "pass" ? green("✓") : check.status === "warn" ? yellow("!") : red("✗");
+    lines.push(`  ${apply(marker)} ${check.message}`);
+    if (check.hint) {
+      lines.push(`    Hint: ${check.hint}`);
+    }
+  }
+
+  lines.push("");
+  lines.push("Related commands:");
+  lines.push("  gh-symphony workflow preview");
+  lines.push("  gh-symphony doctor");
+  lines.push("  gh-symphony project status");
+  lines.push("  gh-symphony logs --issue " + report.issue.identifier);
+  return lines.join("\n") + "\n";
 }
 
 async function readHttpEndpoint(

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -64,6 +64,7 @@ type CliOptionValues = Partial<
     skipSkills?: boolean;
     version?: boolean;
     web?: string | boolean;
+    workflow?: string;
     workspaceDir?: string;
     watch?: boolean;
     sample?: string;
@@ -197,7 +198,10 @@ function createProgram(): { program: Command; wasInvoked: () => boolean } {
       .option("--non-interactive", "Run without prompts")
       .option("--project <id>", "GitHub Project ID or URL")
       .option("--output <path>", "Write WORKFLOW.md to a custom path")
-      .option("--runtime <kind>", "Runtime preset: codex-app-server or claude-print")
+      .option(
+        "--runtime <kind>",
+        "Runtime preset: codex-app-server or claude-print"
+      )
       .option("--skip-skills", "Skip runtime skill generation")
       .option("--skip-context", "Skip .gh-symphony/context.yaml generation")
       .option("--dry-run", "Preview generated files without writing them")
@@ -236,7 +240,10 @@ function createProgram(): { program: Command; wasInvoked: () => boolean } {
       .option("--non-interactive", "Run without prompts")
       .option("--project <id>", "GitHub Project ID or URL")
       .option("--output <path>", "Write WORKFLOW.md to a custom path")
-      .option("--runtime <kind>", "Runtime preset: codex-app-server or claude-print")
+      .option(
+        "--runtime <kind>",
+        "Runtime preset: codex-app-server or claude-print"
+      )
       .option("--skip-skills", "Skip runtime skill generation")
       .option("--skip-context", "Skip .gh-symphony/context.yaml generation")
       .option("--dry-run", "Preview generated files without writing them")
@@ -607,6 +614,7 @@ function createProgram(): { program: Command; wasInvoked: () => boolean } {
       .description("Explain why a project issue is not dispatching")
       .argument("<issue>", "Issue identifier, for example owner/repo#123")
       .option("--project-id <projectId>", "Project identifier")
+      .option("--workflow <path>", "Path to the WORKFLOW.md file to evaluate")
       .addOption(new Option("--project <projectId>").hideHelp())
       .allowExcessArguments(false)
   ).action(async function (this: Command, issue: string) {
@@ -614,6 +622,7 @@ function createProgram(): { program: Command; wasInvoked: () => boolean } {
     const values = this.optsWithGlobals<CliOptionValues>();
     const args = ["explain", issue];
     pushOption(args, "--project-id", resolveProjectId(values));
+    pushOption(args, "--workflow", values.workflow);
     await invokeHandler("project", args, values);
   });
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -601,6 +601,22 @@ function createProgram(): { program: Command; wasInvoked: () => boolean } {
     await invokeHandler("project", args, values);
   });
 
+  addGlobalOptions(
+    project
+      .command("explain")
+      .description("Explain why a project issue is not dispatching")
+      .argument("<issue>", "Issue identifier, for example owner/repo#123")
+      .option("--project-id <projectId>", "Project identifier")
+      .addOption(new Option("--project <projectId>").hideHelp())
+      .allowExcessArguments(false)
+  ).action(async function (this: Command, issue: string) {
+    markInvoked();
+    const values = this.optsWithGlobals<CliOptionValues>();
+    const args = ["explain", issue];
+    pushOption(args, "--project-id", resolveProjectId(values));
+    await invokeHandler("project", args, values);
+  });
+
   const repo = addGlobalOptions(
     program
       .command("repo")

--- a/packages/orchestrator/src/dispatch.test.ts
+++ b/packages/orchestrator/src/dispatch.test.ts
@@ -3,7 +3,8 @@ import { mkdtemp, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { sortCandidatesForDispatch, OrchestratorService } from "./service.js";
+import { OrchestratorService, sortCandidatesForDispatch } from "./service.js";
+import { explainIssueDispatch } from "./explain.js";
 import type {
   OrchestratorTrackerAdapter,
   OrchestratorRunRecord,
@@ -41,6 +42,42 @@ function makeIssue(
       itemId: "item-1",
     },
     metadata: {},
+    ...overrides,
+  };
+}
+
+function makeRun(
+  overrides: Partial<OrchestratorRunRecord> & { runId: string; issueId: string }
+): OrchestratorRunRecord {
+  return {
+    runId: overrides.runId,
+    projectId: "tenant-1",
+    projectSlug: "tenant-1",
+    issueId: overrides.issueId,
+    issueSubjectId: overrides.issueId,
+    issueIdentifier: "acme/repo#1",
+    issueTitle: "Test",
+    issueState: "Todo",
+    repository: {
+      owner: "acme",
+      name: "repo",
+      cloneUrl: "https://github.com/acme/repo.git",
+    },
+    status: "running",
+    attempt: 1,
+    processId: null,
+    port: null,
+    workingDirectory: "/tmp/work",
+    issueWorkspaceKey: "acme-repo-1",
+    workspaceRuntimeDir: "/tmp/runtime",
+    workflowPath: null,
+    retryKind: null,
+    createdAt: "2026-03-09T00:00:00.000Z",
+    updatedAt: "2026-03-09T00:00:00.000Z",
+    startedAt: "2026-03-09T00:00:00.000Z",
+    completedAt: null,
+    lastError: null,
+    nextRetryAt: null,
     ...overrides,
   };
 }
@@ -131,6 +168,124 @@ describe("sortCandidatesForDispatch", () => {
 
   it("returns empty array for empty input", () => {
     expect(sortCandidatesForDispatch([])).toEqual([]);
+  });
+});
+
+describe("explainIssueDispatch", () => {
+  const lifecycle = {
+    stateFieldName: "Status",
+    activeStates: ["Todo", "In Progress"],
+    terminalStates: ["Done"],
+    blockerCheckStates: ["Todo"],
+  };
+  const projectRepository = {
+    owner: "acme",
+    name: "repo",
+    cloneUrl: "https://github.com/acme/repo.git",
+  };
+
+  it("explains inactive workflow states", () => {
+    const issue = makeIssue({ identifier: "acme/repo#1", state: "Backlog" });
+    const report = explainIssueDispatch({
+      identifier: issue.identifier,
+      issue,
+      projectRepository,
+      allIssues: [issue],
+      lifecycle,
+      issueRecords: [],
+      runs: [],
+      activeRunCount: 0,
+      maxConcurrentAgents: 3,
+      maxConcurrentAgentsByState: {},
+    });
+
+    expect(report.dispatchable).toBe(false);
+    expect(report.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "workflow_state",
+          status: "block",
+        }),
+      ])
+    );
+  });
+
+  it("explains unresolved blockers", () => {
+    const blocker = makeIssue({
+      id: "blocker-1",
+      identifier: "acme/repo#2",
+      state: "Todo",
+    });
+    const issue = makeIssue({
+      identifier: "acme/repo#1",
+      blockedBy: [{ id: "blocker-1", identifier: blocker.identifier, state: null }],
+    });
+    const report = explainIssueDispatch({
+      identifier: issue.identifier,
+      issue,
+      projectRepository,
+      allIssues: [issue, blocker],
+      lifecycle,
+      issueRecords: [],
+      runs: [],
+      activeRunCount: 0,
+      maxConcurrentAgents: 3,
+      maxConcurrentAgentsByState: {},
+    });
+
+    expect(report.dispatchable).toBe(false);
+    expect(report.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "blockers", status: "block" }),
+      ])
+    );
+  });
+
+  it("explains already running ownership", () => {
+    const issue = makeIssue({ id: "issue-1", identifier: "acme/repo#1" });
+    const run = makeRun({ runId: "run-1", issueId: issue.id });
+    const report = explainIssueDispatch({
+      identifier: issue.identifier,
+      issue,
+      projectRepository,
+      allIssues: [issue],
+      lifecycle,
+      issueRecords: [],
+      runs: [run],
+      activeRunCount: 1,
+      maxConcurrentAgents: 3,
+      maxConcurrentAgentsByState: {},
+    });
+
+    expect(report.dispatchable).toBe(false);
+    expect(report.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "runtime_ownership", status: "block" }),
+      ])
+    );
+  });
+
+  it("explains project concurrency limits", () => {
+    const issue = makeIssue({ id: "issue-1", identifier: "acme/repo#1" });
+    const report = explainIssueDispatch({
+      identifier: issue.identifier,
+      issue,
+      projectRepository,
+      allIssues: [issue],
+      lifecycle,
+      issueRecords: [],
+      runs: [],
+      activeRunCount: 2,
+      maxConcurrentAgents: 2,
+      maxConcurrentAgentsByState: {},
+    });
+
+    expect(report.dispatchable).toBe(false);
+    expect(report.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "dispatch_limits", status: "block" }),
+      ])
+    );
   });
 });
 

--- a/packages/orchestrator/src/dispatch.test.ts
+++ b/packages/orchestrator/src/dispatch.test.ts
@@ -218,7 +218,9 @@ describe("explainIssueDispatch", () => {
     });
     const issue = makeIssue({
       identifier: "acme/repo#1",
-      blockedBy: [{ id: "blocker-1", identifier: blocker.identifier, state: null }],
+      blockedBy: [
+        { id: "blocker-1", identifier: blocker.identifier, state: null },
+      ],
     });
     const report = explainIssueDispatch({
       identifier: issue.identifier,
@@ -285,6 +287,26 @@ describe("explainIssueDispatch", () => {
       expect.arrayContaining([
         expect.objectContaining({ id: "dispatch_limits", status: "block" }),
       ])
+    );
+  });
+
+  it("prioritizes repository linkage in the not-found summary", () => {
+    const report = explainIssueDispatch({
+      identifier: "other/repo#1",
+      issue: null,
+      projectRepository,
+      allIssues: [],
+      lifecycle,
+      issueRecords: [],
+      runs: [],
+      activeRunCount: 0,
+      maxConcurrentAgents: 3,
+      maxConcurrentAgentsByState: {},
+    });
+
+    expect(report.dispatchable).toBe(false);
+    expect(report.summary).toContain(
+      "Repository other/repo is not the active managed project repository"
     );
   });
 });

--- a/packages/orchestrator/src/explain.ts
+++ b/packages/orchestrator/src/explain.ts
@@ -39,6 +39,12 @@ export type DispatchExplainReport = {
   checks: DispatchExplainCheck[];
 };
 
+export type ParsedIssueIdentifier = {
+  owner: string;
+  name: string;
+  number: number;
+};
+
 export type ExplainDispatchInput = {
   identifier: string;
   issue: TrackedIssue | null;
@@ -71,6 +77,11 @@ export function explainIssueDispatch(
 
   if (!issue) {
     const dispatchable = false;
+    const blocking = checks.filter((check) => check.status === "block");
+    const summary =
+      blocking.length > 0
+        ? `Not dispatchable: ${blocking[0]!.message}`
+        : "Not dispatchable: the issue is not present in the managed GitHub Project item set.";
     return {
       issue: {
         identifier: input.identifier,
@@ -81,20 +92,14 @@ export function explainIssueDispatch(
         url: null,
       },
       dispatchable,
-      summary: "Not dispatchable: the issue is not present in the managed GitHub Project item set.",
+      summary,
       checks,
     };
   }
 
   checks.push(explainWorkflowState(issue, input.lifecycle));
   checks.push(explainBlockers(issue, input.lifecycle, input.allIssues));
-  checks.push(
-    explainRuntimeOwnership(
-      issue,
-      input.issueRecords,
-      input.runs
-    )
-  );
+  checks.push(explainRuntimeOwnership(issue, input.issueRecords, input.runs));
   checks.push(
     explainDispatchLimits(
       issue,
@@ -199,7 +204,8 @@ function explainRepositoryLinked(
   }
 
   const configured = `${projectRepository.owner}/${projectRepository.name}`;
-  const linked = normalizeIdentifier(configured) === normalizeIdentifier(repository);
+  const linked =
+    normalizeIdentifier(configured) === normalizeIdentifier(repository);
   return {
     id: "repository_linked",
     status: linked ? "pass" : "block",
@@ -297,13 +303,12 @@ function explainRuntimeOwnership(
 ): DispatchExplainCheck {
   const record = issueRecords.find(
     (candidate) =>
-      candidate.issueId === issue.id || candidate.identifier === issue.identifier
+      candidate.issueId === issue.id ||
+      candidate.identifier === issue.identifier
   );
   const latestRun = latestRunForIssue(runs, issue.id);
   const activeRun = runs.find(
-    (run) =>
-      run.issueId === issue.id &&
-      isActiveRunRecordStatus(run.status)
+    (run) => run.issueId === issue.id && isActiveRunRecordStatus(run.status)
   );
 
   if (activeRun) {
@@ -366,11 +371,16 @@ function explainRuntimeOwnership(
     const suppressedAtMs = parseTimestampMs(
       latestRun.completedAt ?? latestRun.updatedAt
     );
-    if (issueUpdatedAtMs === null || suppressedAtMs === null || issueUpdatedAtMs <= suppressedAtMs) {
+    if (
+      issueUpdatedAtMs === null ||
+      suppressedAtMs === null ||
+      issueUpdatedAtMs <= suppressedAtMs
+    ) {
       return {
         id: "runtime_ownership",
         status: "block",
-        message: "Failure retry limit has suppressed redispatch for the current tracker state.",
+        message:
+          "Failure retry limit has suppressed redispatch for the current tracker state.",
         details: {
           failureRetryCount: record.failureRetryCount,
           runId: latestRun.runId,
@@ -384,7 +394,8 @@ function explainRuntimeOwnership(
   return {
     id: "runtime_ownership",
     status: "pass",
-    message: "No active run, retry, convergence lock, or suppression owns the issue.",
+    message:
+      "No active run, retry, convergence lock, or suppression owns the issue.",
     details: record
       ? {
           orchestrationState: record.state,
@@ -416,8 +427,7 @@ function explainDispatchLimits(
   if (stateLimit !== undefined) {
     const activeInState = runs.filter(
       (run) =>
-        run.issueState === issue.state &&
-        isActiveRunRecordStatus(run.status)
+        run.issueState === issue.state && isActiveRunRecordStatus(run.status)
     ).length;
     if (activeInState >= stateLimit) {
       return {
@@ -433,7 +443,8 @@ function explainDispatchLimits(
   return {
     id: "dispatch_limits",
     status: "pass",
-    message: "Project and per-state concurrency limits have available capacity.",
+    message:
+      "Project and per-state concurrency limits have available capacity.",
     details: {
       activeRunCount,
       maxConcurrentAgents,
@@ -461,7 +472,11 @@ function unresolvedBlockers(
   issue: TrackedIssue,
   lifecycle: WorkflowLifecycleConfig,
   issues: readonly TrackedIssue[]
-): Array<{ id: string | null; identifier: string | null; state: string | null }> {
+): Array<{
+  id: string | null;
+  identifier: string | null;
+  state: string | null;
+}> {
   return issue.blockedBy.filter((blockerRef) => {
     if (blockerRef.state && isStateTerminal(blockerRef.state, lifecycle)) {
       return false;
@@ -503,9 +518,9 @@ function parseTimestampMs(value: string | null | undefined): number | null {
   return Number.isFinite(parsed) ? parsed : null;
 }
 
-function parseIssueIdentifier(
+export function parseIssueIdentifier(
   identifier: string
-): { owner: string; name: string; number: number } | null {
+): ParsedIssueIdentifier | null {
   const match = identifier.match(/^([^/\s#]+)\/([^/\s#]+)#(\d+)$/);
   if (!match) {
     return null;

--- a/packages/orchestrator/src/explain.ts
+++ b/packages/orchestrator/src/explain.ts
@@ -1,0 +1,522 @@
+import {
+  isStateActive,
+  isStateTerminal,
+  matchesWorkflowState,
+  type IssueOrchestrationRecord,
+  type OrchestratorRunRecord,
+  type RepositoryRef,
+  type TrackedIssue,
+  type WorkflowLifecycleConfig,
+} from "@gh-symphony/core";
+
+export type DispatchExplainSeverity = "pass" | "warn" | "block";
+
+export type DispatchExplainCheck = {
+  id:
+    | "repository_linked"
+    | "project_item_present"
+    | "workflow_state"
+    | "blockers"
+    | "runtime_ownership"
+    | "dispatch_limits";
+  status: DispatchExplainSeverity;
+  message: string;
+  details?: Record<string, unknown>;
+  hint?: string;
+};
+
+export type DispatchExplainReport = {
+  issue: {
+    identifier: string;
+    id: string | null;
+    state: string | null;
+    repository: string;
+    title: string | null;
+    url: string | null;
+  };
+  dispatchable: boolean;
+  summary: string;
+  checks: DispatchExplainCheck[];
+};
+
+export type ExplainDispatchInput = {
+  identifier: string;
+  issue: TrackedIssue | null;
+  projectRepository: RepositoryRef | null;
+  allIssues: readonly TrackedIssue[];
+  lifecycle: WorkflowLifecycleConfig;
+  issueRecords: readonly IssueOrchestrationRecord[];
+  runs: readonly OrchestratorRunRecord[];
+  activeRunCount: number;
+  maxConcurrentAgents: number;
+  maxConcurrentAgentsByState: Readonly<Record<string, number>>;
+};
+
+const MAX_FAILURE_RETRIES_EXCEEDED_REASON = "max_failure_retries_exceeded";
+
+export function explainIssueDispatch(
+  input: ExplainDispatchInput
+): DispatchExplainReport {
+  const parsed = parseIssueIdentifier(input.identifier);
+  const repository = parsed
+    ? `${parsed.owner}/${parsed.name}`
+    : input.issue
+      ? `${input.issue.repository.owner}/${input.issue.repository.name}`
+      : "unknown";
+  const issue = input.issue;
+  const checks: DispatchExplainCheck[] = [];
+
+  checks.push(explainRepositoryLinked(input.projectRepository, repository));
+  checks.push(explainProjectItemPresent(input.identifier, issue));
+
+  if (!issue) {
+    const dispatchable = false;
+    return {
+      issue: {
+        identifier: input.identifier,
+        id: null,
+        state: null,
+        repository,
+        title: null,
+        url: null,
+      },
+      dispatchable,
+      summary: "Not dispatchable: the issue is not present in the managed GitHub Project item set.",
+      checks,
+    };
+  }
+
+  checks.push(explainWorkflowState(issue, input.lifecycle));
+  checks.push(explainBlockers(issue, input.lifecycle, input.allIssues));
+  checks.push(
+    explainRuntimeOwnership(
+      issue,
+      input.issueRecords,
+      input.runs
+    )
+  );
+  checks.push(
+    explainDispatchLimits(
+      issue,
+      input.runs,
+      input.activeRunCount,
+      input.maxConcurrentAgents,
+      input.maxConcurrentAgentsByState
+    )
+  );
+
+  const blocking = checks.filter((check) => check.status === "block");
+  const dispatchable = blocking.length === 0;
+  const summary = dispatchable
+    ? "Dispatchable: no blocking project, workflow, runtime, or budget condition was found."
+    : `Not dispatchable: ${blocking[0]!.message}`;
+
+  return {
+    issue: {
+      identifier: issue.identifier,
+      id: issue.id,
+      state: issue.state,
+      repository: `${issue.repository.owner}/${issue.repository.name}`,
+      title: issue.title,
+      url: issue.url,
+    },
+    dispatchable,
+    summary,
+    checks,
+  };
+}
+
+export function isIssueCandidateEligibleWithReason(
+  issue: TrackedIssue,
+  lifecycle: WorkflowLifecycleConfig,
+  issues: readonly TrackedIssue[]
+): { eligible: boolean; reason: "inactive_state" | "blocked" | null } {
+  if (!isStateActive(issue.state, lifecycle)) {
+    return { eligible: false, reason: "inactive_state" };
+  }
+
+  if (!issueHasBlockingDependency(issue, lifecycle, issues)) {
+    return { eligible: true, reason: null };
+  }
+
+  return { eligible: false, reason: "blocked" };
+}
+
+export function hasConvergenceLockedRunForIssue(
+  runs: readonly OrchestratorRunRecord[],
+  issueId: string,
+  issueState: string,
+  issueUpdatedAt: string | null | undefined
+): OrchestratorRunRecord | null {
+  const latestRun = latestRunForIssue(runs, issueId);
+
+  if (
+    latestRun?.runtimeSession?.exitClassification !== "convergence-detected" ||
+    latestRun.issueState !== issueState
+  ) {
+    return null;
+  }
+
+  const convergedAtMs = parseTimestampMs(
+    latestRun.completedAt ?? latestRun.updatedAt
+  );
+  const issueUpdatedAtMs = parseTimestampMs(issueUpdatedAt);
+  if (convergedAtMs === null || issueUpdatedAtMs === null) {
+    return latestRun;
+  }
+
+  return issueUpdatedAtMs <= convergedAtMs ? latestRun : null;
+}
+
+export function isIssueOrchestrationClaimedState(
+  state: IssueOrchestrationRecord["state"]
+): boolean {
+  return state === "claimed" || state === "running" || state === "retry_queued";
+}
+
+export function isActiveRunRecordStatus(
+  status: OrchestratorRunRecord["status"]
+): boolean {
+  return (
+    status === "pending" ||
+    status === "starting" ||
+    status === "running" ||
+    status === "retrying"
+  );
+}
+
+function explainRepositoryLinked(
+  projectRepository: RepositoryRef | null,
+  repository: string
+): DispatchExplainCheck {
+  if (!projectRepository) {
+    return {
+      id: "repository_linked",
+      status: "warn",
+      message: "No repository is configured for the active managed project.",
+      hint: "Run 'gh-symphony repo add <owner/name>' or re-run 'gh-symphony project add'.",
+    };
+  }
+
+  const configured = `${projectRepository.owner}/${projectRepository.name}`;
+  const linked = normalizeIdentifier(configured) === normalizeIdentifier(repository);
+  return {
+    id: "repository_linked",
+    status: linked ? "pass" : "block",
+    message: linked
+      ? `Repository ${repository} is linked to the active managed project.`
+      : `Repository ${repository} is not the active managed project repository (${configured}).`,
+    details: { configuredRepository: configured, issueRepository: repository },
+    hint: linked
+      ? undefined
+      : "Run 'gh-symphony repo add <owner/name>' or select the correct project with 'gh-symphony project switch'.",
+  };
+}
+
+function explainProjectItemPresent(
+  identifier: string,
+  issue: TrackedIssue | null
+): DispatchExplainCheck {
+  return {
+    id: "project_item_present",
+    status: issue ? "pass" : "block",
+    message: issue
+      ? "Issue is present in the bound GitHub Project item set."
+      : `Issue ${identifier} was not returned by the bound GitHub Project item set.`,
+    details: issue ? { itemId: issue.tracker.itemId } : undefined,
+    hint: issue
+      ? undefined
+      : "Add the issue to the GitHub Project or run 'gh-symphony project status' to confirm the active project.",
+  };
+}
+
+function explainWorkflowState(
+  issue: TrackedIssue,
+  lifecycle: WorkflowLifecycleConfig
+): DispatchExplainCheck {
+  if (isStateActive(issue.state, lifecycle)) {
+    return {
+      id: "workflow_state",
+      status: "pass",
+      message: `Project state "${issue.state}" maps to an active state in WORKFLOW.md.`,
+      details: { activeStates: lifecycle.activeStates },
+    };
+  }
+
+  const role = isStateTerminal(issue.state, lifecycle) ? "terminal" : "wait";
+  return {
+    id: "workflow_state",
+    status: "block",
+    message: `Project state "${issue.state}" maps to ${role}, not active, in WORKFLOW.md.`,
+    details: {
+      activeStates: lifecycle.activeStates,
+      terminalStates: lifecycle.terminalStates,
+      blockerCheckStates: lifecycle.blockerCheckStates,
+    },
+    hint: "Move the GitHub Project item to an active state or run 'gh-symphony workflow preview' to inspect WORKFLOW.md state mappings.",
+  };
+}
+
+function explainBlockers(
+  issue: TrackedIssue,
+  lifecycle: WorkflowLifecycleConfig,
+  issues: readonly TrackedIssue[]
+): DispatchExplainCheck {
+  if (!matchesWorkflowState(issue.state, lifecycle.blockerCheckStates)) {
+    return {
+      id: "blockers",
+      status: "pass",
+      message: `Blocker checks do not apply to state "${issue.state}".`,
+      details: { blockerCheckStates: lifecycle.blockerCheckStates },
+    };
+  }
+
+  const blockers = unresolvedBlockers(issue, lifecycle, issues);
+  if (blockers.length === 0) {
+    return {
+      id: "blockers",
+      status: "pass",
+      message: "No unresolved blockers prevent dispatch.",
+      details: { blockedBy: issue.blockedBy },
+    };
+  }
+
+  return {
+    id: "blockers",
+    status: "block",
+    message: `Issue has ${blockers.length} unresolved blocker${blockers.length === 1 ? "" : "s"}.`,
+    details: { blockers },
+    hint: "Move blocker issues to a terminal state or update the blocker relationship in GitHub.",
+  };
+}
+
+function explainRuntimeOwnership(
+  issue: TrackedIssue,
+  issueRecords: readonly IssueOrchestrationRecord[],
+  runs: readonly OrchestratorRunRecord[]
+): DispatchExplainCheck {
+  const record = issueRecords.find(
+    (candidate) =>
+      candidate.issueId === issue.id || candidate.identifier === issue.identifier
+  );
+  const latestRun = latestRunForIssue(runs, issue.id);
+  const activeRun = runs.find(
+    (run) =>
+      run.issueId === issue.id &&
+      isActiveRunRecordStatus(run.status)
+  );
+
+  if (activeRun) {
+    return {
+      id: "runtime_ownership",
+      status: "block",
+      message: `Existing ${activeRun.status} run ${activeRun.runId} already owns the issue.`,
+      details: {
+        runId: activeRun.runId,
+        status: activeRun.status,
+        retryKind: activeRun.retryKind,
+        nextRetryAt: activeRun.nextRetryAt,
+      },
+      hint: "Run 'gh-symphony status' or 'gh-symphony logs --issue <owner/repo#number>' to inspect the current owner.",
+    };
+  }
+
+  if (record && isIssueOrchestrationClaimedState(record.state)) {
+    return {
+      id: "runtime_ownership",
+      status: "block",
+      message: `Issue is already claimed by orchestration state "${record.state}".`,
+      details: {
+        state: record.state,
+        currentRunId: record.currentRunId,
+        retryEntry: record.retryEntry,
+      },
+      hint: "Run 'gh-symphony status' to inspect active and retrying work.",
+    };
+  }
+
+  const convergenceRun = hasConvergenceLockedRunForIssue(
+    runs,
+    issue.id,
+    issue.state,
+    issue.updatedAt
+  );
+  if (convergenceRun) {
+    return {
+      id: "runtime_ownership",
+      status: "block",
+      message: `Latest run ${convergenceRun.runId} is convergence-locked for state "${issue.state}".`,
+      details: {
+        runId: convergenceRun.runId,
+        completedAt: convergenceRun.completedAt,
+        lastError: convergenceRun.lastError,
+      },
+      hint: "Update the GitHub Project item or issue activity to trigger a newer tracker timestamp after resolving the unchanged workspace diff.",
+    };
+  }
+
+  if (
+    record &&
+    record.failureRetryCount > 0 &&
+    latestRun?.status === "suppressed" &&
+    latestRun.issueState === issue.state &&
+    latestRun.lastError?.includes(MAX_FAILURE_RETRIES_EXCEEDED_REASON)
+  ) {
+    const issueUpdatedAtMs = parseTimestampMs(issue.updatedAt);
+    const suppressedAtMs = parseTimestampMs(
+      latestRun.completedAt ?? latestRun.updatedAt
+    );
+    if (issueUpdatedAtMs === null || suppressedAtMs === null || issueUpdatedAtMs <= suppressedAtMs) {
+      return {
+        id: "runtime_ownership",
+        status: "block",
+        message: "Failure retry limit has suppressed redispatch for the current tracker state.",
+        details: {
+          failureRetryCount: record.failureRetryCount,
+          runId: latestRun.runId,
+          lastError: latestRun.lastError,
+        },
+        hint: "Fix the underlying failure and update the GitHub Project item or issue to create a newer tracker timestamp.",
+      };
+    }
+  }
+
+  return {
+    id: "runtime_ownership",
+    status: "pass",
+    message: "No active run, retry, convergence lock, or suppression owns the issue.",
+    details: record
+      ? {
+          orchestrationState: record.state,
+          currentRunId: record.currentRunId,
+          latestRunId: latestRun?.runId ?? null,
+        }
+      : undefined,
+  };
+}
+
+function explainDispatchLimits(
+  issue: TrackedIssue,
+  runs: readonly OrchestratorRunRecord[],
+  activeRunCount: number,
+  maxConcurrentAgents: number,
+  maxConcurrentAgentsByState: Readonly<Record<string, number>>
+): DispatchExplainCheck {
+  if (activeRunCount >= maxConcurrentAgents) {
+    return {
+      id: "dispatch_limits",
+      status: "block",
+      message: `Project concurrency is full (${activeRunCount}/${maxConcurrentAgents}).`,
+      details: { activeRunCount, maxConcurrentAgents },
+      hint: "Wait for an active run to finish or adjust agent.max_concurrent_agents in WORKFLOW.md.",
+    };
+  }
+
+  const stateLimit = maxConcurrentAgentsByState[issue.state];
+  if (stateLimit !== undefined) {
+    const activeInState = runs.filter(
+      (run) =>
+        run.issueState === issue.state &&
+        isActiveRunRecordStatus(run.status)
+    ).length;
+    if (activeInState >= stateLimit) {
+      return {
+        id: "dispatch_limits",
+        status: "block",
+        message: `State concurrency is full for "${issue.state}" (${activeInState}/${stateLimit}).`,
+        details: { activeInState, stateLimit, state: issue.state },
+        hint: "Wait for a same-state run to finish or adjust agent.max_concurrent_agents_by_state in WORKFLOW.md.",
+      };
+    }
+  }
+
+  return {
+    id: "dispatch_limits",
+    status: "pass",
+    message: "Project and per-state concurrency limits have available capacity.",
+    details: {
+      activeRunCount,
+      maxConcurrentAgents,
+      stateLimit: stateLimit ?? null,
+    },
+  };
+}
+
+function issueHasBlockingDependency(
+  issue: TrackedIssue,
+  lifecycle: WorkflowLifecycleConfig,
+  issues: readonly TrackedIssue[]
+): boolean {
+  if (
+    !matchesWorkflowState(issue.state, lifecycle.blockerCheckStates) ||
+    issue.blockedBy.length === 0
+  ) {
+    return false;
+  }
+
+  return unresolvedBlockers(issue, lifecycle, issues).length > 0;
+}
+
+function unresolvedBlockers(
+  issue: TrackedIssue,
+  lifecycle: WorkflowLifecycleConfig,
+  issues: readonly TrackedIssue[]
+): Array<{ id: string | null; identifier: string | null; state: string | null }> {
+  return issue.blockedBy.filter((blockerRef) => {
+    if (blockerRef.state && isStateTerminal(blockerRef.state, lifecycle)) {
+      return false;
+    }
+
+    if (blockerRef.identifier) {
+      const blockerIssue = issues.find(
+        (candidate) => candidate.identifier === blockerRef.identifier
+      );
+      if (blockerIssue?.state) {
+        return !isStateTerminal(blockerIssue.state, lifecycle);
+      }
+    }
+
+    return true;
+  });
+}
+
+function latestRunForIssue(
+  runs: readonly OrchestratorRunRecord[],
+  issueId: string
+): OrchestratorRunRecord | null {
+  return (
+    runs
+      .filter((run) => run.issueId === issueId)
+      .sort(
+        (left, right) =>
+          (parseTimestampMs(right.updatedAt) ?? -Infinity) -
+          (parseTimestampMs(left.updatedAt) ?? -Infinity)
+      )[0] ?? null
+  );
+}
+
+function parseTimestampMs(value: string | null | undefined): number | null {
+  if (!value) {
+    return null;
+  }
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function parseIssueIdentifier(
+  identifier: string
+): { owner: string; name: string; number: number } | null {
+  const match = identifier.match(/^([^/\s#]+)\/([^/\s#]+)#(\d+)$/);
+  if (!match) {
+    return null;
+  }
+  return {
+    owner: match[1]!,
+    name: match[2]!,
+    number: Number.parseInt(match[3]!, 10),
+  };
+}
+
+function normalizeIdentifier(value: string): string {
+  return value.trim().toLowerCase();
+}

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -15,6 +15,8 @@ import {
 export { OrchestratorService, createStore };
 export type { OrchestratorLogLevel };
 export * from "./runtime-factory.js";
+export * from "./explain.js";
+export { resolveTrackerAdapter } from "./tracker-adapters.js";
 export {
   acquireProjectLock,
   assertValidProjectId,

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -16,7 +16,10 @@ export { OrchestratorService, createStore };
 export type { OrchestratorLogLevel };
 export * from "./runtime-factory.js";
 export * from "./explain.js";
-export { resolveTrackerAdapter } from "./tracker-adapters.js";
+export {
+  findGithubProjectIssue,
+  resolveTrackerAdapter,
+} from "./tracker-adapters.js";
 export {
   acquireProjectLock,
   assertValidProjectId,

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -14,11 +14,9 @@ import {
   deriveIssueWorkspaceKey,
   deriveLegacyIssueWorkspaceKey,
   executeWorkspaceHook,
-  isStateActive,
   isStateTerminal,
   isMatchingIssueRun,
   isOrchestratorChannelEvent,
-  matchesWorkflowState,
   mapIssueOrchestrationStateToStatus,
   readEnvFile,
   renderPrompt,
@@ -54,6 +52,12 @@ import {
 } from "./git.js";
 import { OrchestratorFsStore } from "./fs-store.js";
 import { resolveTrackerAdapter } from "./tracker-adapters.js";
+import {
+  hasConvergenceLockedRunForIssue,
+  isActiveRunRecordStatus,
+  isIssueCandidateEligibleWithReason,
+  isIssueOrchestrationClaimedState,
+} from "./explain.js";
 
 const DEFAULT_POLL_INTERVAL_MS = 30_000;
 const DEFAULT_CONCURRENCY = 3;
@@ -407,7 +411,7 @@ export class OrchestratorService {
     const allRuns = (await this.store.loadAllRuns()).filter(
       (run) => run.projectId === tenant.projectId
     );
-    const activeRuns = allRuns.filter((run) => isActiveRunStatus(run.status));
+    const activeRuns = allRuns.filter((run) => isActiveRunRecordStatus(run.status));
     for (const run of activeRuns) {
       const outcome = await this.reconcileRun(
         tenant,
@@ -422,7 +426,7 @@ export class OrchestratorService {
     }
     const reconciledRuns = (await this.store.loadAllRuns()).filter(
       (run) =>
-        run.projectId === tenant.projectId && isActiveRunStatus(run.status)
+        run.projectId === tenant.projectId && isActiveRunRecordStatus(run.status)
     );
     const projectRunsAfterReconcile = (await this.store.loadAllRuns()).filter(
       (run) => run.projectId === tenant.projectId
@@ -433,7 +437,7 @@ export class OrchestratorService {
       pollIntervalMs = await this.loadProjectPollInterval(tenant);
       const currentActiveRuns = (await this.store.loadAllRuns()).filter(
         (run) =>
-          run.projectId === tenant.projectId && isActiveRunStatus(run.status)
+          run.projectId === tenant.projectId && isActiveRunRecordStatus(run.status)
       );
       const {
         runs: syncedActiveRuns,
@@ -487,7 +491,7 @@ export class OrchestratorService {
       );
       const concurrency = await this.getProjectConcurrency(tenant);
       const currentlyActive = issueRecords.filter((record) =>
-        isIssueOrchestrationClaimed(record.state)
+        isIssueOrchestrationClaimedState(record.state)
       ).length;
       const availableSlots = Math.max(0, concurrency - currentlyActive);
       const latestRunsByIssueId = buildLatestRunMapByIssueId(
@@ -496,7 +500,7 @@ export class OrchestratorService {
 
       const unscheduledCandidates = actionableCandidates.filter((issue) => {
         if (
-          hasConvergenceLockedRun(
+          hasConvergenceLockedRunForIssue(
             projectRunsAfterReconcile,
             issue.id,
             issue.state,
@@ -509,7 +513,7 @@ export class OrchestratorService {
         return !issueRecords.some(
           (record) =>
             record.issueId === issue.id &&
-            isIssueOrchestrationClaimed(record.state)
+            isIssueOrchestrationClaimedState(record.state)
         );
       });
 
@@ -607,7 +611,7 @@ export class OrchestratorService {
       }
 
       for (const issueRecord of issueRecords) {
-        if (!isIssueOrchestrationClaimed(issueRecord.state)) {
+        if (!isIssueOrchestrationClaimedState(issueRecord.state)) {
           continue;
         }
 
@@ -703,7 +707,7 @@ export class OrchestratorService {
       (run) => run.projectId === tenant.projectId
     );
     const latestRuns = allTenantRuns.filter((run) =>
-      isActiveRunStatus(run.status)
+      isActiveRunRecordStatus(run.status)
     );
     rateLimits = rateLimits ?? resolveProjectRateLimits(latestRuns, []);
     const status = buildProjectSnapshot({
@@ -990,33 +994,7 @@ export class OrchestratorService {
     lifecycle: WorkflowLifecycleConfig,
     issues: readonly TrackedIssue[]
   ): boolean {
-    if (!isStateActive(issue.state, lifecycle)) {
-      return false;
-    }
-
-    if (
-      !matchesWorkflowState(issue.state, lifecycle.blockerCheckStates) ||
-      issue.blockedBy.length === 0
-    ) {
-      return true;
-    }
-
-    return !issue.blockedBy.some((blockerRef) => {
-      if (blockerRef.state && isStateTerminal(blockerRef.state, lifecycle)) {
-        return false;
-      }
-
-      if (blockerRef.identifier) {
-        const blockerIssue = issues.find(
-          (candidate) => candidate.identifier === blockerRef.identifier
-        );
-        if (blockerIssue?.state) {
-          return !isStateTerminal(blockerIssue.state, lifecycle);
-        }
-      }
-
-      return true;
-    });
+    return isIssueCandidateEligibleWithReason(issue, lifecycle, issues).eligible;
   }
 
   private async loadProjectWorkflow(
@@ -2346,7 +2324,7 @@ export class OrchestratorService {
   }> {
     // Mark the old retrying record as terminal BEFORE creating a new run.
     // Without this, the old record stays in the store with status "retrying"
-    // and isActiveRunStatus() picks it up on every tick, calling restartRun()
+    // and isActiveRunRecordStatus() picks it up on every tick, calling restartRun()
     // again each time → exponential run multiplication.
     const supersededRecord: OrchestratorRunRecord = {
       ...run,
@@ -3026,37 +3004,6 @@ function resolvePersistedCumulativeTurnCount(
   return run.cumulativeTurnCount ?? run.turnCount ?? 0;
 }
 
-function hasConvergenceLockedRun(
-  runs: readonly OrchestratorRunRecord[],
-  issueId: string,
-  issueState: string,
-  issueUpdatedAt: string | null | undefined
-): boolean {
-  const latestRun = runs
-    .filter((run) => run.issueId === issueId)
-    .sort(
-      (left, right) =>
-        new Date(right.updatedAt).getTime() - new Date(left.updatedAt).getTime()
-    )[0];
-
-  if (
-    latestRun?.runtimeSession?.exitClassification !== "convergence-detected" ||
-    latestRun.issueState !== issueState
-  ) {
-    return false;
-  }
-
-  const convergedAtMs = parseTimestampMs(
-    latestRun.completedAt ?? latestRun.updatedAt
-  );
-  const issueUpdatedAtMs = parseTimestampMs(issueUpdatedAt);
-  if (convergedAtMs === null || issueUpdatedAtMs === null) {
-    return true;
-  }
-
-  return issueUpdatedAtMs <= convergedAtMs;
-}
-
 function resolveCumulativeTurnCount(
   run: OrchestratorRunRecord,
   turnCount: number | null
@@ -3235,12 +3182,6 @@ function buildLatestRunMapByIssueId(
   return latestRuns;
 }
 
-function isIssueOrchestrationClaimed(
-  state: IssueOrchestrationRecord["state"]
-): boolean {
-  return state === "claimed" || state === "running" || state === "retry_queued";
-}
-
 function upsertIssueOrchestration(
   issueRecords: IssueOrchestrationRecord[],
   nextRecord: Omit<
@@ -3284,14 +3225,5 @@ function releaseIssueOrchestration(
           updatedAt: now.toISOString(),
         }
       : record
-  );
-}
-
-function isActiveRunStatus(status: OrchestratorRunRecord["status"]): boolean {
-  return (
-    status === "pending" ||
-    status === "starting" ||
-    status === "running" ||
-    status === "retrying"
   );
 }

--- a/packages/orchestrator/src/tracker-adapters.ts
+++ b/packages/orchestrator/src/tracker-adapters.ts
@@ -1,4 +1,5 @@
 import { resolveTrackerAdapter as resolveGitHubAdapter } from "@gh-symphony/tracker-github";
+export { findGithubProjectIssue } from "@gh-symphony/tracker-github";
 import { fileTrackerAdapter } from "@gh-symphony/tracker-file";
 import type {
   OrchestratorTrackerAdapter,
@@ -10,7 +11,7 @@ const localAdapters = new Map<string, OrchestratorTrackerAdapter>([
 ]);
 
 export function resolveTrackerAdapter(
-  tracker: OrchestratorTrackerConfig,
+  tracker: OrchestratorTrackerConfig
 ): OrchestratorTrackerAdapter {
   const local = localAdapters.get(tracker.adapter);
   if (local) return local;

--- a/packages/tracker-github/src/orchestrator-adapter.ts
+++ b/packages/tracker-github/src/orchestrator-adapter.ts
@@ -6,6 +6,7 @@ import type {
 } from "@gh-symphony/core";
 import {
   fetchGithubIssueStatesByIds,
+  fetchGithubProjectIssueByRepositoryAndNumber,
   fetchGithubProjectIssues,
 } from "./adapter.js";
 
@@ -75,12 +76,17 @@ export async function findGithubProjectIssue(
   identifier: string,
   dependencies: Parameters<OrchestratorTrackerAdapter["listIssues"]>[1] = {}
 ) {
-  const normalizedIdentifier = identifier.trim().toLowerCase();
-  const issues = await listProjectIssues(project, dependencies);
-  return (
-    issues.find(
-      (issue) => issue.identifier.trim().toLowerCase() === normalizedIdentifier
-    ) ?? null
+  const parsed = parseIssueIdentifier(identifier);
+  if (!parsed) {
+    return null;
+  }
+
+  const trackerConfig = resolveGitHubTrackerConfig(project, dependencies);
+  return fetchGithubProjectIssueByRepositoryAndNumber(
+    trackerConfig,
+    { owner: parsed.owner, name: parsed.name },
+    parsed.number,
+    dependencies.fetchImpl
   );
 }
 
@@ -103,7 +109,9 @@ async function listProjectIssues(
 async function fetchProjectIssueStatesByIds(
   project: Parameters<OrchestratorTrackerAdapter["fetchIssueStatesByIds"]>[0],
   issueIds: Parameters<OrchestratorTrackerAdapter["fetchIssueStatesByIds"]>[1],
-  dependencies: Parameters<OrchestratorTrackerAdapter["fetchIssueStatesByIds"]>[2] = {}
+  dependencies: Parameters<
+    OrchestratorTrackerAdapter["fetchIssueStatesByIds"]
+  >[2] = {}
 ) {
   const trackerConfig = resolveGitHubTrackerConfig(project, dependencies);
 
@@ -241,4 +249,19 @@ function readOptionalStringTrackerSetting(
 function parseIssueNumber(identifier: string): number {
   const match = identifier.match(/#(\d+)$/);
   return match ? Number.parseInt(match[1] ?? "0", 10) : 0;
+}
+
+function parseIssueIdentifier(
+  identifier: string
+): { owner: string; name: string; number: number } | null {
+  const match = identifier.match(/^([^/\s#]+)\/([^/\s#]+)#(\d+)$/);
+  if (!match) {
+    return null;
+  }
+
+  return {
+    owner: match[1]!,
+    name: match[2]!,
+    number: Number.parseInt(match[3]!, 10),
+  };
 }

--- a/packages/tracker-github/src/orchestrator-adapter.ts
+++ b/packages/tracker-github/src/orchestrator-adapter.ts
@@ -70,6 +70,20 @@ export const githubProjectTrackerAdapter: OrchestratorTrackerAdapter = {
   },
 };
 
+export async function findGithubProjectIssue(
+  project: Parameters<OrchestratorTrackerAdapter["listIssues"]>[0],
+  identifier: string,
+  dependencies: Parameters<OrchestratorTrackerAdapter["listIssues"]>[1] = {}
+) {
+  const normalizedIdentifier = identifier.trim().toLowerCase();
+  const issues = await listProjectIssues(project, dependencies);
+  return (
+    issues.find(
+      (issue) => issue.identifier.trim().toLowerCase() === normalizedIdentifier
+    ) ?? null
+  );
+}
+
 async function listProjectIssues(
   project: Parameters<OrchestratorTrackerAdapter["listIssues"]>[0],
   dependencies: Parameters<OrchestratorTrackerAdapter["listIssues"]>[1] = {}

--- a/packages/tracker-github/src/tracker-github.test.ts
+++ b/packages/tracker-github/src/tracker-github.test.ts
@@ -9,7 +9,10 @@ import {
   normalizeGithubProjectItem,
   resetGitHubRateLimitCacheForTests,
 } from "./adapter.js";
-import { resolveTrackerAdapter } from "./orchestrator-adapter.js";
+import {
+  findGithubProjectIssue,
+  resolveTrackerAdapter,
+} from "./orchestrator-adapter.js";
 import {
   validateWorkflowFieldMapping,
   detectDuplicatePlacements,
@@ -303,6 +306,93 @@ describe("resolveTrackerAdapter", () => {
     expect(adapter.fetchIssueStatesByIds).toBeTypeOf("function");
     expect(adapter.buildWorkerEnvironment).toBeTypeOf("function");
     expect(adapter.reviveIssue).toBeTypeOf("function");
+  });
+
+  it("finds one GitHub Project issue through the targeted issue lookup", async () => {
+    const fetchImpl = vi.fn(async (_url, init) => {
+      const body =
+        typeof init?.body === "string"
+          ? (JSON.parse(init.body) as { query?: string })
+          : {};
+      expect(body.query).toContain("RepositoryIssue");
+      return new Response(
+        JSON.stringify({
+          data: {
+            repository: {
+              issue: {
+                __typename: "Issue",
+                id: "issue-42",
+                number: 42,
+                title: "Target issue",
+                body: null,
+                url: "https://github.com/acme/platform/issues/42",
+                createdAt: "2026-05-01T00:00:00.000Z",
+                updatedAt: "2026-05-02T00:00:00.000Z",
+                labels: { nodes: [] },
+                assignees: { nodes: [] },
+                repository: {
+                  name: "platform",
+                  url: "https://github.com/acme/platform",
+                  owner: { login: "acme" },
+                },
+                blockedBy: { nodes: [] },
+                projectItems: {
+                  nodes: [
+                    {
+                      id: "item-42",
+                      updatedAt: "2026-05-02T00:00:00.000Z",
+                      project: { id: "project-123" },
+                      fieldValues: {
+                        nodes: [
+                          {
+                            __typename: "ProjectV2ItemFieldSingleSelectValue",
+                            name: "Todo",
+                            field: { name: "Status" },
+                          },
+                        ],
+                      },
+                    },
+                  ],
+                  pageInfo: { endCursor: null, hasNextPage: false },
+                },
+              },
+            },
+          },
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }
+      );
+    });
+
+    const issue = await findGithubProjectIssue(
+      {
+        projectId: "workspace-1",
+        slug: "workspace-1",
+        workspaceDir: "/tmp/workspace-1",
+        repository: {
+          owner: "acme",
+          name: "platform",
+          cloneUrl: "https://github.com/acme/platform.git",
+        },
+        tracker: {
+          adapter: "github-project",
+          bindingId: "project-123",
+          settings: {
+            projectId: "project-123",
+          },
+        },
+      },
+      "acme/platform#42",
+      {
+        token: "dependencies-token",
+        fetchImpl,
+      }
+    );
+
+    expect(issue?.identifier).toBe("acme/platform#42");
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
 
   it("revives issue title from run records when available", () => {


### PR DESCRIPTION
## Issues

- Fixes #190

## Summary

- Adds `gh-symphony project explain <owner/repo#number>` as the first-line answer for why a GitHub Project issue is not dispatching.
- Reuses shared orchestrator eligibility reasoning for workflow state, blockers, runtime ownership, convergence locks, retry suppression, and dispatch capacity.
- Addresses review feedback by using targeted GitHub issue lookup, friendly auth failures, deterministic workflow loading, and clearer not-found summaries.

## Changes

- Added a reusable orchestrator explanation module and wired the service candidate checks through it.
- Added CLI routing and human/JSON report formatting under `project explain`, including `--workflow <path>` for explicit workflow resolution.
- Exposed and used `findGithubProjectIssue`, now backed by the tracker-github targeted repository issue lookup instead of scanning the full project set.
- Removed silent default workflow fallback; `project explain` now requires a configured path, explicit `--workflow`, or prior run workflow path and exits with a diagnostic if none is available.
- Centralized issue identifier parsing through the orchestrator explain module and improved issue-not-found summary prioritization.
- Covered inactive state, unresolved blockers, active ownership, concurrency limits, auth failure, workflow resolution, targeted lookup, and summary ordering in tests.
- Documented the troubleshooting flow in the root README, CLI README, and CLI help.

## Evidence

- `pnpm --filter @gh-symphony/orchestrator test -- --run src/dispatch.test.ts && pnpm --filter @gh-symphony/cli test -- --run src/commands/project.test.ts src/index.test.ts`
- `pnpm --filter @gh-symphony/tracker-github test -- --run src/tracker-github.test.ts && pnpm --filter @gh-symphony/cli test -- --run src/commands/project.test.ts`
- `pnpm --filter @gh-symphony/orchestrator typecheck && pnpm --filter @gh-symphony/cli typecheck && pnpm --filter @gh-symphony/orchestrator lint && pnpm --filter @gh-symphony/cli lint && pnpm --filter @gh-symphony/tracker-github lint`
- `pnpm --filter @gh-symphony/tracker-github typecheck && pnpm --filter @gh-symphony/cli typecheck && pnpm --filter @gh-symphony/tracker-github lint && pnpm --filter @gh-symphony/cli lint`
- `pnpm lint && pnpm test && pnpm typecheck && pnpm build`
- Docker E2E TC from initial implementation: started `docker-compose.e2e.yml` with events override, injected `e2e/fixtures/blocked-issue.json`, refreshed `/api/v1/refresh`, and confirmed only `test-owner/test-repo#20` was active/retrying while blocked issue `#21` was not dispatched; cleaned container, fixture, and evidence state.
- Manual check: re-read issue #190 and PR review feedback against the final diff; all requested checks remain present, and the rework removes the silent workflow fallback noted by reviewers.

## Human Validation

- [ ] Run `gh-symphony project explain <owner/repo#number>` against a real managed GitHub Project issue.
- [ ] Confirm `--json` contains machine-readable checks for project linkage, item presence, workflow state, blockers, ownership, and dispatch limits.
- [ ] Confirm `--workflow ./WORKFLOW.md` works when no previous local run snapshot can identify the workflow file.
- [ ] Confirm remediation hints point to the expected operational commands or GitHub Project state changes.

## Risks

- The command explains current local runtime state from persisted project files; stale local state can affect ownership/concurrency findings until the orchestrator writes a fresh snapshot.
- First-run environments without a configured repository path or previous run snapshot now need `--workflow <path>` instead of receiving a potentially misleading default lifecycle report.