### PR TITLE
feat(worker): route non-codex runtimes through adapters

### DIFF
--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -1,4 +1,4 @@
-import { spawn } from "node:child_process";
+import { spawn, type ChildProcess } from "node:child_process";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import {
@@ -7,9 +7,11 @@ import {
   parseWorkflowMarkdown,
   resolveWorkflowRuntimeCommand,
   type AgentEvent,
+  type AgentRuntimeAdapter,
   type OrchestratorChannelEvent,
   type RunAttemptPhase,
   type SessionExitClassification,
+  type WorkflowDefinition,
   type WorkflowExecutionPhase,
 } from "@gh-symphony/core";
 import {
@@ -40,7 +42,13 @@ import {
   evaluateTurnProgress,
   resolveMaxNonProductiveTurns,
 } from "./convergence-detection.js";
+import {
+  createWorkerNonCodexRuntimeAdapter,
+  type WorkerNonCodexRuntimeAdapter,
+  type WorkerNonCodexTurnResult,
+} from "./non-codex-runtime.js";
 import { resolveExitRunPhase } from "./run-phase.js";
+import { resolveWorkerRuntimeRoute } from "./runtime-routing.js";
 import { buildContinuationTurnInput } from "./thread-resume.js";
 import { resolveMaxTurns } from "./turn-limits.js";
 import { persistTokenUsageArtifact, type TokenUsage } from "./token-usage.js";
@@ -128,7 +136,8 @@ console.log(
   )
 );
 
-let childProcess: ReturnType<typeof launchCodexAppServer> | null = null;
+let childProcess: ChildProcess | null = null;
+let runtimeAdapter: AgentRuntimeAdapter | null = null;
 let shutdownPromise: Promise<void> | null = null;
 let orchestratorChannelDrainPending = false;
 const pendingOrchestratorChannelPayloads: string[] = [];
@@ -169,6 +178,7 @@ function shutdown(signal: NodeJS.Signals) {
         // Ignore shutdown races.
       }
     }
+    await runtimeAdapter?.cancel(`worker received ${signal}`);
 
     stopOrchestratorHeartbeatTimer();
     emitOrchestratorHeartbeat();
@@ -479,7 +489,12 @@ async function startAssignedRun() {
       await readFile(workflowPath, "utf8"),
       launcherEnv
     );
-    if (isClaudeRuntimeCommand(workflow.codex.command)) {
+    const route = resolveWorkerRuntimeRoute(workflow);
+    if (
+      route === "runtime-adapter" &&
+      workflow.runtime?.kind === "claude-print" &&
+      isClaudeRuntimeCommand(resolveWorkflowRuntimeCommand(workflow))
+    ) {
       const hasGitHubGraphqlToken =
         typeof launcherEnv.GITHUB_GRAPHQL_TOKEN === "string" &&
         launcherEnv.GITHUB_GRAPHQL_TOKEN.trim().length > 0;
@@ -499,21 +514,21 @@ async function startAssignedRun() {
         );
         return;
       }
-      await exitWorkerStartupFailure(
-        "Claude runtime worker launch is not yet implemented in this branch."
-      );
-      return;
     }
     runtimeState.executionPhase = resolveInitialExecutionPhase({
       issueState: runtimeState.run?.state,
       blockerCheckStates: workflow.lifecycle.blockerCheckStates,
       activeStates: workflow.lifecycle.activeStates,
     });
+    runtimeState.runPhase = "launching_agent";
+
+    if (route === "runtime-adapter") {
+      await runNonCodexRuntimeAdapterLifecycle(workflow, launcherEnv);
+      return;
+    }
+
     const config = resolveLocalRuntimeLaunchConfig(launcherEnv);
     config.agentCommand = resolveWorkflowRuntimeCommand(workflow);
-    runtimeState.runPhase = "launching_agent";
-    // TODO(#254): route claude-print/custom runtime kinds through runtime
-    // adapters instead of the Codex app-server client protocol.
     const plan = await prepareCodexRuntimePlan(config);
     childProcess = launchCodexAppServer(plan);
     runtimeState.status = "running";
@@ -565,15 +580,268 @@ async function startAssignedRun() {
       void persistSessionTokenUsageArtifact(launcherEnv);
     });
   } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Unknown worker startup error";
     runtimeState.status = "failed";
     runtimeState.runPhase = "failed";
 
     if (runtimeState.run) {
-      runtimeState.run.lastError =
-        error instanceof Error ? error.message : "Unknown worker startup error";
+      runtimeState.run.lastError = message;
     }
+    process.stderr.write(`[worker] startup failed: ${message}\n`);
     await persistSessionTokenUsageArtifact(launcherEnv);
   }
+}
+
+async function runNonCodexRuntimeAdapterLifecycle(
+  workflow: WorkflowDefinition,
+  env: NodeJS.ProcessEnv
+): Promise<void> {
+  const renderedPrompt = env.SYMPHONY_RENDERED_PROMPT;
+  if (!renderedPrompt) {
+    await exitWorkerStartupFailure(
+      "SYMPHONY_RENDERED_PROMPT not set; cannot run runtime adapter lifecycle."
+    );
+    return;
+  }
+
+  const runId = env.SYMPHONY_RUN_ID;
+  if (!runId) {
+    await exitWorkerStartupFailure(
+      "SYMPHONY_RUN_ID not set; cannot prepare runtime adapter lifecycle."
+    );
+    return;
+  }
+
+  const runtimeKind = workflow.runtime?.kind;
+  if (runtimeKind !== "claude-print" && runtimeKind !== "custom") {
+    await exitWorkerStartupFailure(
+      "Runtime adapter lifecycle requested for an unsupported runtime kind."
+    );
+    return;
+  }
+
+  const adapter = createWorkerNonCodexRuntimeAdapter(workflow, {
+    workingDirectory: env.WORKING_DIRECTORY!,
+    env,
+    runtimeRoot: env.WORKSPACE_RUNTIME_DIR,
+    runtimeDirectory: env.WORKSPACE_RUNTIME_DIR,
+    onSpawned: (child) => {
+      childProcess = child;
+      if (runtimeState.run) {
+        runtimeState.run.processId = child.pid ?? null;
+      }
+    },
+  });
+  runtimeAdapter = adapter as AgentRuntimeAdapter;
+
+  let terminalFailure: string | null = null;
+  const unsubscribe = adapter.onEvent((event) => {
+    const agentEvent = event as AgentEvent;
+    handleNonCodexRuntimeEvent(agentEvent);
+    if (agentEvent.name === "agent.inputRequired") {
+      terminalFailure = agentEvent.payload.reason;
+    }
+    if (
+      agentEvent.name === "agent.turnFailed" ||
+      agentEvent.name === "agent.error"
+    ) {
+      terminalFailure =
+        agentEvent.name === "agent.error"
+          ? agentEvent.payload.error
+          : JSON.stringify(agentEvent.payload.params);
+    }
+  });
+
+  const turnTelemetry: ActiveTurnTelemetry = {
+    startedAt: new Date().toISOString(),
+    threadId: null,
+    turnId: `${runId}-turn-1`,
+    turnCount: 1,
+    sessionId: runId,
+    tokenUsageBaseline: cloneTokenUsageSnapshot(),
+  };
+
+  try {
+    await (adapter as AgentRuntimeAdapter<{ runId: string }>).prepare({
+      runId,
+    });
+    runtimeState.status = "running";
+    runtimeState.runPhase = "streaming_turn";
+    runtimeState.sessionInfo = {
+      threadId: turnTelemetry.threadId,
+      turnId: turnTelemetry.turnId,
+      turnCount: turnTelemetry.turnCount,
+      sessionId: turnTelemetry.sessionId,
+      exitClassification: null,
+    };
+    runtimeState.sessionId = turnTelemetry.sessionId;
+    emitTurnStartedEvent(turnTelemetry);
+
+    const result = await spawnNonCodexRuntimeTurn(
+      adapter,
+      runtimeKind,
+      renderedPrompt,
+      env
+    );
+    if (isNonCodexTurnFailure(result)) {
+      terminalFailure = describeNonCodexTurnFailure(result);
+    }
+
+    runtimeState.status = terminalFailure ? "failed" : "completed";
+    runtimeState.runPhase = terminalFailure ? "failed" : "succeeded";
+    if (runtimeState.run) {
+      runtimeState.run.lastError = terminalFailure;
+    }
+    runtimeState.sessionInfo.exitClassification = classifySessionExit({
+      runPhase: runtimeState.runPhase,
+      userInputRequired:
+        terminalFailure === DEFAULT_AGENT_INPUT_REQUIRED_REASON ||
+        terminalFailure?.startsWith("turn_input_required:") === true,
+      budgetExceeded: false,
+      convergenceDetected: false,
+      maxTurnsReached: false,
+    });
+
+    if (terminalFailure) {
+      emitTurnFailedEvent(turnTelemetry, terminalFailure);
+    } else {
+      emitTurnCompletedEvent(turnTelemetry);
+    }
+  } catch (error) {
+    const message =
+      error instanceof Error
+        ? error.message
+        : "Unknown runtime adapter lifecycle error";
+    runtimeState.status = "failed";
+    runtimeState.runPhase = "failed";
+    if (runtimeState.run) {
+      runtimeState.run.lastError = message;
+    }
+    runtimeState.sessionInfo.exitClassification = classifySessionExit({
+      runPhase: runtimeState.runPhase,
+      userInputRequired: false,
+      budgetExceeded: false,
+      convergenceDetected: false,
+      maxTurnsReached: false,
+    });
+    emitTurnFailedEvent(turnTelemetry, message);
+  } finally {
+    unsubscribe();
+    await adapter.shutdown();
+    runtimeAdapter = null;
+    childProcess = null;
+    runtimeState.runPhase = runtimeState.runPhase ?? "failed";
+    stopOrchestratorHeartbeatTimer();
+    emitOrchestratorHeartbeat();
+    await persistSessionTokenUsageArtifact(env);
+    await waitForPendingOrchestratorChannelFlush(
+      resolveTerminalOrchestratorChannelFlushTimeoutMs()
+    );
+    setTimeout(() => {
+      process.exit(runtimeState.status === "completed" ? 0 : 1);
+    }, 1500);
+  }
+}
+
+async function spawnNonCodexRuntimeTurn(
+  adapter: WorkerNonCodexRuntimeAdapter,
+  runtimeKind: "claude-print" | "custom",
+  renderedPrompt: string,
+  env: NodeJS.ProcessEnv
+): Promise<WorkerNonCodexTurnResult> {
+  if (runtimeKind === "claude-print") {
+    return await (
+      adapter as {
+        spawnTurn(input: {
+          messages: Array<{ type: "user"; text: string }>;
+          cwd?: string;
+          env?: NodeJS.ProcessEnv;
+        }): Promise<WorkerNonCodexTurnResult>;
+      }
+    ).spawnTurn({
+      messages: [{ type: "user", text: renderedPrompt }],
+      cwd: env.WORKING_DIRECTORY,
+      env,
+    });
+  }
+
+  return await (
+    adapter as {
+      spawnTurn(input: {
+        prompt: string;
+        cwd?: string;
+        env?: NodeJS.ProcessEnv;
+      }): Promise<WorkerNonCodexTurnResult>;
+    }
+  ).spawnTurn({
+    prompt: renderedPrompt,
+    cwd: env.WORKING_DIRECTORY,
+    env,
+  });
+}
+
+function handleNonCodexRuntimeEvent(event: AgentEvent): void {
+  if (event.payload.suppressUpdate) {
+    return;
+  }
+  runtimeState.lastEventAt = new Date().toISOString();
+
+  switch (event.name) {
+    case "agent.tokenUsageUpdated": {
+      const tokenUsage = extractAbsoluteTokenUsage(event.payload.params);
+      if (tokenUsage) {
+        applyTokenUsageUpdate(
+          event.payload.observabilityEvent ?? event.name,
+          tokenUsage
+        );
+      }
+      break;
+    }
+    case "agent.rateLimit": {
+      const rateLimits = extractRateLimitPayload(event.payload.params);
+      if (rateLimits) {
+        applyRateLimitUpdate(
+          event.payload.observabilityEvent ?? event.name,
+          rateLimits,
+          "runtime-adapter"
+        );
+      }
+      break;
+    }
+    case "agent.inputRequired":
+      runtimeState.status = "failed";
+      if (runtimeState.run) {
+        runtimeState.run.lastError = event.payload.reason;
+      }
+      break;
+    case "agent.turnFailed":
+    case "agent.turnCancelled":
+    case "agent.error":
+      runtimeState.status = "failed";
+      if (runtimeState.run) {
+        runtimeState.run.lastError =
+          event.name === "agent.error"
+            ? event.payload.error
+            : JSON.stringify(event.payload.params);
+      }
+      break;
+    default:
+      break;
+  }
+
+  emitOrchestratorChannelEvent(event.payload.observabilityEvent ?? event.name);
+}
+
+function isNonCodexTurnFailure(result: WorkerNonCodexTurnResult): boolean {
+  return result.result !== "success";
+}
+
+function describeNonCodexTurnFailure(result: WorkerNonCodexTurnResult): string {
+  return (
+    result.errorMessage ??
+    `${result.command} exited with ${result.signal ?? result.exitCode ?? "unknown"}`
+  );
 }
 
 async function exitWorkerStartupFailure(message: string): Promise<void> {
@@ -1412,11 +1680,12 @@ function applyTokenUsageUpdate(
 
 function applyRateLimitUpdate(
   source: string,
-  rateLimits: Record<string, unknown>
+  rateLimits: Record<string, unknown>,
+  runtimeSource = "codex"
 ): void {
   runtimeState.rateLimits = {
     ...rateLimits,
-    source: "codex",
+    source: runtimeSource,
   };
   process.stderr.write(
     `[worker] rate_limits source=${source} payload=${JSON.stringify(runtimeState.rateLimits).slice(0, 300)}\n`

--- a/packages/worker/src/non-codex-runtime.test.ts
+++ b/packages/worker/src/non-codex-runtime.test.ts
@@ -1,0 +1,188 @@
+import { EventEmitter } from "node:events";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { PassThrough } from "node:stream";
+import type { ChildProcess } from "node:child_process";
+import { describe, expect, it, vi } from "vitest";
+import {
+  DEFAULT_WORKFLOW_DEFINITION,
+  type WorkflowDefinition,
+} from "@gh-symphony/core";
+import {
+  CustomCommandWorkerRuntimeAdapter,
+  createWorkerNonCodexRuntimeAdapter,
+} from "./non-codex-runtime.js";
+
+describe("CustomCommandWorkerRuntimeAdapter", () => {
+  it("spawns a custom command without the Codex JSON-RPC protocol", async () => {
+    const fake = createFakeChild();
+    const spawnImpl = vi.fn(() => fake.child);
+    const adapter = new CustomCommandWorkerRuntimeAdapter(
+      {
+        workingDirectory: "/repo",
+        command: "agent",
+        args: ["--run"],
+        env: {
+          EXISTING_ENV: "1",
+        },
+      },
+      { spawnImpl }
+    );
+
+    const resultPromise = adapter.spawnTurn({
+      prompt: "implement issue",
+      env: {
+        TURN_ENV: "2",
+      },
+    });
+    fake.stdout.end("done");
+    fake.stderr.end("warn");
+    fake.emitExit(0, null);
+    const result = await resultPromise;
+
+    expect(spawnImpl).toHaveBeenCalledWith(
+      "agent",
+      ["--run"],
+      expect.objectContaining({
+        cwd: "/repo",
+        stdio: "pipe",
+        env: expect.objectContaining({
+          EXISTING_ENV: "1",
+          TURN_ENV: "2",
+          SYMPHONY_RENDERED_PROMPT: "implement issue",
+        }),
+      })
+    );
+    expect(fake.stdinText()).toBe("implement issue");
+    expect(result).toMatchObject({
+      command: "agent",
+      args: ["--run"],
+      stdout: "done",
+      stderr: "warn",
+      result: "success",
+    });
+  });
+});
+
+describe("createWorkerNonCodexRuntimeAdapter", () => {
+  it("creates a claude-print adapter that receives the rendered prompt as a user message", async () => {
+    const fake = createFakeChild();
+    const spawnImpl = vi.fn(() => fake.child);
+    const root = await mkdtemp(join(tmpdir(), "worker-claude-runtime-"));
+    const adapter = createWorkerNonCodexRuntimeAdapter(
+      workflowWithRuntime("claude-print", "claude", []),
+      {
+        workingDirectory: root,
+        env: {},
+        runtimeRoot: join(root, "runtime"),
+        claudeDependencies: {
+          spawnImpl,
+          createSessionId: () => "session-1",
+        },
+      }
+    );
+
+    await adapter.prepare({ runId: "run-1" });
+    const resultPromise = adapter.spawnTurn({
+      messages: [{ type: "user", text: "rendered prompt" }],
+    });
+    fake.stdout.end(
+      `${JSON.stringify({ type: "result", subtype: "success", session_id: "session-1" })}\n`
+    );
+    fake.stderr.end();
+    fake.emitExit(0, null);
+    const result = await resultPromise;
+
+    expect(spawnImpl).toHaveBeenCalledWith(
+      "claude",
+      expect.arrayContaining(["-p", "--output-format", "stream-json"]),
+      expect.objectContaining({
+        cwd: root,
+        stdio: "pipe",
+      })
+    );
+    expect(fake.stdinText()).toBe(
+      `${JSON.stringify({ type: "user", text: "rendered prompt" })}\n`
+    );
+    expect(result.result).toBe("success");
+  });
+
+  it("creates a custom adapter for custom runtime kind", () => {
+    const adapter = createWorkerNonCodexRuntimeAdapter(
+      workflowWithRuntime("custom", "agent", ["--flag"]),
+      {
+        workingDirectory: "/repo",
+        env: {},
+      }
+    );
+
+    expect(adapter).toBeInstanceOf(CustomCommandWorkerRuntimeAdapter);
+  });
+});
+
+function workflowWithRuntime(
+  kind: "claude-print" | "custom",
+  command: string,
+  args: readonly string[]
+): WorkflowDefinition {
+  return {
+    ...DEFAULT_WORKFLOW_DEFINITION,
+    runtime: {
+      kind,
+      command,
+      args,
+      isolation: {
+        bare: false,
+        strictMcpConfig: false,
+      },
+      auth: {
+        env: null,
+      },
+      timeouts: DEFAULT_WORKFLOW_DEFINITION.codex,
+    },
+  };
+}
+
+function createFakeChild(): {
+  child: ChildProcess;
+  stdinText: () => string;
+  emitExit: (code: number | null, signal: NodeJS.Signals | null) => void;
+  stdout: PassThrough;
+  stderr: PassThrough;
+} {
+  const emitter = new EventEmitter();
+  const stdin = new PassThrough();
+  const stdout = new PassThrough();
+  const stderr = new PassThrough();
+  let stdinText = "";
+  stdin.setEncoding("utf8");
+  stdin.on("data", (chunk: string) => {
+    stdinText += chunk;
+  });
+  stdin.resume();
+
+  const child = {
+    pid: 1234,
+    stdin,
+    stdout,
+    stderr,
+    killed: false,
+    kill: vi.fn(),
+    once: emitter.once.bind(emitter),
+    on: emitter.on.bind(emitter),
+    removeListener: emitter.removeListener.bind(emitter),
+    emit: emitter.emit.bind(emitter),
+  } as unknown as ChildProcess;
+
+  return {
+    child,
+    stdout,
+    stderr,
+    stdinText: () => stdinText,
+    emitExit: (code, signal) => {
+      emitter.emit("exit", code, signal);
+      emitter.emit("close", code, signal);
+    },
+  };
+}

--- a/packages/worker/src/non-codex-runtime.ts
+++ b/packages/worker/src/non-codex-runtime.ts
@@ -1,0 +1,251 @@
+import {
+  spawn,
+  type ChildProcess,
+  type SpawnOptions,
+} from "node:child_process";
+import { finished } from "node:stream/promises";
+import type {
+  AgentRuntimeAdapter,
+  AgentRuntimeCredentialBrokerResponse,
+  AgentRuntimeEnv,
+  AgentRuntimeEvent,
+  AgentRuntimeEventHandler,
+  AgentRuntimeEventSubscription,
+  WorkflowDefinition,
+} from "@gh-symphony/core";
+import { extractEnvForClaude } from "@gh-symphony/core";
+import {
+  createClaudePrintRuntimeAdapter,
+  type ClaudeRuntimeDependencies,
+  type ClaudePrintRuntimeAdapter,
+  type ClaudeRuntimeTurnResult,
+} from "@gh-symphony/runtime-claude";
+
+export type WorkerNonCodexRuntimeContext = {
+  workingDirectory: string;
+  env: NodeJS.ProcessEnv;
+  runtimeRoot?: string;
+  runtimeDirectory?: string;
+  onSpawned?: (child: ChildProcess) => void;
+  claudeDependencies?: ClaudeRuntimeDependencies;
+  customDependencies?: {
+    spawnImpl?: CustomCommandSpawnLike;
+  };
+};
+
+export type WorkerNonCodexRuntimeAdapter =
+  | ClaudePrintRuntimeAdapter
+  | CustomCommandWorkerRuntimeAdapter;
+
+export type WorkerNonCodexTurnResult =
+  | ClaudeRuntimeTurnResult
+  | CustomCommandTurnResult;
+
+export type CustomCommandTurnInput = {
+  prompt: string;
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+};
+
+export type CustomCommandTurnResult = {
+  command: string;
+  args: string[];
+  cwd: string;
+  stdout: string;
+  stderr: string;
+  exitCode: number | null;
+  signal: NodeJS.Signals | null;
+  result: "success" | "process-error";
+  errorMessage?: string;
+};
+
+export type CustomCommandSpawnLike = (
+  command: string,
+  args: ReadonlyArray<string>,
+  options: SpawnOptions
+) => ChildProcess;
+
+export class CustomCommandWorkerRuntimeAdapter implements AgentRuntimeAdapter<
+  void,
+  CustomCommandTurnInput,
+  CustomCommandTurnResult,
+  AgentRuntimeEvent
+> {
+  private activeChild: ChildProcess | null = null;
+
+  constructor(
+    private readonly config: {
+      workingDirectory: string;
+      command: string;
+      args: readonly string[];
+      env?: NodeJS.ProcessEnv;
+      authEnvKey?: string;
+      onSpawned?: (child: ChildProcess) => void;
+    },
+    private readonly dependencies: {
+      spawnImpl?: CustomCommandSpawnLike;
+    } = {}
+  ) {}
+
+  prepare(): void {}
+
+  async spawnTurn(
+    input: CustomCommandTurnInput
+  ): Promise<CustomCommandTurnResult> {
+    const command = this.config.command;
+    const args = [...this.config.args];
+    const cwd = input.cwd ?? this.config.workingDirectory;
+    const child = (this.dependencies.spawnImpl ?? spawn)(command, args, {
+      cwd,
+      env: {
+        ...this.config.env,
+        ...input.env,
+        SYMPHONY_RENDERED_PROMPT: input.prompt,
+      },
+      stdio: "pipe",
+    });
+    this.activeChild = child;
+    this.config.onSpawned?.(child);
+
+    let stdout = "";
+    let stderr = "";
+    let spawnError: string | undefined;
+    child.stdout?.setEncoding("utf8");
+    child.stderr?.setEncoding("utf8");
+    child.stdout?.on("data", (chunk: string) => {
+      stdout += chunk;
+    });
+    child.stderr?.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+    child.once("error", (error) => {
+      spawnError = error.message;
+    });
+
+    if (child.stdin && !child.stdin.destroyed) {
+      child.stdin.end(input.prompt);
+    }
+
+    const { exitCode, signal } = await waitForChildExit(child);
+    await Promise.all([
+      child.stdout ? finished(child.stdout).catch(() => undefined) : undefined,
+      child.stderr ? finished(child.stderr).catch(() => undefined) : undefined,
+    ]);
+    this.activeChild = null;
+
+    const result =
+      exitCode === 0 && signal === null && !spawnError
+        ? "success"
+        : "process-error";
+
+    return {
+      command,
+      args,
+      cwd,
+      stdout,
+      stderr,
+      exitCode,
+      signal,
+      result,
+      errorMessage: spawnError,
+    };
+  }
+
+  onEvent(
+    _handler: AgentRuntimeEventHandler<AgentRuntimeEvent>
+  ): AgentRuntimeEventSubscription {
+    return () => {};
+  }
+
+  resolveCredentials(
+    brokerResponse: AgentRuntimeCredentialBrokerResponse
+  ): AgentRuntimeEnv {
+    if (!this.config.authEnvKey) {
+      return {};
+    }
+    return extractEnvForClaude(brokerResponse.env, this.config.authEnvKey);
+  }
+
+  shutdown(): void {
+    this.stopActiveChild();
+  }
+
+  cancel(): void {
+    this.stopActiveChild();
+  }
+
+  private stopActiveChild(): void {
+    if (!this.activeChild || this.activeChild.killed) {
+      this.activeChild = null;
+      return;
+    }
+    this.activeChild.kill("SIGTERM");
+    this.activeChild = null;
+  }
+}
+
+export function createWorkerNonCodexRuntimeAdapter(
+  workflow: WorkflowDefinition,
+  context: WorkerNonCodexRuntimeContext
+): WorkerNonCodexRuntimeAdapter {
+  const runtime = workflow.runtime;
+
+  if (!runtime || runtime.kind === "codex-app-server") {
+    throw new Error(
+      "Worker non-Codex runtime adapter requested for a Codex runtime."
+    );
+  }
+
+  switch (runtime.kind) {
+    case "claude-print":
+      return createClaudePrintRuntimeAdapter(
+        {
+          workingDirectory: context.workingDirectory,
+          runtimeRoot: context.runtimeRoot,
+          runtimeDirectory: context.runtimeDirectory,
+          command: runtime.command,
+          args: runtime.args,
+          env: context.env,
+          authEnvKey: runtime.auth.env ?? undefined,
+          isolation: {
+            bare: runtime.isolation.bare,
+            strictMcpConfig: runtime.isolation.strictMcpConfig,
+          },
+        },
+        {
+          ...context.claudeDependencies,
+          onSpawned: context.onSpawned,
+        }
+      );
+    case "custom":
+      return new CustomCommandWorkerRuntimeAdapter(
+        {
+          workingDirectory: context.workingDirectory,
+          command: runtime.command,
+          args: runtime.args,
+          env: context.env,
+          authEnvKey: runtime.auth.env ?? undefined,
+          onSpawned: context.onSpawned,
+        },
+        context.customDependencies
+      );
+  }
+}
+
+function waitForChildExit(
+  child: ChildProcess
+): Promise<{ exitCode: number | null; signal: NodeJS.Signals | null }> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const settle = (exitCode: number | null, signal: NodeJS.Signals | null) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      resolve({ exitCode, signal });
+    };
+
+    child.once("exit", settle);
+    child.once("error", () => settle(1, null));
+  });
+}

--- a/packages/worker/src/runtime-routing.test.ts
+++ b/packages/worker/src/runtime-routing.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_WORKFLOW_DEFINITION,
+  type WorkflowDefinition,
+} from "@gh-symphony/core";
+import { resolveWorkerRuntimeRoute } from "./runtime-routing.js";
+
+describe("resolveWorkerRuntimeRoute", () => {
+  it("keeps legacy codex fallback on the Codex app-server route", () => {
+    expect(resolveWorkerRuntimeRoute(workflowWithRuntime(null))).toBe(
+      "codex-app-server"
+    );
+  });
+
+  it("keeps explicit codex-app-server runtime on the Codex route", () => {
+    expect(
+      resolveWorkerRuntimeRoute(
+        workflowWithRuntime({
+          kind: "codex-app-server",
+          command: "codex",
+          args: ["app-server"],
+        })
+      )
+    ).toBe("codex-app-server");
+  });
+
+  it.each(["claude-print", "custom"] as const)(
+    "routes %s through runtime adapters",
+    (kind) => {
+      expect(
+        resolveWorkerRuntimeRoute(
+          workflowWithRuntime({
+            kind,
+            command: kind === "custom" ? "agent" : "claude",
+            args: [],
+          })
+        )
+      ).toBe("runtime-adapter");
+    }
+  );
+});
+
+function workflowWithRuntime(
+  runtime: null | {
+    kind: "codex-app-server" | "claude-print" | "custom";
+    command: string;
+    args: readonly string[];
+  }
+): WorkflowDefinition {
+  return {
+    ...DEFAULT_WORKFLOW_DEFINITION,
+    runtime:
+      runtime === null
+        ? null
+        : {
+            kind: runtime.kind,
+            command: runtime.command,
+            args: runtime.args,
+            isolation: {
+              bare: false,
+              strictMcpConfig: false,
+            },
+            auth: {
+              env: null,
+            },
+            timeouts: DEFAULT_WORKFLOW_DEFINITION.codex,
+          },
+  };
+}

--- a/packages/worker/src/runtime-routing.ts
+++ b/packages/worker/src/runtime-routing.ts
@@ -1,0 +1,15 @@
+import type { WorkflowDefinition } from "@gh-symphony/core";
+
+export type WorkerRuntimeRoute = "codex-app-server" | "runtime-adapter";
+
+export function resolveWorkerRuntimeRoute(
+  workflow: WorkflowDefinition
+): WorkerRuntimeRoute {
+  const kind = workflow.runtime?.kind;
+
+  if (!kind || kind === "codex-app-server") {
+    return "codex-app-server";
+  }
+
+  return "runtime-adapter";
+}

--- a/test/e2e/claude/claude-docker.spec.ts
+++ b/test/e2e/claude/claude-docker.spec.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { spawn } from "node:child_process";
 import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
@@ -71,6 +72,59 @@ describe("Claude Docker E2E with stub claude binary", () => {
       "In review",
     ]);
     expect(await harness.readInvocations()).toHaveLength(1);
+  });
+
+  it("routes worker claude-print runtime through the adapter lifecycle", async () => {
+    const root = await mkdtemp(join(tmpdir(), "worker-claude-e2e-"));
+    createdRoots.push(root);
+    const workspace = join(root, "workspace");
+    const runtimeRoot = join(root, "runtime");
+    const logDir = join(root, "stub-log");
+    const workflowPath = join(workspace, "WORKFLOW.md");
+    await mkdir(workspace, { recursive: true });
+    await mkdir(runtimeRoot, { recursive: true });
+    await mkdir(logDir, { recursive: true });
+    await writeFile(
+      workflowPath,
+      `---
+tracker:
+  kind: github-project
+runtime:
+  kind: claude-print
+  command: claude
+---
+Worker prompt.
+`,
+      "utf8"
+    );
+
+    const result = await runWorkerProcess({
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        PATH: `${resolve(repoRoot, "test/e2e/stubs")}:${process.env.PATH ?? ""}`,
+        CLAUDE_STUB_LOG_DIR: logDir,
+        CLAUDE_STUB_SCENARIO: "success",
+        ANTHROPIC_API_KEY: "stub-anthropic-key",
+        GITHUB_GRAPHQL_TOKEN: "stub-token",
+        GITHUB_PROJECT_ID: "stub-project",
+        WORKING_DIRECTORY: workspace,
+        WORKSPACE_RUNTIME_DIR: runtimeRoot,
+        SYMPHONY_WORKFLOW_PATH: workflowPath,
+        SYMPHONY_RENDERED_PROMPT: "Handle worker runtime adapter issue.",
+        SYMPHONY_RUN_ID: "run-worker-claude",
+        SYMPHONY_ISSUE_ID: "issue-worker-claude",
+        SYMPHONY_ISSUE_IDENTIFIER: "test-owner/test-repo#254",
+        SYMPHONY_ISSUE_STATE: "In progress",
+      },
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toContain("Claude runtime preflight");
+    expect(result.stderr).toContain("claude-print/result");
+    expect(result.stderr).toContain('"type":"turn_completed"');
+    expect(result.stderr).not.toContain("sending codex initialize");
+    expect(result.stderr).not.toContain("codex client protocol");
   });
 
   it("keeps --resume within an intra-run continuation without --fork-session", async () => {
@@ -263,11 +317,7 @@ async function createHarness(initialScenario: string) {
       const events = eventsByRun.get(runId) ?? [];
       const flushedEventCount = flushedEventCountsByRun.get(runId) ?? 0;
       const newEvents = events.slice(flushedEventCount);
-      await appendRunEvents(
-        runDirectory,
-        result.args,
-        newEvents
-      );
+      await appendRunEvents(runDirectory, result.args, newEvents);
       flushedEventCountsByRun.set(runId, events.length);
       return result;
     },
@@ -362,6 +412,37 @@ async function readOptional(path: string): Promise<string> {
     }
     throw error;
   }
+}
+
+function runWorkerProcess(options: {
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+}): Promise<{
+  exitCode: number | null;
+  signal: NodeJS.Signals | null;
+  stderr: string;
+}> {
+  return new Promise((resolveResult, reject) => {
+    const child = spawn("node", ["packages/worker/dist/index.js"], {
+      cwd: options.cwd,
+      env: options.env,
+      stdio: ["ignore", "ignore", "pipe"],
+    });
+    let stderr = "";
+    let settled = false;
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+    child.once("error", reject);
+    child.once("close", (exitCode, signal) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      resolveResult({ exitCode, signal, stderr });
+    });
+  });
 }
 
 function valueAfter(argv: readonly string[], flag: string): string | undefined {


### PR DESCRIPTION
## Issues

- Fixes #254

## Summary

- worker `startAssignedRun`가 `runtime.kind`를 기준으로 Codex app-server 경로와 runtime adapter 경로를 분기합니다.
- `claude-print` / `custom` 런타임은 Codex JSON-RPC client protocol 대신 worker용 runtime adapter lifecycle을 사용합니다.
- 기존 `codex:` fallback 및 명시적 `codex-app-server` 동작은 Codex app-server 경로에 남겨 두었습니다.

## Changes

- `resolveWorkerRuntimeRoute`를 추가해 legacy fallback, `codex-app-server`, non-Codex runtime adapter 경로를 명시적으로 구분했습니다.
- worker non-Codex adapter wrapper를 추가해 `claude-print`는 Claude print adapter로, `custom`은 process lifecycle adapter로 실행합니다.
- worker lifecycle에서 non-Codex turn 시작/완료/실패 이벤트, rate limit/token usage 이벤트, shutdown/cancel 처리를 연결했습니다.
- worker 단위 테스트와 Docker Claude blackbox spec에 worker `claude-print` adapter lifecycle TC를 추가했습니다.

## Evidence

- `pnpm --filter @gh-symphony/worker test -- runtime-routing.test.ts non-codex-runtime.test.ts`
- `pnpm --filter @gh-symphony/worker typecheck`
- `pnpm lint && pnpm test && pnpm typecheck && pnpm build`
- `pnpm e2e:claude`

## Human Validation

- [ ] `runtime.kind: claude-print` worker 실행이 Codex initialize/client protocol 없이 완료되는지 확인
- [ ] `runtime.kind: custom` worker 실행이 configured command lifecycle로 동작하는지 확인
- [ ] 기존 Codex app-server worker 흐름이 회귀하지 않았는지 확인

## Risks

- non-Codex worker lifecycle은 현재 단일 turn 실행으로 연결됩니다. 기존 Codex continuation loop와 동일한 multi-turn semantics가 필요한 경우 별도 후속 설계가 필요합니다.
