### PR TITLE
test(e2e): verify single-repo transition

### DIFF
--- a/.changeset/single-repo-orchestrator-epic.md
+++ b/.changeset/single-repo-orchestrator-epic.md
@@ -1,0 +1,13 @@
+---
+"@gh-symphony/cli": minor
+"@gh-symphony/core": minor
+"@gh-symphony/orchestrator": minor
+"@gh-symphony/control-plane": minor
+"@gh-symphony/dashboard": minor
+"@gh-symphony/tracker-file": minor
+---
+
+BREAKING: complete the single-repository orchestrator transition. Runtime
+state is now repo-local, project routing is no longer part of the public status
+surface, project configs use one canonical `repository`, and Docker E2E now
+validates the `git clone -> cd -> repo init -> repo start` golden path.

--- a/AGENT_TEST.md
+++ b/AGENT_TEST.md
@@ -56,7 +56,7 @@ pnpm e2e:init       # .runtime/ 구조 생성, stub worker 컴파일, seed repo 
 `e2e:init`이 수행하는 작업:
 1. `e2e/stub-worker.ts` → `e2e/dist/stub-worker.js` 컴파일
 2. `.runtime/e2e/repos/test-owner/test-repo` bare git repo 생성 (WORKFLOW.md 포함)
-3. `.runtime/projects/e2e-project/project.json` 프로젝트 설정
+3. `.runtime/projects/e2e-project/project.json` 단일 `repository` 프로젝트 설정
 4. `e2e/fixtures/issues.json` 빈 배열로 초기화
 
 ### 실행
@@ -145,8 +145,9 @@ AI Agent
 │  File Tracker                                     │
 │  (/e2e/fixtures/issues.json)                      │
 │                                                   │
-│  .runtime/ (tmpfs, 컨테이너 종료 시 소멸)         │
+│  /app/.runtime (tmpfs, 컨테이너 종료 시 소멸)     │
 │  /e2e/repos/ (pre-seeded local git repo)          │
+│  /e2e/work/test-repo/.runtime/orchestrator        │
 │                                                   │
 │  :4680 dashboard API (외부 노출)                  │
 └──────────────────────────────────────────────────┘
@@ -156,6 +157,7 @@ AI Agent
 - **Stub Worker** (`e2e/stub-worker.ts`): Codex AI 없이 Worker 동작을 시뮬레이션
 - **격리**: 모든 상태는 tmpfs에 저장되어 컨테이너 종료 시 소멸. 로컬 `.runtime/`에 아무 영향 없음
 - **이벤트 미러링(선택)**: `docker-compose.e2e.events.yml` override를 함께 쓰면 `events.ndjson`이 호스트 `./evidence/`에도 복제됨
+- **골든 패스**: 컨테이너 entrypoint는 `git clone /e2e/repos/test-owner/test-repo /e2e/work/test-repo → cd /e2e/work/test-repo → gh-symphony repo init → gh-symphony repo start --http 4680` 순서로 단일-리포 런타임을 기동한다.
 
 ### Stub Worker 시나리오
 
@@ -287,13 +289,13 @@ run `events.ndjson`를 직접 읽어 다음을 검증한다.
 docker logs symphony-e2e
 
 # 이벤트 로그 (구조화된 NDJSON, 기본 tmpfs)
-docker exec symphony-e2e sh -c 'cat /app/.runtime/projects/e2e-project/runs/*/events.ndjson'
+docker exec symphony-e2e sh -c 'cat /e2e/work/test-repo/.runtime/orchestrator/runs/*/events.ndjson'
 
 # 호스트 미러 로그 (events override 활성화 시)
-tail -f evidence/projects/e2e-project/runs/*/events.ndjson
+tail -f evidence/runs/*/events.ndjson
 
 # Worker 로그 (stderr만 캡처됨)
-docker exec symphony-e2e sh -c 'cat /app/.runtime/projects/e2e-project/runs/*/worker.log'
+docker exec symphony-e2e sh -c 'cat /e2e/work/test-repo/.runtime/orchestrator/runs/*/worker.log'
 ```
 
 ### 7. 정리

--- a/AGENT_TEST.md
+++ b/AGENT_TEST.md
@@ -34,15 +34,16 @@ pnpm e2e:start
 ┌─────────────────────────────────────────────────┐
 │  Local Process                                   │
 │                                                  │
-│  CLI (start) ──→ Orchestrator ──spawn──→ Stub Worker │
+│  CLI (repo start) ──→ Orchestrator ──spawn──→ Stub Worker │
 │       │                                          │
 │  Dashboard :4680     File Tracker                │
 │  /api/v1/state       (e2e/fixtures/issues.json)  │
 │                                                  │
 │  .runtime/           (프로젝트 루트, gitignored)  │
-│    ├─ e2e/repos/     (seed git repo)             │
-│    ├─ e2e/workspaces/(worker 작업 공간)           │
-│    └─ projects/      (orchestrator 상태)          │
+│    └─ e2e/                                      │
+│       ├─ repos/      (seed git repo)             │
+│       ├─ fixtures/   (로컬 경로 fixture 사본)      │
+│       └─ work/test-repo/.runtime/orchestrator    │
 └─────────────────────────────────────────────────┘
 ```
 
@@ -55,8 +56,8 @@ pnpm e2e:init       # .runtime/ 구조 생성, stub worker 컴파일, seed repo 
 
 `e2e:init`이 수행하는 작업:
 1. `e2e/stub-worker.ts` → `e2e/dist/stub-worker.js` 컴파일
-2. `.runtime/e2e/repos/test-owner/test-repo` bare git repo 생성 (WORKFLOW.md 포함)
-3. `.runtime/projects/e2e-project/project.json` 단일 `repository` 프로젝트 설정
+2. `.runtime/e2e/repos/test-owner/test-repo` seed git repo 생성 (WORKFLOW.md 포함)
+3. `.runtime/e2e/work/test-repo`로 clone 후 `repo init`으로 단일 `repository` 프로젝트 설정
 4. `e2e/fixtures/issues.json` 빈 배열로 초기화
 
 ### 실행
@@ -102,10 +103,10 @@ curl -X POST http://localhost:4680/api/v1/refresh
 
 ```bash
 # 이벤트 로그 (구조화된 NDJSON)
-cat .runtime/projects/e2e-project/runs/*/events.ndjson | jq .
+cat .runtime/e2e/work/test-repo/.runtime/orchestrator/runs/*/events.ndjson | jq .
 
 # Worker 로그 (stderr 캡처)
-cat .runtime/projects/e2e-project/runs/*/worker.log
+cat .runtime/e2e/work/test-repo/.runtime/orchestrator/runs/*/worker.log
 ```
 
 ### 이슈 제거 (retry 중단)
@@ -145,9 +146,9 @@ AI Agent
 │  File Tracker                                     │
 │  (/e2e/fixtures/issues.json)                      │
 │                                                   │
-│  /app/.runtime (tmpfs, 컨테이너 종료 시 소멸)     │
 │  /e2e/repos/ (pre-seeded local git repo)          │
-│  /e2e/work/test-repo/.runtime/orchestrator        │
+│  /e2e/work (tmpfs, 컨테이너 종료 시 소멸)         │
+│    └─ test-repo/.runtime/orchestrator             │
 │                                                   │
 │  :4680 dashboard API (외부 노출)                  │
 └──────────────────────────────────────────────────┘
@@ -155,9 +156,10 @@ AI Agent
 
 - **File Tracker** (`@gh-symphony/tracker-file`): GitHub API 없이 JSON 파일에서 이슈를 읽음
 - **Stub Worker** (`e2e/stub-worker.ts`): Codex AI 없이 Worker 동작을 시뮬레이션
-- **격리**: 모든 상태는 tmpfs에 저장되어 컨테이너 종료 시 소멸. 로컬 `.runtime/`에 아무 영향 없음
+- **격리**: clone된 work repo와 repo-local orchestrator 상태는 `/e2e/work` tmpfs에 저장되어 컨테이너 종료 시 소멸. 로컬 `.runtime/`에 아무 영향 없음
 - **이벤트 미러링(선택)**: `docker-compose.e2e.events.yml` override를 함께 쓰면 `events.ndjson`이 호스트 `./evidence/`에도 복제됨
 - **골든 패스**: 컨테이너 entrypoint는 `git clone /e2e/repos/test-owner/test-repo /e2e/work/test-repo → cd /e2e/work/test-repo → gh-symphony repo init → gh-symphony repo start --http 4680` 순서로 단일-리포 런타임을 기동한다.
+- **File tracker fixture**: `GH_SYMPHONY_FILE_TRACKER_ISSUES_PATH`는 이 Docker/로컬 E2E의 `kind: file` 워크플로에서만 mounted fixture를 `repo init` 결과에 연결하기 위한 테스트 전용 환경변수다.
 
 ### Stub Worker 시나리오
 

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -9,6 +9,6 @@ services:
     volumes:
       - ./e2e/fixtures:/e2e/fixtures
     tmpfs:
-      - /app/.runtime:size=100M
+      - /e2e/work:size=100M,uid=1000,gid=1000,mode=1777
     environment:
       STUB_SCENARIO: ${STUB_SCENARIO:-happy}

--- a/docs/spec-gap-analysis.md
+++ b/docs/spec-gap-analysis.md
@@ -306,7 +306,7 @@ Implementation: GitHub Symphony (pnpm monorepo, TypeScript)
 | **D1** | `tracker.kind: github-project` (spec: `linear`) | Intentional — GitHub target |
 | **D2** | `tracker.project_slug` → `projectId` | GitHub Project V2 ID scheme |
 | **D3** | `linear_graphql` → `github_graphql` tool | Target platform change |
-| **D4** | Workspace path `<root>/<projectId>/issues/<key>` | Multi-tenant support extension |
+| **D4** | Workspace path `<root>/<projectId>/issues/<key>` | **CLOSED** — single-repo runtime stores issue workspaces directly under repo-local `.runtime/orchestrator/<key>` |
 | **D5** | `WorkflowExecutionPhase` added (planning → human-review → implementation → awaiting-merge → completed) | GitHub workflow extension not in spec |
 | **D6** | `assignedOnly` filtering option | GitHub-specific extension |
 

--- a/e2e/run-e2e.sh
+++ b/e2e/run-e2e.sh
@@ -126,11 +126,11 @@ done
 
 echo ""
 log "=== Worker Logs ==="
-docker exec symphony-e2e sh -c 'for f in $(find /app/.runtime/projects/e2e-project/runs -name worker.log 2>/dev/null | sort | tail -1); do cat "$f"; done' 2>/dev/null || true
+docker exec symphony-e2e sh -c 'for f in $(find /e2e/work/test-repo/.runtime/orchestrator/runs -name worker.log 2>/dev/null | sort | tail -1); do cat "$f"; done' 2>/dev/null || true
 
 echo ""
 log "=== Event Logs ==="
-docker exec symphony-e2e sh -c 'find /app/.runtime/projects/e2e-project/runs -name events.ndjson -exec cat {} \; 2>/dev/null' 2>/dev/null || true
+docker exec symphony-e2e sh -c 'find /e2e/work/test-repo/.runtime/orchestrator/runs -name events.ndjson -exec cat {} \; 2>/dev/null' 2>/dev/null || true
 
 echo ""
 if [ "$SAW_RUNNING" = true ]; then

--- a/e2e/scenarios/01-happy-path.md
+++ b/e2e/scenarios/01-happy-path.md
@@ -62,7 +62,7 @@ curl --fail --retry-all-errors --retry 10 --retry-delay 2 http://localhost:4680/
 
 9. **Verify event log**
    ```bash
-   docker exec symphony-e2e sh -c 'cat /app/.runtime/projects/e2e-project/runs/*/events.ndjson'
+   docker exec symphony-e2e sh -c 'cat /e2e/work/test-repo/.runtime/orchestrator/runs/*/events.ndjson'
    # Expected: run-dispatched and run-recovered events
    ```
 

--- a/e2e/scenarios/03-stall-detection.md
+++ b/e2e/scenarios/03-stall-detection.md
@@ -42,7 +42,7 @@ docker compose -f docker-compose.e2e.yml -f docker-compose.e2e.events.yml up -d 
 
 5. **Verify graceful shutdown**
    ```bash
-   docker exec symphony-e2e sh -c 'cat /app/.runtime/projects/e2e-project/runs/*/events.ndjson' | tail -5
+   docker exec symphony-e2e sh -c 'cat /e2e/work/test-repo/.runtime/orchestrator/runs/*/events.ndjson' | tail -5
    # Expected: events showing stall detection and worker termination
    ```
 

--- a/e2e/scenarios/03-stall-detection.md
+++ b/e2e/scenarios/03-stall-detection.md
@@ -55,7 +55,7 @@ docker compose -f docker-compose.e2e.yml -f docker-compose.e2e.events.yml up -d 
 
 7. **Verify token usage artifact saved**
    ```bash
-   docker exec symphony-e2e sh -c 'find /app/.runtime -name token-usage.json -exec cat {} \;'
+   docker exec symphony-e2e sh -c 'find /e2e/work/test-repo/.runtime/orchestrator -name token-usage.json -exec cat {} \;'
    # Expected: { "inputTokens": 150, "outputTokens": 42, "totalTokens": 192 }
    ```
 

--- a/e2e/scenarios/04-fail-retry.md
+++ b/e2e/scenarios/04-fail-retry.md
@@ -47,7 +47,7 @@ curl --retry 10 --retry-delay 2 http://localhost:4680/healthz
 
 5. **Check event log**
    ```bash
-   docker exec symphony-e2e sh -c 'cat /app/.runtime/projects/e2e-project/runs/*/events.ndjson'
+   docker exec symphony-e2e sh -c 'cat /e2e/work/test-repo/.runtime/orchestrator/runs/*/events.ndjson'
    # Expected: dispatch event, failure event, retry-scheduled event
    ```
 

--- a/e2e/scenarios/05-before-remove-hook-failure.md
+++ b/e2e/scenarios/05-before-remove-hook-failure.md
@@ -13,7 +13,7 @@ curl --retry 10 --retry-delay 2 http://localhost:4680/healthz
 1. Seed a failing `before_remove` hook into the E2E repository.
    ```bash
    docker exec symphony-e2e sh -lc '
-     cd /e2e/repos/test-owner/test-repo &&
+     cd /e2e/work/test-repo &&
      mkdir -p hooks &&
      cat > hooks/before_remove.sh <<'"'"'EOF'"'"'
 #!/usr/bin/env bash
@@ -46,7 +46,7 @@ EOF
    ```bash
    docker exec symphony-e2e sh -lc '
       for i in $(seq 1 20); do
-        find /app/.runtime/projects -name workspace.json | grep -q . && exit 0
+        find /e2e/work/test-repo/.runtime/orchestrator -name workspace.json | grep -q . && exit 0
        sleep 1
      done
      exit 1
@@ -90,7 +90,7 @@ EOF
    ```bash
    docker exec symphony-e2e sh -lc '
       for i in $(seq 1 20); do
-        record=$(find /app/.runtime/projects -name workspace.json | head -n 1)
+        record=$(find /e2e/work/test-repo/.runtime/orchestrator -name workspace.json | head -n 1)
        [ -n "$record" ] || { sleep 1; continue; }
        python3 - "$record" <<'"'"'PY'"'"'
 import json, sys

--- a/e2e/scenarios/06-retry-title-preservation.md
+++ b/e2e/scenarios/06-retry-title-preservation.md
@@ -24,7 +24,7 @@ curl --retry 10 --retry-delay 2 http://localhost:4680/healthz
    ```
 4. Inspect persisted run records inside the container.
    ```bash
-   docker exec symphony-e2e sh -c 'find /app/.runtime/projects/e2e-project/runs -name run.json -exec cat {} \;'
+   docker exec symphony-e2e sh -c 'find /e2e/work/test-repo/.runtime/orchestrator/runs -name run.json -exec cat {} \;'
    ```
 5. Verify that both the original run and the recovered retry run preserve the original issue title instead of replacing it with the identifier.
 

--- a/e2e/scenarios/08-evidence-permissions.md
+++ b/e2e/scenarios/08-evidence-permissions.md
@@ -17,14 +17,14 @@ curl --fail --retry-all-errors --retry 10 --retry-delay 2 http://localhost:4680/
    curl -s -X POST http://localhost:4680/api/v1/refresh
    ```
 
-2. Wait until `evidence/projects/e2e-project/runs/*/events.ndjson` is created on the host.
+2. Wait until `evidence/runs/*/events.ndjson` is created on the host.
    ```bash
    find evidence -name events.ndjson -print
    ```
 
 3. Verify the mirrored artifact is owned by the host user instead of `root`.
    ```bash
-   stat -c '%U:%G %a %n' evidence/projects/e2e-project/runs/*/events.ndjson
+   stat -c '%U:%G %a %n' evidence/runs/*/events.ndjson
    ```
 
 4. Run the standard E2E cleanup and confirm the evidence directory can be deleted without `Permission denied`.

--- a/e2e/seed/README.md
+++ b/e2e/seed/README.md
@@ -1,0 +1,8 @@
+# E2E Seed Files
+
+The Docker golden path does not copy `config.json` into the runtime. The
+entrypoint clones `/e2e/repos/test-owner/test-repo`, changes into the cloned
+repo, runs `repo init`, then starts `repo start`.
+
+`config.json` is kept as a reference snapshot for the single-repository
+project shape that `repo init` is expected to generate in E2E.

--- a/e2e/seed/WORKFLOW.md
+++ b/e2e/seed/WORKFLOW.md
@@ -1,6 +1,7 @@
 ---
 tracker:
   kind: file
+  project_id: e2e-test
   state_field: Status
   active_states:
     - Ready

--- a/e2e/seed/config.json
+++ b/e2e/seed/config.json
@@ -1,7 +1,7 @@
 {
-  "projectId": "e2e-project",
-  "slug": "e2e-project",
-  "workspaceDir": "/e2e/workspaces",
+  "projectId": "repository",
+  "slug": "test-repo",
+  "workspaceDir": "/e2e/work/test-repo",
   "repository": {
     "owner": "test-owner",
     "name": "test-repo",

--- a/e2e/seed/config.json
+++ b/e2e/seed/config.json
@@ -5,15 +5,9 @@
   "repository": {
     "owner": "test-owner",
     "name": "test-repo",
-    "cloneUrl": "/e2e/repos/test-owner/test-repo"
+    "cloneUrl": "/e2e/repos/test-owner/test-repo",
+    "path": "/e2e/work/test-repo"
   },
-  "repositories": [
-    {
-      "owner": "test-owner",
-      "name": "test-repo",
-      "cloneUrl": "/e2e/repos/test-owner/test-repo"
-    }
-  ],
   "tracker": {
     "adapter": "file",
     "bindingId": "e2e-test",

--- a/e2e/seed/config.json
+++ b/e2e/seed/config.json
@@ -1,19 +1,21 @@
 {
   "projectId": "repository",
   "slug": "test-repo",
+  "displayName": "test-owner/test-repo",
   "workspaceDir": "/e2e/work/test-repo",
   "repository": {
     "owner": "test-owner",
     "name": "test-repo",
-    "cloneUrl": "/e2e/repos/test-owner/test-repo",
+    "cloneUrl": "https://github.com/test-owner/test-repo.git",
     "path": "/e2e/work/test-repo"
   },
   "tracker": {
     "adapter": "file",
     "bindingId": "e2e-test",
     "settings": {
-      "issuesPath": "/e2e/fixtures/issues.json",
-      "repository": "test-owner/test-repo"
+      "projectId": "e2e-test",
+      "repository": "test-owner/test-repo",
+      "issuesPath": "/e2e/fixtures/issues.json"
     }
   }
 }

--- a/e2e/seed/entrypoint.sh
+++ b/e2e/seed/entrypoint.sh
@@ -1,24 +1,18 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-RUNTIME_DIR="/app/.runtime"
-PROJECT_ID="e2e-project"
-CONFIG_DIR="$RUNTIME_DIR/projects/$PROJECT_ID"
+REPO_DIR="/e2e/repos/test-owner/test-repo"
+WORK_DIR="/e2e/work/test-repo"
 
 # Ensure runtime directories exist
-mkdir -p "$CONFIG_DIR"
-mkdir -p /e2e/workspaces
+mkdir -p /e2e/work /e2e/workspaces
+rm -rf "$WORK_DIR"
+git clone "$REPO_DIR" "$WORK_DIR"
+git -C "$WORK_DIR" remote set-url origin test-owner/test-repo
 
-# Place CLI config where the start command expects it
-cat > "$RUNTIME_DIR/config.json" <<EOF
-{
-  "activeProject": "$PROJECT_ID",
-  "projects": ["$PROJECT_ID"]
-}
-EOF
-
-# Place project config where the CLI/orchestrator expect it
-cp /e2e/seed/config.json "$CONFIG_DIR/project.json"
+cd "$WORK_DIR"
+GH_SYMPHONY_FILE_TRACKER_ISSUES_PATH="/e2e/fixtures/issues.json" \
+node /app/packages/cli/dist/index.js repo init
 
 # Create an empty issues.json if none mounted
 if [ ! -f /e2e/fixtures/issues.json ]; then
@@ -26,8 +20,7 @@ if [ ! -f /e2e/fixtures/issues.json ]; then
 fi
 
 echo "[entrypoint] Starting CLI orchestrator with HTTP composition..."
-GH_SYMPHONY_CONFIG_DIR="$RUNTIME_DIR" \
-node /app/packages/cli/dist/index.js start \
+node /app/packages/cli/dist/index.js repo start \
   --http 4680 &
 CLI_PID=$!
 

--- a/e2e/seed/entrypoint.sh
+++ b/e2e/seed/entrypoint.sh
@@ -4,12 +4,14 @@ set -euo pipefail
 REPO_DIR="/e2e/repos/test-owner/test-repo"
 WORK_DIR="/e2e/work/test-repo"
 
-# Ensure runtime directories exist
-mkdir -p /e2e/work /e2e/workspaces
+# Ensure the tmpfs-backed work root exists.
+mkdir -p /e2e/work
 rm -rf "$WORK_DIR"
 git clone "$REPO_DIR" "$WORK_DIR"
 git -C "$WORK_DIR" remote set-url origin test-owner/test-repo
 
+# GH_SYMPHONY_FILE_TRACKER_ISSUES_PATH is intentionally limited to the
+# file-tracker E2E workflow so repo init can bind the mounted fixture file.
 cd "$WORK_DIR"
 GH_SYMPHONY_FILE_TRACKER_ISSUES_PATH="/e2e/fixtures/issues.json" \
 node /app/packages/cli/dist/index.js repo init

--- a/e2e/seed/init-local.sh
+++ b/e2e/seed/init-local.sh
@@ -7,10 +7,8 @@ set -euo pipefail
 
 ROOT_DIR="$(pwd)"
 RUNTIME_DIR="$ROOT_DIR/.runtime"
-PROJECT_ID="e2e-project"
 REPO_DIR="$RUNTIME_DIR/e2e/repos/test-owner/test-repo"
-WORKSPACE_DIR="$RUNTIME_DIR/e2e/workspaces"
-CONFIG_DIR="$RUNTIME_DIR/projects/$PROJECT_ID"
+WORK_DIR="$RUNTIME_DIR/e2e/work/test-repo"
 ISSUES_PATH="$ROOT_DIR/e2e/fixtures/issues.json"
 STUB_WORKER_JS="$ROOT_DIR/e2e/dist/stub-worker.js"
 
@@ -28,9 +26,9 @@ npx tsc e2e/stub-worker.ts \
   --moduleResolution nodenext \
   --skipLibCheck
 
-# ── 2. Create bare git repo ─────────────────────────────────────
+# ── 2. Create source git repo ───────────────────────────────────
 log "Creating test git repo at $REPO_DIR"
-rm -rf "$REPO_DIR"
+rm -rf "$REPO_DIR" "$WORK_DIR"
 mkdir -p "$REPO_DIR"
 (
   cd "$REPO_DIR"
@@ -72,39 +70,18 @@ EOF
   git commit -m "Initial commit with WORKFLOW.md"
 )
 
-# ── 3. Create runtime directory structure ────────────────────────
-log "Setting up runtime at $RUNTIME_DIR"
-mkdir -p "$CONFIG_DIR"
-mkdir -p "$WORKSPACE_DIR"
+# ── 3. Clone work repo and initialize repo-local runtime ─────────
+log "Cloning work repo to $WORK_DIR"
+mkdir -p "$(dirname "$WORK_DIR")"
+git clone "$REPO_DIR" "$WORK_DIR"
+git -C "$WORK_DIR" remote set-url origin test-owner/test-repo
 
-cat > "$RUNTIME_DIR/config.json" << EOF
-{
-  "activeProject": "$PROJECT_ID",
-  "projects": ["$PROJECT_ID"]
-}
-EOF
-
-cat > "$CONFIG_DIR/project.json" << EOF
-{
-  "projectId": "$PROJECT_ID",
-  "slug": "$PROJECT_ID",
-  "workspaceDir": "$WORKSPACE_DIR",
-  "repository": {
-    "owner": "test-owner",
-    "name": "test-repo",
-    "cloneUrl": "$REPO_DIR",
-    "path": "$REPO_DIR"
-  },
-  "tracker": {
-    "adapter": "file",
-    "bindingId": "e2e-test",
-    "settings": {
-      "issuesPath": "$ISSUES_PATH",
-      "repository": "test-owner/test-repo"
-    }
-  }
-}
-EOF
+log "Initializing repo-local runtime at $WORK_DIR/.runtime/orchestrator"
+(
+  cd "$WORK_DIR"
+  GH_SYMPHONY_FILE_TRACKER_ISSUES_PATH="$ISSUES_PATH" \
+    node "$ROOT_DIR/packages/cli/dist/index.js" repo init
+)
 
 # ── 4. Generate local fixtures (Docker paths → local paths) ──────
 DOCKER_CLONE_URL="/e2e/repos/test-owner/test-repo"

--- a/e2e/seed/init-local.sh
+++ b/e2e/seed/init-local.sh
@@ -41,6 +41,7 @@ mkdir -p "$REPO_DIR"
 ---
 tracker:
   kind: file
+  project_id: e2e-test
   state_field: Status
   active_states:
     - Ready

--- a/e2e/seed/init-local.sh
+++ b/e2e/seed/init-local.sh
@@ -92,15 +92,9 @@ cat > "$CONFIG_DIR/project.json" << EOF
   "repository": {
     "owner": "test-owner",
     "name": "test-repo",
-    "cloneUrl": "$REPO_DIR"
+    "cloneUrl": "$REPO_DIR",
+    "path": "$REPO_DIR"
   },
-  "repositories": [
-    {
-      "owner": "test-owner",
-      "name": "test-repo",
-      "cloneUrl": "$REPO_DIR"
-    }
-  ],
   "tracker": {
     "adapter": "file",
     "bindingId": "e2e-test",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build:cli": "pnpm --filter @gh-symphony/cli... build",
     "cli": "node packages/cli/dist/index.js --config .runtime",
     "e2e:init": "bash e2e/seed/init-local.sh",
-    "e2e:start": "SYMPHONY_WORKER_COMMAND=\"node $(pwd)/e2e/dist/stub-worker.js\" node packages/cli/dist/index.js --config .runtime start --http 4680",
+    "e2e:start": "cd .runtime/e2e/work/test-repo && GH_SYMPHONY_FILE_TRACKER_ISSUES_PATH=\"$(pwd)/../../../../e2e/fixtures/issues.json\" SYMPHONY_WORKER_COMMAND=\"node $(pwd)/../../../../e2e/dist/stub-worker.js\" node ../../../../packages/cli/dist/index.js repo start --http 4680",
     "e2e:claude": "bash test/e2e/claude/run-docker-e2e.sh",
     "dev:orchestrator": "pnpm --filter @gh-symphony/orchestrator dev",
     "dev:worker": "pnpm --filter @gh-symphony/worker dev",

--- a/packages/cli/src/commands/repo.test.ts
+++ b/packages/cli/src/commands/repo.test.ts
@@ -869,6 +869,50 @@ describe("repo init runtime migration", () => {
     });
     expect(stdout.output()).toContain("Repository initialized: acme/platform");
   });
+
+  it("fails fast when file-tracker repo init has no issues fixture path", async () => {
+    const repoDir = await mkdtemp(join(tmpdir(), "repo-init-file-missing-"));
+    const stderr = captureWrites(process.stderr);
+    const repoCommand = await loadRepoCommand();
+    const originalIssuesPath = process.env.GH_SYMPHONY_FILE_TRACKER_ISSUES_PATH;
+    execFileSync("git", ["-C", repoDir, "init"]);
+    execFileSync("git", [
+      "-C",
+      repoDir,
+      "remote",
+      "add",
+      "origin",
+      "https://github.com/acme/platform.git",
+    ]);
+    await writeFile(
+      join(repoDir, "WORKFLOW.md"),
+      VALID_WORKFLOW.replace("github-project", "file").replace(
+        "PVT_project_123",
+        "e2e-test"
+      ),
+      "utf8"
+    );
+    delete process.env.GH_SYMPHONY_FILE_TRACKER_ISSUES_PATH;
+
+    try {
+      await repoCommand(
+        ["init", "--repo-dir", repoDir],
+        baseOptions(join(repoDir, "unused"))
+      );
+    } finally {
+      if (originalIssuesPath === undefined) {
+        delete process.env.GH_SYMPHONY_FILE_TRACKER_ISSUES_PATH;
+      } else {
+        process.env.GH_SYMPHONY_FILE_TRACKER_ISSUES_PATH = originalIssuesPath;
+      }
+      stderr.restore();
+    }
+
+    expect(process.exitCode).toBe(1);
+    expect(stderr.output()).toContain(
+      "File tracker repo init requires GH_SYMPHONY_FILE_TRACKER_ISSUES_PATH"
+    );
+  });
 });
 
 describe("repo add", () => {

--- a/packages/cli/src/commands/repo.test.ts
+++ b/packages/cli/src/commands/repo.test.ts
@@ -799,6 +799,76 @@ describe("repo init runtime migration", () => {
     expect(stderr.output()).toContain("--project-id has been removed");
     expect(stderr.output()).toContain("current repository directory");
   });
+
+  it("writes a single-repository file-tracker config for repo-local E2E init", async () => {
+    const repoDir = await mkdtemp(join(tmpdir(), "repo-init-file-tracker-"));
+    const stdout = captureWrites(process.stdout);
+    const repoCommand = await loadRepoCommand();
+    const originalIssuesPath = process.env.GH_SYMPHONY_FILE_TRACKER_ISSUES_PATH;
+    execFileSync("git", ["-C", repoDir, "init"]);
+    execFileSync("git", [
+      "-C",
+      repoDir,
+      "remote",
+      "add",
+      "origin",
+      "https://github.com/acme/platform.git",
+    ]);
+    await writeFile(
+      join(repoDir, "WORKFLOW.md"),
+      VALID_WORKFLOW.replace("github-project", "file").replace(
+        "PVT_project_123",
+        "e2e-test"
+      ),
+      "utf8"
+    );
+    process.env.GH_SYMPHONY_FILE_TRACKER_ISSUES_PATH =
+      "/e2e/fixtures/issues.json";
+
+    try {
+      await repoCommand(
+        ["init", "--repo-dir", repoDir],
+        baseOptions(join(repoDir, "unused"))
+      );
+    } finally {
+      if (originalIssuesPath === undefined) {
+        delete process.env.GH_SYMPHONY_FILE_TRACKER_ISSUES_PATH;
+      } else {
+        process.env.GH_SYMPHONY_FILE_TRACKER_ISSUES_PATH = originalIssuesPath;
+      }
+      stdout.restore();
+    }
+
+    const projectConfig = JSON.parse(
+      await readFile(
+        join(
+          repoDir,
+          ".runtime",
+          "orchestrator",
+          "projects",
+          "repository",
+          "project.json"
+        ),
+        "utf8"
+      )
+    ) as CliProjectConfig;
+
+    expect(projectConfig.repository).toMatchObject({
+      owner: "acme",
+      name: "platform",
+    });
+    expect(projectConfig.repositories).toBeUndefined();
+    expect(projectConfig.tracker).toMatchObject({
+      adapter: "file",
+      bindingId: "e2e-test",
+      settings: {
+        projectId: "e2e-test",
+        repository: "acme/platform",
+        issuesPath: "/e2e/fixtures/issues.json",
+      },
+    });
+    expect(stdout.output()).toContain("Repository initialized: acme/platform");
+  });
 });
 
 describe("repo add", () => {

--- a/packages/cli/src/repo-runtime.ts
+++ b/packages/cli/src/repo-runtime.ts
@@ -82,10 +82,12 @@ export async function initRepoRuntime(flags: RepoInitFlags): Promise<{
       : {}),
     repository: `${repository.owner}/${repository.name}`,
   };
-  if (
-    trackerAdapter === "file" &&
-    process.env.GH_SYMPHONY_FILE_TRACKER_ISSUES_PATH
-  ) {
+  if (trackerAdapter === "file") {
+    if (!process.env.GH_SYMPHONY_FILE_TRACKER_ISSUES_PATH) {
+      throw new Error(
+        "File tracker repo init requires GH_SYMPHONY_FILE_TRACKER_ISSUES_PATH to point to the issues fixture."
+      );
+    }
     // E2E-only escape hatch for binding the file tracker to a mounted fixture.
     trackerSettings.issuesPath =
       process.env.GH_SYMPHONY_FILE_TRACKER_ISSUES_PATH;

--- a/packages/cli/src/repo-runtime.ts
+++ b/packages/cli/src/repo-runtime.ts
@@ -73,23 +73,32 @@ export async function initRepoRuntime(flags: RepoInitFlags): Promise<{
   const workflowPath = resolve(repoDir, flags.workflowFile ?? "WORKFLOW.md");
   const workflow = parseWorkflowMarkdown(await readFile(workflowPath, "utf8"));
   const repository = resolveRepository(repoDir);
+  const trackerAdapter = workflow.tracker.kind ?? "github-project";
+  const trackerBindingId =
+    workflow.tracker.projectId ?? workflow.tracker.projectSlug ?? "";
+  const trackerSettings: Record<string, string> = {
+    ...(workflow.tracker.projectId
+      ? { projectId: workflow.tracker.projectId }
+      : {}),
+    repository: `${repository.owner}/${repository.name}`,
+  };
+  if (
+    trackerAdapter === "file" &&
+    process.env.GH_SYMPHONY_FILE_TRACKER_ISSUES_PATH
+  ) {
+    trackerSettings.issuesPath =
+      process.env.GH_SYMPHONY_FILE_TRACKER_ISSUES_PATH;
+  }
   const projectConfig: CliProjectConfig = {
     projectId: INTERNAL_PROJECT_ID,
     slug: basename(repoDir) || INTERNAL_PROJECT_ID,
     displayName: `${repository.owner}/${repository.name}`,
     workspaceDir: repoDir,
     repository,
-    repositories: [repository],
     tracker: {
-      adapter: workflow.tracker.kind === "linear" ? "linear" : "github-project",
-      bindingId:
-        workflow.tracker.projectId ?? workflow.tracker.projectSlug ?? "",
-      settings: {
-        ...(workflow.tracker.projectId
-          ? { projectId: workflow.tracker.projectId }
-          : {}),
-        repository: `${repository.owner}/${repository.name}`,
-      },
+      adapter: trackerAdapter,
+      bindingId: trackerBindingId,
+      settings: trackerSettings,
     },
   };
 

--- a/packages/cli/src/repo-runtime.ts
+++ b/packages/cli/src/repo-runtime.ts
@@ -86,6 +86,7 @@ export async function initRepoRuntime(flags: RepoInitFlags): Promise<{
     trackerAdapter === "file" &&
     process.env.GH_SYMPHONY_FILE_TRACKER_ISSUES_PATH
   ) {
+    // E2E-only escape hatch for binding the file tracker to a mounted fixture.
     trackerSettings.issuesPath =
       process.env.GH_SYMPHONY_FILE_TRACKER_ISSUES_PATH;
   }

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -61,6 +61,7 @@ describe("OrchestratorService", () => {
     const first = await service.runOnce();
     const second = await service.runOnce();
     const issueRecords = await store.loadProjectIssueOrchestrations("tenant-1");
+    const workspaceKey = deriveIssueWorkspaceKey("acme/platform#1");
 
     expect(first.summary.dispatched).toBe(1);
     expect(first.tracker).toEqual({
@@ -80,6 +81,22 @@ describe("OrchestratorService", () => {
     expect(second.summary.dispatched).toBe(0);
     expect(issueRecords).toHaveLength(1);
     expect(issueRecords[0]?.state).toBe("retry_queued");
+    await expect(
+      readFile(join(tempRoot, workspaceKey, "workspace.json"), "utf8")
+    ).resolves.toContain(`"workspaceKey": "${workspaceKey}"`);
+    await expect(
+      readFile(
+        join(
+          tempRoot,
+          "projects",
+          "tenant-1",
+          "issues",
+          workspaceKey,
+          "workspace.json"
+        ),
+        "utf8"
+      )
+    ).rejects.toThrow();
     expect(spawnImpl).toHaveBeenCalledTimes(1);
     expect(spawnImpl).toHaveBeenCalledWith(
       "bash",


### PR DESCRIPTION
## Issues

- Fixes #266

## Summary

- 단일-리포 전환을 repo-local E2E로 검증하고 spec gap D4를 closed 상태로 정리했습니다.
- Docker와 로컬 E2E 모두 `git clone -> cd -> repo init -> repo start` 흐름을 기준으로 맞췄습니다.
- 리뷰 후속으로 file-tracker E2E fixture 누락을 `repo init`에서 fast-fail 처리하고, seed snapshot/local WORKFLOW shape를 실제 산출과 정렬했습니다.

## Changes

- Docker E2E 런타임 격리를 `/e2e/work` tmpfs로 이동해 cloned work repo와 `.runtime/orchestrator` 상태가 컨테이너 종료 시 소멸하도록 정렬했습니다.
- `AGENT_TEST.md`, E2E scenario 문서, 로컬 `pnpm e2e:init`/`pnpm e2e:start`를 repo-local runtime 경로와 단일 골든 패스에 맞췄습니다.
- `e2e/seed/config.json`은 실행 입력이 아닌 `repo init` 결과 참조 스냅샷으로 명시하고, actual single-repo file-tracker config shape(`displayName`, normalized `cloneUrl`, `tracker.settings.projectId`)에 맞췄습니다.
- `repo init`은 `tracker.kind: file`에서 `GH_SYMPHONY_FILE_TRACKER_ISSUES_PATH`가 없으면 불완전한 config를 만들지 않고 명확히 실패합니다.
- `service.test.ts`와 CLI repo 테스트에 repo-local `.runtime/orchestrator/<workspaceKey>` 및 file-tracker single-repo config 회귀 커버리지를 유지/보강했습니다.
- `docs/spec-gap-analysis.md` D4 closed 표기와 single-repo epic changeset을 포함했습니다.

## Evidence

- `pnpm --filter @gh-symphony/cli test -- src/commands/repo.test.ts` — PASS (21 tests)
- `pnpm e2e:init` — PASS; `.runtime/e2e/work/test-repo/.runtime/orchestrator` 생성 및 `tracker.bindingId/settings.projectId = e2e-test` 확인
- `timeout 8 pnpm e2e:start` — dashboard 기동 확인 후 timeout 종료(예상된 124)
- `pnpm lint && pnpm test && pnpm typecheck && pnpm build` — PASS
- `./e2e/run-e2e.sh happy 60` — PASS; `/e2e/work` tmpfs 위에서 clone/init/start 후 worker `running -> retrying`, 이슈 제거 후 final `idle` 확인

## Human Validation

- [ ] Docker E2E가 fresh clone에서 시작하고 repo-local runtime state를 `/e2e/work` tmpfs에 쓰는지 확인
- [ ] D4 closure wording이 single-repo ADR 의도와 맞는지 확인
- [ ] breaking-change changeset이 release notes에 적합한지 확인

## Risks

- Docker E2E는 file tracker와 stub worker 기반이라 orchestration shape/lifecycle은 검증하지만 live GitHub API 동작은 검증하지 않습니다.
- `GH_SYMPHONY_FILE_TRACKER_ISSUES_PATH`는 file-tracker E2E fixture 바인딩 전용 escape hatch이며, 누락 시 `repo init`에서 실패하도록 제한했습니다.