### PR TITLE
feat(tracker-github): collect ProjectV2 PR metadata

### DIFF
--- a/packages/tracker-github/src/adapter.ts
+++ b/packages/tracker-github/src/adapter.ts
@@ -29,6 +29,26 @@ export type GitHubRepositoryRef = {
   cloneUrl: string;
 };
 
+export type GitHubPullRequestMetadata = {
+  id: string;
+  number: number;
+  identifier: string;
+  title: string;
+  body: string | null;
+  url: string | null;
+  state: string | null;
+  isDraft: boolean | null;
+  merged: boolean | null;
+  headRefName: string | null;
+  baseRefName: string | null;
+  headRepository: GitHubRepositoryRef | null;
+  repository: GitHubRepositoryRef;
+  labels: string[];
+  assignees: string[];
+  createdAt: string | null;
+  updatedAt: string | null;
+};
+
 export type GitHubTrackedIssue = TrackedIssue & {
   repository: GitHubRepositoryRef;
   tracker: TrackedIssue["tracker"] & {
@@ -82,6 +102,9 @@ type GraphQLIssueNode = {
     url: string;
     owner: { login: string };
   };
+  closedByPullRequestsReferences?: {
+    nodes: Array<GraphQLPullRequestNode | null> | null;
+  } | null;
   blockedBy: {
     nodes: Array<{
       id: string;
@@ -95,11 +118,39 @@ type GraphQLIssueNode = {
   } | null;
 };
 
+type GraphQLPullRequestNode = {
+  __typename: "PullRequest";
+  id: string;
+  number: number;
+  title: string;
+  body: string | null;
+  url: string | null;
+  state: string | null;
+  isDraft: boolean | null;
+  merged: boolean | null;
+  headRefName: string | null;
+  baseRefName: string | null;
+  headRepository: {
+    name: string;
+    url: string;
+    owner: { login: string };
+  } | null;
+  repository: {
+    name: string;
+    url: string;
+    owner: { login: string };
+  };
+  labels: { nodes: Array<{ name: string | null } | null> | null } | null;
+  assignees: { nodes: Array<{ login: string | null } | null> | null } | null;
+  createdAt: string | null;
+  updatedAt: string | null;
+};
+
 type GraphQLProjectItem = {
   id: string;
   updatedAt: string | null;
   fieldValues: { nodes: Array<GraphQLFieldValue | null> | null } | null;
-  content: GraphQLIssueNode | null;
+  content: GraphQLIssueNode | GraphQLPullRequestNode | null;
 };
 
 type GraphQLIssueProjectItemNode = {
@@ -218,12 +269,28 @@ export function normalizeProjectItem(
   } = {},
   rateLimits: Record<string, unknown> | null = null
 ): GitHubTrackedIssue | null {
-  if (item.content?.__typename !== "Issue") {
+  if (
+    item.content?.__typename !== "Issue" &&
+    item.content?.__typename !== "PullRequest"
+  ) {
     return null;
   }
 
   const fieldValues = extractFieldValues(item.fieldValues?.nodes ?? []);
   const state = fieldValues[lifecycle.stateFieldName] ?? "Unknown";
+
+  if (item.content.__typename === "PullRequest") {
+    return normalizePullRequestProjectItem(
+      projectId,
+      item,
+      item.content,
+      fieldValues,
+      state,
+      priority,
+      rateLimits
+    );
+  }
+
   const repository = item.content.repository;
   const blockedBy = (item.content.blockedBy?.nodes ?? []).flatMap((node) =>
     node
@@ -243,6 +310,9 @@ export function normalizeProjectItem(
     (issueUpdatedAtMs === null || itemUpdatedAtMs > issueUpdatedAtMs)
       ? item.updatedAt
       : (item.content.updatedAt ?? item.updatedAt);
+  const linkedPullRequests = normalizePullRequestNodes(
+    item.content.closedByPullRequestsReferences?.nodes ?? []
+  );
 
   return {
     id: item.content.id,
@@ -254,9 +324,7 @@ export function normalizeProjectItem(
     state,
     branchName: null,
     url: item.content.url,
-    labels: (item.content.labels?.nodes ?? [])
-      .flatMap((label) => (label?.name ? [label.name.toLowerCase()] : []))
-      .sort(),
+    labels: normalizeLabelNames(item.content.labels?.nodes ?? []),
     blockedBy,
     createdAt: item.content.createdAt,
     updatedAt: trackedUpdatedAt,
@@ -271,7 +339,57 @@ export function normalizeProjectItem(
       bindingId: projectId,
       itemId: item.id,
     },
-    metadata: fieldValues,
+    metadata: withIssueMetadata(fieldValues, linkedPullRequests),
+    rateLimits,
+  };
+}
+
+function normalizePullRequestProjectItem(
+  projectId: string,
+  item: GraphQLProjectItem,
+  content: GraphQLPullRequestNode,
+  fieldValues: Record<string, string>,
+  state: string,
+  priority: {
+    fieldName?: string;
+    optionIds?: PriorityMap;
+  },
+  rateLimits: Record<string, unknown> | null
+): GitHubTrackedIssue {
+  const pullRequest = normalizePullRequestNode(content);
+  const itemUpdatedAtMs = parseTimestampMs(item.updatedAt);
+  const pullRequestUpdatedAtMs = parseTimestampMs(content.updatedAt);
+  const trackedUpdatedAt =
+    itemUpdatedAtMs !== null &&
+    (pullRequestUpdatedAtMs === null || itemUpdatedAtMs > pullRequestUpdatedAtMs)
+      ? item.updatedAt
+      : (content.updatedAt ?? item.updatedAt);
+
+  return {
+    id: content.id,
+    identifier: pullRequest.identifier,
+    number: content.number,
+    title: content.title,
+    description: content.body,
+    priority: resolvePriority(item, priority),
+    state,
+    branchName: content.headRefName,
+    url: content.url,
+    labels: pullRequest.labels,
+    blockedBy: [],
+    createdAt: content.createdAt,
+    updatedAt: trackedUpdatedAt,
+    repository: pullRequest.repository,
+    tracker: {
+      adapter: "github-project",
+      bindingId: projectId,
+      itemId: item.id,
+    },
+    metadata: withGitHubMetadata(fieldValues, {
+      contentType: "PullRequest",
+      pullRequest,
+      linkedPullRequests: [],
+    }),
     rateLimits,
   };
 }
@@ -543,7 +661,10 @@ function isIssueAssignedToLogin(
   item: GraphQLProjectItem,
   login: string
 ): boolean {
-  if (item.content?.__typename !== "Issue") {
+  if (
+    item.content?.__typename !== "Issue" &&
+    item.content?.__typename !== "PullRequest"
+  ) {
     return false;
   }
 
@@ -670,6 +791,92 @@ function normalizeRepositoryIssueLookup(
     priority,
     rateLimits
   );
+}
+
+function normalizePullRequestNodes(
+  nodes: Array<GraphQLPullRequestNode | null>
+): GitHubPullRequestMetadata[] {
+  return nodes.flatMap((node) => (node ? [normalizePullRequestNode(node)] : []));
+}
+
+function normalizePullRequestNode(
+  node: GraphQLPullRequestNode
+): GitHubPullRequestMetadata {
+  const repository = normalizeRepositoryRef(node.repository);
+
+  return {
+    id: node.id,
+    number: node.number,
+    identifier: `${repository.owner}/${repository.name}#${node.number}`,
+    title: node.title,
+    body: node.body,
+    url: node.url,
+    state: node.state,
+    isDraft: node.isDraft,
+    merged: node.merged,
+    headRefName: node.headRefName,
+    baseRefName: node.baseRefName,
+    headRepository: node.headRepository
+      ? normalizeRepositoryRef(node.headRepository)
+      : null,
+    repository,
+    labels: normalizeLabelNames(node.labels?.nodes ?? []),
+    assignees: normalizeAssigneeLogins(node.assignees?.nodes ?? []),
+    createdAt: node.createdAt,
+    updatedAt: node.updatedAt,
+  };
+}
+
+function normalizeRepositoryRef(repository: {
+  name: string;
+  url: string;
+  owner: { login: string };
+}): GitHubRepositoryRef {
+  return {
+    owner: repository.owner.login,
+    name: repository.name,
+    url: repository.url,
+    cloneUrl: deriveCloneUrl(repository.url),
+  };
+}
+
+function normalizeLabelNames(
+  nodes: Array<{ name: string | null } | null>
+): string[] {
+  return nodes
+    .flatMap((label) => (label?.name ? [label.name.toLowerCase()] : []))
+    .sort();
+}
+
+function normalizeAssigneeLogins(
+  nodes: Array<{ login: string | null } | null>
+): string[] {
+  return nodes.flatMap((assignee) =>
+    assignee?.login ? [assignee.login] : []
+  );
+}
+
+function withGitHubMetadata(
+  fieldValues: Record<string, string>,
+  metadata: Record<string, unknown>
+): TrackedIssue["metadata"] {
+  return {
+    ...fieldValues,
+    ...metadata,
+  } as TrackedIssue["metadata"];
+}
+
+function withIssueMetadata(
+  fieldValues: Record<string, string>,
+  linkedPullRequests: GitHubPullRequestMetadata[]
+): TrackedIssue["metadata"] {
+  if (linkedPullRequests.length === 0) {
+    return fieldValues;
+  }
+
+  return withGitHubMetadata(fieldValues, {
+    linkedPullRequests,
+  });
 }
 
 async function resolveIssueProjectItemForStateLookup(
@@ -1115,6 +1322,14 @@ const PROJECT_ITEMS_QUERY = `
                     }
                   }
                 }
+                closedByPullRequestsReferences(first: 20) {
+                  nodes {
+                    ...PullRequestMetadata
+                  }
+                }
+              }
+              ... on PullRequest {
+                ...PullRequestMetadata
               }
             }
           }
@@ -1125,6 +1340,45 @@ const PROJECT_ITEMS_QUERY = `
         }
       }
     }
+  }
+
+  fragment PullRequestMetadata on PullRequest {
+    id
+    number
+    title
+    body
+    url
+    state
+    isDraft
+    merged
+    headRefName
+    baseRefName
+    headRepository {
+      name
+      url
+      owner {
+        login
+      }
+    }
+    repository {
+      name
+      url
+      owner {
+        login
+      }
+    }
+    labels(first: 20) {
+      nodes {
+        name
+      }
+    }
+    assignees(first: 20) {
+      nodes {
+        login
+      }
+    }
+    createdAt
+    updatedAt
   }
 `;
 
@@ -1306,6 +1560,11 @@ const REPOSITORY_ISSUE_QUERY = `
             }
           }
         }
+        closedByPullRequestsReferences(first: 20) {
+          nodes {
+            ...RepositoryIssuePullRequestMetadata
+          }
+        }
         projectItems(first: 20, includeArchived: false) {
           nodes {
             id
@@ -1343,5 +1602,44 @@ const REPOSITORY_ISSUE_QUERY = `
         }
       }
     }
+  }
+
+  fragment RepositoryIssuePullRequestMetadata on PullRequest {
+    id
+    number
+    title
+    body
+    url
+    state
+    isDraft
+    merged
+    headRefName
+    baseRefName
+    headRepository {
+      name
+      url
+      owner {
+        login
+      }
+    }
+    repository {
+      name
+      url
+      owner {
+        login
+      }
+    }
+    labels(first: 20) {
+      nodes {
+        name
+      }
+    }
+    assignees(first: 20) {
+      nodes {
+        login
+      }
+    }
+    createdAt
+    updatedAt
   }
 `;

--- a/packages/tracker-github/src/adapter.ts
+++ b/packages/tracker-github/src/adapter.ts
@@ -938,7 +938,10 @@ async function fetchIssueProjectItemsPage(
   const data = result.data;
   const issue = data.node;
 
-  if (issue?.__typename !== "Issue" || !issue.projectItems) {
+  if (
+    (issue?.__typename !== "Issue" && issue?.__typename !== "PullRequest") ||
+    !issue.projectItems
+  ) {
     throw new GitHubTrackerQueryError(
       "GitHub GraphQL response did not include issue project items."
     );

--- a/packages/tracker-github/src/adapter.ts
+++ b/packages/tracker-github/src/adapter.ts
@@ -193,10 +193,12 @@ type GraphQLProjectFieldsResponse = {
 };
 
 type GraphQLIssueStateLookupNode = {
-  __typename: "Issue";
+  __typename: "Issue" | "PullRequest";
   id: string;
   number: number;
+  url?: string | null;
   updatedAt: string | null;
+  headRefName?: string | null;
   repository: {
     name: string;
     url: string;
@@ -722,7 +724,7 @@ function normalizeIssueStateLookupNode(
   lifecycle: WorkflowLifecycleConfig = DEFAULT_WORKFLOW_LIFECYCLE,
   rateLimits: Record<string, unknown> | null = null
 ): GitHubTrackedIssue | null {
-  if (issue?.__typename !== "Issue") {
+  if (issue?.__typename !== "Issue" && issue?.__typename !== "PullRequest") {
     return null;
   }
   if (!projectItem) {
@@ -733,6 +735,9 @@ function normalizeIssueStateLookupNode(
   const state = fieldValues[lifecycle.stateFieldName] ?? "Unknown";
   const repository = issue.repository;
   const identifier = `${repository.owner.login}/${repository.name}#${issue.number}`;
+  const url =
+    issue.url ??
+    `${repository.url}/${issue.__typename === "PullRequest" ? "pull" : "issues"}/${issue.number}`;
 
   return {
     id: issue.id,
@@ -742,8 +747,9 @@ function normalizeIssueStateLookupNode(
     description: null,
     priority: null,
     state,
-    branchName: null,
-    url: `${repository.url}/issues/${issue.number}`,
+    branchName:
+      issue.__typename === "PullRequest" ? (issue.headRefName ?? null) : null,
+    url,
     labels: [],
     blockedBy: [],
     createdAt: null,
@@ -884,7 +890,7 @@ async function resolveIssueProjectItemForStateLookup(
   issue: GraphQLIssueStateLookupNode | null,
   fetchImpl: FetchLike
 ): Promise<GraphQLIssueProjectItemNode | null> {
-  if (issue?.__typename !== "Issue") {
+  if (issue?.__typename !== "Issue" && issue?.__typename !== "PullRequest") {
     return null;
   }
 
@@ -1411,7 +1417,57 @@ const ISSUE_STATES_BY_IDS_QUERY = `
       ... on Issue {
         id
         number
+        url
         updatedAt
+        repository {
+          name
+          url
+          owner {
+            login
+          }
+        }
+        projectItems(first: 100, includeArchived: false) {
+          nodes {
+            id
+            updatedAt
+            project {
+              id
+            }
+            fieldValues(first: 20) {
+              nodes {
+                __typename
+                ... on ProjectV2ItemFieldSingleSelectValue {
+                  name
+                  optionId
+                  field {
+                    ... on ProjectV2SingleSelectField {
+                      name
+                    }
+                  }
+                }
+                ... on ProjectV2ItemFieldTextValue {
+                  text
+                  field {
+                    ... on ProjectV2FieldCommon {
+                      name
+                    }
+                  }
+                }
+              }
+            }
+          }
+          pageInfo {
+            endCursor
+            hasNextPage
+          }
+        }
+      }
+      ... on PullRequest {
+        id
+        number
+        url
+        updatedAt
+        headRefName
         repository {
           name
           url
@@ -1466,7 +1522,57 @@ const ISSUE_PROJECT_ITEMS_PAGE_QUERY = `
       ... on Issue {
         id
         number
+        url
         updatedAt
+        repository {
+          name
+          url
+          owner {
+            login
+          }
+        }
+        projectItems(first: 100, after: $cursor, includeArchived: false) {
+          nodes {
+            id
+            updatedAt
+            project {
+              id
+            }
+            fieldValues(first: 20) {
+              nodes {
+                __typename
+                ... on ProjectV2ItemFieldSingleSelectValue {
+                  name
+                  optionId
+                  field {
+                    ... on ProjectV2SingleSelectField {
+                      name
+                    }
+                  }
+                }
+                ... on ProjectV2ItemFieldTextValue {
+                  text
+                  field {
+                    ... on ProjectV2FieldCommon {
+                      name
+                    }
+                  }
+                }
+              }
+            }
+          }
+          pageInfo {
+            endCursor
+            hasNextPage
+          }
+        }
+      }
+      ... on PullRequest {
+        id
+        number
+        url
+        updatedAt
+        headRefName
         repository {
           name
           url

--- a/packages/tracker-github/src/tracker-github.test.ts
+++ b/packages/tracker-github/src/tracker-github.test.ts
@@ -2273,6 +2273,8 @@ describe("resolveTrackerAdapter", () => {
           expect(body.query).toContain(
             "projectItems(first: 100, includeArchived: false)"
           );
+          expect(body.query).toContain("... on Issue");
+          expect(body.query).toContain("... on PullRequest");
           expect(body.query).not.toContain("blockedBy(");
           expect(body.query).not.toContain("labels(");
           expect(body.query).not.toContain("assignees(");
@@ -2316,6 +2318,79 @@ describe("resolveTrackerAdapter", () => {
       "acme/platform#2",
     ]);
     expect(issues.map((issue) => issue.state)).toEqual(["In Progress", "Done"]);
+  });
+
+  it("fetches pull request states by GraphQL pull request ids", async () => {
+    const adapter = resolveTrackerAdapter({
+      adapter: "github-project",
+      bindingId: "project-123",
+      settings: {
+        projectId: "project-123",
+      },
+    });
+
+    const issues = await adapter.fetchIssueStatesByIds(
+      {
+        projectId: "workspace-1",
+        slug: "workspace-1",
+        workspaceDir: "/tmp/workspace-1",
+        repository: {
+          owner: "acme",
+          name: "platform",
+          cloneUrl: "https://github.com/acme/platform.git",
+        },
+        tracker: {
+          adapter: "github-project",
+          bindingId: "project-123",
+          settings: {
+            projectId: "project-123",
+          },
+        },
+      },
+      ["pr-1"],
+      {
+        token: "dependencies-token",
+        fetchImpl: async (_url, init) => {
+          const body = JSON.parse(String(init?.body)) as {
+            query: string;
+            variables: { issueIds: string[] };
+          };
+
+          expect(body.query).toContain("... on PullRequest");
+          expect(body.query).toContain("headRefName");
+          expect(body.variables.issueIds).toEqual(["pr-1"]);
+
+          return new Response(
+            JSON.stringify({
+              data: {
+                nodes: [
+                  makePullRequestStateLookupNode({
+                    projectId: "project-123",
+                    itemId: "item-pr-1",
+                    pullRequestId: "pr-1",
+                    number: 42,
+                    state: "Ready",
+                    headRefName: "feature/pr-card",
+                  }),
+                ],
+              },
+            }),
+            {
+              status: 200,
+              headers: { "content-type": "application/json" },
+            }
+          );
+        },
+      }
+    );
+
+    expect(issues).toHaveLength(1);
+    expect(issues[0]?.id).toBe("pr-1");
+    expect(issues[0]?.identifier).toBe("acme/platform#42");
+    expect(issues[0]?.state).toBe("Ready");
+    expect(issues[0]?.branchName).toBe("feature/pr-card");
+    expect(issues[0]?.url).toBe("https://github.com/acme/platform/pull/42");
+    expect(issues[0]?.tracker.itemId).toBe("item-pr-1");
   });
 
   it("attaches GitHub API rate-limit headers to fetched issue state lookups", async () => {
@@ -2440,6 +2515,7 @@ describe("resolveTrackerAdapter", () => {
       expect(body.query).toContain(
         "query IssueProjectItemsPage($issueId: ID!, $cursor: String)"
       );
+      expect(body.query).toContain("... on PullRequest");
       expect(body.variables.issueId).toBe("issue-1");
       expect(body.variables.cursor).toBe("cursor-1");
 
@@ -2782,6 +2858,55 @@ function makeIssueStateLookupNode(input: {
     id: input.issueId,
     number: input.number,
     updatedAt: "2026-03-14T00:00:00.000Z",
+    repository: {
+      name: "platform",
+      url: "https://github.com/acme/platform",
+      owner: { login: "acme" },
+    },
+    projectItems: {
+      nodes: [
+        {
+          id: input.itemId,
+          updatedAt: "2026-03-14T00:00:00.000Z",
+          project: { id: input.projectId },
+          fieldValues: {
+            nodes: [
+              {
+                __typename: "ProjectV2ItemFieldSingleSelectValue" as const,
+                name: input.state,
+                field: { name: "Status" },
+              },
+            ],
+          },
+        },
+      ],
+      pageInfo: input.pageInfo ?? {
+        endCursor: null,
+        hasNextPage: false,
+      },
+    },
+  };
+}
+
+function makePullRequestStateLookupNode(input: {
+  projectId: string;
+  itemId: string;
+  pullRequestId: string;
+  number: number;
+  state: string;
+  headRefName?: string | null;
+  pageInfo?: {
+    endCursor: string | null;
+    hasNextPage: boolean;
+  };
+}) {
+  return {
+    __typename: "PullRequest" as const,
+    id: input.pullRequestId,
+    number: input.number,
+    url: `https://github.com/acme/platform/pull/${input.number}`,
+    updatedAt: "2026-03-14T00:00:00.000Z",
+    headRefName: input.headRefName ?? null,
     repository: {
       name: "platform",
       url: "https://github.com/acme/platform",

--- a/packages/tracker-github/src/tracker-github.test.ts
+++ b/packages/tracker-github/src/tracker-github.test.ts
@@ -2594,6 +2594,138 @@ describe("resolveTrackerAdapter", () => {
     expect(issues[0]?.tracker.itemId).toBe("item-1");
     expect(issues[0]?.state).toBe("Done");
   });
+
+  it("paginates pull request projectItems until the configured project item is found", async () => {
+    const adapter = resolveTrackerAdapter({
+      adapter: "github-project",
+      bindingId: "project-123",
+      settings: {
+        projectId: "project-123",
+      },
+    });
+
+    const fetchImpl = vi.fn(async (_url, init) => {
+      const body = JSON.parse(String(init?.body)) as {
+        query: string;
+        variables: {
+          issueIds?: string[];
+          issueId?: string;
+          cursor?: string | null;
+        };
+      };
+
+      if (body.query.includes("query IssueStatesByIds")) {
+        return new Response(
+          JSON.stringify({
+            data: {
+              nodes: [
+                makePullRequestStateLookupNode({
+                  projectId: "project-999",
+                  itemId: "item-other",
+                  pullRequestId: "pr-1",
+                  number: 42,
+                  state: "Todo",
+                  headRefName: "feature/pr-card",
+                  pageInfo: {
+                    endCursor: "cursor-1",
+                    hasNextPage: true,
+                  },
+                }),
+              ],
+            },
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }
+        );
+      }
+
+      expect(body.query).toContain(
+        "query IssueProjectItemsPage($issueId: ID!, $cursor: String)"
+      );
+      expect(body.query).toContain("... on PullRequest");
+      expect(body.variables.issueId).toBe("pr-1");
+      expect(body.variables.cursor).toBe("cursor-1");
+
+      return new Response(
+        JSON.stringify({
+          data: {
+            node: {
+              __typename: "PullRequest",
+              id: "pr-1",
+              number: 42,
+              url: "https://github.com/acme/platform/pull/42",
+              updatedAt: "2026-03-14T00:00:00.000Z",
+              headRefName: "feature/pr-card",
+              repository: {
+                name: "platform",
+                url: "https://github.com/acme/platform",
+                owner: { login: "acme" },
+              },
+              projectItems: {
+                nodes: [
+                  {
+                    id: "item-pr-1",
+                    updatedAt: "2026-03-14T00:01:00.000Z",
+                    project: { id: "project-123" },
+                    fieldValues: {
+                      nodes: [
+                        {
+                          __typename: "ProjectV2ItemFieldSingleSelectValue",
+                          name: "Done",
+                          field: { name: "Status" },
+                        },
+                      ],
+                    },
+                  },
+                ],
+                pageInfo: {
+                  endCursor: null,
+                  hasNextPage: false,
+                },
+              },
+            },
+          },
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }
+      );
+    });
+
+    const issues = await adapter.fetchIssueStatesByIds(
+      {
+        projectId: "workspace-1",
+        slug: "workspace-1",
+        workspaceDir: "/tmp/workspace-1",
+        repository: {
+          owner: "acme",
+          name: "platform",
+          cloneUrl: "https://github.com/acme/platform.git",
+        },
+        tracker: {
+          adapter: "github-project",
+          bindingId: "project-123",
+          settings: {
+            projectId: "project-123",
+          },
+        },
+      },
+      ["pr-1"],
+      {
+        token: "dependencies-token",
+        fetchImpl,
+      }
+    );
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(issues).toHaveLength(1);
+    expect(issues[0]?.tracker.itemId).toBe("item-pr-1");
+    expect(issues[0]?.state).toBe("Done");
+    expect(issues[0]?.branchName).toBe("feature/pr-card");
+  });
 });
 
 describe("validateWorkflowFieldMapping", () => {

--- a/packages/tracker-github/src/tracker-github.test.ts
+++ b/packages/tracker-github/src/tracker-github.test.ts
@@ -155,6 +155,189 @@ describe("resolveTrackerAdapter", () => {
     expect(issue?.priority).toBe(1);
   });
 
+  it("keeps existing Issue content normalization unchanged", () => {
+    const issue = normalizeGithubProjectItem(
+      "project-123",
+      makeProjectItem({
+        itemId: "item-1",
+        issueId: "issue-1",
+        number: 1,
+        title: "Regression issue",
+        assignees: [],
+        state: "Ready",
+      }),
+      DEFAULT_WORKFLOW_LIFECYCLE
+    );
+
+    expect(issue).toMatchObject({
+      id: "issue-1",
+      identifier: "acme/platform#1",
+      number: 1,
+      title: "Regression issue",
+      description: null,
+      priority: null,
+      state: "Ready",
+      branchName: null,
+      url: "https://github.com/acme/platform/issues/1",
+      labels: [],
+      blockedBy: [],
+      createdAt: "2026-03-14T00:00:00.000Z",
+      updatedAt: "2026-03-14T00:00:00.000Z",
+      repository: {
+        owner: "acme",
+        name: "platform",
+        url: "https://github.com/acme/platform",
+        cloneUrl: "https://github.com/acme/platform.git",
+      },
+      tracker: {
+        adapter: "github-project",
+        bindingId: "project-123",
+        itemId: "item-1",
+      },
+    });
+    expect(issue?.metadata).toEqual({ Status: "Ready" });
+  });
+
+  it("normalizes PullRequest Project item content instead of dropping it", () => {
+    const issue = normalizeGithubProjectItem(
+      "project-123",
+      makePullRequestProjectItem({
+        itemId: "item-pr-7",
+        pullRequestId: "pr-7",
+        number: 7,
+        title: "Ship tracker PR metadata",
+        state: "Ready",
+      }),
+      DEFAULT_WORKFLOW_LIFECYCLE
+    );
+
+    expect(issue).toMatchObject({
+      id: "pr-7",
+      identifier: "acme/platform#7",
+      number: 7,
+      title: "Ship tracker PR metadata",
+      description: "PR body",
+      state: "Ready",
+      branchName: "feature/pr-metadata",
+      url: "https://github.com/acme/platform/pull/7",
+      labels: ["enhancement", "tracker"],
+      blockedBy: [],
+      repository: {
+        owner: "acme",
+        name: "platform",
+        url: "https://github.com/acme/platform",
+        cloneUrl: "https://github.com/acme/platform.git",
+      },
+    });
+    expect(issue?.metadata).toMatchObject({
+      Status: "Ready",
+      contentType: "PullRequest",
+      linkedPullRequests: [],
+      pullRequest: {
+        id: "pr-7",
+        number: 7,
+        identifier: "acme/platform#7",
+        title: "Ship tracker PR metadata",
+        body: "PR body",
+        url: "https://github.com/acme/platform/pull/7",
+        state: "OPEN",
+        isDraft: false,
+        merged: false,
+        headRefName: "feature/pr-metadata",
+        baseRefName: "main",
+        headRepository: {
+          owner: "acme",
+          name: "platform",
+          url: "https://github.com/acme/platform",
+          cloneUrl: "https://github.com/acme/platform.git",
+        },
+        repository: {
+          owner: "acme",
+          name: "platform",
+          url: "https://github.com/acme/platform",
+          cloneUrl: "https://github.com/acme/platform.git",
+        },
+        labels: ["enhancement", "tracker"],
+        assignees: ["octocat"],
+        createdAt: "2026-03-13T00:00:00.000Z",
+        updatedAt: "2026-03-14T00:00:00.000Z",
+      },
+    });
+  });
+
+  it("attaches Issue linked pull request metadata from closedByPullRequestsReferences", () => {
+    const issue = normalizeGithubProjectItem(
+      "project-123",
+      {
+        ...makeProjectItem({
+          itemId: "item-1",
+          issueId: "issue-1",
+          number: 1,
+          title: "Issue with linked PR",
+          assignees: [],
+        }),
+        content: {
+          ...makeProjectItem({
+            itemId: "item-1",
+            issueId: "issue-1",
+            number: 1,
+            title: "Issue with linked PR",
+            assignees: [],
+          }).content,
+          closedByPullRequestsReferences: {
+            nodes: [
+              makePullRequestProjectItem({
+                itemId: "item-pr-7",
+                pullRequestId: "pr-7",
+                number: 7,
+                title: "Fix linked issue",
+              }).content,
+            ],
+          },
+        },
+      },
+      DEFAULT_WORKFLOW_LIFECYCLE
+    );
+
+    const metadata = issue?.metadata as Record<string, unknown> | undefined;
+
+    expect(metadata?.linkedPullRequests).toEqual([
+      expect.objectContaining({
+        id: "pr-7",
+        number: 7,
+        identifier: "acme/platform#7",
+        url: "https://github.com/acme/platform/pull/7",
+        headRefName: "feature/pr-metadata",
+        baseRefName: "main",
+        repository: {
+          owner: "acme",
+          name: "platform",
+          url: "https://github.com/acme/platform",
+          cloneUrl: "https://github.com/acme/platform.git",
+        },
+      }),
+    ]);
+  });
+
+  it("continues to ignore unsupported Project item content types", () => {
+    const issue = normalizeGithubProjectItem(
+      "project-123",
+      {
+        id: "item-1",
+        updatedAt: "2026-03-14T00:00:00.000Z",
+        fieldValues: { nodes: [] },
+        content: {
+          __typename: "DraftIssue",
+          id: "draft-1",
+          title: "Unsupported draft",
+        },
+      } as unknown as Parameters<typeof normalizeGithubProjectItem>[1],
+      DEFAULT_WORKFLOW_LIFECYCLE
+    );
+
+    expect(issue).toBeNull();
+  });
+
   it("uses the newer project item timestamp when it is later than the issue timestamp", () => {
     const issue = normalizeGithubProjectItem(
       "project-123",
@@ -2525,6 +2708,59 @@ function makeProjectItem(input: {
         owner: { login: "acme" },
       },
       blockedBy: { nodes: [] },
+    },
+  };
+}
+
+function makePullRequestProjectItem(input: {
+  itemId: string;
+  pullRequestId: string;
+  number: number;
+  title: string;
+  state?: string;
+}) {
+  return {
+    id: input.itemId,
+    updatedAt: "2026-03-14T00:05:00.000Z",
+    fieldValues: {
+      nodes: [
+        {
+          __typename: "ProjectV2ItemFieldSingleSelectValue" as const,
+          name: input.state ?? "Todo",
+          field: { name: "Status" },
+        },
+      ],
+    },
+    content: {
+      __typename: "PullRequest" as const,
+      id: input.pullRequestId,
+      number: input.number,
+      title: input.title,
+      body: "PR body",
+      url: `https://github.com/acme/platform/pull/${input.number}`,
+      state: "OPEN",
+      isDraft: false,
+      merged: false,
+      headRefName: "feature/pr-metadata",
+      baseRefName: "main",
+      headRepository: {
+        name: "platform",
+        url: "https://github.com/acme/platform",
+        owner: { login: "acme" },
+      },
+      repository: {
+        name: "platform",
+        url: "https://github.com/acme/platform",
+        owner: { login: "acme" },
+      },
+      labels: {
+        nodes: [{ name: "tracker" }, { name: "enhancement" }],
+      },
+      assignees: {
+        nodes: [{ login: "octocat" }],
+      },
+      createdAt: "2026-03-13T00:00:00.000Z",
+      updatedAt: "2026-03-14T00:00:00.000Z",
     },
   };
 }


### PR DESCRIPTION
## Issues

- Fixes #276

## Summary

- GitHub ProjectV2의 `PullRequest` item을 `tracker-github` adapter가 버리지 않고 normalize하도록 했습니다.
- Issue content에서 `closedByPullRequestsReferences` 기반 linked PR metadata를 수집합니다.
- PR-backed run의 state refresh lookup과 paginated projectItems lookup이 `PullRequest` node ID를 처리하도록 보강했습니다.

## Changes

- ProjectV2 item GraphQL query에 `... on PullRequest` fragment와 PR metadata fragment를 추가했습니다.
- PR metadata(`number`, `url`, `headRefName`, `baseRefName`, repository 등)를 `metadata.pullRequest`와 `metadata.linkedPullRequests`에 정규화합니다.
- `ISSUE_STATES_BY_IDS_QUERY` / `ISSUE_PROJECT_ITEMS_PAGE_QUERY`가 `PullRequest` projectItems를 조회하도록 확장했습니다.
- `normalizeIssueStateLookupNode`가 PR node를 state lookup 결과로 정규화하고 PR head branch/url을 보존합니다.
- `fetchIssueProjectItemsPage`의 runtime guard를 `Issue | PullRequest`로 정합화해 첫 페이지 밖의 PR project item도 pagination으로 찾을 수 있게 했습니다.
- Issue normalize 회귀, PullRequest item normalize, linked PR metadata, unsupported content 무시, PR ID state refresh, PR projectItems pagination 테스트를 추가했습니다.

## Evidence

- `pnpm --filter @gh-symphony/tracker-github test` (43 tests)
- `pnpm --filter @gh-symphony/tracker-github typecheck`
- `pnpm lint && pnpm test && pnpm typecheck && pnpm build`
- Docker E2E TC: `docker compose -f docker-compose.e2e.yml -f docker-compose.e2e.events.yml up -d --build`, `curl --fail --retry-all-errors --retry 10 --retry-delay 2 http://localhost:4680/healthz`, happy-path fixture 주입 후 active run 생성 및 worker `completed` → `continuation` retry 관찰, fixture/container 정리

## Human Validation

- [ ] ProjectV2 PR 카드가 active status에 있을 때 tracker 후보로 표시되는지 확인
- [ ] PR-backed active run의 project state 변경이 refresh 후 `run.issueState`에 반영되는지 확인
- [ ] PR 카드의 project item이 첫 페이지 밖에 있을 때 state lookup pagination이 동작하는지 확인
- [ ] Issue에 연결된 PR metadata가 downstream prompt/status에서 기대 shape로 보이는지 확인
- [ ] 기존 Issue Project item 동작에 회귀가 없는지 확인

## Risks

- GitHub linked PR 수집은 `closedByPullRequestsReferences(first: 20)` 경로에 기반합니다. GitHub UI의 모든 linked PR 표현을 포괄하지 못할 수 있어 리뷰 시 실제 프로젝트 데이터로 확인이 필요합니다.
