### PR TITLE
feat(core): expose linked PR prompt context

### DIFF
--- a/packages/core/src/contracts/tracker-adapter.ts
+++ b/packages/core/src/contracts/tracker-adapter.ts
@@ -17,6 +17,35 @@ export type BlockerRef = {
   state: string | null;
 };
 
+export type TrackedIssueContentType = "Issue" | "PullRequest";
+
+export type TrackedPullRequestContext = {
+  id: string;
+  number: number;
+  identifier: string;
+  url: string | null;
+  state: string | null;
+  projectState?: string | null;
+  isDraft?: boolean | null;
+  merged?: boolean | null;
+  headRefName?: string | null;
+  baseRefName?: string | null;
+  repository?: {
+    owner: string;
+    name: string;
+    url: string;
+    cloneUrl: string;
+  };
+  [key: string]: unknown;
+};
+
+export type TrackedIssueMetadata = {
+  contentType?: TrackedIssueContentType;
+  linkedPullRequests?: TrackedPullRequestContext[];
+  pullRequest?: TrackedPullRequestContext;
+  [key: string]: unknown;
+};
+
 export type TrackedIssue = {
   id: string;
   identifier: string;
@@ -37,7 +66,7 @@ export type TrackedIssue = {
   tracker: TrackerBindingSummary & {
     itemId: string;
   };
-  metadata: Record<string, string>;
+  metadata: TrackedIssueMetadata;
   rateLimits?: Record<string, unknown> | null;
 };
 

--- a/packages/core/src/contracts/tracker-adapter.ts
+++ b/packages/core/src/contracts/tracker-adapter.ts
@@ -24,7 +24,15 @@ export type TrackedPullRequestContext = {
   number: number;
   identifier: string;
   url: string | null;
+  /**
+   * Pull request state from the tracker source when available
+   * (for example, GitHub GraphQL states such as OPEN, CLOSED, or MERGED).
+   */
   state: string | null;
+  /**
+   * Workflow/project state for the pull request item, when distinct from the
+   * pull request's source state.
+   */
   projectState?: string | null;
   isDraft?: boolean | null;
   merged?: boolean | null;

--- a/packages/core/src/workflow/render.test.ts
+++ b/packages/core/src/workflow/render.test.ts
@@ -1,5 +1,140 @@
 import { describe, expect, it } from "vitest";
-import { renderContinuationGuidance } from "./render.js";
+import {
+  buildPromptVariables,
+  renderContinuationGuidance,
+  renderPrompt,
+} from "./render.js";
+import type { TrackedIssue } from "../contracts/tracker-adapter.js";
+
+function createTrackedIssue(overrides: Partial<TrackedIssue> = {}): TrackedIssue {
+  return {
+    id: "issue-1",
+    identifier: "acme/platform#42",
+    number: 42,
+    title: "Fix the bug",
+    description: "It crashes on startup",
+    priority: null,
+    state: "Ready",
+    branchName: null,
+    url: "https://github.com/acme/platform/issues/42",
+    labels: [],
+    blockedBy: [],
+    createdAt: null,
+    updatedAt: null,
+    repository: {
+      owner: "acme",
+      name: "platform",
+      cloneUrl: "https://github.com/acme/platform.git",
+      url: "https://github.com/acme/platform",
+    },
+    tracker: {
+      adapter: "github-project",
+      bindingId: "project-123",
+      itemId: "item-1",
+    },
+    metadata: {},
+    ...overrides,
+  };
+}
+
+describe("buildPromptVariables", () => {
+  it("keeps legacy issue prompts working and defaults content type to Issue", () => {
+    const variables = buildPromptVariables(createTrackedIssue(), {
+      attempt: null,
+    });
+
+    expect(variables.issue.content_type).toBe("Issue");
+    expect(variables.issue.linked_pull_requests).toEqual([]);
+    expect(variables.issue.primary_pull_request).toBeNull();
+    expect(variables.issue.has_linked_pr).toBe(false);
+    expect(
+      renderPrompt(
+        "Fix {{issue.title}} on {{issue.branch_name}}.",
+        variables
+      )
+    ).toBe("Fix Fix the bug on .");
+  });
+
+  it("exposes linked pull request context to Liquid templates", () => {
+    const variables = buildPromptVariables(
+      createTrackedIssue({
+        metadata: {
+          contentType: "Issue",
+          linkedPullRequests: [
+            {
+              id: "pr-1",
+              number: 7,
+              identifier: "acme/platform#7",
+              url: "https://github.com/acme/platform/pull/7",
+              state: "OPEN",
+              projectState: "In review",
+              isDraft: false,
+              merged: false,
+              headRefName: "fix/issue-42",
+              baseRefName: "main",
+              repository: {
+                owner: "acme",
+                name: "platform",
+                url: "https://github.com/acme/platform",
+                cloneUrl: "https://github.com/acme/platform.git",
+              },
+            },
+          ],
+        },
+      }),
+      { attempt: null }
+    );
+
+    const rendered = renderPrompt(
+      [
+        "type={{ issue.content_type }}",
+        "has_pr={{ issue.has_linked_pr }}",
+        "primary={{ issue.primary_pull_request.identifier }}",
+        "branch={{ issue.primary_pull_request.headRefName }}",
+        "{% for pr in issue.linked_pull_requests %}[{{ pr.number }}:{{ pr.state }}]{% endfor %}",
+      ].join("\n"),
+      variables
+    );
+
+    expect(rendered).toContain("type=Issue");
+    expect(rendered).toContain("has_pr=true");
+    expect(rendered).toContain("primary=acme/platform#7");
+    expect(rendered).toContain("branch=fix/issue-42");
+    expect(rendered).toContain("[7:OPEN]");
+  });
+
+  it("represents standalone pull request subjects with a primary pull request", () => {
+    const variables = buildPromptVariables(
+      createTrackedIssue({
+        id: "pr-9",
+        identifier: "acme/platform#9",
+        number: 9,
+        title: "Ship PR metadata",
+        state: "Ready",
+        branchName: "feature/pr-metadata",
+        url: "https://github.com/acme/platform/pull/9",
+        metadata: {
+          contentType: "PullRequest",
+        },
+      }),
+      { attempt: null }
+    );
+
+    expect(variables.issue.content_type).toBe("PullRequest");
+    expect(variables.issue.has_linked_pr).toBe(false);
+    expect(variables.issue.primary_pull_request).toMatchObject({
+      id: "pr-9",
+      number: 9,
+      identifier: "acme/platform#9",
+      url: "https://github.com/acme/platform/pull/9",
+      state: "Ready",
+      headRefName: "feature/pr-metadata",
+    });
+    expect(renderPrompt("branch={{ issue.branch_name }}", variables)).toBe(
+      "branch=feature/pr-metadata"
+    );
+  });
+});
 
 describe("renderContinuationGuidance", () => {
   it("renders supported continuation variables", () => {

--- a/packages/core/src/workflow/render.test.ts
+++ b/packages/core/src/workflow/render.test.ts
@@ -127,12 +127,59 @@ describe("buildPromptVariables", () => {
       number: 9,
       identifier: "acme/platform#9",
       url: "https://github.com/acme/platform/pull/9",
-      state: "Ready",
+      state: null,
+      projectState: "Ready",
       headRefName: "feature/pr-metadata",
     });
     expect(renderPrompt("branch={{ issue.branch_name }}", variables)).toBe(
       "branch=feature/pr-metadata"
     );
+  });
+
+  it("prefers the subject pull request over linked pull requests for pull request subjects", () => {
+    const variables = buildPromptVariables(
+      createTrackedIssue({
+        id: "pr-9",
+        identifier: "acme/platform#9",
+        number: 9,
+        title: "Ship PR metadata",
+        state: "In review",
+        branchName: "feature/pr-metadata",
+        url: "https://github.com/acme/platform/pull/9",
+        metadata: {
+          contentType: "PullRequest",
+          pullRequest: {
+            id: "pr-9",
+            number: 9,
+            identifier: "acme/platform#9",
+            url: "https://github.com/acme/platform/pull/9",
+            state: "OPEN",
+            projectState: "In review",
+            headRefName: "feature/pr-metadata",
+            baseRefName: "main",
+          },
+          linkedPullRequests: [
+            {
+              id: "pr-8",
+              number: 8,
+              identifier: "acme/platform#8",
+              url: "https://github.com/acme/platform/pull/8",
+              state: "OPEN",
+              projectState: "Ready",
+            },
+          ],
+        },
+      }),
+      { attempt: null }
+    );
+
+    expect(variables.issue.has_linked_pr).toBe(true);
+    expect(variables.issue.primary_pull_request).toMatchObject({
+      id: "pr-9",
+      identifier: "acme/platform#9",
+      state: "OPEN",
+      projectState: "In review",
+    });
   });
 });
 

--- a/packages/core/src/workflow/render.ts
+++ b/packages/core/src/workflow/render.ts
@@ -1,4 +1,8 @@
 import type { TrackedIssue } from "../contracts/tracker-adapter.js";
+import type {
+  TrackedIssueContentType,
+  TrackedPullRequestContext,
+} from "../contracts/tracker-adapter.js";
 import {
   Liquid,
   ParseError,
@@ -25,6 +29,10 @@ export type PromptIssueVariables = {
   labels: string[];
   blocked_by: TrackedIssue["blockedBy"];
   branch_name: string | null;
+  content_type: TrackedIssueContentType;
+  linked_pull_requests: TrackedPullRequestContext[];
+  primary_pull_request: TrackedPullRequestContext | null;
+  has_linked_pr: boolean;
   created_at: string | null;
   updated_at: string | null;
   repository: string;
@@ -55,6 +63,16 @@ export function buildPromptVariables(
     attempt: number | null;
   }
 ): PromptVariables {
+  const contentType = issue.metadata.contentType ?? "Issue";
+  const linkedPullRequests = Array.isArray(issue.metadata.linkedPullRequests)
+    ? issue.metadata.linkedPullRequests
+    : [];
+  const primaryPullRequest =
+    linkedPullRequests[0] ??
+    (contentType === "PullRequest"
+      ? (issue.metadata.pullRequest ?? buildPullRequestContextFromIssue(issue))
+      : null);
+
   return {
     issue: {
       id: issue.id,
@@ -68,11 +86,34 @@ export function buildPromptVariables(
       labels: issue.labels,
       blocked_by: issue.blockedBy,
       branch_name: issue.branchName,
+      content_type: contentType,
+      linked_pull_requests: linkedPullRequests,
+      primary_pull_request: primaryPullRequest,
+      has_linked_pr: linkedPullRequests.length > 0,
       created_at: issue.createdAt,
       updated_at: issue.updatedAt,
       repository: `${issue.repository.owner}/${issue.repository.name}`,
     },
     attempt: options.attempt,
+  };
+}
+
+function buildPullRequestContextFromIssue(
+  issue: TrackedIssue
+): TrackedPullRequestContext {
+  return {
+    id: issue.id,
+    number: issue.number,
+    identifier: issue.identifier,
+    url: issue.url,
+    state: issue.state,
+    headRefName: issue.branchName,
+    repository: {
+      owner: issue.repository.owner,
+      name: issue.repository.name,
+      url: issue.repository.url ?? "",
+      cloneUrl: issue.repository.cloneUrl,
+    },
   };
 }
 

--- a/packages/core/src/workflow/render.ts
+++ b/packages/core/src/workflow/render.ts
@@ -68,10 +68,11 @@ export function buildPromptVariables(
     ? issue.metadata.linkedPullRequests
     : [];
   const primaryPullRequest =
-    linkedPullRequests[0] ??
-    (contentType === "PullRequest"
-      ? (issue.metadata.pullRequest ?? buildPullRequestContextFromIssue(issue))
-      : null);
+    contentType === "PullRequest"
+      ? (issue.metadata.pullRequest ??
+        linkedPullRequests[0] ??
+        buildPullRequestContextFromIssue(issue))
+      : (linkedPullRequests[0] ?? null);
 
   return {
     issue: {
@@ -106,7 +107,8 @@ function buildPullRequestContextFromIssue(
     number: issue.number,
     identifier: issue.identifier,
     url: issue.url,
-    state: issue.state,
+    state: null,
+    projectState: issue.state,
     headRefName: issue.branchName,
     repository: {
       owner: issue.repository.owner,


### PR DESCRIPTION
## Issues

- Fixes #277

## Summary

- `TrackedIssue` 이름은 유지하면서 metadata contract에 subject type과 linked PR context를 추가했습니다.
- prompt rendering에서 `issue.content_type`, `issue.linked_pull_requests`, `issue.primary_pull_request`, `issue.has_linked_pr`를 사용할 수 있게 했습니다.
- PR review 피드백을 반영해 `PullRequest` subject의 primary PR 선택과 fallback `state` 의미를 정리했습니다.

## Changes

- `TrackedIssueMetadata`, `TrackedIssueContentType`, `TrackedPullRequestContext` 타입을 core contract에 추가했습니다.
- `buildPromptVariables()`가 linked PR 목록, primary PR, linked PR 존재 여부를 Liquid 변수로 노출하도록 확장했습니다.
- `PullRequest` subject에서는 `metadata.pullRequest`를 `linkedPullRequests[0]`보다 우선해 subject PR을 primary로 선택합니다.
- standalone `PullRequest` fallback은 source PR state를 추정하지 않고 `state: null`, `projectState: issue.state`로 분리합니다.
- render tests에 legacy Issue prompt, Issue linked PR, PR-only subject, PR subject primary 우선순위 TC를 추가했습니다.

## Evidence

- `pnpm --filter @gh-symphony/core test` — passed, 13 files / 123 tests
- `pnpm --filter @gh-symphony/core typecheck` — passed
- `pnpm lint && pnpm test && pnpm typecheck && pnpm build` — passed
- `git push origin codex/issue-277-tracked-issue-pr-context` — branch pushed to `386c048`; local git credential helper printed a missing helper module warning, but push completed successfully
- Spec check: `docs/symphony-spec.md`의 stable issue model 및 prompt rendering input 확장 범위에 부합하며 upstream spec 파일은 수정하지 않았습니다. 의도적 divergence는 없습니다.

## Human Validation

- [ ] 기존 WORKFLOW prompt가 `issue.branch_name`을 계속 렌더링하는지 확인
- [ ] linked PR이 있는 Issue prompt에서 PR 목록과 primary PR 값이 기대대로 보이는지 확인
- [ ] PR-only Project item prompt에서 `issue.content_type = "PullRequest"`와 primary PR fallback이 기대대로 보이는지 확인
- [ ] PR subject에 linked PR 목록이 함께 있어도 `issue.primary_pull_request`가 subject PR을 가리키는지 확인

## Risks

- `metadata` index signature를 `unknown`으로 넓혀 tracker-specific nested metadata를 허용합니다. 기존 문자열 field metadata는 계속 담기지만, 새 consumer는 필요한 키를 명시적으로 좁혀 읽어야 합니다.