### PR TITLE
feat(cli): add removed command handler

### DIFF
--- a/packages/cli/src/commands/removed-command.test.ts
+++ b/packages/cli/src/commands/removed-command.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createRemovedCommandHandler } from "./removed-command.js";
+
+function captureWrites(stream: NodeJS.WriteStream): {
+  output: () => string;
+  restore: () => void;
+} {
+  let buffer = "";
+  const spy = vi.spyOn(stream, "write").mockImplementation(((
+    chunk: string | Uint8Array
+  ) => {
+    buffer +=
+      typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8");
+    return true;
+  }) as typeof stream.write);
+
+  return {
+    output: () => buffer,
+    restore: () => spy.mockRestore(),
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  process.exitCode = undefined;
+});
+
+describe("createRemovedCommandHandler", () => {
+  it("writes the migration message to stderr and exits 2", async () => {
+    const stderr = captureWrites(process.stderr);
+    const handler = createRemovedCommandHandler(
+      "Use 'gh-symphony repo status'."
+    );
+
+    try {
+      await handler([], {
+        configDir: "/tmp/gh-symphony-test",
+        verbose: false,
+        json: true,
+        noColor: true,
+      });
+    } finally {
+      stderr.restore();
+    }
+
+    expect(stderr.output()).toBe("Use 'gh-symphony repo status'.\n");
+    expect(process.exitCode).toBe(2);
+  });
+});

--- a/packages/cli/src/commands/removed-command.ts
+++ b/packages/cli/src/commands/removed-command.ts
@@ -1,0 +1,8 @@
+import type { CommandHandler } from "../index.js";
+
+export function createRemovedCommandHandler(message: string): CommandHandler {
+  return async () => {
+    process.stderr.write(`${message}\n`);
+    process.exitCode = 2;
+  };
+}


### PR DESCRIPTION
## Issues

- Fixes #289

## Summary

- Add a reusable removed-command `CommandHandler` factory for CLI deprecation shims.
- Keep removed command wiring out of this PR; follow-up issues can import the helper and attach command-specific migration messages.

## Changes

- Created `packages/cli/src/commands/removed-command.ts` with `createRemovedCommandHandler(message: string)`.
- Added focused Vitest coverage for stderr output and `process.exitCode = 2`, including `json: true` options to confirm plain text behavior.

## Evidence

- `pnpm --filter @gh-symphony/cli test -- removed-command.test.ts`
- `pnpm lint && pnpm test && pnpm typecheck && pnpm build`
- Spec check: Configuration Layer only; no `docs/symphony-spec.md` edits and no intentional divergence.

## Human Validation

- [ ] Confirm removed command follow-up issues can import this helper cleanly.
- [ ] Confirm migration messages render exactly once on stderr.
- [ ] Confirm no top-level removed commands are wired in this PR.

## Risks

- Low: helper is currently unused until the follow-up command-removal issues wire it into Commander.