### PR TITLE
feat(cli): refresh root help output

### DIFF
--- a/packages/cli/src/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/src/commands/__snapshots__/help.test.ts.snap
@@ -1,0 +1,83 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`help output > renders the colored grouped help snapshot 1`] = `
+"gh-symphony — AI Coding Agent Orchestrator
+
+[33m[1mSetup:[0m[0m
+  [36msetup[0m                Run the one-command first-run setup flow
+  [36mworkflow init[0m        Generate WORKFLOW.md and workflow support files
+  [36mworkflow validate[0m    Strictly validate WORKFLOW.md
+  [36mworkflow preview[0m     Render the worker prompt from a sample or live issue
+  [36mdoctor[0m               Run diagnostics and optional remediation
+  [36mconfig show[0m          Show current configuration
+  [36mconfig set[0m           Set a configuration value
+  [36mconfig edit[0m          Open config in $EDITOR
+
+[33m[1mOrchestration (current repository):[0m[0m
+  [36mrepo init[0m            Initialize gh-symphony for the current repository
+  [36mrepo start[0m           Start the orchestrator (foreground)
+  [36mrepo start --daemon[0m  Start the orchestrator in the background
+  [36mrepo stop[0m            Stop the background orchestrator
+  [36mrepo status[0m          Show orchestrator status
+  [36mrepo run <issue>[0m     Dispatch a single issue
+  [36mrepo recover[0m         Recover stalled runs
+  [36mrepo logs[0m            View orchestrator logs
+  [36mrepo explain <issue>[0m Explain why an issue is not dispatching
+
+[33m[1mMaintenance:[0m[0m
+  [36mupgrade[0m              Upgrade the CLI to the latest published version
+  [36mcompletion <shell>[0m   Print shell completion (bash/zsh/fish)
+  [36mversion[0m              Show version
+  [36mhelp [command][0m       Show help for a command
+
+[33m[1mGlobal Options:[0m[0m
+  [36m--config <dir>[0m       Config directory override (advanced; default resolves
+                       per-repo to <repo>/.runtime/orchestrator)
+  [36m--verbose, -v[0m        Verbose output
+  [36m--json[0m               JSON output
+  [36m--no-color[0m           Disable color output
+  [36m--help, -h[0m           Show help
+  [36m--version, -V[0m        Show version
+"
+`;
+
+exports[`help output > renders the non-colored grouped help snapshot 1`] = `
+"gh-symphony — AI Coding Agent Orchestrator
+
+Setup:
+  setup                Run the one-command first-run setup flow
+  workflow init        Generate WORKFLOW.md and workflow support files
+  workflow validate    Strictly validate WORKFLOW.md
+  workflow preview     Render the worker prompt from a sample or live issue
+  doctor               Run diagnostics and optional remediation
+  config show          Show current configuration
+  config set           Set a configuration value
+  config edit          Open config in $EDITOR
+
+Orchestration (current repository):
+  repo init            Initialize gh-symphony for the current repository
+  repo start           Start the orchestrator (foreground)
+  repo start --daemon  Start the orchestrator in the background
+  repo stop            Stop the background orchestrator
+  repo status          Show orchestrator status
+  repo run <issue>     Dispatch a single issue
+  repo recover         Recover stalled runs
+  repo logs            View orchestrator logs
+  repo explain <issue> Explain why an issue is not dispatching
+
+Maintenance:
+  upgrade              Upgrade the CLI to the latest published version
+  completion <shell>   Print shell completion (bash/zsh/fish)
+  version              Show version
+  help [command]       Show help for a command
+
+Global Options:
+  --config <dir>       Config directory override (advanced; default resolves
+                       per-repo to <repo>/.runtime/orchestrator)
+  --verbose, -v        Verbose output
+  --json               JSON output
+  --no-color           Disable color output
+  --help, -h           Show help
+  --version, -V        Show version
+"
+`;

--- a/packages/cli/src/commands/help.test.ts
+++ b/packages/cli/src/commands/help.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { setNoColor, stripAnsi } from "../ansi.js";
+import { runCli } from "../index.js";
+import { renderHelp } from "./help.js";
+
+function captureWrites(stream: NodeJS.WriteStream): {
+  output: () => string;
+  restore: () => void;
+} {
+  let buffer = "";
+  const spy = vi.spyOn(stream, "write").mockImplementation(((
+    chunk: string | Uint8Array
+  ) => {
+    buffer +=
+      typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8");
+    return true;
+  }) as typeof stream.write);
+
+  return {
+    output: () => buffer,
+    restore: () => spy.mockRestore(),
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  setNoColor(false);
+  delete process.env.NO_COLOR;
+  process.exitCode = undefined;
+});
+
+describe("help output", () => {
+  it("renders the colored grouped help snapshot", () => {
+    expect(renderHelp({ color: true })).toMatchSnapshot();
+  });
+
+  it("renders the non-colored grouped help snapshot", () => {
+    expect(renderHelp({ color: false })).toMatchSnapshot();
+  });
+
+  it("honors the shared no-color switch", () => {
+    setNoColor(true);
+
+    const output = renderHelp({ color: true });
+
+    expect(output).toBe(stripAnsi(output));
+  });
+
+  it("prints byte-identical output for help and root --help", async () => {
+    const helpStdout = captureWrites(process.stdout);
+    try {
+      await runCli(["help"]);
+    } finally {
+      helpStdout.restore();
+    }
+
+    const rootHelpStdout = captureWrites(process.stdout);
+    try {
+      await runCli(["--help"]);
+    } finally {
+      rootHelpStdout.restore();
+    }
+
+    expect(helpStdout.output()).toBe(rootHelpStdout.output());
+  });
+
+  it("strips ANSI escapes for root --no-color help", async () => {
+    const stdout = captureWrites(process.stdout);
+
+    try {
+      await runCli(["--no-color", "--help"]);
+    } finally {
+      stdout.restore();
+    }
+
+    const output = stdout.output();
+    expect(output).toBe(stripAnsi(output));
+    expect(output).toBe(renderHelp({ color: false }));
+  });
+});

--- a/packages/cli/src/commands/help.test.ts
+++ b/packages/cli/src/commands/help.test.ts
@@ -1,7 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { setNoColor, stripAnsi } from "../ansi.js";
 import { runCli } from "../index.js";
-import { renderHelp } from "./help.js";
+import {
+  COMMAND_COLUMN_WIDTH,
+  HELP_SECTIONS,
+  renderHelp,
+} from "./help.js";
 
 function captureWrites(stream: NodeJS.WriteStream): {
   output: () => string;
@@ -46,6 +50,16 @@ describe("help output", () => {
     expect(output).toBe(stripAnsi(output));
   });
 
+  it("keeps command names within the fixed help column", () => {
+    const longestName = Math.max(
+      ...HELP_SECTIONS.flatMap((section) =>
+        section.entries.map((entry) => entry.name.length)
+      )
+    );
+
+    expect(longestName).toBeLessThanOrEqual(COMMAND_COLUMN_WIDTH);
+  });
+
   it("prints byte-identical output for help and root --help", async () => {
     const helpStdout = captureWrites(process.stdout);
     try {
@@ -53,6 +67,9 @@ describe("help output", () => {
     } finally {
       helpStdout.restore();
     }
+    setNoColor(false);
+    delete process.env.NO_COLOR;
+    process.exitCode = undefined;
 
     const rootHelpStdout = captureWrites(process.stdout);
     try {

--- a/packages/cli/src/commands/help.ts
+++ b/packages/cli/src/commands/help.ts
@@ -1,81 +1,200 @@
+import { bold, cyan, yellow } from "../ansi.js";
 import type { GlobalOptions } from "../index.js";
 
-const HELP_TEXT = `
-gh-symphony — AI Coding Agent Orchestrator
+type HelpEntry = {
+  name: string;
+  description: string | string[];
+};
 
-Usage: gh-symphony <command> [options]
+type HelpSection = {
+  title: string;
+  entries: HelpEntry[];
+};
 
-Setup:
-  setup           Run the one-command setup flow
-  workflow init   Generate WORKFLOW.md and workflow support files
-  workflow validate
-                  Parse and strictly validate WORKFLOW.md
-  workflow preview
-                  Render the final worker prompt from a sample issue
-  doctor          Run diagnostics and optional first-run remediation
-  config show     Show current configuration
-  config set      Set a configuration value
-  config edit     Open config in $EDITOR
+const DESCRIPTION_COLUMN = 23;
+const COMMAND_COLUMN_WIDTH = DESCRIPTION_COLUMN - 2;
 
-Orchestration:
-  start           Start the orchestrator (foreground)
-  start --daemon  Start the orchestrator (background)
-  stop            Stop the background orchestrator
-  status          Show orchestrator status
-  run <issue>     Dispatch a single issue
-  recover         Recover stalled runs
-  logs            View orchestrator logs
+const HELP_SECTIONS: HelpSection[] = [
+  {
+    title: "Setup",
+    entries: [
+      {
+        name: "setup",
+        description: "Run the one-command first-run setup flow",
+      },
+      {
+        name: "workflow init",
+        description: "Generate WORKFLOW.md and workflow support files",
+      },
+      {
+        name: "workflow validate",
+        description: "Strictly validate WORKFLOW.md",
+      },
+      {
+        name: "workflow preview",
+        description: "Render the worker prompt from a sample or live issue",
+      },
+      {
+        name: "doctor",
+        description: "Run diagnostics and optional remediation",
+      },
+      {
+        name: "config show",
+        description: "Show current configuration",
+      },
+      {
+        name: "config set",
+        description: "Set a configuration value",
+      },
+      {
+        name: "config edit",
+        description: "Open config in $EDITOR",
+      },
+    ],
+  },
+  {
+    title: "Orchestration (current repository)",
+    entries: [
+      {
+        name: "repo init",
+        description: "Initialize gh-symphony for the current repository",
+      },
+      {
+        name: "repo start",
+        description: "Start the orchestrator (foreground)",
+      },
+      {
+        name: "repo start --daemon",
+        description: "Start the orchestrator in the background",
+      },
+      {
+        name: "repo stop",
+        description: "Stop the background orchestrator",
+      },
+      {
+        name: "repo status",
+        description: "Show orchestrator status",
+      },
+      {
+        name: "repo run <issue>",
+        description: "Dispatch a single issue",
+      },
+      {
+        name: "repo recover",
+        description: "Recover stalled runs",
+      },
+      {
+        name: "repo logs",
+        description: "View orchestrator logs",
+      },
+      {
+        name: "repo explain <issue>",
+        description: "Explain why an issue is not dispatching",
+      },
+    ],
+  },
+  {
+    title: "Maintenance",
+    entries: [
+      {
+        name: "upgrade",
+        description: "Upgrade the CLI to the latest published version",
+      },
+      {
+        name: "completion <shell>",
+        description: "Print shell completion (bash/zsh/fish)",
+      },
+      {
+        name: "version",
+        description: "Show version",
+      },
+      {
+        name: "help [command]",
+        description: "Show help for a command",
+      },
+    ],
+  },
+  {
+    title: "Global Options",
+    entries: [
+      {
+        name: "--config <dir>",
+        description: [
+          "Config directory override (advanced; default resolves",
+          "per-repo to <repo>/.runtime/orchestrator)",
+        ],
+      },
+      {
+        name: "--verbose, -v",
+        description: "Verbose output",
+      },
+      {
+        name: "--json",
+        description: "JSON output",
+      },
+      {
+        name: "--no-color",
+        description: "Disable color output",
+      },
+      {
+        name: "--help, -h",
+        description: "Show help",
+      },
+      {
+        name: "--version, -V",
+        description: "Show version",
+      },
+    ],
+  },
+];
 
-Project Management:
-  project add      Add a new project (interactive wizard)
-  project list     List all configured projects
-  project remove   Remove a project
+function sectionTitle(title: string, color: boolean): string {
+  const label = `${title}:`;
+  return color ? yellow(bold(label)) : label;
+}
 
-Project / Repo:
-  project list    List projects
-  project switch  Switch active project
-  project status  Show orchestrator status for a project
-  project explain Explain why a project issue is not dispatching
-  repo list       List configured repositories
-  repo add        Validate and add a repository
-  repo remove     Remove a repository
-  repo sync       Sync repositories from the linked GitHub Project
+function entryName(name: string, color: boolean): string {
+  return color ? cyan(name) : name;
+}
 
-Global Options:
-  --config <dir>  Config directory (default: ~/.gh-symphony)
-  --verbose       Enable verbose output
-  --json          Output in JSON format
-  --no-color      Disable color output
-  --help, -h      Show this help message
-  --version, -V   Show version
+function renderEntry(entry: HelpEntry, color: boolean): string[] {
+  const descriptions = Array.isArray(entry.description)
+    ? entry.description
+    : [entry.description];
+  const lines = [
+    `  ${entryName(entry.name, color)}${" ".repeat(
+      Math.max(COMMAND_COLUMN_WIDTH - entry.name.length, 1)
+    )}${descriptions[0]}`,
+  ];
 
-Examples:
-  gh-symphony setup                   # Generate workflow files and register the project
-  gh-symphony workflow init           # Generate WORKFLOW.md for the current repo
-  gh-symphony workflow validate       # Strictly validate WORKFLOW.md authoring changes
-  gh-symphony workflow preview --attempt 2
-  gh-symphony project add              # Add a project (interactive)
-  gh-symphony doctor                   # Validate local setup and prerequisites
-  gh-symphony doctor --fix             # Apply safe remediation and print manual follow-ups
-  gh-symphony doctor --smoke --issue owner/repo#123
-  gh-symphony project add --non-interactive --project <id> --workspace-dir <path>
-  gh-symphony project list             # List all projects
-  gh-symphony project remove <id>      # Remove a project
-  gh-symphony project explain owner/repo#123
-  gh-symphony project explain owner/repo#123 --workflow ./WORKFLOW.md
-  gh-symphony repo add owner/name      # Validate a repo target before saving it
-  gh-symphony repo sync --dry-run      # Preview linked repository drift
-  gh-symphony start                   # Start orchestrator
-  gh-symphony start --daemon          # Start in background
-  gh-symphony run org/repo#123        # Dispatch a specific issue
-  gh-symphony status --watch          # Watch status in real-time
-`.trimStart();
+  for (const line of descriptions.slice(1)) {
+    lines.push(`${" ".repeat(DESCRIPTION_COLUMN)}${line}`);
+  }
+
+  return lines;
+}
+
+export function renderHelp(options: { color: boolean }): string {
+  const lines = ["gh-symphony — AI Coding Agent Orchestrator", ""];
+
+  for (const [index, section] of HELP_SECTIONS.entries()) {
+    if (index > 0) {
+      lines.push("");
+    }
+    lines.push(sectionTitle(section.title, options.color));
+    for (const entry of section.entries) {
+      lines.push(...renderEntry(entry, options.color));
+    }
+  }
+
+  return `${lines.join("\n")}\n`;
+}
 
 const handler = async (
   _args: string[],
-  _options: GlobalOptions
+  options: GlobalOptions
 ): Promise<void> => {
-  process.stdout.write(HELP_TEXT);
+  process.stdout.write(renderHelp({ color: !options.noColor }));
 };
 
 export default handler;

--- a/packages/cli/src/commands/help.ts
+++ b/packages/cli/src/commands/help.ts
@@ -1,20 +1,20 @@
 import { bold, cyan, yellow } from "../ansi.js";
 import type { GlobalOptions } from "../index.js";
 
-type HelpEntry = {
+export type HelpEntry = {
   name: string;
   description: string | string[];
 };
 
-type HelpSection = {
+export type HelpSection = {
   title: string;
   entries: HelpEntry[];
 };
 
-const DESCRIPTION_COLUMN = 23;
-const COMMAND_COLUMN_WIDTH = DESCRIPTION_COLUMN - 2;
+export const DESCRIPTION_COLUMN = 23;
+export const COMMAND_COLUMN_WIDTH = DESCRIPTION_COLUMN - 2;
 
-const HELP_SECTIONS: HelpSection[] = [
+export const HELP_SECTIONS: HelpSection[] = [
   {
     title: "Setup",
     entries: [

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -146,8 +146,9 @@ describe("Commander CLI entrypoint", () => {
     }
 
     const output = stdout.output() + stderr.output();
-    expect(output).toContain("Usage: gh-symphony");
-    expect(output).toContain("workflow");
+    expect(output).toContain("gh-symphony — AI Coding Agent Orchestrator");
+    expect(output).toContain("Setup:");
+    expect(output).toContain("workflow init");
     expect(output).toContain("setup");
     expect(output).toContain("doctor");
     expect(output).toContain("upgrade");

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,8 +6,10 @@ import {
   InvalidArgumentError,
   Option,
 } from "commander";
+import { setNoColor } from "./ansi.js";
 import { resolveConfigDir } from "./config.js";
 import { renderCompletionScript } from "./completion.js";
+import { renderHelp } from "./commands/help.js";
 
 export type GlobalOptions = {
   configDir: string;
@@ -120,6 +122,7 @@ function resolveGlobalOptions(values: CliOptionValues): GlobalOptions {
   if (options.noColor) {
     process.env.NO_COLOR = "1";
   }
+  setNoColor(options.noColor);
 
   return options;
 }
@@ -173,8 +176,16 @@ function resolveVersionOptions(argv: string[]): GlobalOptions {
   if (options.noColor) {
     process.env.NO_COLOR = "1";
   }
+  setNoColor(options.noColor);
 
   return options;
+}
+
+function renderRootHelp(command: Command): string {
+  const values = command.optsWithGlobals<CliOptionValues>();
+  const noColor = Boolean(values.noColor);
+  setNoColor(noColor);
+  return renderHelp({ color: !noColor });
 }
 
 function createProgram(): { program: Command; wasInvoked: () => boolean } {
@@ -193,6 +204,7 @@ function createProgram(): { program: Command; wasInvoked: () => boolean } {
       .showHelpAfterError("(run with --help for usage)")
       .option("-V, --version", "Show version")
   );
+  program.helpInformation = () => renderRootHelp(program);
 
   addGlobalOptions(
     program

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -184,7 +184,6 @@ function resolveVersionOptions(argv: string[]): GlobalOptions {
 function renderRootHelp(command: Command): string {
   const values = command.optsWithGlobals<CliOptionValues>();
   const noColor = Boolean(values.noColor);
-  setNoColor(noColor);
   return renderHelp({ color: !noColor });
 }
 


### PR DESCRIPTION
## Issues

- Fixes #288

## Summary

- Replaces the root `gh-symphony help` / `gh-symphony --help` surface with the grouped CLI restructure layout.
- Keeps command behavior unchanged while listing the upcoming repo command tree expected before the next user-facing release.
- Adds review-feedback hardening for the fixed help column and repeated root-help test state.

## Changes

- Added a programmatic `renderHelp({ color })` renderer with yellow bold section headers, cyan command names, aligned descriptions, and blank lines between sections.
- Wired root Commander help output to the same renderer so `help` and `--help` produce byte-identical output.
- Added colored and non-colored help snapshots plus CLI integration coverage for `--no-color` and root help equivalence.
- Added a regression guard that fails if future help entries exceed the fixed command-name column, and removed redundant root-help color state mutation.

## Evidence

- `pnpm --filter @gh-symphony/cli test -- src/commands/help.test.ts src/index.test.ts`
- `pnpm lint && pnpm test && pnpm typecheck && pnpm build`
- Manual TC: `node packages/cli/dist/index.js --no-color --help > /tmp/ghs-help-a.txt && node packages/cli/dist/index.js --no-color help > /tmp/ghs-help-b.txt && cmp -s /tmp/ghs-help-a.txt /tmp/ghs-help-b.txt && perl -ne 'print if /\e/' /tmp/ghs-help-a.txt | wc -l` returned `0` ANSI-containing lines and `cmp` succeeded.

## Human Validation

- [ ] Confirm root help visually matches the maintainer-supplied grouped layout.
- [ ] Confirm the listed future `repo run` / `repo recover` / `repo logs` / `repo explain` entries are acceptable before the release tag.
- [ ] Confirm nested command help such as `gh-symphony repo --help` still uses Commander defaults.

## Risks

- The root help intentionally lists commands that are not all registered yet; per #288 this PR must merge before any release tag that exposes the refreshed surface.