### PR TITLE
fix(tracker-github): expose linked PR truncation

### DIFF
--- a/packages/tracker-github/src/adapter.ts
+++ b/packages/tracker-github/src/adapter.ts
@@ -104,6 +104,9 @@ type GraphQLIssueNode = {
   };
   closedByPullRequestsReferences?: {
     nodes: Array<GraphQLPullRequestNode | null> | null;
+    pageInfo?: {
+      hasNextPage: boolean;
+    } | null;
   } | null;
   blockedBy: {
     nodes: Array<{
@@ -315,6 +318,8 @@ export function normalizeProjectItem(
   const linkedPullRequests = normalizePullRequestNodes(
     item.content.closedByPullRequestsReferences?.nodes ?? []
   );
+  const linkedPullRequestsTruncated =
+    item.content.closedByPullRequestsReferences?.pageInfo?.hasNextPage ?? false;
 
   return {
     id: item.content.id,
@@ -341,7 +346,11 @@ export function normalizeProjectItem(
       bindingId: projectId,
       itemId: item.id,
     },
-    metadata: withIssueMetadata(fieldValues, linkedPullRequests),
+    metadata: withIssueMetadata(
+      fieldValues,
+      linkedPullRequests,
+      linkedPullRequestsTruncated
+    ),
     rateLimits,
   };
 }
@@ -874,14 +883,16 @@ function withGitHubMetadata(
 
 function withIssueMetadata(
   fieldValues: Record<string, string>,
-  linkedPullRequests: GitHubPullRequestMetadata[]
+  linkedPullRequests: GitHubPullRequestMetadata[],
+  linkedPullRequestsTruncated = false
 ): TrackedIssue["metadata"] {
-  if (linkedPullRequests.length === 0) {
+  if (linkedPullRequests.length === 0 && !linkedPullRequestsTruncated) {
     return fieldValues;
   }
 
   return withGitHubMetadata(fieldValues, {
     linkedPullRequests,
+    linkedPullRequestsTruncated,
   });
 }
 
@@ -1335,6 +1346,9 @@ const PROJECT_ITEMS_QUERY = `
                   nodes {
                     ...PullRequestMetadata
                   }
+                  pageInfo {
+                    hasNextPage
+                  }
                 }
               }
               ... on PullRequest {
@@ -1672,6 +1686,9 @@ const REPOSITORY_ISSUE_QUERY = `
         closedByPullRequestsReferences(first: 20) {
           nodes {
             ...RepositoryIssuePullRequestMetadata
+          }
+          pageInfo {
+            hasNextPage
           }
         }
         projectItems(first: 20, includeArchived: false) {

--- a/packages/tracker-github/src/tracker-github.test.ts
+++ b/packages/tracker-github/src/tracker-github.test.ts
@@ -317,6 +317,61 @@ describe("resolveTrackerAdapter", () => {
         },
       }),
     ]);
+    expect(metadata?.linkedPullRequestsTruncated).toBe(false);
+  });
+
+  it("marks Issue linked pull request metadata as truncated when GitHub has another page", () => {
+    const linkedPullRequests = Array.from({ length: 20 }, (_, index) => {
+      const number = index + 1;
+      return makePullRequestProjectItem({
+        itemId: `item-pr-${number}`,
+        pullRequestId: `pr-${number}`,
+        number,
+        title: `Linked PR ${number}`,
+      }).content;
+    });
+    const issue = normalizeGithubProjectItem(
+      "project-123",
+      {
+        ...makeProjectItem({
+          itemId: "item-1",
+          issueId: "issue-1",
+          number: 1,
+          title: "Issue with many linked PRs",
+          assignees: [],
+        }),
+        content: {
+          ...makeProjectItem({
+            itemId: "item-1",
+            issueId: "issue-1",
+            number: 1,
+            title: "Issue with many linked PRs",
+            assignees: [],
+          }).content,
+          closedByPullRequestsReferences: {
+            nodes: linkedPullRequests,
+            pageInfo: {
+              hasNextPage: true,
+            },
+          },
+        },
+      },
+      DEFAULT_WORKFLOW_LIFECYCLE
+    );
+
+    const metadata = issue?.metadata as Record<string, unknown> | undefined;
+
+    expect(metadata?.linkedPullRequests).toHaveLength(20);
+    expect(metadata?.linkedPullRequestsTruncated).toBe(true);
+    expect(metadata?.linkedPullRequests).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "pr-20",
+          number: 20,
+          identifier: "acme/platform#20",
+        }),
+      ])
+    );
   });
 
   it("continues to ignore unsupported Project item content types", () => {


### PR DESCRIPTION
## Issues

- Fixes #285

## Summary

- Exposes GitHub linked PR truncation through `metadata.linkedPullRequestsTruncated`.
- Keeps the existing `metadata.linkedPullRequests` array shape intact.

## Changes

- Adds `pageInfo.hasNextPage` to both `closedByPullRequestsReferences(first: 20)` GraphQL selections.
- Threads the page flag through issue normalization and metadata construction.
- Adds tracker-github coverage for a 20-item page with another linked PR page available.

## Evidence

- `pnpm --filter @gh-symphony/tracker-github test`
- `pnpm --filter @gh-symphony/tracker-github typecheck`
- `pnpm --filter @gh-symphony/tracker-github lint`
- `pnpm lint && pnpm test && pnpm typecheck && pnpm build`
- Docker E2E: `docker compose -f docker-compose.e2e.yml -f docker-compose.e2e.events.yml up -d --build`, `/healthz`, happy-path fixture dispatch/worker completion/continuation observation, cleanup

## Human Validation

- [ ] Confirm linked PR metadata remains consumable by existing callers.
- [ ] Confirm issues with more than 20 linked PRs expose `linkedPullRequestsTruncated: true`.
- [ ] Confirm tracker-github behavior matches the issue requirements.

## Risks

- The adapter still fetches only the first 20 linked PRs; this change makes truncation visible rather than paginating the full linked PR set.