### PR TITLE
feat(orchestrator): checkout same-repo PR branches

### DIFF
--- a/packages/core/src/contracts/tracker-adapter.ts
+++ b/packages/core/src/contracts/tracker-adapter.ts
@@ -44,6 +44,12 @@ export type TrackedPullRequestContext = {
     url: string;
     cloneUrl: string;
   };
+  headRepository?: {
+    owner: string;
+    name: string;
+    url: string;
+    cloneUrl: string;
+  } | null;
   [key: string]: unknown;
 };
 

--- a/packages/orchestrator/src/git.test.ts
+++ b/packages/orchestrator/src/git.test.ts
@@ -201,6 +201,59 @@ describe("cloneRepositoryForRun", () => {
     });
   });
 
+  it("checks out a same-repo pull request head branch for new issue workspaces", async () => {
+    const tempRoot = await mkdtemp(join(tmpdir(), "orchestrator-git-pr-"));
+    const repository = await createRepositoryFixture(tempRoot);
+    const issueWorkspacePath = join(tempRoot, "workspaces", "acme_platform_2");
+
+    execSync(`git -C "${repository.path}" checkout -b feature/pr-branch`);
+    await writeFile(
+      join(repository.path, "WORKFLOW.md"),
+      "# pull request workflow\n",
+      "utf8"
+    );
+    execSync(`git -C "${repository.path}" add WORKFLOW.md`);
+    execSync(`git -C "${repository.path}" commit -m "Update PR workflow"`);
+    execSync(`git -C "${repository.path}" push origin feature/pr-branch`);
+
+    const repositoryDirectory = await ensureIssueWorkspaceRepository({
+      repository,
+      issueWorkspacePath,
+      existingWorkspace: false,
+      pullRequestBranch: {
+        headRefName: "feature/pr-branch",
+      },
+    });
+
+    expect(
+      execSync(`git -C "${repositoryDirectory}" branch --show-current`, {
+        encoding: "utf8",
+      }).trim()
+    ).toBe("feature/pr-branch");
+    expect(
+      await readFile(join(repositoryDirectory, "WORKFLOW.md"), "utf8")
+    ).toBe("# pull request workflow\n");
+  });
+
+  it("keeps checkout failures actionable when the pull request branch is missing", async () => {
+    const tempRoot = await mkdtemp(join(tmpdir(), "orchestrator-git-pr-"));
+    const repository = await createRepositoryFixture(tempRoot);
+    const issueWorkspacePath = join(tempRoot, "workspaces", "acme_platform_2");
+
+    await expect(
+      ensureIssueWorkspaceRepository({
+        repository,
+        issueWorkspacePath,
+        existingWorkspace: false,
+        pullRequestBranch: {
+          headRefName: "feature/missing-pr-branch",
+        },
+      })
+    ).rejects.toThrow(
+      /Cannot checkout pull request branch feature\/missing-pr-branch: git fetch origin feature\/missing-pr-branch failed/
+    );
+  });
+
   it("only releases repository locks owned by the current caller", async () => {
     const tempRoot = await mkdtemp(join(tmpdir(), "orchestrator-git-lock-"));
     const lockDirectory = join(tempRoot, "repository.lock");

--- a/packages/orchestrator/src/git.test.ts
+++ b/packages/orchestrator/src/git.test.ts
@@ -235,6 +235,103 @@ describe("cloneRepositoryForRun", () => {
     ).toBe("# pull request workflow\n");
   });
 
+  it("keeps pull request branch workspaces reusable on the second cycle", async () => {
+    const tempRoot = await mkdtemp(join(tmpdir(), "orchestrator-git-pr-"));
+    const repository = await createRepositoryFixture(tempRoot);
+    const issueWorkspacePath = join(tempRoot, "workspaces", "acme_platform_2");
+
+    execSync(`git -C "${repository.path}" checkout -b feature/pr-branch`);
+    await writeFile(
+      join(repository.path, "WORKFLOW.md"),
+      "# pull request workflow\n",
+      "utf8"
+    );
+    execSync(`git -C "${repository.path}" add WORKFLOW.md`);
+    execSync(`git -C "${repository.path}" commit -m "Update PR workflow"`);
+    execSync(`git -C "${repository.path}" push origin feature/pr-branch`);
+
+    const firstDirectory = await ensureIssueWorkspaceRepository({
+      repository,
+      issueWorkspacePath,
+      existingWorkspace: false,
+      pullRequestBranch: {
+        headRefName: "feature/pr-branch",
+      },
+    });
+    const secondDirectory = await ensureIssueWorkspaceRepository({
+      repository,
+      issueWorkspacePath,
+      existingWorkspace: true,
+      pullRequestBranch: {
+        headRefName: "feature/pr-branch",
+      },
+    });
+
+    expect(secondDirectory).toBe(firstDirectory);
+    expect(
+      execSync(
+        `git -C "${secondDirectory}" rev-parse --abbrev-ref --symbolic-full-name "@{u}"`,
+        {
+          encoding: "utf8",
+        }
+      ).trim()
+    ).toBe("origin/feature/pr-branch");
+    expect(
+      execSync(`git -C "${secondDirectory}" branch --show-current`, {
+        encoding: "utf8",
+      }).trim()
+    ).toBe("feature/pr-branch");
+  });
+
+  it("updates pull request branch workspaces after a force-push", async () => {
+    const tempRoot = await mkdtemp(join(tmpdir(), "orchestrator-git-pr-"));
+    const repository = await createRepositoryFixture(tempRoot);
+    const issueWorkspacePath = join(tempRoot, "workspaces", "acme_platform_2");
+
+    execSync(`git -C "${repository.path}" checkout -b feature/pr-branch`);
+    await writeFile(
+      join(repository.path, "WORKFLOW.md"),
+      "# pull request workflow v1\n",
+      "utf8"
+    );
+    execSync(`git -C "${repository.path}" add WORKFLOW.md`);
+    execSync(`git -C "${repository.path}" commit -m "Update PR workflow v1"`);
+    execSync(`git -C "${repository.path}" push origin feature/pr-branch`);
+
+    const repositoryDirectory = await ensureIssueWorkspaceRepository({
+      repository,
+      issueWorkspacePath,
+      existingWorkspace: false,
+      pullRequestBranch: {
+        headRefName: "feature/pr-branch",
+      },
+    });
+
+    execSync(`git -C "${repository.path}" checkout feature/pr-branch`);
+    execSync(`git -C "${repository.path}" reset --hard main`);
+    await writeFile(
+      join(repository.path, "WORKFLOW.md"),
+      "# pull request workflow v2\n",
+      "utf8"
+    );
+    execSync(`git -C "${repository.path}" add WORKFLOW.md`);
+    execSync(`git -C "${repository.path}" commit -m "Update PR workflow v2"`);
+    execSync(`git -C "${repository.path}" push --force origin feature/pr-branch`);
+
+    await ensureIssueWorkspaceRepository({
+      repository,
+      issueWorkspacePath,
+      existingWorkspace: true,
+      pullRequestBranch: {
+        headRefName: "feature/pr-branch",
+      },
+    });
+
+    expect(
+      await readFile(join(repositoryDirectory, "WORKFLOW.md"), "utf8")
+    ).toBe("# pull request workflow v2\n");
+  });
+
   it("keeps checkout failures actionable when the pull request branch is missing", async () => {
     const tempRoot = await mkdtemp(join(tmpdir(), "orchestrator-git-pr-"));
     const repository = await createRepositoryFixture(tempRoot);

--- a/packages/orchestrator/src/git.test.ts
+++ b/packages/orchestrator/src/git.test.ts
@@ -308,7 +308,7 @@ describe("cloneRepositoryForRun", () => {
     });
 
     execSync(`git -C "${repository.path}" checkout feature/pr-branch`);
-    execSync(`git -C "${repository.path}" reset --hard main`);
+    execSync(`git -C "${repository.path}" reset --hard HEAD~1`);
     await writeFile(
       join(repository.path, "WORKFLOW.md"),
       "# pull request workflow v2\n",

--- a/packages/orchestrator/src/git.ts
+++ b/packages/orchestrator/src/git.ts
@@ -114,7 +114,10 @@ export async function ensureIssueWorkspaceRepository(input: {
   pullRequestBranch?: PullRequestBranchCheckoutTarget | null;
 }): Promise<string> {
   const repositoryDirectory = input.existingWorkspace
-    ? await syncExistingIssueWorkspaceRepository(input)
+    ? await syncExistingIssueWorkspaceRepository({
+        ...input,
+        skipPull: Boolean(input.pullRequestBranch),
+      })
     : await cloneRepositoryForRun({
         repository: input.repository,
         targetDirectory: input.issueWorkspacePath,
@@ -193,6 +196,7 @@ async function readGitHead(
 async function syncExistingIssueWorkspaceRepository(input: {
   repository: RepositoryRef;
   issueWorkspacePath: string;
+  skipPull?: boolean;
 }): Promise<string> {
   await mkdir(input.issueWorkspacePath, { recursive: true });
   const repositoryDirectory = join(input.issueWorkspacePath, "repository");
@@ -220,19 +224,24 @@ async function syncExistingIssueWorkspaceRepository(input: {
         );
       }
 
-      try {
-        await runCommand("git", [
-          "-C",
-          repositoryDirectory,
-          "pull",
-          "--ff-only",
-        ]);
-      } catch (error) {
-        const message = formatCommandError(error, "git pull --ff-only failed");
-        throw createIssueWorkspacePreservedError(
-          repositoryDirectory,
-          `could not be fast-forwarded: ${message}`
-        );
+      if (!input.skipPull) {
+        try {
+          await runCommand("git", [
+            "-C",
+            repositoryDirectory,
+            "pull",
+            "--ff-only",
+          ]);
+        } catch (error) {
+          const message = formatCommandError(
+            error,
+            "git pull --ff-only failed"
+          );
+          throw createIssueWorkspacePreservedError(
+            repositoryDirectory,
+            `could not be fast-forwarded: ${message}`
+          );
+        }
       }
 
       return repositoryDirectory;
@@ -294,13 +303,28 @@ async function checkoutPullRequestBranch(
       repositoryDirectory,
       "fetch",
       "origin",
-      `${branchName}:${remoteRef}`,
+      `+refs/heads/${branchName}:${remoteRef}`,
       "--depth",
       "1",
     ]);
   } catch (error) {
     throw new Error(
       `Cannot checkout pull request branch ${branchName}: git fetch origin ${branchName} failed (${formatCommandError(error, "git fetch failed")}).`
+    );
+  }
+
+  try {
+    await runCommand("git", [
+      "-C",
+      repositoryDirectory,
+      "config",
+      "--replace-all",
+      "remote.origin.fetch",
+      "+refs/heads/*:refs/remotes/origin/*",
+    ]);
+  } catch (error) {
+    throw new Error(
+      `Cannot checkout pull request branch ${branchName}: git config remote.origin.fetch failed (${formatCommandError(error, "git config failed")}).`
     );
   }
 
@@ -316,6 +340,21 @@ async function checkoutPullRequestBranch(
   } catch (error) {
     throw new Error(
       `Cannot checkout pull request branch ${branchName}: git checkout failed (${formatCommandError(error, "git checkout failed")}).`
+    );
+  }
+
+  try {
+    await runCommand("git", [
+      "-C",
+      repositoryDirectory,
+      "branch",
+      "--set-upstream-to",
+      `origin/${branchName}`,
+      branchName,
+    ]);
+  } catch (error) {
+    throw new Error(
+      `Cannot checkout pull request branch ${branchName}: git branch --set-upstream-to failed (${formatCommandError(error, "git branch --set-upstream-to failed")}).`
     );
   }
 }

--- a/packages/orchestrator/src/git.ts
+++ b/packages/orchestrator/src/git.ts
@@ -29,6 +29,10 @@ export type RepositorySyncResult = {
   changed: boolean;
 };
 
+export type PullRequestBranchCheckoutTarget = {
+  headRefName: string;
+};
+
 export async function cloneRepositoryForRun(input: {
   repository: RepositoryRef;
   targetDirectory: string;
@@ -107,15 +111,23 @@ export async function ensureIssueWorkspaceRepository(input: {
   repository: RepositoryRef;
   issueWorkspacePath: string;
   existingWorkspace: boolean;
+  pullRequestBranch?: PullRequestBranchCheckoutTarget | null;
 }): Promise<string> {
-  if (!input.existingWorkspace) {
-    return cloneRepositoryForRun({
-      repository: input.repository,
-      targetDirectory: input.issueWorkspacePath,
-    });
+  const repositoryDirectory = input.existingWorkspace
+    ? await syncExistingIssueWorkspaceRepository(input)
+    : await cloneRepositoryForRun({
+        repository: input.repository,
+        targetDirectory: input.issueWorkspacePath,
+      });
+
+  if (input.pullRequestBranch) {
+    await checkoutPullRequestBranch(
+      repositoryDirectory,
+      input.pullRequestBranch
+    );
   }
 
-  return syncExistingIssueWorkspaceRepository(input);
+  return repositoryDirectory;
 }
 
 export async function loadRepositoryWorkflow(
@@ -253,6 +265,59 @@ async function syncExistingIssueWorkspaceRepository(input: {
       await rm(tempRepositoryDirectory, { recursive: true, force: true });
     }
   });
+}
+
+async function checkoutPullRequestBranch(
+  repositoryDirectory: string,
+  target: PullRequestBranchCheckoutTarget
+): Promise<void> {
+  const branchName = target.headRefName.trim();
+
+  if (!branchName) {
+    throw new Error(
+      "Cannot checkout pull request branch because headRefName is empty."
+    );
+  }
+
+  try {
+    await runCommand("git", ["check-ref-format", "--branch", branchName]);
+  } catch (error) {
+    throw new Error(
+      `Cannot checkout pull request branch ${branchName}: invalid branch name (${formatCommandError(error, "git check-ref-format failed")}).`
+    );
+  }
+
+  const remoteRef = `refs/remotes/origin/${branchName}`;
+  try {
+    await runCommand("git", [
+      "-C",
+      repositoryDirectory,
+      "fetch",
+      "origin",
+      `${branchName}:${remoteRef}`,
+      "--depth",
+      "1",
+    ]);
+  } catch (error) {
+    throw new Error(
+      `Cannot checkout pull request branch ${branchName}: git fetch origin ${branchName} failed (${formatCommandError(error, "git fetch failed")}).`
+    );
+  }
+
+  try {
+    await runCommand("git", [
+      "-C",
+      repositoryDirectory,
+      "checkout",
+      "-B",
+      branchName,
+      remoteRef,
+    ]);
+  } catch (error) {
+    throw new Error(
+      `Cannot checkout pull request branch ${branchName}: git checkout failed (${formatCommandError(error, "git checkout failed")}).`
+    );
+  }
 }
 
 function createIssueWorkspacePreservedError(

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -3033,6 +3033,7 @@ linked={% for pr in issue.linked_pull_requests %}{{ pr.identifier }}:{{ pr.proje
     const store = new OrchestratorFsStore(tempRoot);
     const projectConfig = createProjectConfig(tempRoot, repository);
     await store.saveProjectConfig(projectConfig);
+    createPullRequestBranchFixture(repository.path);
 
     const spawnImpl = vi.fn().mockReturnValue({
       pid: 4308,
@@ -3060,6 +3061,12 @@ linked={% for pr in issue.linked_pull_requests %}{{ pr.identifier }}:{{ pr.proje
     expect(workerEnv?.SYMPHONY_RENDERED_PROMPT).toContain(
       "linked=acme/platform#2:Todo"
     );
+    expect(
+      execSync(
+        `git -C ${shell(workerEnv?.WORKING_DIRECTORY ?? "")} branch --show-current`,
+        { encoding: "utf8" }
+      ).trim()
+    ).toBe("feature/canonical-pr");
   });
 
   it("does not dispatch a ready pull request when its linked issue is in review", async () => {
@@ -3110,6 +3117,7 @@ linked={% for pr in issue.linked_pull_requests %}{{ pr.identifier }}:{{ pr.proje
     const store = new OrchestratorFsStore(tempRoot);
     const projectConfig = createProjectConfig(tempRoot, repository);
     await store.saveProjectConfig(projectConfig);
+    createPullRequestBranchFixture(repository.path);
 
     const spawnImpl = vi.fn().mockReturnValue({
       pid: 4310,
@@ -3133,6 +3141,55 @@ linked={% for pr in issue.linked_pull_requests %}{{ pr.identifier }}:{{ pr.proje
     expect(result.summary.dispatched).toBe(1);
     expect(workerEnv?.SYMPHONY_ISSUE_SUBJECT_ID).toBe("pr-2");
     expect(workerEnv?.SYMPHONY_ISSUE_IDENTIFIER).toBe("acme/platform#2");
+    expect(
+      execSync(
+        `git -C ${shell(workerEnv?.WORKING_DIRECTORY ?? "")} branch --show-current`,
+        { encoding: "utf8" }
+      ).trim()
+    ).toBe("feature/canonical-pr");
+  });
+
+  it("blocks fork pull request subjects before automatic checkout", async () => {
+    process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
+    const tempRoot = await mkdtemp(
+      join(tmpdir(), "orchestrator-canonical-pr-fork-")
+    );
+    const repository = await createRepositoryFixture(
+      tempRoot,
+      "acme",
+      "platform"
+    );
+    const store = new OrchestratorFsStore(tempRoot);
+    const projectConfig = createProjectConfig(tempRoot, repository);
+    await store.saveProjectConfig(projectConfig);
+
+    const spawnImpl = vi.fn().mockReturnValue({
+      pid: 4313,
+      unref: vi.fn(),
+    });
+    const service = new OrchestratorService(store, projectConfig, {
+      fetchImpl: vi.fn().mockResolvedValue(
+        createTrackerResponseFromProjectItems([
+          makeTrackerProjectPullRequest(repository, "Todo", {
+            headRepository: {
+              owner: "contributor",
+              name: "platform",
+              cloneUrl: join(tempRoot, "contributor-platform"),
+            },
+          }),
+        ])
+      ),
+      spawnImpl: spawnImpl as never,
+      now: () => new Date("2026-03-08T00:00:00.000Z"),
+    });
+
+    const result = await service.runOnce();
+
+    expect(result.health).toBe("degraded");
+    expect(result.lastError).toMatch(
+      /fork pull requests are unsupported for automatic checkout\/push \(contributor\/platform -> acme\/platform\)/
+    );
+    expect(spawnImpl).not.toHaveBeenCalled();
   });
 
   it("syncs active run state for a standalone pull request subject", async () => {
@@ -3148,6 +3205,7 @@ linked={% for pr in issue.linked_pull_requests %}{{ pr.identifier }}:{{ pr.proje
     const store = new OrchestratorFsStore(tempRoot);
     const projectConfig = createProjectConfig(tempRoot, repository);
     await store.saveProjectConfig(projectConfig);
+    createPullRequestBranchFixture(repository.path);
 
     const fetchImpl = vi
       .fn()
@@ -9125,7 +9183,14 @@ function makeTrackerProjectIssueWithLinkedPullRequest(
 
 function makeTrackerProjectPullRequest(
   repository: { owner: string; name: string; cloneUrl: string },
-  state: string
+  state: string,
+  options: {
+    headRepository?: {
+      owner: string;
+      name: string;
+      cloneUrl: string;
+    };
+  } = {}
 ) {
   return {
     id: "item-pr-2",
@@ -9141,15 +9206,26 @@ function makeTrackerProjectPullRequest(
         },
       ],
     },
-    content: makeTrackerPullRequestContent(repository),
+    content: makeTrackerPullRequestContent(repository, options),
   };
 }
 
-function makeTrackerPullRequestContent(repository: {
-  owner: string;
-  name: string;
-  cloneUrl: string;
-}) {
+function makeTrackerPullRequestContent(
+  repository: {
+    owner: string;
+    name: string;
+    cloneUrl: string;
+  },
+  options: {
+    headRepository?: {
+      owner: string;
+      name: string;
+      cloneUrl: string;
+    };
+  } = {}
+) {
+  const headRepository = options.headRepository ?? repository;
+
   return {
     __typename: "PullRequest",
     id: "pr-2",
@@ -9163,10 +9239,10 @@ function makeTrackerPullRequestContent(repository: {
     headRefName: "feature/canonical-pr",
     baseRefName: "main",
     headRepository: {
-      name: repository.name,
-      url: `file://${repository.cloneUrl}`,
+      name: headRepository.name,
+      url: `file://${headRepository.cloneUrl}`,
       owner: {
-        login: repository.owner,
+        login: headRepository.owner,
       },
     },
     repository: {
@@ -9185,6 +9261,12 @@ function makeTrackerPullRequestContent(repository: {
     createdAt: "2026-03-08T00:00:00.000Z",
     updatedAt: "2026-03-08T00:00:00.000Z",
   };
+}
+
+function createPullRequestBranchFixture(repositoryRoot: string): void {
+  execSync(`git -C ${shell(repositoryRoot)} branch feature/canonical-pr`, {
+    stdio: "ignore",
+  });
 }
 
 function makeTrackerIssueStateLookupNode(

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -3149,6 +3149,47 @@ linked={% for pr in issue.linked_pull_requests %}{{ pr.identifier }}:{{ pr.proje
     ).toBe("feature/canonical-pr");
   });
 
+  it("treats case-only repository owner/name differences as same-repo pull requests", async () => {
+    process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
+    const tempRoot = await mkdtemp(
+      join(tmpdir(), "orchestrator-canonical-pr-case-")
+    );
+    const repository = await createRepositoryFixture(
+      tempRoot,
+      "acme",
+      "platform"
+    );
+    const store = new OrchestratorFsStore(tempRoot);
+    const projectConfig = createProjectConfig(tempRoot, repository);
+    await store.saveProjectConfig(projectConfig);
+    createPullRequestBranchFixture(repository.path);
+
+    const spawnImpl = vi.fn().mockReturnValue({
+      pid: 4314,
+      unref: vi.fn(),
+    });
+    const service = new OrchestratorService(store, projectConfig, {
+      fetchImpl: vi.fn().mockResolvedValue(
+        createTrackerResponseFromProjectItems([
+          makeTrackerProjectPullRequest(repository, "Todo", {
+            headRepository: {
+              owner: "ACME",
+              name: "Platform",
+              cloneUrl: repository.cloneUrl,
+            },
+          }),
+        ])
+      ),
+      spawnImpl: spawnImpl as never,
+      now: () => new Date("2026-03-08T00:00:00.000Z"),
+    });
+
+    const result = await service.runOnce();
+
+    expect(result.summary.dispatched).toBe(1);
+    expect(spawnImpl).toHaveBeenCalledTimes(1);
+  });
+
   it("blocks fork pull request subjects before automatic checkout", async () => {
     process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
     const tempRoot = await mkdtemp(
@@ -3188,6 +3229,45 @@ linked={% for pr in issue.linked_pull_requests %}{{ pr.identifier }}:{{ pr.proje
     expect(result.health).toBe("degraded");
     expect(result.lastError).toMatch(
       /fork pull requests are unsupported for automatic checkout\/push \(contributor\/platform -> acme\/platform\)/
+    );
+    expect(spawnImpl).not.toHaveBeenCalled();
+  });
+
+  it("blocks pull request subjects with missing head repository metadata", async () => {
+    process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
+    const tempRoot = await mkdtemp(
+      join(tmpdir(), "orchestrator-canonical-pr-missing-head-repo-")
+    );
+    const repository = await createRepositoryFixture(
+      tempRoot,
+      "acme",
+      "platform"
+    );
+    const store = new OrchestratorFsStore(tempRoot);
+    const projectConfig = createProjectConfig(tempRoot, repository);
+    await store.saveProjectConfig(projectConfig);
+
+    const spawnImpl = vi.fn().mockReturnValue({
+      pid: 4315,
+      unref: vi.fn(),
+    });
+    const service = new OrchestratorService(store, projectConfig, {
+      fetchImpl: vi.fn().mockResolvedValue(
+        createTrackerResponseFromProjectItems([
+          makeTrackerProjectPullRequest(repository, "Todo", {
+            headRepository: null,
+          }),
+        ])
+      ),
+      spawnImpl: spawnImpl as never,
+      now: () => new Date("2026-03-08T00:00:00.000Z"),
+    });
+
+    const result = await service.runOnce();
+
+    expect(result.health).toBe("degraded");
+    expect(result.lastError).toMatch(
+      /fork pull requests are unsupported for automatic checkout\/push \(unknown fork -> acme\/platform\)/
     );
     expect(spawnImpl).not.toHaveBeenCalled();
   });
@@ -9189,7 +9269,7 @@ function makeTrackerProjectPullRequest(
       owner: string;
       name: string;
       cloneUrl: string;
-    };
+    } | null;
   } = {}
 ) {
   return {
@@ -9221,10 +9301,11 @@ function makeTrackerPullRequestContent(
       owner: string;
       name: string;
       cloneUrl: string;
-    };
+    } | null;
   } = {}
 ) {
-  const headRepository = options.headRepository ?? repository;
+  const headRepository =
+    options.headRepository === undefined ? repository : options.headRepository;
 
   return {
     __typename: "PullRequest",
@@ -9238,13 +9319,15 @@ function makeTrackerPullRequestContent(
     merged: false,
     headRefName: "feature/canonical-pr",
     baseRefName: "main",
-    headRepository: {
-      name: headRepository.name,
-      url: `file://${headRepository.cloneUrl}`,
-      owner: {
-        login: headRepository.owner,
-      },
-    },
+    headRepository: headRepository
+      ? {
+          name: headRepository.name,
+          url: `file://${headRepository.cloneUrl}`,
+          owner: {
+            login: headRepository.owner,
+          },
+        }
+      : null,
     repository: {
       name: repository.name,
       url: `file://${repository.cloneUrl}`,

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -43,7 +43,6 @@ import {
   type RuntimeSessionRow,
   type SessionExitClassification,
   type TrackedIssue,
-  type TrackedPullRequestContext,
   type WorkflowLifecycleConfig,
   type WorkflowResolution,
 } from "@gh-symphony/core";
@@ -207,12 +206,16 @@ function resolvePullRequestBranchCheckoutTarget(
 ): { headRefName: string } | null {
   const pullRequest =
     issue.metadata.contentType === "PullRequest"
-      ? (issue.metadata.pullRequest ??
-        issue.metadata.linkedPullRequests?.[0] ??
-        buildPullRequestContextFromIssue(issue))
+      ? (issue.metadata.pullRequest ?? issue.metadata.linkedPullRequests?.[0])
       : (issue.metadata.linkedPullRequests?.[0] ?? null);
 
   if (!pullRequest) {
+    if (issue.metadata.contentType === "PullRequest") {
+      throw new Error(
+        `Cannot checkout pull request branch for ${issue.identifier}: missing pull request metadata.`
+      );
+    }
+
     return null;
   }
 
@@ -224,10 +227,14 @@ function resolvePullRequestBranchCheckoutTarget(
   }
 
   const headRepository = pullRequest.headRepository ?? null;
+  const sameOwner =
+    headRepository?.owner.toLowerCase() === issue.repository.owner.toLowerCase();
+  const sameName =
+    headRepository?.name.toLowerCase() === issue.repository.name.toLowerCase();
   if (
     !headRepository ||
-    headRepository.owner !== issue.repository.owner ||
-    headRepository.name !== issue.repository.name
+    !sameOwner ||
+    !sameName
   ) {
     const source = headRepository
       ? `${headRepository.owner}/${headRepository.name}`
@@ -238,28 +245,6 @@ function resolvePullRequestBranchCheckoutTarget(
   }
 
   return { headRefName };
-}
-
-function buildPullRequestContextFromIssue(
-  issue: TrackedIssue
-): TrackedPullRequestContext {
-  const repository = {
-    owner: issue.repository.owner,
-    name: issue.repository.name,
-    url: issue.repository.url ?? "",
-    cloneUrl: issue.repository.cloneUrl,
-  };
-
-  return {
-    id: issue.id,
-    number: issue.number,
-    identifier: issue.identifier,
-    url: issue.url,
-    state: issue.state,
-    headRefName: issue.branchName,
-    repository,
-    headRepository: repository,
-  };
 }
 
 export class OrchestratorService {

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -43,6 +43,7 @@ import {
   type RuntimeSessionRow,
   type SessionExitClassification,
   type TrackedIssue,
+  type TrackedPullRequestContext,
   type WorkflowLifecycleConfig,
   type WorkflowResolution,
 } from "@gh-symphony/core";
@@ -199,6 +200,66 @@ function resolveCanonicalSubjectIssues(
   }
 
   return canonicalIssues;
+}
+
+function resolvePullRequestBranchCheckoutTarget(
+  issue: TrackedIssue
+): { headRefName: string } | null {
+  const pullRequest =
+    issue.metadata.contentType === "PullRequest"
+      ? (issue.metadata.pullRequest ??
+        issue.metadata.linkedPullRequests?.[0] ??
+        buildPullRequestContextFromIssue(issue))
+      : (issue.metadata.linkedPullRequests?.[0] ?? null);
+
+  if (!pullRequest) {
+    return null;
+  }
+
+  const headRefName = pullRequest.headRefName?.trim();
+  if (!headRefName) {
+    throw new Error(
+      `Cannot checkout pull request branch for ${pullRequest.identifier}: missing headRefName.`
+    );
+  }
+
+  const headRepository = pullRequest.headRepository ?? null;
+  if (
+    !headRepository ||
+    headRepository.owner !== issue.repository.owner ||
+    headRepository.name !== issue.repository.name
+  ) {
+    const source = headRepository
+      ? `${headRepository.owner}/${headRepository.name}`
+      : "unknown fork";
+    throw new Error(
+      `Cannot checkout pull request branch for ${pullRequest.identifier}: fork pull requests are unsupported for automatic checkout/push (${source} -> ${issue.repository.owner}/${issue.repository.name}).`
+    );
+  }
+
+  return { headRefName };
+}
+
+function buildPullRequestContextFromIssue(
+  issue: TrackedIssue
+): TrackedPullRequestContext {
+  const repository = {
+    owner: issue.repository.owner,
+    name: issue.repository.name,
+    url: issue.repository.url ?? "",
+    cloneUrl: issue.repository.cloneUrl,
+  };
+
+  return {
+    id: issue.id,
+    number: issue.number,
+    identifier: issue.identifier,
+    url: issue.url,
+    state: issue.state,
+    headRefName: issue.branchName,
+    repository,
+    headRepository: repository,
+  };
 }
 
 export class OrchestratorService {
@@ -495,7 +556,9 @@ export class OrchestratorService {
     const allRuns = (await this.store.loadAllRuns()).filter(
       (run) => run.projectId === tenant.projectId
     );
-    const activeRuns = allRuns.filter((run) => isActiveRunRecordStatus(run.status));
+    const activeRuns = allRuns.filter((run) =>
+      isActiveRunRecordStatus(run.status)
+    );
     for (const run of activeRuns) {
       const outcome = await this.reconcileRun(
         tenant,
@@ -510,7 +573,8 @@ export class OrchestratorService {
     }
     const reconciledRuns = (await this.store.loadAllRuns()).filter(
       (run) =>
-        run.projectId === tenant.projectId && isActiveRunRecordStatus(run.status)
+        run.projectId === tenant.projectId &&
+        isActiveRunRecordStatus(run.status)
     );
     const projectRunsAfterReconcile = (await this.store.loadAllRuns()).filter(
       (run) => run.projectId === tenant.projectId
@@ -521,7 +585,8 @@ export class OrchestratorService {
       pollIntervalMs = await this.loadProjectPollInterval(tenant);
       const currentActiveRuns = (await this.store.loadAllRuns()).filter(
         (run) =>
-          run.projectId === tenant.projectId && isActiveRunRecordStatus(run.status)
+          run.projectId === tenant.projectId &&
+          isActiveRunRecordStatus(run.status)
       );
       const {
         runs: syncedActiveRuns,
@@ -710,11 +775,7 @@ export class OrchestratorService {
           : null;
         const activeRun =
           syncedActiveRuns.find((run) =>
-            isMatchingIssueRun(
-              run,
-              issueRecord.issueId,
-              issueRecord.identifier
-            )
+            isMatchingIssueRun(run, issueRecord.issueId, issueRecord.identifier)
           ) ?? persistedRun;
         const resolvedIssue = actionableCandidates.find(
           (candidate) => candidate.identifier === issue.identifier
@@ -1078,7 +1139,8 @@ export class OrchestratorService {
     lifecycle: WorkflowLifecycleConfig,
     issues: readonly TrackedIssue[]
   ): boolean {
-    return isIssueCandidateEligibleWithReason(issue, lifecycle, issues).eligible;
+    return isIssueCandidateEligibleWithReason(issue, lifecycle, issues)
+      .eligible;
   }
 
   private async loadProjectWorkflow(
@@ -1175,11 +1237,13 @@ export class OrchestratorService {
       projectDir,
       workspaceKey
     );
+    const pullRequestBranch = resolvePullRequestBranchCheckoutTarget(issue);
 
     const repositoryDirectory = await ensureIssueWorkspaceRepository({
       repository: issue.repository,
       issueWorkspacePath,
       existingWorkspace: Boolean(existingWorkspaceRecord),
+      pullRequestBranch,
     });
 
     if (!existingWorkspaceRecord) {


### PR DESCRIPTION
## Issues

- Fixes #279

## Summary

- same-repo linked/standalone PR subject가 default branch 대신 PR `headRefName` branch에서 workspace를 시작합니다.
- 기존 PR workspace 재사용 시 dirty check는 유지하되 PR branch fetch/checkout을 single source로 사용해 두 번째 dispatch와 force-push branch를 안정적으로 처리합니다.
- fork 또는 head repository metadata가 없는 PR은 자동 checkout/push를 시도하지 않고 명확한 unsupported error로 차단합니다.

## Changes

- PR branch checkout에서 `+refs/heads/<branch>:refs/remotes/origin/<branch>` refspec을 사용해 force-push된 PR branch도 갱신합니다.
- checkout 후 `remote.origin.fetch`와 upstream tracking을 명시해 기존 workspace의 후속 cycle에서 branch tracking이 깨지지 않게 했습니다.
- PR subject metadata fallback을 제거하고, same-repo 판별은 owner/name case-insensitive 비교로 바꿨습니다.
- regression test를 추가했습니다: 두 번째 PR workspace cycle, force-push branch, 대소문자만 다른 same-repo, head repository metadata 누락.

## Evidence

- `pnpm --filter @gh-symphony/orchestrator test -- src/git.test.ts src/service.test.ts`
- `pnpm lint && pnpm test && pnpm typecheck && pnpm build`
- Docker E2E blackbox TC: `docker-compose.e2e.yml` + `docker-compose.e2e.events.yml`로 컨테이너를 기동하고 standalone PR subject(`headRefName: feature/e2e-pr`)를 주입한 뒤 `/api/v1/refresh`를 호출했습니다. 생성된 workspace repository가 `feature/e2e-pr` branch이고 `PR_BRANCH.txt`를 포함하며 upstream이 `origin/feature/e2e-pr`인 것을 확인했습니다.
- GitHub CI: PR #300 commit `3685984`에서 `Test`, `Container Smoke` 통과.

## Human Validation

- [ ] Confirm same-repo linked PR workspaces continue on the existing PR branch.
- [ ] Confirm standalone PR subjects start on the PR head branch.
- [ ] Confirm force-pushed PR branches are refreshed without preserving the workspace as failed.
- [ ] Confirm fork PR subjects do not attempt automatic checkout/push and surface an actionable error.

## Risks

- PR workspaces now broaden `remote.origin.fetch` to `+refs/heads/*:refs/remotes/origin/*` so Git recognizes fetched PR heads as remote-tracking branches for upstream setup.