### PR TITLE
feat(workflow): expose linked PR context

### DIFF
--- a/.changeset/linked-pr-context.md
+++ b/.changeset/linked-pr-context.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/core": patch
+---
+
+Expose normalized linked pull request prompt variables, including top-level `issue.linked_pull_requests` entries with missing optional PR fields represented as `null`.

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -54,16 +54,20 @@ You are an AI coding agent working on issue {{issue.identifier}}: "{{issue.title
 
 - Primary PR: {{pull_request_context.primary_pull_request.identifier}}
 - PR URL: {{pull_request_context.primary_pull_request.url}}
-- Head branch: {{pull_request_context.primary_pull_request.headRefName}}
-- Base branch: {{pull_request_context.primary_pull_request.baseRefName}}
-- PR status: {{pull_request_context.primary_pull_request.state}}
-- Draft: {{pull_request_context.primary_pull_request.isDraft}}
-- Merged: {{pull_request_context.primary_pull_request.merged}}
-- Checkout branch: {{pull_request_context.checkout_branch}}
+- Head branch: {% if pull_request_context.primary_pull_request.headRefName == null %}unknown{% else %}{{pull_request_context.primary_pull_request.headRefName}}{% endif %}
+- Base branch: {% if pull_request_context.primary_pull_request.baseRefName == null %}unknown{% else %}{{pull_request_context.primary_pull_request.baseRefName}}{% endif %}
+- PR status: {% if pull_request_context.primary_pull_request.state == null %}unknown{% else %}{{pull_request_context.primary_pull_request.state}}{% endif %}
+- Draft: {% if pull_request_context.primary_pull_request.isDraft == null %}unknown{% else %}{{pull_request_context.primary_pull_request.isDraft}}{% endif %}
+- Merged: {% if pull_request_context.primary_pull_request.merged == null %}unknown{% else %}{{pull_request_context.primary_pull_request.merged}}{% endif %}
+- Checkout branch: {% if pull_request_context.checkout_branch == null %}unknown{% else %}{{pull_request_context.checkout_branch}}{% endif %}
+{% if pull_request_context.linked_pull_requests.size > 0 -%}
 - Linked PRs:
-  {% for pr in pull_request_context.linked_pull_requests %}
-  - {{pr.identifier}} — {{pr.url}} — head: {{pr.headRefName}} — base: {{pr.baseRefName}} — status: {{pr.state}} — draft: {{pr.isDraft}} — merged: {{pr.merged}}
-    {% endfor %}
+{%- for pr in pull_request_context.linked_pull_requests %}
+  - {{pr.identifier}} — {{pr.url}} — head: {% if pr.headRefName == null %}unknown{% else %}{{pr.headRefName}}{% endif %} — base: {% if pr.baseRefName == null %}unknown{% else %}{{pr.baseRefName}}{% endif %} — status: {% if pr.state == null %}unknown{% else %}{{pr.state}}{% endif %} — draft: {% if pr.isDraft == null %}unknown{% else %}{{pr.isDraft}}{% endif %} — merged: {% if pr.merged == null %}unknown{% else %}{{pr.merged}}{% endif %}
+{%- endfor %}
+{% else -%}
+- Linked PRs: none
+{% endif %}
 
 Before changing code, inspect review comments, failing checks, and unresolved review threads for the primary PR and linked PRs. If this is an Issue with a linked PR, do not create a new branch; checkout and update the existing PR head branch. If this is a PR-only item, perform the rework on the PR branch.
 {% endif %}

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -31,13 +31,14 @@ codex:
   turn_timeout_ms: 3600000
   stall_timeout_ms: 900000
 ---
+
 ## Status Map
 
-- **Backlog** [wait] *(Do not work. Exit quietly without commenting.)*
-- **Ready** [active] *(Triage scope and clarity first. If the issue returns here with an existing PR, this starts a new work cycle — create a new workpad comment with the rework plan before coding.)*
-- **In progress** [active] *(Continue implementation. If a PR exists and this is a new work cycle, create a new workpad comment with the rework plan. If the current cycle's workpad already exists, update it in place.)*
-- **In review** [wait] *(Wait by default. Reactivate only when review feedback requires code changes.)*
-- **Done** [terminal] *(Completed, agent exits immediately.)*
+- **Backlog** [wait] _(Do not work. Exit quietly without commenting.)_
+- **Ready** [active] _(Triage scope and clarity first. If the issue returns here with an existing PR, this starts a new work cycle — create a new workpad comment with the rework plan before coding.)_
+- **In progress** [active] _(Continue implementation. If a PR exists and this is a new work cycle, create a new workpad comment with the rework plan. If the current cycle's workpad already exists, update it in place.)_
+- **In review** [wait] _(Wait by default. Reactivate only when review feedback requires code changes.)_
+- **Done** [terminal] _(Completed, agent exits immediately.)_
 
 ## Agent Instructions
 
@@ -45,6 +46,27 @@ You are an AI coding agent working on issue {{issue.identifier}}: "{{issue.title
 
 **Repository:** {{issue.repository}}
 **Current state:** {{issue.state}}
+**Subject type:** {{pull_request_context.subject_type}}
+
+{% if pull_request_context.review_first %}
+
+### Pull Request Context
+
+- Primary PR: {{pull_request_context.primary_pull_request.identifier}}
+- PR URL: {{pull_request_context.primary_pull_request.url}}
+- Head branch: {{pull_request_context.primary_pull_request.headRefName}}
+- Base branch: {{pull_request_context.primary_pull_request.baseRefName}}
+- PR status: {{pull_request_context.primary_pull_request.state}}
+- Draft: {{pull_request_context.primary_pull_request.isDraft}}
+- Merged: {{pull_request_context.primary_pull_request.merged}}
+- Checkout branch: {{pull_request_context.checkout_branch}}
+- Linked PRs:
+  {% for pr in pull_request_context.linked_pull_requests %}
+  - {{pr.identifier}} — {{pr.url}} — head: {{pr.headRefName}} — base: {{pr.baseRefName}} — status: {{pr.state}} — draft: {{pr.isDraft}} — merged: {{pr.merged}}
+    {% endfor %}
+
+Before changing code, inspect review comments, failing checks, and unresolved review threads for the primary PR and linked PRs. If this is an Issue with a linked PR, do not create a new branch; checkout and update the existing PR head branch. If this is a PR-only item, perform the rework on the PR branch.
+{% endif %}
 
 ### Task
 
@@ -61,6 +83,7 @@ You are an AI coding agent working on issue {{issue.identifier}}: "{{issue.title
 7. Keep code, commands, identifiers, and raw tool output in their original form when translating reports.
 8. **Whenever you transition the issue to a different state, post a comment on the issue** in the report language explaining the transition: what state it is moving to, why, and what was decided or completed. This is mandatory for every state change — do not transition silently.
 9. If the issue re-enters `Ready` or `In progress` while a PR already exists, treat that as a **new work cycle**: inspect the PR's main merge blockers first, then create a new workpad comment with the revised plan before making code changes. Within the same work cycle, always update the existing workpad comment in place instead of creating additional ones.
+10. If the current subject is an Issue and `Pull Request Context` is present, treat the Issue as the canonical project item and treat any PR card as context only.
 
 ### Workflow
 
@@ -85,7 +108,7 @@ You are an AI coding agent working on issue {{issue.identifier}}: "{{issue.title
 5. Treat the issue as too large in scope if it would likely require changes to more than 20 files or more than 3 packages.
 6. If the issue is actionable and a PR already exists, inspect the PR review timeline, failing checks, and unresolved comments to identify the major merge blockers before touching the code.
 7. If Step 6 applies, this is a new work cycle — create a new workpad comment in the report language that records the re-entry trigger, the major merge blockers, and the revised implementation plan.
-8. If the issue is actionable and Step 7 did not apply, create or continue the workpad, create a branch if needed, post a comment indicating that triage passed and implementation is starting, and continue to Step 2.
+8. If the issue is actionable and Step 7 did not apply, create or continue the workpad, create a branch if needed, post a comment indicating that triage passed and implementation is starting, and continue to Step 2. If `Pull Request Context` is present, do not create a branch; checkout the existing PR head branch instead.
 
 #### Step 2: Execution phase
 
@@ -105,6 +128,7 @@ You are an AI coding agent working on issue {{issue.identifier}}: "{{issue.title
 9. Distill the main merge blockers into a short prioritized list, then update the current cycle's workpad comment in the report language to capture those blockers and the revised execution plan. If no workpad exists for this cycle yet, create one.
 10. Reply to each inline review comment in the report language with a concrete resolution summary or rationale once you have addressed or triaged it.
 11. If review feedback requires code changes, implement them, update tests if needed, re-run the pre-review validation in Step 6, push the changes, refresh the PR body with `/gh-pr-writeup` so the linked issue, evidence, and human validation sections stay current, post a comment describing what was addressed, and move the issue back to `In review`.
+12. If the current subject is `PullRequest`, perform all rework on the PR head branch and keep the PR as the primary review surface.
 
 #### Step 3: In review handling
 
@@ -123,6 +147,8 @@ You are an AI coding agent working on issue {{issue.identifier}}: "{{issue.title
 - Do not start implementation for issues sent back to `Backlog` in the same run.
 - When a PR exists, do not ignore inline review comments; read them all and reply to each one.
 - When an issue re-enters `Ready` or `In progress` with an existing PR, do not silently resume work; inspect the main merge blockers first and create a new workpad comment that restates the plan for the new work cycle. Within that cycle, update the same workpad comment — never create a second one.
+- If both an Issue and its linked PR appear in the Project, the Issue is the canonical item for planning, workpad lifecycle, and state transitions. The PR card supplies PR context only.
+- Current limitation: if only the PR card status changes while the canonical Issue card does not move into an active state, the worker may not be re-dispatched from that PR card status change alone.
 
 ### Workpad Lifecycle
 

--- a/packages/core/src/workflow/render.test.ts
+++ b/packages/core/src/workflow/render.test.ts
@@ -6,7 +6,9 @@ import {
 } from "./render.js";
 import type { TrackedIssue } from "../contracts/tracker-adapter.js";
 
-function createTrackedIssue(overrides: Partial<TrackedIssue> = {}): TrackedIssue {
+function createTrackedIssue(
+  overrides: Partial<TrackedIssue> = {}
+): TrackedIssue {
   return {
     id: "issue-1",
     identifier: "acme/platform#42",
@@ -47,11 +49,17 @@ describe("buildPromptVariables", () => {
     expect(variables.issue.linked_pull_requests).toEqual([]);
     expect(variables.issue.primary_pull_request).toBeNull();
     expect(variables.issue.has_linked_pr).toBe(false);
+    expect(variables.pull_request_context).toMatchObject({
+      subject_type: "Issue",
+      linked_pull_requests: [],
+      primary_pull_request: null,
+      has_linked_pr: false,
+      has_primary_pr: false,
+      checkout_branch: null,
+      review_first: false,
+    });
     expect(
-      renderPrompt(
-        "Fix {{issue.title}} on {{issue.branch_name}}.",
-        variables
-      )
+      renderPrompt("Fix {{issue.title}} on {{issue.branch_name}}.", variables)
     ).toBe("Fix Fix the bug on .");
   });
 
@@ -89,8 +97,10 @@ describe("buildPromptVariables", () => {
       [
         "type={{ issue.content_type }}",
         "has_pr={{ issue.has_linked_pr }}",
+        "review_first={{ pull_request_context.review_first }}",
         "primary={{ issue.primary_pull_request.identifier }}",
-        "branch={{ issue.primary_pull_request.headRefName }}",
+        "branch={{ pull_request_context.checkout_branch }}",
+        "base={{ pull_request_context.primary_pull_request.baseRefName }}",
         "{% for pr in issue.linked_pull_requests %}[{{ pr.number }}:{{ pr.state }}]{% endfor %}",
       ].join("\n"),
       variables
@@ -98,8 +108,10 @@ describe("buildPromptVariables", () => {
 
     expect(rendered).toContain("type=Issue");
     expect(rendered).toContain("has_pr=true");
+    expect(rendered).toContain("review_first=true");
     expect(rendered).toContain("primary=acme/platform#7");
     expect(rendered).toContain("branch=fix/issue-42");
+    expect(rendered).toContain("base=main");
     expect(rendered).toContain("[7:OPEN]");
   });
 
@@ -122,6 +134,13 @@ describe("buildPromptVariables", () => {
 
     expect(variables.issue.content_type).toBe("PullRequest");
     expect(variables.issue.has_linked_pr).toBe(false);
+    expect(variables.pull_request_context).toMatchObject({
+      subject_type: "PullRequest",
+      has_linked_pr: false,
+      has_primary_pr: true,
+      checkout_branch: "feature/pr-metadata",
+      review_first: true,
+    });
     expect(variables.issue.primary_pull_request).toMatchObject({
       id: "pr-9",
       number: 9,
@@ -130,7 +149,16 @@ describe("buildPromptVariables", () => {
       state: null,
       projectState: "Ready",
       headRefName: "feature/pr-metadata",
+      baseRefName: null,
+      isDraft: null,
+      merged: null,
     });
+    expect(
+      renderPrompt(
+        "draft={{ pull_request_context.primary_pull_request.isDraft }} base={{ pull_request_context.primary_pull_request.baseRefName }}",
+        variables
+      )
+    ).toBe("draft= base=");
     expect(renderPrompt("branch={{ issue.branch_name }}", variables)).toBe(
       "branch=feature/pr-metadata"
     );
@@ -174,6 +202,13 @@ describe("buildPromptVariables", () => {
     );
 
     expect(variables.issue.has_linked_pr).toBe(true);
+    expect(variables.pull_request_context).toMatchObject({
+      subject_type: "PullRequest",
+      has_linked_pr: true,
+      has_primary_pr: true,
+      checkout_branch: "feature/pr-metadata",
+      review_first: true,
+    });
     expect(variables.issue.primary_pull_request).toMatchObject({
       id: "pr-9",
       identifier: "acme/platform#9",
@@ -193,17 +228,18 @@ describe("renderContinuationGuidance", () => {
           lastTurnSummary: "Validated the workflow prompt.",
         }
       )
-    ).toBe(
-      "Continue after 3 turns. Summary: Validated the workflow prompt."
-    );
+    ).toBe("Continue after 3 turns. Summary: Validated the workflow prompt.");
   });
 
   it("rejects Liquid tags", () => {
     expect(() =>
-      renderContinuationGuidance("{% if cumulativeTurnCount %}resume{% endif %}", {
-        cumulativeTurnCount: "3",
-        lastTurnSummary: "Validated the workflow prompt.",
-      })
+      renderContinuationGuidance(
+        "{% if cumulativeTurnCount %}resume{% endif %}",
+        {
+          cumulativeTurnCount: "3",
+          lastTurnSummary: "Validated the workflow prompt.",
+        }
+      )
     ).toThrow("continuation guidance does not support Liquid tags");
   });
 

--- a/packages/core/src/workflow/render.test.ts
+++ b/packages/core/src/workflow/render.test.ts
@@ -155,13 +155,75 @@ describe("buildPromptVariables", () => {
     });
     expect(
       renderPrompt(
-        "draft={{ pull_request_context.primary_pull_request.isDraft }} base={{ pull_request_context.primary_pull_request.baseRefName }}",
+        "draft={% if pull_request_context.primary_pull_request.isDraft == null %}unknown{% else %}{{ pull_request_context.primary_pull_request.isDraft }}{% endif %} base={% if pull_request_context.primary_pull_request.baseRefName == null %}unknown{% else %}{{ pull_request_context.primary_pull_request.baseRefName }}{% endif %}",
         variables
       )
-    ).toBe("draft= base=");
+    ).toBe("draft=unknown base=unknown");
     expect(renderPrompt("branch={{ issue.branch_name }}", variables)).toBe(
       "branch=feature/pr-metadata"
     );
+  });
+
+  it("renders PR lists without whitespace-only list artifacts", () => {
+    const variables = buildPromptVariables(
+      createTrackedIssue({
+        metadata: {
+          contentType: "Issue",
+          linkedPullRequests: [
+            {
+              id: "pr-7",
+              number: 7,
+              identifier: "acme/platform#7",
+              url: "https://github.com/acme/platform/pull/7",
+              state: "OPEN",
+              headRefName: "fix/issue-42",
+              baseRefName: "main",
+              isDraft: false,
+              merged: false,
+              repository: {
+                owner: "acme",
+                name: "platform",
+                url: "https://github.com/acme/platform",
+                cloneUrl: "https://github.com/acme/platform.git",
+              },
+            },
+            {
+              id: "pr-8",
+              number: 8,
+              identifier: "acme/platform#8",
+              url: "https://github.com/acme/platform/pull/8",
+              state: null,
+              repository: {
+                owner: "acme",
+                name: "platform",
+                url: "https://github.com/acme/platform",
+                cloneUrl: "https://github.com/acme/platform.git",
+              },
+            },
+          ],
+        },
+      }),
+      { attempt: null }
+    );
+
+    const rendered = renderPrompt(
+      [
+        "- Linked PRs:",
+        "{%- for pr in pull_request_context.linked_pull_requests %}",
+        "  - {{pr.identifier}} -- head: {% if pr.headRefName == null %}unknown{% else %}{{pr.headRefName}}{% endif %} -- status: {% if pr.state == null %}unknown{% else %}{{pr.state}}{% endif %} -- draft: {% if pr.isDraft == null %}unknown{% else %}{{pr.isDraft}}{% endif %} -- merged: {% if pr.merged == null %}unknown{% else %}{{pr.merged}}{% endif %}",
+        "{%- endfor %}",
+      ].join("\n"),
+      variables
+    );
+
+    expect(rendered).toBe(
+      [
+        "- Linked PRs:",
+        "  - acme/platform#7 -- head: fix/issue-42 -- status: OPEN -- draft: false -- merged: false",
+        "  - acme/platform#8 -- head: unknown -- status: unknown -- draft: unknown -- merged: unknown",
+      ].join("\n")
+    );
+    expect(rendered).not.toMatch(/\n\s+\n/);
   });
 
   it("prefers the subject pull request over linked pull requests for pull request subjects", () => {

--- a/packages/core/src/workflow/render.ts
+++ b/packages/core/src/workflow/render.ts
@@ -152,6 +152,8 @@ function buildPullRequestVariables(options: {
     has_linked_pr: options.linkedPullRequests.length > 0,
     has_primary_pr: hasPrimaryPr,
     checkout_branch: checkoutBranch,
+    // Policy flag for prompt templates: any primary PR means the worker must
+    // inspect review threads and checks before editing code.
     review_first: hasPrimaryPr,
   };
 }

--- a/packages/core/src/workflow/render.ts
+++ b/packages/core/src/workflow/render.ts
@@ -38,14 +38,26 @@ export type PromptIssueVariables = {
   repository: string;
 };
 
+export type PromptPullRequestVariables = {
+  subject_type: TrackedIssueContentType;
+  linked_pull_requests: TrackedPullRequestContext[];
+  primary_pull_request: TrackedPullRequestContext | null;
+  has_linked_pr: boolean;
+  has_primary_pr: boolean;
+  checkout_branch: string | null;
+  review_first: boolean;
+};
+
 /**
  * Variables available for prompt template rendering.
  *
  * - `issue` — normalized issue payload
+ * - `pull_request_context` — normalized PR context and checkout guidance
  * - `attempt` — null for first execution, attempt number for retries
  */
 export type PromptVariables = {
   issue: PromptIssueVariables;
+  pull_request_context: PromptPullRequestVariables;
   attempt: number | null;
 };
 
@@ -65,14 +77,22 @@ export function buildPromptVariables(
 ): PromptVariables {
   const contentType = issue.metadata.contentType ?? "Issue";
   const linkedPullRequests = Array.isArray(issue.metadata.linkedPullRequests)
-    ? issue.metadata.linkedPullRequests
+    ? issue.metadata.linkedPullRequests.map(normalizePullRequestContext)
     : [];
   const primaryPullRequest =
     contentType === "PullRequest"
-      ? (issue.metadata.pullRequest ??
-        linkedPullRequests[0] ??
-        buildPullRequestContextFromIssue(issue))
+      ? normalizePullRequestContext(
+          issue.metadata.pullRequest ??
+            linkedPullRequests[0] ??
+            buildPullRequestContextFromIssue(issue)
+        )
       : (linkedPullRequests[0] ?? null);
+  const pullRequestContext = buildPullRequestVariables({
+    contentType,
+    linkedPullRequests,
+    primaryPullRequest,
+    issueBranchName: issue.branchName,
+  });
 
   return {
     issue: {
@@ -95,7 +115,44 @@ export function buildPromptVariables(
       updated_at: issue.updatedAt,
       repository: `${issue.repository.owner}/${issue.repository.name}`,
     },
+    pull_request_context: pullRequestContext,
     attempt: options.attempt,
+  };
+}
+
+function normalizePullRequestContext(
+  pullRequest: TrackedPullRequestContext
+): TrackedPullRequestContext {
+  return {
+    ...pullRequest,
+    state: pullRequest.state ?? null,
+    projectState: pullRequest.projectState ?? null,
+    isDraft: pullRequest.isDraft ?? null,
+    merged: pullRequest.merged ?? null,
+    headRefName: pullRequest.headRefName ?? null,
+    baseRefName: pullRequest.baseRefName ?? null,
+  };
+}
+
+function buildPullRequestVariables(options: {
+  contentType: TrackedIssueContentType;
+  linkedPullRequests: TrackedPullRequestContext[];
+  primaryPullRequest: TrackedPullRequestContext | null;
+  issueBranchName: string | null;
+}): PromptPullRequestVariables {
+  const checkoutBranch =
+    options.primaryPullRequest?.headRefName ??
+    (options.contentType === "PullRequest" ? options.issueBranchName : null);
+  const hasPrimaryPr = options.primaryPullRequest !== null;
+
+  return {
+    subject_type: options.contentType,
+    linked_pull_requests: options.linkedPullRequests,
+    primary_pull_request: options.primaryPullRequest,
+    has_linked_pr: options.linkedPullRequests.length > 0,
+    has_primary_pr: hasPrimaryPr,
+    checkout_branch: checkoutBranch,
+    review_first: hasPrimaryPr,
   };
 }
 


### PR DESCRIPTION
## Issues

- Fixes #280

## Summary

- Worker prompt 변수에 `pull_request_context`를 추가해 subject type, linked PR, primary PR, checkout branch, review-first 여부를 명확히 노출했습니다.
- `WORKFLOW.md`에 linked PR / PR-only / Issue+PR canonical 정책과 PR card status 단독 변경 한계를 반영했습니다.
- Review rework로 PR context 렌더링의 whitespace artifact를 제거하고, 누락된 optional PR 필드는 `unknown`으로 표시하도록 정리했습니다.

## Changes

- `buildPromptVariables()`에서 PR optional 필드를 `null`로 정규화해 strict Liquid 렌더링에서 안정적으로 접근할 수 있게 했습니다.
- `review_first`는 primary PR 존재 여부와 현재 값은 같지만, worker가 review threads/checks를 먼저 확인해야 하는 prompt policy flag임을 코드 주석으로 명시했습니다.
- `WORKFLOW.md`의 linked PR loop에 Liquid whitespace control을 적용하고, PR-only/adapter metadata 누락 시 `Draft: unknown`, `Merged: unknown`처럼 명시적으로 렌더링합니다.
- prompt render tests에 기존 Issue-only 하위호환, linked PR 컨텍스트, PR-only subject, whitespace-free linked PR list 케이스를 보강했습니다.
- `issue.linked_pull_requests`도 정규화된 entries를 노출한다는 publish-facing 변경 사항을 changeset에 기록했습니다.
- PR-card-only status 변경 재디스패치 한계는 후속 이슈 #305로 분리했습니다.

## Evidence

- `pnpm --filter @gh-symphony/core test -- src/workflow/render.test.ts`
- `node packages/cli/dist/index.js workflow validate --file WORKFLOW.md`
- `pnpm lint && pnpm test && pnpm typecheck && pnpm build`
- `git diff --check`

## Human Validation

- [ ] Issue-only worker prompt가 과도하게 길어지지 않는지 확인
- [ ] linked PR이 있는 Issue prompt에서 primary PR, branch, status, review-first 지시가 보이는지 확인
- [ ] PR-only item prompt가 PR branch rework 지시와 unknown fallback을 포함하는지 확인

## Risks

- `WORKFLOW.md`의 PR 컨텍스트 섹션은 `pull_request_context.review_first`가 true일 때만 렌더링됩니다. 실제 PR metadata shape가 부족한 경우는 renderer에서 `null` 기본값과 template의 `unknown` 출력으로 완화했습니다.
- 변경 범위는 prompt 변수와 repository-local workflow policy 문서에 한정됩니다. orchestrator dispatch / worker lifecycle / tracker adapter 동작은 변경하지 않았습니다.