### PR TITLE
chore(cli)!: finalize repo-centric CLI surface

### DIFF
--- a/.changeset/cli-repo-centric-major.md
+++ b/.changeset/cli-repo-centric-major.md
@@ -1,0 +1,13 @@
+---
+"@gh-symphony/cli": major
+---
+
+@gh-symphony/cli: BREAKING — restructure CLI to repo-centric model
+
+- Removed: top-level `start`, `stop`, `status`, `run`, `recover`, `logs`, `init`
+- Removed: `project` namespace (add/list/remove/switch/start/stop/status/explain)
+- Removed: `repo add`, `repo remove`, `repo sync`, `repo list`
+- Added: `repo run`, `repo recover`, `repo logs`, `repo explain`
+- The orchestrator now binds strictly to the cwd repository via `repo init`.
+  Per-repo runtime: `<repo>/.runtime/orchestrator/`.
+- Migrate by running `gh-symphony repo init` in each target repository.

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ GITHUB_GRAPHQL_TOKEN=ghp_your_classic_token gh-symphony doctor --json
 The official image is designed for headless orchestration and defaults to:
 
 - image: `ghcr.io/hojinzs/github-symphony:<tag>`
-- config/state volume: `/var/lib/gh-symphony`
-- default command: `gh-symphony start`
+- repository runtime volume: `<repo>/.runtime/orchestrator`
+- default command: `gh-symphony repo start`
 - runtime user: `symphony` (`UID:GID 1000:1000`)
 
 Supported container environment variables:
@@ -68,7 +68,7 @@ Supported container environment variables:
 
 Supported volume mounts:
 
-- `/var/lib/gh-symphony`: persists `config.json`, `projects/<project-id>/project.json`, project `.env`, logs, and orchestrator workspaces across restarts
+- a cloned repository directory: persists `WORKFLOW.md` and `.runtime/orchestrator/` across restarts
 
 Named Docker volumes work as-is. If you use a host bind mount such as `-v ./data:/var/lib/gh-symphony`, the host directory must be writable by `UID:GID 1000:1000` or the container will fail to persist state.
 
@@ -87,17 +87,18 @@ docker run --rm -it \
   -e GITHUB_GRAPHQL_TOKEN=ghp_your_classic_token \
   -v "$(pwd)/data:/var/lib/gh-symphony" \
   ghcr.io/hojinzs/github-symphony:latest \
-  gh-symphony start --once
+  gh-symphony repo start --once
 ```
 
-Seed the managed-project config into the mounted volume once:
+Initialize the repository runtime from inside the mounted repository once:
 
 ```bash
 docker run --rm -it \
   -e GITHUB_GRAPHQL_TOKEN=ghp_your_classic_token \
-  -v gh-symphony-data:/var/lib/gh-symphony \
+  -v "$(pwd):/repo" \
+  -w /repo \
   ghcr.io/hojinzs/github-symphony:latest \
-  gh-symphony project add --non-interactive --project PVT_xxx --workspace-dir /var/lib/gh-symphony/workspaces
+  gh-symphony setup --non-interactive
 ```
 
 Then start the long-running orchestrator:
@@ -107,7 +108,8 @@ docker run -d \
   --name gh-symphony \
   --restart unless-stopped \
   -e GITHUB_GRAPHQL_TOKEN=ghp_your_classic_token \
-  -v gh-symphony-data:/var/lib/gh-symphony \
+  -v "$(pwd):/repo" \
+  -w /repo \
   ghcr.io/hojinzs/github-symphony:latest
 ```
 
@@ -166,7 +168,7 @@ The one-command setup flow will:
 1. Authenticate via `gh` CLI
 2. Let you select a **GitHub Project**
 3. Map project status columns to workflow phases (active / wait / terminal)
-4. Configure managed-project settings for the orchestrator
+4. Configure the repository runtime for the orchestrator
 5. Generate the following files:
 
 | File                                    | Description                                                       |
@@ -176,12 +178,12 @@ The one-command setup flow will:
 | `.gh-symphony/reference-workflow.md`    | Reference workflow documentation                                  |
 | `.codex/skills/` (or `.claude/skills/`) | Agent skill definitions                                           |
 
-Before writing anything, the interactive wizard shows a final summary that combines the workflow file preview and the managed-project configuration that will be saved under `~/.gh-symphony/`.
+Before writing anything, the interactive wizard shows a final summary that combines the workflow file preview and the repository runtime that will be saved under `.runtime/orchestrator/`.
 
 Non-interactive mode:
 
 ```bash
-gh-symphony setup --non-interactive --project PVT_xxx --workspace-dir ~/.gh-symphony/workspaces
+gh-symphony setup --non-interactive
 ```
 
 ### 3. Set Repository Only
@@ -245,12 +247,12 @@ The generated skill files (under `.codex/skills/` or `.claude/skills/`) define h
 
 > Currently supported runtimes: **Codex**, **Claude Code**
 
-### 4. Set Orchestrator Runner (Project)
+### 4. Set Orchestrator Runner (Repository)
 
-On the machine where you want the orchestrator to run, register a project:
+From inside the cloned repository that should run orchestration, initialize the workflow and repository runtime:
 
 ```bash
-gh-symphony project add
+gh-symphony setup
 ```
 
 The interactive wizard will:
@@ -258,84 +260,76 @@ The interactive wizard will:
 1. Authenticate via `GITHUB_GRAPHQL_TOKEN` or fall back to `gh` CLI
 2. Let you select a **GitHub Project**
 3. Optionally limit processing to issues assigned to the authenticated user
-4. Optionally customize advanced settings for repository filtering and workspace root directory
-5. Write project configuration to `~/.gh-symphony/`
+4. Write `WORKFLOW.md`, support files, and `.runtime/orchestrator/` in the repository
 
 Project discovery is pagination-aware here as well, so large personal and organization-backed GitHub accounts can browse across multiple project pages. If discovery stops at a safety limit, the wizard warns that the visible list may be incomplete.
 
-Token-only project registration is supported too:
+Token-only setup is supported too when exactly one GitHub Project is visible to the token:
 
 ```bash
 export GITHUB_GRAPHQL_TOKEN=ghp_your_classic_token
-gh-symphony project add
+gh-symphony setup
 ```
 
-If the selected GitHub Project does not have any linked repositories yet, `gh-symphony project add` still saves the project. The CLI reports `0 repositories` and points to the two supported follow-up paths:
-
-- run `gh-symphony repo add <owner/name>` to register a repository immediately
-- add a repo-linked issue to the GitHub Project, then re-run setup later if you want the local repository list refreshed
-
-Non-interactive mode:
+If non-interactive setup needs an explicit GitHub Project selection, run the two commands directly:
 
 ```bash
 GITHUB_GRAPHQL_TOKEN=ghp_your_classic_token gh-symphony workflow init --non-interactive --project PVT_xxx --output WORKFLOW.md
-GITHUB_GRAPHQL_TOKEN=ghp_your_classic_token gh-symphony project add --non-interactive --project PVT_xxx --workspace-dir ~/.gh-symphony/workspaces
+GITHUB_GRAPHQL_TOKEN=ghp_your_classic_token gh-symphony repo init
 ```
 
-Managing projects:
+Repository commands:
 
 ```bash
 gh-symphony doctor                   # Validate local prerequisites, auth, config, WORKFLOW.md, and runtime command
 gh-symphony doctor --fix             # Create safe missing paths and print/run remediation follow-ups
 gh-symphony doctor --smoke           # Final preflight: validate a live issue without dispatching work
-gh-symphony project list             # List all configured projects
-gh-symphony project remove <id>      # Remove a project
-gh-symphony project switch           # Switch the active project
-gh-symphony project status           # Show status for a specific project
-gh-symphony project explain owner/repo#123  # Explain why one issue is not dispatching
-gh-symphony project start            # Start a specific project
-gh-symphony project start --once     # Run one orchestration tick for a specific project
-gh-symphony project stop             # Stop a specific project
+gh-symphony repo init                # Bind .runtime/orchestrator to the cwd repository
+gh-symphony repo status              # Show current repository orchestration status
+gh-symphony repo explain owner/repo#123  # Explain why one issue is not dispatching
+gh-symphony repo start               # Start this repository
+gh-symphony repo start --once        # Run one orchestration tick for this repository
+gh-symphony repo stop                # Stop this repository
 ```
 
 ### 5. Run the Orchestrator
 
 ```bash
-gh-symphony start                   # Start (foreground)
-gh-symphony start --once            # First managed-project smoke run, then exit
-gh-symphony start --daemon          # Start (background)
-gh-symphony stop                    # Stop the daemon
-gh-symphony stop --force            # Force stop with SIGKILL
+gh-symphony repo start                   # Start (foreground)
+gh-symphony repo start --once            # First managed-project smoke run, then exit
+gh-symphony repo start --daemon          # Start (background)
+gh-symphony repo stop                    # Stop the daemon
+gh-symphony repo stop --force            # Force stop with SIGKILL
 ```
 
 Monitor:
 
 ```bash
-gh-symphony status                  # Show current status
-gh-symphony status --watch          # Live dashboard
-gh-symphony logs                    # View event logs
-gh-symphony logs --follow           # Stream logs in real-time
-gh-symphony logs --issue org/repo#1 # Filter by issue
-gh-symphony logs --run <run-id>     # Read events for a specific run
-gh-symphony logs --level <level>    # Filter by log level
+gh-symphony repo status                  # Show current status
+gh-symphony repo status --watch          # Live dashboard
+gh-symphony repo logs                    # View event logs
+gh-symphony repo logs --follow           # Stream logs in real-time
+gh-symphony repo logs --issue org/repo#1 # Filter by issue
+gh-symphony repo logs --run <run-id>     # Read events for a specific run
+gh-symphony repo logs --level <level>    # Filter by log level
 ```
 
 Dispatch a single issue:
 
 ```bash
-gh-symphony run org/repo#123
-gh-symphony run org/repo#123 --watch  # Watch status after dispatch
+gh-symphony repo run org/repo#123
+gh-symphony repo run org/repo#123 --watch  # Watch status after dispatch
 ```
 
 ### Why Is My Issue Not Running?
 
-Use `gh-symphony project explain <owner/repo#number>` as the first diagnostic
+Use `gh-symphony repo explain <owner/repo#number>` as the first diagnostic
 when a GitHub Project issue stays idle:
 
 ```bash
-gh-symphony project explain owner/repo#123
-gh-symphony project explain owner/repo#123 --json
-gh-symphony project explain owner/repo#123 --workflow ./WORKFLOW.md
+gh-symphony repo explain owner/repo#123
+gh-symphony repo explain owner/repo#123 --json
+gh-symphony repo explain owner/repo#123 --workflow ./WORKFLOW.md
 ```
 
 The report checks whether the repository is linked to the active managed
@@ -362,39 +356,18 @@ Checks:
 ```
 
 Hints point back to existing troubleshooting commands such as `workflow
-preview`, `doctor`, `project status`, and `logs --issue`.
+preview`, `doctor`, `repo status`, and `repo logs --issue`.
 
 Recover stalled runs:
 
 ```bash
-gh-symphony recover                 # Recover stalled runs
-gh-symphony recover --dry-run       # Preview what would be recovered
+gh-symphony repo recover                 # Recover stalled runs
+gh-symphony repo recover --dry-run       # Preview what would be recovered
 ```
 
-### Managing Repositories
+### Repository Runtime
 
-```bash
-gh-symphony repo list               # List repositories in active project
-gh-symphony repo add owner/name     # Validate and add a repository
-gh-symphony repo remove owner/name  # Remove a repository
-gh-symphony repo sync               # Add newly linked repositories from GitHub Project
-gh-symphony repo sync --dry-run     # Preview linked repository changes
-gh-symphony repo sync --prune       # Fully realign with linked repositories
-```
-
-`gh-symphony repo add owner/name` is the safest onboarding path when a project is
-still empty. It validates the target repository against the GitHub API before
-saving config and stores the canonical clone URL returned by GitHub. If
-authentication is unavailable or the network is offline, the CLI keeps the
-current fallback behavior but prints an explicit warning that the repository was
-saved without validation.
-
-`gh-symphony repo sync` refreshes the active managed project's repository list
-from the current GitHub Project `linkedRepositories`. The default mode is
-additive: newly linked repositories are added, while existing local-only
-entries stay in place until you opt into `--prune`.
-
-This is also the intended first-run recovery path when a newly created GitHub Project is still empty.
+`gh-symphony repo init` binds the orchestrator to the cwd repository. It reads `WORKFLOW.md`, infers `owner/name` from the Git remote, and writes per-repo runtime state under `.runtime/orchestrator/`.
 
 ### Configuration
 
@@ -406,7 +379,7 @@ gh-symphony config edit             # Open config in $EDITOR
 
 ### Diagnostics
 
-`gh-symphony doctor` runs a single first-run diagnostic pass and exits non-zero if any required prerequisite is missing. `gh-symphony doctor --fix` adds a remediation pass on top of the same checks. `gh-symphony doctor --smoke` is the recommended final preflight before `gh-symphony start --once`: it resolves the active managed project, checks the GitHub Project binding, confirms the repository and target issue are readable through the project, renders `WORKFLOW.md` for that issue, verifies the runtime command, workspace root, and configured hook paths, and exits without dispatching a worker.
+`gh-symphony doctor` runs a single first-run diagnostic pass and exits non-zero if any required prerequisite is missing. `gh-symphony doctor --fix` adds a remediation pass on top of the same checks. `gh-symphony doctor --smoke` is the recommended final preflight before `gh-symphony repo start --once`: it resolves the active managed project, checks the GitHub Project binding, confirms the repository and target issue are readable through the project, renders `WORKFLOW.md` for that issue, verifies the runtime command, workspace root, and configured hook paths, and exits without dispatching a worker.
 
 Use an explicit issue when you want a deterministic check:
 
@@ -421,8 +394,8 @@ Without `--issue`, doctor auto-selects one active live issue from the managed pr
 
 - create missing config, runtime, and workspace directories
 - launch `gh auth login` / `gh auth refresh` in TTY environments, or print the exact command in non-interactive environments
-- launch `gh-symphony init` when `WORKFLOW.md` is missing or invalid
-- launch `gh-symphony project add` when the managed project or GitHub Project binding must be reconfigured
+- launch `gh-symphony workflow init` when `WORKFLOW.md` is missing or invalid
+- launch `gh-symphony setup` when the repository runtime or GitHub Project binding must be reconfigured
 - print environment-specific runtime install guidance when the configured command is missing from `PATH`
 
 The diagnostic checks cover:
@@ -430,8 +403,8 @@ The diagnostic checks cover:
 - the active GitHub auth source (`GITHUB_GRAPHQL_TOKEN` first, otherwise `gh`) and required scopes (`repo`, `read:org`, `project`)
 - Node.js runtime version against the documented minimum (`v24+`) and the current `process.version`
 - Git installation availability on `PATH`, including `git --version` when available
-- active managed project resolution and GitHub Project binding lookup
-- config directory, runtime root, and managed workspace writability
+- repository runtime resolution and GitHub Project binding lookup
+- runtime root and repository workspace writability
 - repository `WORKFLOW.md` presence and parse validity
 - configured runtime command availability on `PATH`
 - with `--smoke`: linked repository readiness, live issue readability, strict prompt rendering, and hook path resolution
@@ -442,13 +415,7 @@ Use `--json` for setup automation and smoke checks. When combined with `--fix`, 
 gh-symphony doctor --json
 gh-symphony doctor --fix --json
 gh-symphony doctor --smoke --json
-gh-symphony start --once
-```
-
-Repository sync also supports structured output:
-
-```bash
-gh-symphony repo sync --json
+gh-symphony repo start --once
 ```
 
 JSON output includes the resolved auth source as `env` or `gh`.
@@ -491,7 +458,7 @@ Use `GITHUB_GRAPHQL_TOKEN` when `gh` is unavailable or undesirable:
 export GITHUB_GRAPHQL_TOKEN=ghp_your_classic_token
 ```
 
-`GITHUB_GRAPHQL_TOKEN` takes priority over `gh` CLI. Interactive `gh-symphony workflow init` and `gh-symphony project add` will use the env token first when it is present and valid, and only fall back to `gh` when no usable env token is available. `gh-symphony doctor` also reports the resolved auth source as `env` or `gh`.
+`GITHUB_GRAPHQL_TOKEN` takes priority over `gh` CLI. Interactive `gh-symphony workflow init` and `gh-symphony setup` will use the env token first when it is present and valid, and only fall back to `gh` when no usable env token is available. `gh-symphony doctor` also reports the resolved auth source as `env` or `gh`.
 
 ## WORKFLOW.md
 
@@ -656,14 +623,14 @@ echo "Issue: $SYMPHONY_ISSUE_IDENTIFIER"
 
 ## Headless orchestration
 
-The orchestrator runs independently as long as project config exists under `~/.gh-symphony/`.
+The orchestrator runs independently as long as the repository has been initialized with `gh-symphony repo init`.
 
 ```bash
 # Via the CLI daemon
-gh-symphony start                    # continuous polling + status API on 127.0.0.1:4680
-gh-symphony start --once             # run startup cleanup + one poll/reconcile/dispatch tick
-gh-symphony start --once --http      # keep the dashboard/API available after the one-shot tick until Ctrl+C
-gh-symphony run beta/api#42          # dispatch a single issue
+gh-symphony repo start                    # continuous polling + status API on 127.0.0.1:4680
+gh-symphony repo start --once             # run startup cleanup + one poll/reconcile/dispatch tick
+gh-symphony repo start --once --http      # keep the dashboard/API available after the one-shot tick until Ctrl+C
+gh-symphony repo run beta/api#42          # dispatch a single issue
 
 # Via the orchestrator package directly
 pnpm --filter @gh-symphony/orchestrator start -- run
@@ -676,18 +643,18 @@ pnpm --filter @gh-symphony/orchestrator start -- status
 
 Runtime state lives under `.runtime/orchestrator/`:
 
-| Path                          | Contents                                      |
-| ----------------------------- | --------------------------------------------- |
-| `projects/<id>/config.json`   | Project metadata                              |
-| `projects/<id>/WORKFLOW.md`   | Project-level workflow policy (repo fallback) |
-| `projects/<id>/leases.json`   | Active or released issue-phase leases         |
-| `projects/<id>/status.json`   | Latest project status snapshot                |
-| `runs/<run-id>/run.json`      | Run snapshot, retry state, worker assignment  |
-| `runs/<run-id>/events.ndjson` | Structured orchestration events               |
+| Path                          | Contents                                     |
+| ----------------------------- | -------------------------------------------- |
+| `project.json`                | Repository runtime metadata                  |
+| `config.json`                 | Active repository runtime pointer            |
+| `leases.json`                 | Active or released issue-phase leases        |
+| `status.json`                 | Latest repository status snapshot            |
+| `runs/<run-id>/run.json`      | Run snapshot, retry state, worker assignment |
+| `runs/<run-id>/events.ndjson` | Structured orchestration events              |
 
 Read orchestration state via the status API (`/api/v1/projects/<id>/status`) rather than reading status files directly.
 
-Run `gh-symphony doctor --smoke` before the first `start --once` when you want a safe pre-dispatch readiness check. `gh-symphony start --once` is the first production-like run: it validates the real GitHub Project binding, repository `WORKFLOW.md`, and dispatch eligibility, then performs one poll/reconcile/dispatch tick instead of starting a long-lived poller. Add `--http` when you want the dashboard/API available; with `--once --http`, the one-shot tick still completes, but the HTTP server stays up afterward and the process keeps the project lock until you stop it with `Ctrl+C`.
+Run `gh-symphony doctor --smoke` before the first `start --once` when you want a safe pre-dispatch readiness check. `gh-symphony repo start --once` is the first production-like run: it validates the real GitHub Project binding, repository `WORKFLOW.md`, and dispatch eligibility, then performs one poll/reconcile/dispatch tick instead of starting a long-lived poller. Add `--http` when you want the dashboard/API available; with `--once --http`, the one-shot tick still completes, but the HTTP server stays up afterward and the process keeps the project lock until you stop it with `Ctrl+C`.
 
 ## Verification
 

--- a/docs/2026-05-04_single-repo-orchestrator-feasibility.md
+++ b/docs/2026-05-04_single-repo-orchestrator-feasibility.md
@@ -22,7 +22,7 @@ upstream Symphony spec (`docs/symphony-spec.md` §3, §5) 은 명시적으로 **
 
 1. **PR #255 와의 충돌** — Linear 어댑터는 "이슈에 repo 가 없다 → config 에서 단일 repo 를 주입한다" 는 단일-repo 매핑을 1차 범위로 권장. GitHub 쪽은 array, Linear 쪽은 single 으로 양식이 갈라진다.
 2. **upstream spec 부합 약화** — `docs/symphony-spec.md` §5.1 은 "the workflow file is expected to be repository-owned"; 현재는 `loadProjectWorkflow` 가 `tenant.repositories[0]` 또는 `issue.repository` 의 WORKFLOW.md 를 로드하는 정책 의존 동작이 됐다 (`packages/orchestrator/src/service.ts:1100-1140`).
-3. **부트스트랩 복잡도** — 사용자가 GitHub Project ID, projectSlug, projectConfig 디렉터리를 거쳐야 시작할 수 있다. 한편 spec/레퍼런스는 `cd repo && gh-symphony start` 의 단일 동작이다.
+3. **부트스트랩 복잡도** — 사용자가 GitHub Project ID, projectSlug, projectConfig 디렉터리를 거쳐야 시작할 수 있다. 현재 repo-centric CLI 방향은 `cd repo && gh-symphony repo init && gh-symphony repo start` 로 이 경로를 단순화한다.
 
 ---
 

--- a/docs/CONTROL_PLANE.md
+++ b/docs/CONTROL_PLANE.md
@@ -269,18 +269,18 @@ pnpm --filter @gh-symphony/control-plane dev:server
 pnpm --filter @gh-symphony/control-plane dev:client
 ```
 
-During development, the React app is served by Vite on `:5173`. API calls are proxied to the Node.js server on `:4680`. The `gh-symphony project start --web` command starts only the Node.js server; point a browser at `:5173` during dev, `:4680` in production.
+During development, the React app is served by Vite on `:5173`. API calls are proxied to the Node.js server on `:4680`. The `gh-symphony repo start --web` command starts only the Node.js server; point a browser at `:5173` during dev, `:4680` in production.
 
 ---
 
 ## 5. CLI Integration
 
-The `--web` flag is added to `gh-symphony start` (and `gh-symphony project start`):
+The `--web` flag is available on `gh-symphony repo start`:
 
 ```bash
-gh-symphony project start --web          # orchestrator + HTML dashboard
-gh-symphony project start --web 4680     # explicit port
-gh-symphony project start --http         # orchestrator + JSON API only (existing)
+gh-symphony repo start --web       # orchestrator + HTML dashboard
+gh-symphony repo start --web 4680  # explicit port
+gh-symphony repo start --http      # orchestrator + JSON API only
 ```
 
 In `packages/cli/src/commands/start.ts`:

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -107,16 +107,16 @@ You can further customize the agent's behavior by editing `WORKFLOW.md` — this
 
 > Currently supported runtimes: **Codex**, **Claude Code**
 
-### Project `.env` Mapping
+### Repository `.env` Mapping
 
-If your hooks or worker runs need staging hosts, database URLs, Playwright base URLs, or other runtime-only values, store them in the project runtime directory instead of hardcoding them in `WORKFLOW.md`.
+If your hooks or worker runs need staging hosts, database URLs, Playwright base URLs, or other runtime-only values, store them in the repository runtime directory instead of hardcoding them in `WORKFLOW.md`.
 
-1. Find the project id from `gh-symphony project list`.
+1. Initialize the repository runtime with `gh-symphony repo init`.
 2. Create the runtime env file:
 
 ```bash
-mkdir -p ~/.gh-symphony/projects/<project-id>
-cat > ~/.gh-symphony/projects/<project-id>/.env <<'EOF'
+mkdir -p .runtime/orchestrator
+cat > .runtime/orchestrator/.env <<'EOF'
 STAGING_API_HOST=https://staging.example.com
 DATABASE_URL=postgres://user:pass@staging-db:5432/app
 PLAYWRIGHT_BASE_URL=http://localhost:3000
@@ -137,14 +137,14 @@ Env precedence during hook execution and worker spawn is:
 - system env as the override layer
 - Symphony context vars such as `SYMPHONY_*` as the highest-priority layer
 
-If you use `--config <dir>`, replace `~/.gh-symphony` with that directory.
+The repository runtime always lives under `.runtime/orchestrator/`.
 
-## 3. Set Orchestrator Runner (Project)
+## 3. Set Orchestrator Runner (Repository)
 
-On the machine where you want the orchestrator to run, register a project:
+From inside the cloned repository that should run orchestration, initialize the workflow and repository runtime:
 
 ```bash
-gh-symphony project add
+gh-symphony setup
 ```
 
 The interactive wizard will:
@@ -152,8 +152,7 @@ The interactive wizard will:
 1. Authenticate via `GITHUB_GRAPHQL_TOKEN` or fall back to `gh` CLI
 2. Let you select a **GitHub Project**
 3. Optionally limit processing to issues assigned to the authenticated user
-4. Optionally customize advanced settings for repository filtering and workspace root directory
-5. Write project configuration to `~/.gh-symphony/`
+4. Write `WORKFLOW.md`, support files, and `.runtime/orchestrator/` in the repository
 
 This wizard uses the same pagination-aware discovery path as `workflow init`, so it can enumerate large personal and organization-backed GitHub accounts more reliably. If the CLI stops at a safety limit, it warns that the visible project list may be incomplete.
 
@@ -164,56 +163,40 @@ GITHUB_GRAPHQL_TOKEN=ghp_your_classic_token \
   gh-symphony workflow init --non-interactive --project PVT_xxx --output WORKFLOW.md
 
 GITHUB_GRAPHQL_TOKEN=ghp_your_classic_token \
-  gh-symphony project add --non-interactive --project PVT_xxx --workspace-dir ~/.gh-symphony/workspaces
+  gh-symphony repo init
 ```
 
-Token-only project registration is also supported:
+Token-only setup is also supported when exactly one GitHub Project is visible to the token:
 
 ```bash
 export GITHUB_GRAPHQL_TOKEN=ghp_your_classic_token
-gh-symphony project add
+gh-symphony setup
 ```
 
-If the selected GitHub Project is brand new and has no linked repositories yet, the setup still succeeds. The completion message reports `0 repositories` and suggests either `gh-symphony repo add <owner/name>` or adding a repo-linked issue to the GitHub Project.
-
-### Project Management
+### Repository Management
 
 ```bash
 gh-symphony doctor                   # Validate local prerequisites, auth, config, WORKFLOW.md, and runtime command
 gh-symphony doctor --fix             # Apply safe fixes and guide/launch follow-up recovery commands
 gh-symphony doctor --smoke           # Final preflight: validate a live issue without dispatching work
-gh-symphony project list             # List all configured projects
-gh-symphony project remove <id>      # Remove a project
-gh-symphony project explain owner/repo#123  # Explain why one issue is not dispatching
-gh-symphony repo add owner/name      # Validate and save a repo target manually
-gh-symphony repo sync                # Add newly linked repositories from the GitHub Project
-gh-symphony repo sync --dry-run      # Preview linked repository drift
-gh-symphony repo sync --prune        # Remove local repositories no longer linked
+gh-symphony repo init                # Bind .runtime/orchestrator to the cwd repository
+gh-symphony repo status              # Show current repository orchestration status
+gh-symphony repo explain owner/repo#123  # Explain why one issue is not dispatching
+gh-symphony repo start               # Start this repository
+gh-symphony repo stop                # Stop this repository
 ```
 
-Use `gh-symphony repo add owner/name` as the onboarding safety check when a
-project starts empty or when you want to register a repository before it is
-linked on the GitHub Project board. Successful validation stores the canonical
-clone URL from the GitHub API. If auth is unavailable or the API is offline,
-the CLI still saves the repo with the fallback HTTPS clone URL and prints a
-warning that validation was skipped.
-
-Use `gh-symphony repo sync` when the GitHub Project board has gained or lost
-linked repositories since the project was first added locally. Default sync is
-additive; `--prune` switches to strict alignment, and `--json` prints the added,
-removed, unchanged, and final repository sets.
-
-For empty projects, use `gh-symphony repo add owner/name` after setup to seed the local repository list without re-running the whole wizard.
+`gh-symphony repo init` reads `WORKFLOW.md`, infers `owner/name` from the Git remote, and writes per-repo runtime state under `.runtime/orchestrator/`.
 
 ### Why Is My Issue Not Running?
 
-Use `gh-symphony project explain <owner/repo#number>` before digging through
+Use `gh-symphony repo explain <owner/repo#number>` before digging through
 logs manually:
 
 ```bash
-gh-symphony project explain owner/repo#123
-gh-symphony project explain owner/repo#123 --json
-gh-symphony project explain owner/repo#123 --workflow ./WORKFLOW.md
+gh-symphony repo explain owner/repo#123
+gh-symphony repo explain owner/repo#123 --json
+gh-symphony repo explain owner/repo#123 --workflow ./WORKFLOW.md
 ```
 
 The command checks project repository linkage, GitHub Project item presence,
@@ -238,23 +221,22 @@ Checks:
 ```
 
 The remediation hints point to existing commands such as `workflow preview`,
-`doctor`, `project status`, and `logs --issue`.
+`doctor`, `repo status`, and `repo logs --issue`.
 
 ## 4. Run the Orchestrator
 
 ### Foreground
 
 ```bash
-gh-symphony start
-gh-symphony start --once            # Run startup cleanup + one orchestration tick, then exit
-gh-symphony project start --once    # Same one-shot flow for an explicit project
+gh-symphony repo start
+gh-symphony repo start --once            # Run startup cleanup + one orchestration tick, then exit
 ```
 
 ### Background (daemon)
 
 ```bash
-gh-symphony start --daemon          # Start in background
-gh-symphony stop                    # Stop the daemon
+gh-symphony repo start --daemon          # Start in background
+gh-symphony repo stop                    # Stop the daemon
 ```
 
 Run `doctor --smoke` before the first `start --once` when you want a safe pre-dispatch readiness check. Use `start --once` for the first real managed-project run or a CI smoke check. It reuses the configured GitHub Project binding and `WORKFLOW.md` and performs exactly one poll/reconcile/dispatch cycle instead of entering the long-running orchestration loop. `--daemon --once` is rejected because the modes conflict. If you add `--http`, the dashboard/API remains available after that one-shot tick completes, and the process stays up until you interrupt it with `Ctrl+C`.
@@ -262,28 +244,28 @@ Run `doctor --smoke` before the first `start --once` when you want a safe pre-di
 ### Monitor
 
 ```bash
-gh-symphony status                  # Show current status
-gh-symphony status --watch          # Live dashboard
-gh-symphony logs                    # View event logs
-gh-symphony logs --follow           # Stream logs in real-time
+gh-symphony repo status                  # Show current status
+gh-symphony repo status --watch          # Live dashboard
+gh-symphony repo logs                    # View event logs
+gh-symphony repo logs --follow           # Stream logs in real-time
 ```
 
 ### Dispatch a Single Issue
 
 ```bash
-gh-symphony run org/repo#123
+gh-symphony repo run org/repo#123
 ```
 
 ### Recover Stalled Runs
 
 ```bash
-gh-symphony recover                 # Recover stalled runs
-gh-symphony recover --dry-run       # Preview what would be recovered
+gh-symphony repo recover                 # Recover stalled runs
+gh-symphony repo recover --dry-run       # Preview what would be recovered
 ```
 
 ## Diagnostics
 
-`gh-symphony doctor` validates the most common first-run prerequisites in one pass. `gh-symphony doctor --smoke` is the recommended final preflight before `gh-symphony start --once`: it resolves the active managed project, checks the GitHub Project binding, confirms the repository and target issue are readable through the project, renders `WORKFLOW.md` for that issue, verifies the runtime command, workspace root, and configured hook paths, and exits without dispatching a worker.
+`gh-symphony doctor` validates the most common first-run prerequisites in one pass. `gh-symphony doctor --smoke` is the recommended final preflight before `gh-symphony repo start --once`: it resolves the active managed project, checks the GitHub Project binding, confirms the repository and target issue are readable through the project, renders `WORKFLOW.md` for that issue, verifies the runtime command, workspace root, and configured hook paths, and exits without dispatching a worker.
 
 Use an explicit issue when you want a deterministic check:
 
@@ -298,8 +280,8 @@ Without `--issue`, doctor auto-selects one active live issue from the managed pr
 
 - creates missing config/runtime/workspace directories
 - launches `gh auth login` or `gh auth refresh` when a TTY is available, otherwise prints the exact command to run
-- launches `gh-symphony init` when `WORKFLOW.md` is missing or invalid
-- launches `gh-symphony project add` when managed project setup or GitHub Project binding must be repaired
+- launches `gh-symphony workflow init` when `WORKFLOW.md` is missing or invalid
+- launches `gh-symphony setup` when repository runtime setup or GitHub Project binding must be repaired
 - prints concrete runtime install guidance when the configured command is missing on `PATH`
 
 The diagnostic checks cover:
@@ -308,8 +290,8 @@ The diagnostic checks cover:
 - Node.js runtime version against the documented minimum (`v24+`) and the current `process.version`
 - Git installation availability on `PATH`, including `git --version` when available
 - GitHub authentication via `GITHUB_GRAPHQL_TOKEN` or `gh`, including required scopes
-- managed project selection plus GitHub Project binding resolution
-- config/runtime/workspace path writability
+- repository runtime selection plus GitHub Project binding resolution
+- runtime/workspace path writability
 - repository `WORKFLOW.md` presence and parse validity
 - runtime command availability on `PATH`
 - with `--smoke`: linked repository readiness, live issue readability, strict prompt rendering, and hook path resolution
@@ -320,7 +302,7 @@ Use JSON output for scripts and CI smoke checks. `--fix --json` includes a remed
 gh-symphony doctor --json
 gh-symphony doctor --fix --json
 gh-symphony doctor --smoke --json
-gh-symphony start --once
+gh-symphony repo start --once
 ```
 
 JSON output includes the resolved auth source as `env` or `gh`.
@@ -329,6 +311,7 @@ JSON output includes the resolved auth source as `env` or `gh`.
 
 ```
 Setup:
+  setup               Generate WORKFLOW.md and initialize the cwd repository runtime
   workflow init       Interactive repository setup wizard
   workflow validate   Parse and strictly validate WORKFLOW.md
   workflow preview    Render the final worker prompt from a sample or live issue
@@ -338,21 +321,17 @@ Setup:
   config edit         Open config in $EDITOR
 
 Orchestration:
-  start               Start the orchestrator (foreground)
-  start --once        Run a single orchestration tick and exit
-  start --daemon      Start the orchestrator (background)
-  stop                Stop the background orchestrator
-  status              Show orchestrator status
-  run <issue>         Dispatch a single issue
-  recover             Recover stalled runs
-  logs                View orchestrator logs
+  repo init           Bind .runtime/orchestrator to the cwd repository
+  repo start          Start the orchestrator (foreground)
+  repo start --once   Run a single orchestration tick and exit
+  repo start --daemon Start the orchestrator (background)
+  repo stop           Stop the background orchestrator
+  repo status         Show orchestrator status
+  repo run <issue>    Dispatch a single issue
+  repo recover        Recover stalled runs
+  repo logs           View orchestrator logs
+  repo explain        Explain why an issue is not dispatching
   completion <shell>  Print shell completion for bash/zsh/fish
-
-Project Management:
-  project add          Add a new project (interactive wizard)
-  project list         List all configured projects
-  project remove       Remove a project
-  repo sync            Refresh repositories from the linked GitHub Project
 
 Global Options:
   --config <dir>      Config directory (default: ~/.gh-symphony)

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -334,7 +334,7 @@ Orchestration:
   completion <shell>  Print shell completion for bash/zsh/fish
 
 Global Options:
-  --config <dir>      Config directory (default: ~/.gh-symphony)
+  --config <dir>      Config directory (default: initialized cwd runtime, then ~/.gh-symphony)
   --verbose           Enable verbose output
   --json              Output in JSON format
   --no-color          Disable color output

--- a/packages/cli/src/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/src/commands/__snapshots__/help.test.ts.snap
@@ -31,8 +31,8 @@ exports[`help output > renders the colored grouped help snapshot 1`] = `
   [36mhelp [command][0m       Show help for a command
 
 [33m[1mGlobal Options:[0m[0m
-  [36m--config <dir>[0m       Config directory override (advanced; default resolves
-                       per-repo to <repo>/.runtime/orchestrator)
+  [36m--config <dir>[0m       Config directory override (advanced; default uses initialized
+                       cwd runtime, then ~/.gh-symphony)
   [36m--verbose, -v[0m        Verbose output
   [36m--json[0m               JSON output
   [36m--no-color[0m           Disable color output
@@ -72,8 +72,8 @@ Maintenance:
   help [command]       Show help for a command
 
 Global Options:
-  --config <dir>       Config directory override (advanced; default resolves
-                       per-repo to <repo>/.runtime/orchestrator)
+  --config <dir>       Config directory override (advanced; default uses initialized
+                       cwd runtime, then ~/.gh-symphony)
   --verbose, -v        Verbose output
   --json               JSON output
   --no-color           Disable color output

--- a/packages/cli/src/commands/doctor.test.ts
+++ b/packages/cli/src/commands/doctor.test.ts
@@ -1250,6 +1250,63 @@ describe("doctor command handler", () => {
     );
   });
 
+  it("reports workflow init for missing workflow file remediation", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "doctor-missing-workflow-"));
+    const configDir = join(rootDir, "config");
+    const workspaceDir = join(rootDir, "workspace");
+    const repoDir = join(rootDir, "repo");
+    const binDir = join(rootDir, "bin");
+    await mkdir(repoDir, { recursive: true });
+    await mkdir(binDir, { recursive: true });
+    await prepareDoctorPaths(configDir, workspaceDir);
+
+    const gitExecutable = join(binDir, "git");
+    await writeFile(
+      gitExecutable,
+      '#!/bin/sh\nif [ "$1" = "--version" ]; then\n  echo \'git version 2.44.0\'\n  exit 0\nfi\nexit 1\n',
+      "utf8"
+    );
+    await chmod(gitExecutable, 0o755);
+
+    const stdout = captureWrites(process.stdout);
+
+    try {
+      await withCwd(repoDir, () =>
+        runDoctorCommand(
+          ["--fix"],
+          { ...baseOptions(configDir), json: true },
+          {
+            ...authDependencies(),
+            inspectManagedProjectSelection: async () => ({
+              kind: "resolved",
+              projectId: "tenant-a",
+              projectConfig: createProjectConfig(workspaceDir),
+            }),
+            getProjectDetail: (async () => createProjectDetail() as never) as never,
+            pathEnv: binDir,
+          }
+        )
+      );
+    } finally {
+      stdout.restore();
+    }
+
+    const report = JSON.parse(stdout.output()) as {
+      remediation?: {
+        steps: Array<{ checkId: string; status: string; command?: string }>;
+      };
+    };
+    expect(report.remediation?.steps).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          checkId: "workflow_file",
+          status: "manual",
+          command: `gh-symphony --config ${configDir} workflow init`,
+        }),
+      ])
+    );
+  });
+
   it("does not launch remediation subprocesses while preserving JSON-only stdout", async () => {
     const configDir = await mkdtemp(join(tmpdir(), "doctor-json-fix-"));
     const { repoDir } = await createWorkflowFixture();

--- a/packages/cli/src/commands/doctor.test.ts
+++ b/packages/cli/src/commands/doctor.test.ts
@@ -615,7 +615,7 @@ describe("runDoctorDiagnostics", () => {
         inspectManagedProjectSelection: async () => ({
           kind: "no_projects",
           message:
-            "No managed projects are configured. Run 'gh-symphony project add' first.",
+            "No repository runtime config is configured. Run 'gh-symphony repo init' first.",
         }),
         pathEnv: "",
       })
@@ -632,7 +632,7 @@ describe("runDoctorDiagnostics", () => {
       report.checks.find((check) => check.id === "managed_project")
     ).toMatchObject({
       status: "fail",
-      summary: expect.stringContaining("project add"),
+      summary: expect.stringContaining("repo init"),
     });
   });
 
@@ -797,7 +797,7 @@ describe("runDoctorDiagnostics", () => {
         inspectManagedProjectSelection: async () => ({
           kind: "no_projects",
           message:
-            "No managed projects are configured. Run 'gh-symphony project add' first.",
+            "No repository runtime config is configured. Run 'gh-symphony repo init' first.",
         }),
       })
     );
@@ -1018,7 +1018,7 @@ describe("runDoctorDiagnostics", () => {
     ).toMatchObject({
       status: "fail",
       summary: expect.stringContaining("is not bound to a GitHub Project"),
-      remediation: expect.stringContaining("project add"),
+      remediation: expect.stringContaining("workflow init"),
     });
   });
 
@@ -1216,7 +1216,7 @@ describe("doctor command handler", () => {
             inspectManagedProjectSelection: async () => ({
               kind: "no_projects",
               message:
-                "No managed projects are configured. Run 'gh-symphony project add' first.",
+                "No repository runtime config is configured. Run 'gh-symphony repo init' first.",
             }),
             stdinIsTTY: false,
             stdoutIsTTY: false,
@@ -1244,7 +1244,7 @@ describe("doctor command handler", () => {
         expect.objectContaining({
           checkId: "managed_project",
           status: "manual",
-          command: `gh-symphony --config ${configDir} project add`,
+          command: `gh-symphony --config ${configDir} repo init`,
         }),
       ])
     );
@@ -1274,7 +1274,7 @@ describe("doctor command handler", () => {
             inspectManagedProjectSelection: async () => ({
               kind: "no_projects",
               message:
-                "No managed projects are configured. Run 'gh-symphony project add' first.",
+                "No repository runtime config is configured. Run 'gh-symphony repo init' first.",
             }),
             stdinIsTTY: true,
             stdoutIsTTY: true,
@@ -1334,7 +1334,7 @@ describe("doctor command handler", () => {
           inspectManagedProjectSelection: async () => ({
             kind: "no_projects",
             message:
-              "No managed projects are configured. Run 'gh-symphony project add' first.",
+              "No repository runtime config is configured. Run 'gh-symphony repo init' first.",
           }),
           stdinIsTTY: true,
           stdoutIsTTY: true,
@@ -1349,7 +1349,7 @@ describe("doctor command handler", () => {
 
     expect(spawnSync).toHaveBeenCalledWith(
       process.execPath,
-      ["/tmp/gh-symphony.js", "--config", configDir, "project", "add"],
+      ["/tmp/gh-symphony.js", "--config", configDir, "repo", "init"],
       { stdio: "inherit" }
     );
   });
@@ -1364,7 +1364,7 @@ describe("doctor command handler", () => {
         inspectManagedProjectSelection: async () => ({
           kind: "no_projects",
           message:
-            "No managed projects are configured. Run 'gh-symphony project add' first.",
+            "No repository runtime config is configured. Run 'gh-symphony repo init' first.",
         }),
         pathEnv,
       })

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -1966,7 +1966,7 @@ async function runDoctorFixes(
           runCliRemediation(
             title,
             check.id,
-            ["init"],
+            ["workflow", "init"],
             deps,
             options,
             interactive,

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -603,7 +603,7 @@ async function checkWorkflow(
       workflowPath,
       summary: "WORKFLOW.md was not found in the repository root.",
       remediation:
-        "Run 'gh-symphony init' in this repository or add a valid WORKFLOW.md at the repo root.",
+        "Run 'gh-symphony workflow init' in this repository or add a valid WORKFLOW.md at the repo root.",
     };
   }
 
@@ -623,7 +623,7 @@ async function checkWorkflow(
       workflowPath,
       summary: "WORKFLOW.md could not be parsed.",
       remediation:
-        "Fix the WORKFLOW.md front matter or re-run 'gh-symphony init' to regenerate it.",
+        "Fix the WORKFLOW.md front matter or re-run 'gh-symphony workflow init' to regenerate it.",
       error:
         error instanceof Error
           ? error.message
@@ -890,7 +890,7 @@ async function buildDoctorSmokeChecks(input: {
           "project_repository_link",
           "Project repository link",
           `Repository ${issueRef.owner}/${issueRef.name} is not linked to GitHub Project "${input.projectDetail.title}".`,
-          "Run 'gh-symphony repo init' from the target repository or re-run 'gh-symphony project add' with the correct project binding.",
+          "Run 'gh-symphony setup' from inside the target repository, or run 'gh-symphony workflow init' followed by 'gh-symphony repo init'.",
           {
             repository: `${issueRef.owner}/${issueRef.name}`,
             projectTitle: input.projectDetail.title,
@@ -1003,7 +1003,7 @@ async function buildDoctorSmokeChecks(input: {
           "project_repository_link",
           "Project repository link",
           `Repository ${repositoryName} is not linked to GitHub Project "${input.projectDetail.title}".`,
-          "Run 'gh-symphony repo init' from the target repository or re-run 'gh-symphony project add' with the correct project binding.",
+          "Run 'gh-symphony setup' from inside the target repository, or run 'gh-symphony workflow init' followed by 'gh-symphony repo init'.",
           {
             repository: repositoryName,
             projectTitle: input.projectDetail.title,
@@ -1324,7 +1324,7 @@ export async function runDoctorDiagnostics(
         "managed_project",
         "Managed project selection",
         resolvedProjectConfig.message,
-        "Run 'gh-symphony project add' to register a project, or select one with 'gh-symphony project switch' / '--project-id'.",
+        "Run 'gh-symphony repo init' from the target repository.",
         {
           reason: resolvedProjectConfig.kind,
           ...(resolvedProjectConfig.projectId
@@ -1367,7 +1367,7 @@ export async function runDoctorDiagnostics(
         "github_project_resolution",
         "GitHub project resolution",
         `Managed project "${resolvedProjectConfig.projectId}" is not bound to a GitHub Project.`,
-        "Re-run 'gh-symphony project add' and select a valid GitHub Project binding, then run the doctor command again.",
+        "Run 'gh-symphony workflow init' to select a valid GitHub Project binding, then run 'gh-symphony repo init' again.",
         {
           reason: "missing_binding" satisfies ProjectResolutionReason,
           projectId: resolvedProjectConfig.projectId,
@@ -1413,7 +1413,7 @@ export async function runDoctorDiagnostics(
           "github_project_resolution",
           "GitHub project resolution",
           `Failed to resolve configured project binding '${resolvedGithubProjectBindingId}'.`,
-          "Re-run 'gh-symphony project add' and select a valid GitHub Project, then run the doctor command again.",
+          "Run 'gh-symphony workflow init' to select a valid GitHub Project, then run 'gh-symphony repo init' again.",
           {
             reason: "api_error" satisfies ProjectResolutionReason,
             bindingId: resolvedGithubProjectBindingId,
@@ -1869,9 +1869,9 @@ async function runDoctorFixes(
         if (check.details?.reason === "multiple_projects_require_selection") {
           steps.push(
             runCliRemediation(
-              "Managed project selection",
+              "Repository runtime setup",
               check.id,
-              ["project", "switch"],
+              ["repo", "init"],
               deps,
               options,
               interactive,
@@ -1882,9 +1882,9 @@ async function runDoctorFixes(
         }
         steps.push(
           runCliRemediation(
-            "Managed project setup",
+            "Repository runtime setup",
             check.id,
-            ["project", "add"],
+            ["repo", "init"],
             deps,
             options,
             interactive,
@@ -1914,7 +1914,7 @@ async function runDoctorFixes(
             runCliRemediation(
               "GitHub project binding setup",
               check.id,
-              ["project", "add"],
+              ["setup"],
               deps,
               options,
               interactive,
@@ -1930,7 +1930,7 @@ async function runDoctorFixes(
             check.title,
             "manual",
             check.remediation ?? "Resolve the GitHub Project binding manually.",
-            formatGhSymphonyCommand(["project", "add"], deps, options),
+            formatGhSymphonyCommand(["setup"], deps, options),
             check.details
           )
         );

--- a/packages/cli/src/commands/help.ts
+++ b/packages/cli/src/commands/help.ts
@@ -120,8 +120,8 @@ export const HELP_SECTIONS: HelpSection[] = [
       {
         name: "--config <dir>",
         description: [
-          "Config directory override (advanced; default resolves",
-          "per-repo to <repo>/.runtime/orchestrator)",
+          "Config directory override (advanced; default uses initialized",
+          "cwd runtime, then ~/.gh-symphony)",
         ],
       },
       {

--- a/packages/cli/src/commands/lifecycle.test.ts
+++ b/packages/cli/src/commands/lifecycle.test.ts
@@ -163,7 +163,7 @@ describe("lifecycle command integration", () => {
 
     expect(spawnMock).toHaveBeenCalledWith(
       process.execPath,
-      [process.argv[1], "start"],
+      [process.argv[1], "repo", "start"],
       expect.any(Object)
     );
   });
@@ -212,7 +212,7 @@ describe("lifecycle command integration", () => {
     expect(orchestratorRunCli).not.toHaveBeenCalled();
     expect(cancelMock).toHaveBeenCalledWith("Cancelled.");
     expect(stderr.mock.calls.map((call) => String(call[0])).join("")).not.toContain(
-      "No project configured. Run 'gh-symphony project add' first."
+      "No repository runtime config found. Run 'gh-symphony repo init' first."
     );
     expect(process.exitCode).toBe(130);
   });
@@ -235,7 +235,7 @@ describe("lifecycle command integration", () => {
     expect(orchestratorRunCli).not.toHaveBeenCalled();
     const output = stderr.mock.calls.map((call) => String(call[0])).join("");
     expect(output).toContain(
-      "Multiple projects are configured. Re-run with --project-id in non-interactive environments."
+      "Multiple repository runtime configs are present. Run 'gh-symphony repo init' from the target repository to refresh the cwd runtime."
     );
     expect(process.exitCode).toBe(1);
   });
@@ -314,7 +314,7 @@ describe("lifecycle command integration", () => {
     const output = stderr.mock.calls.map((call) => String(call[0])).join("");
     expect(output).toContain("Unknown option '--proejct-id'");
     expect(output).toContain(
-      "Usage: gh-symphony stop [--force]"
+      "Usage: gh-symphony repo stop [--force]"
     );
     expect(killSpy).not.toHaveBeenCalled();
     await expect(

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -66,7 +66,7 @@ const handler = async (
   }
 
   if (!parsed.issue) {
-    process.stderr.write("Usage: gh-symphony run <owner/repo#number>\n");
+    process.stderr.write("Usage: gh-symphony repo run <owner/repo#number>\n");
     process.exitCode = 2;
     return;
   }

--- a/packages/cli/src/commands/setup.test.ts
+++ b/packages/cli/src/commands/setup.test.ts
@@ -1,4 +1,5 @@
 import { mkdtemp, readFile } from "node:fs/promises";
+import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -35,8 +36,6 @@ import * as p from "@clack/prompts";
 import setupCommand from "./setup.js";
 import * as ghAuth from "../github/gh-auth.js";
 import * as githubClient from "../github/client.js";
-import type { CliProjectConfig } from "../config.js";
-import { generateProjectId } from "./workflow-init.js";
 
 const MOCK_PROJECT_SUMMARY = {
   id: "PVT_setup_1",
@@ -114,6 +113,14 @@ const MOCK_PROJECT_DETAIL_WITH_AMBIGUOUS_PRIORITY = {
   ],
 };
 
+function initializeGitRemote(cwd: string, remote = "https://github.com/acme/repo-a.git"): void {
+  execFileSync("git", ["init"], { cwd, stdio: "ignore" });
+  execFileSync("git", ["remote", "add", "origin", remote], {
+    cwd,
+    stdio: "ignore",
+  });
+}
+
 describe("setup command", () => {
   const originalCwd = process.cwd();
 
@@ -156,37 +163,29 @@ describe("setup command", () => {
   it("writes workflow files and managed-project config in non-interactive mode", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "setup-non-interactive-cwd-"));
     const configDir = await mkdtemp(join(tmpdir(), "setup-non-interactive-config-"));
+    initializeGitRemote(cwd);
     process.chdir(cwd);
 
-    await setupCommand(
-      ["--non-interactive", "--project", MOCK_PROJECT_SUMMARY.id],
-      {
-        configDir,
-        verbose: false,
-        json: false,
-        noColor: true,
-      }
-    );
+    await setupCommand(["--non-interactive"], {
+      configDir,
+      verbose: false,
+      json: false,
+      noColor: true,
+    });
 
-    const projectId = generateProjectId(
-      MOCK_PROJECT_DETAIL.title,
-      MOCK_PROJECT_DETAIL.id
-    );
     const workflow = await readFile(join(cwd, "WORKFLOW.md"), "utf8");
     const contextYaml = await readFile(
       join(cwd, ".gh-symphony", "context.yaml"),
       "utf8"
     );
     const project = JSON.parse(
-      await readFile(
-        join(configDir, "projects", projectId, "project.json"),
-        "utf8"
-      )
-    ) as CliProjectConfig;
+      await readFile(join(cwd, ".runtime", "orchestrator", "project.json"), "utf8")
+    );
 
     expect(workflow).toContain("project_id: PVT_setup_1");
     expect(contextYaml).toContain("PVT_setup_1");
-    expect(project.displayName).toBe("Setup Project");
+    expect(project.projectId).toBe("repository");
+    expect(project.workspaceDir).toBe(cwd);
     expect(project.repository).toMatchObject({
       owner: "acme",
       name: "repo-a",
@@ -197,6 +196,7 @@ describe("setup command", () => {
   it("shows a final summary and writes the selected repositories in interactive mode", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "setup-interactive-cwd-"));
     const configDir = await mkdtemp(join(tmpdir(), "setup-interactive-config-"));
+    initializeGitRemote(cwd, "https://github.com/acme/repo-b.git");
     process.chdir(cwd);
 
     vi.mocked(p.select)
@@ -209,11 +209,6 @@ describe("setup command", () => {
       .mockResolvedValueOnce(true as never)
       .mockResolvedValueOnce(true as never)
       .mockResolvedValueOnce(true as never);
-    vi.mocked(p.multiselect).mockResolvedValue([
-      MOCK_PROJECT_DETAIL.linkedRepositories[1],
-    ] as never);
-    vi.mocked(p.text).mockResolvedValue("/tmp/setup-workspaces" as never);
-
     await setupCommand([], {
       configDir,
       verbose: false,
@@ -221,26 +216,21 @@ describe("setup command", () => {
       noColor: true,
     });
 
-    const projectId = generateProjectId(
-      MOCK_PROJECT_DETAIL.title,
-      MOCK_PROJECT_DETAIL.id
-    );
     const project = JSON.parse(
       await readFile(
-        join(configDir, "projects", projectId, "project.json"),
+        join(cwd, ".runtime", "orchestrator", "project.json"),
         "utf8"
       )
-    ) as CliProjectConfig;
+    );
 
-    expect(project.workspaceDir).toBe("/tmp/setup-workspaces");
+    expect(project.workspaceDir).toBe(cwd);
     expect(project.repository?.name).toBe("repo-b");
-    expect(project).not.toHaveProperty("repositories");
     expect(p.note).toHaveBeenCalledWith(
       expect.stringContaining("Init dry-run preview"),
       "Final summary"
     );
     expect(p.note).toHaveBeenCalledWith(
-      expect.stringContaining("Repos:      acme/repo-b  (1 of 2 linked)"),
+      expect.stringContaining("Repository:     current working directory"),
       "Final summary"
     );
   });
@@ -250,6 +240,7 @@ describe("setup command", () => {
     const configDir = await mkdtemp(
       join(tmpdir(), "setup-non-interactive-priority-config-")
     );
+    initializeGitRemote(cwd);
     process.chdir(cwd);
 
     vi.spyOn(githubClient, "getProjectDetail").mockResolvedValue(
@@ -259,15 +250,12 @@ describe("setup command", () => {
       .spyOn(process.stderr, "write")
       .mockImplementation(() => true);
 
-    await setupCommand(
-      ["--non-interactive", "--project", MOCK_PROJECT_SUMMARY.id],
-      {
-        configDir,
-        verbose: false,
-        json: false,
-        noColor: true,
-      }
-    );
+    await setupCommand(["--non-interactive"], {
+      configDir,
+      verbose: false,
+      json: false,
+      noColor: true,
+    });
 
     const workflow = await readFile(join(cwd, "WORKFLOW.md"), "utf8");
 
@@ -282,6 +270,7 @@ describe("setup command", () => {
     const configDir = await mkdtemp(
       join(tmpdir(), "setup-interactive-assigned-config-")
     );
+    initializeGitRemote(cwd);
     process.chdir(cwd);
 
     vi.mocked(p.select)
@@ -290,8 +279,6 @@ describe("setup command", () => {
       .mockResolvedValueOnce("active" as never)
       .mockResolvedValueOnce("terminal" as never);
     vi.mocked(p.confirm)
-      .mockResolvedValueOnce(true as never)
-      .mockResolvedValueOnce(false as never)
       .mockResolvedValueOnce(true as never)
       .mockResolvedValueOnce(true as never);
 
@@ -302,16 +289,12 @@ describe("setup command", () => {
       noColor: true,
     });
 
-    const projectId = generateProjectId(
-      MOCK_PROJECT_DETAIL.title,
-      MOCK_PROJECT_DETAIL.id
-    );
     const project = JSON.parse(
       await readFile(
-        join(configDir, "projects", projectId, "project.json"),
+        join(cwd, ".runtime", "orchestrator", "project.json"),
         "utf8"
       )
-    ) as CliProjectConfig;
+    );
 
     expect(project.tracker.settings?.assignedOnly).toBe(true);
     expect(vi.mocked(p.confirm).mock.calls[0]?.[0]).toMatchObject({

--- a/packages/cli/src/commands/setup.test.ts
+++ b/packages/cli/src/commands/setup.test.ts
@@ -160,6 +160,31 @@ describe("setup command", () => {
     process.chdir(originalCwd);
   });
 
+  it("reports removed project/workspace setup flags with migration guidance", async () => {
+    const stderrWrite = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+
+    await setupCommand(["--project", "PVT_removed"], {
+      configDir: "/tmp/unused",
+      verbose: false,
+      json: false,
+      noColor: true,
+    });
+
+    expect(process.exitCode).toBe(2);
+    expect(stderrWrite).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Removed project/workspace flags are no longer supported"
+      )
+    );
+    expect(stderrWrite).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Supported flags: --non-interactive, --assigned-only, --output, --skip-skills, --skip-context."
+      )
+    );
+  });
+
   it("writes workflow files and managed-project config in non-interactive mode", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "setup-non-interactive-cwd-"));
     const configDir = await mkdtemp(join(tmpdir(), "setup-non-interactive-config-"));

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -68,7 +68,7 @@ function parseSetupFlags(args: string[]): SetupFlags {
       default:
         if (arg?.startsWith("-")) {
           throw new Error(
-            `Unknown option '${arg}'. Use 'gh-symphony setup' from inside the target repository.`
+            `Unknown option '${arg}'. Removed project/workspace flags are no longer supported; run 'gh-symphony setup' from inside the target repository. Supported flags: --non-interactive, --assigned-only, --output, --skip-skills, --skip-context.`
           );
         }
     }

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -1,5 +1,5 @@
 import * as p from "@clack/prompts";
-import { join, resolve } from "node:path";
+import { resolve } from "node:path";
 import type { GlobalOptions } from "../index.js";
 import {
   createClient,
@@ -16,28 +16,21 @@ import { ensureGhAuth, getGhToken, GhAuthError } from "../github/gh-auth.js";
 import {
   abortIfCancelled,
   buildAutomaticStateMappings,
-  generateProjectId,
   planWorkflowArtifacts,
   resolvePriorityField,
   renderDryRunPreview,
   resolveStatusField,
-  writeConfig,
   writeEcosystem,
   writeWorkflowPlan,
   promptStateMappings,
 } from "./workflow-init.js";
 import { validateStateMapping } from "../mapping/smart-defaults.js";
-import {
-  promptProjectRegistrationOptions,
-  renderProjectRegistrationSummary,
-} from "./setup-project-registration.js";
+import { initRepoRuntime } from "../repo-runtime.js";
 
 const KNOWN_REQUIRED_SCOPES = ["repo", "read:org", "project"] as const;
 
 type SetupFlags = {
   nonInteractive: boolean;
-  project?: string;
-  workspaceDir?: string;
   assignedOnly?: boolean;
   output?: string;
   skipSkills: boolean;
@@ -59,14 +52,6 @@ function parseSetupFlags(args: string[]): SetupFlags {
       case "--non-interactive":
         flags.nonInteractive = true;
         break;
-      case "--project":
-        flags.project = next;
-        i += 1;
-        break;
-      case "--workspace-dir":
-        flags.workspaceDir = next;
-        i += 1;
-        break;
       case "--assigned-only":
         flags.assignedOnly = true;
         break;
@@ -80,6 +65,12 @@ function parseSetupFlags(args: string[]): SetupFlags {
       case "--skip-context":
         flags.skipContext = true;
         break;
+      default:
+        if (arg?.startsWith("-")) {
+          throw new Error(
+            `Unknown option '${arg}'. Use 'gh-symphony setup' from inside the target repository.`
+          );
+        }
     }
   }
 
@@ -106,10 +97,7 @@ function displayScopeError(
   );
 }
 
-async function resolveProjectDetail(
-  client: GitHubClient,
-  projectArg?: string
-): Promise<ProjectDetail> {
+async function resolveProjectDetail(client: GitHubClient): Promise<ProjectDetail> {
   const projects = await listUserProjects(client);
 
   if (projects.length === 0) {
@@ -118,21 +106,13 @@ async function resolveProjectDetail(
     );
   }
 
-  if (projectArg) {
-    const match = projects.find(
-      (project) => project.id === projectArg || project.url === projectArg
-    );
-    if (!match) {
-      throw new Error(`Project not found: ${projectArg}`);
-    }
-    return getProjectDetail(client, match.id);
-  }
-
   if (projects.length === 1) {
     return getProjectDetail(client, projects[0]!.id);
   }
 
-  throw new Error("Error: --project is required when multiple projects exist.");
+  throw new Error(
+    "Error: non-interactive setup requires exactly one GitHub Project. Use 'gh-symphony workflow init' for project selection, then run 'gh-symphony repo init'."
+  );
 }
 
 async function selectProjectSummary(
@@ -160,29 +140,20 @@ async function selectProjectSummary(
   return projects.find((project) => project.id === selectedProjectId)!;
 }
 
-function formatRepoSummary(
-  projectDetail: ProjectDetail,
-  selectedRepos: ProjectDetail["linkedRepositories"]
-): string {
-  return selectedRepos.length === projectDetail.linkedRepositories.length
-    ? `${selectedRepos.map((repo) => `${repo.owner}/${repo.name}`).join(", ")}  (all ${selectedRepos.length} linked)`
-    : `${selectedRepos.map((repo) => `${repo.owner}/${repo.name}`).join(", ")}  (${selectedRepos.length} of ${projectDetail.linkedRepositories.length} linked)`;
-}
-
 function printNonInteractiveSummary(input: {
-  projectId: string;
   githubProjectTitle: string;
   githubProjectId: string;
   workflowPath: string;
-  workspaceDir: string;
+  runtimeDir: string;
+  repository: string;
 }): void {
   process.stdout.write(
     [
       `GitHub Project   ${input.githubProjectTitle}  (${input.githubProjectId})`,
-      `Managed project  ${input.projectId}`,
+      `Repository       ${input.repository}`,
       `WORKFLOW.md      ${input.workflowPath}`,
-      `Workspace root   ${input.workspaceDir}`,
-      "Ready. Run 'gh-symphony start' to begin orchestration.",
+      `Runtime          ${input.runtimeDir}`,
+      "Ready. Run 'gh-symphony repo start' to begin orchestration.",
     ]
       .map((line) => `  ${line}`)
       .join("\n") + "\n"
@@ -193,7 +164,16 @@ const handler = async (
   args: string[],
   options: GlobalOptions
 ): Promise<void> => {
-  const flags = parseSetupFlags(args);
+  let flags: SetupFlags;
+  try {
+    flags = parseSetupFlags(args);
+  } catch (error) {
+    process.stderr.write(
+      `${error instanceof Error ? error.message : "Invalid setup arguments"}\n`
+    );
+    process.exitCode = 2;
+    return;
+  }
 
   if (flags.nonInteractive) {
     await runNonInteractive(flags, options);
@@ -242,7 +222,7 @@ async function runNonInteractive(
 
   let projectDetail: ProjectDetail;
   try {
-    projectDetail = await resolveProjectDetail(client, flags.project);
+    projectDetail = await resolveProjectDetail(client);
   } catch (error) {
     process.stderr.write(
       `${error instanceof Error ? error.message : "Unknown error"}\n`
@@ -299,14 +279,9 @@ async function runNonInteractive(
     skipContext: flags.skipContext,
   });
 
-  const projectId = generateProjectId(projectDetail.title, projectDetail.id);
-  const workspaceDir = flags.workspaceDir ?? join(options.configDir, "workspaces");
-
-  await writeConfig(options.configDir, {
-    projectId,
-    project: projectDetail,
-    repos: projectDetail.linkedRepositories,
-    workspaceDir,
+  const runtime = await initRepoRuntime({
+    repoDir: process.cwd(),
+    workflowFile: workflowPath,
     assignedOnly: flags.assignedOnly,
   });
 
@@ -315,7 +290,8 @@ async function runNonInteractive(
       JSON.stringify({
         status: "created",
         output: workflowPath,
-        projectId,
+        runtimeDir: runtime.configDir,
+        repository: `${runtime.repository.owner}/${runtime.repository.name}`,
         githubProjectId: projectDetail.id,
       }) + "\n"
     );
@@ -323,17 +299,17 @@ async function runNonInteractive(
   }
 
   printNonInteractiveSummary({
-    projectId,
     githubProjectTitle: projectDetail.title,
     githubProjectId: projectDetail.id,
     workflowPath,
-    workspaceDir,
+    runtimeDir: runtime.configDir,
+    repository: `${runtime.repository.owner}/${runtime.repository.name}`,
   });
 }
 
 async function runInteractive(
   flags: SetupFlags,
-  options: GlobalOptions
+  _options: GlobalOptions
 ): Promise<void> {
   p.intro("gh-symphony — One-command Setup");
 
@@ -399,14 +375,6 @@ async function runInteractive(
     return;
   }
 
-  if (projectDetail.linkedRepositories.length === 0) {
-    p.log.error(
-      "No linked repositories found in this project. Add issues from repositories to the project first."
-    );
-    process.exitCode = 1;
-    return;
-  }
-
   const statusField = resolveStatusField(projectDetail);
   if (!statusField) {
     p.log.error(
@@ -464,20 +432,15 @@ async function runInteractive(
         })()
       : priorityResolution.field;
 
-  const {
-    assignedOnly: promptAssignedOnly,
-    selectedRepos,
-    workspaceDir,
-  } =
-    await promptProjectRegistrationOptions({
-      projectDetail,
-      defaultWorkspaceDir: flags.workspaceDir ?? join(options.configDir, "workspaces"),
-      assignedOnlyMessage:
+  const promptAssignedOnly = await abortIfCancelled(
+    p.confirm({
+      message:
         `${
           priorityResolution.ambiguous.length > 0 ? "Step 4/4" : "Step 3/3"
         } — Only process issues assigned to the authenticated GitHub user?`,
-      assignedOnlyInitialValue: flags.assignedOnly,
-    });
+      initialValue: flags.assignedOnly ?? false,
+    })
+  );
   const assignedOnly = flags.assignedOnly || promptAssignedOnly;
 
   const workflowPath = resolve(flags.output ?? "WORKFLOW.md");
@@ -493,16 +456,12 @@ async function runInteractive(
     skipContext: flags.skipContext,
   });
 
-  const projectId = generateProjectId(projectDetail.title, projectDetail.id);
   p.note(
     [
-      renderProjectRegistrationSummary({
-        login,
-        projectTitle: projectDetail.title,
-        repoSummary: formatRepoSummary(projectDetail, selectedRepos),
-        assignedOnly,
-        workspaceDir,
-      }),
+      `GitHub Project: ${projectDetail.title}`,
+      `Authenticated:  ${login}`,
+      `Repository:     current working directory`,
+      `Assigned:       ${assignedOnly ? `Only issues assigned to ${login}` : "All project issues"}`,
       "",
       renderDryRunPreview(workflowPath, workflowPlan, ecosystemPlan).trimEnd(),
     ].join("\n"),
@@ -533,14 +492,12 @@ async function runInteractive(
       skipSkills: flags.skipSkills,
       skipContext: flags.skipContext,
     });
-    await writeConfig(options.configDir, {
-      projectId,
-      project: projectDetail,
-      repos: selectedRepos,
-      workspaceDir,
+    const runtime = await initRepoRuntime({
+      repoDir: process.cwd(),
+      workflowFile: workflowPath,
       assignedOnly,
     });
-    writeSpinner.stop("Setup saved.");
+    writeSpinner.stop(`Setup saved for ${runtime.repository.owner}/${runtime.repository.name}.`);
   } catch (error) {
     writeSpinner.stop("Setup failed.");
     p.log.error(error instanceof Error ? error.message : "Unknown error");
@@ -549,6 +506,6 @@ async function runInteractive(
   }
 
   p.outro(
-    `Project "${projectId}" is ready.\n  Run 'gh-symphony start' to begin orchestration.`
+    "Repository runtime is ready.\n  Run 'gh-symphony repo start' to begin orchestration."
   );
 }

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -438,7 +438,7 @@ const handler = async (
   if (parsed.error) {
     process.stderr.write(`${parsed.error}\n`);
     process.stderr.write(
-      "Usage: gh-symphony start [--daemon] [--once] [--http [port]] [--web [port]]\n"
+      "Usage: gh-symphony repo start [--daemon] [--once] [--http [port]] [--web [port]]\n"
     );
     process.exitCode = 2;
     return;
@@ -818,6 +818,7 @@ async function startDaemon(
     process.execPath,
     [
       process.argv[1]!,
+      "repo",
       "start",
       ...(httpPort !== undefined ? ["--http", String(httpPort)] : []),
       ...(webPort !== undefined ? ["--web", String(webPort)] : []),

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -209,7 +209,7 @@ const handler = async (
   const parsed = parseStatusArgs(args);
   if (parsed.error) {
     process.stderr.write(`${parsed.error}\n`);
-    process.stderr.write("Usage: gh-symphony status [--watch]\n");
+    process.stderr.write("Usage: gh-symphony repo status [--watch]\n");
     process.exitCode = 2;
     return;
   }

--- a/packages/cli/src/commands/stop.ts
+++ b/packages/cli/src/commands/stop.ts
@@ -40,7 +40,7 @@ const handler = async (
   const parsed = parseStopArgs(args);
   if (parsed.error) {
     process.stderr.write(`${parsed.error}\n`);
-    process.stderr.write("Usage: gh-symphony stop [--force]\n");
+    process.stderr.write("Usage: gh-symphony repo stop [--force]\n");
     process.exitCode = 2;
     return;
   }

--- a/packages/cli/src/commands/workflow-init.ts
+++ b/packages/cli/src/commands/workflow-init.ts
@@ -1085,7 +1085,7 @@ async function runNonInteractive(
   } else {
     printEcosystemSummary(ecosystemResult, outputPath, {
       interactive: false,
-      nextSteps: "Run 'gh-symphony project add' to register a project.",
+      nextSteps: "Run 'gh-symphony repo init' from the target repository.",
     });
   }
 }
@@ -1261,7 +1261,7 @@ async function runInteractiveStandalone(
 
   printEcosystemSummary(ecosystemResult, outputPath, {
     interactive: true,
-    nextSteps: "Run 'gh-symphony project add' to register a project.",
+    nextSteps: "Run 'gh-symphony repo init' from the target repository.",
   });
 }
 

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -587,7 +587,7 @@ async function loadLiveIssue(
   const githubProjectId = readGitHubProjectBinding(selection.projectConfig);
   if (!githubProjectId) {
     throw new Error(
-      `Managed project "${selection.projectId}" is not bound to a GitHub Project. Re-run 'gh-symphony project add' and select a valid GitHub Project binding.`
+      `Managed project "${selection.projectId}" is not bound to a GitHub Project. Run 'gh-symphony workflow init' to select a valid GitHub Project binding, then run 'gh-symphony repo init'.`
     );
   }
 
@@ -629,7 +629,7 @@ async function loadLiveIssue(
 
   if (!findLinkedRepository(detail, issue.owner, issue.name)) {
     throw new Error(
-      `Repository ${issue.owner}/${issue.name} is not linked to the configured GitHub Project "${detail.title}". Run 'gh-symphony repo init' from the target repository or re-run 'gh-symphony project add' with the correct project binding.`
+      `Repository ${issue.owner}/${issue.name} is not linked to the configured GitHub Project "${detail.title}". Run 'gh-symphony setup' from inside the target repository, or run 'gh-symphony workflow init' followed by 'gh-symphony repo init'.`
     );
   }
 

--- a/packages/cli/src/completion.test.ts
+++ b/packages/cli/src/completion.test.ts
@@ -37,10 +37,10 @@ describe("completion renderer", () => {
     expect(output).toContain("workflow setup doctor upgrade");
     expect(output).not.toContain("upgrade start stop status");
     expect(output).toContain("workflow:init");
-    expect(output).toContain("project repo config completion");
+    expect(output).toContain("repo config completion");
     expect(output).toContain("setup)");
-    expect(output).toContain("project:add");
-    expect(output).toContain("repo:sync");
+    expect(output).toContain("repo:init");
+    expect(output).toContain("repo:explain");
   });
 
   it("renders zsh completion wrapper", () => {
@@ -55,7 +55,7 @@ describe("completion renderer", () => {
     expect(output).toContain("complete -c gh-symphony -f -l config");
     expect(output).toContain("complete -c gh-symphony -f -s v");
     expect(output).toContain("__fish_seen_subcommand_from workflow");
-    expect(output).toContain("__fish_seen_subcommand_from project");
+    expect(output).toContain("__fish_seen_subcommand_from repo");
     expect(output).toContain("__fish_seen_subcommand_from completion");
   });
 
@@ -66,16 +66,18 @@ describe("completion renderer", () => {
     );
   });
 
-  it("suggests project subcommands when completing the second token", () => {
-    const suggestions = runBashCompletion(["gh-symphony", "project", ""], 2);
+  it("suggests repo subcommands when completing the second token", () => {
+    const suggestions = runBashCompletion(["gh-symphony", "repo", ""], 2);
     expect(suggestions).toEqual(
       expect.arrayContaining([
-        "add",
-        "list",
-        "remove",
+        "init",
         "start",
-        "stop",
         "status",
+        "stop",
+        "run",
+        "recover",
+        "logs",
+        "explain",
       ])
     );
   });
@@ -86,7 +88,7 @@ describe("completion renderer", () => {
       3
     );
     expect(suggestions).toEqual(
-      expect.arrayContaining(["list", "add", "remove", "sync"])
+      expect.arrayContaining(["init", "start", "status", "run", "logs"])
     );
   });
 
@@ -97,7 +99,7 @@ describe("completion renderer", () => {
     );
     expect(suggestions).not.toEqual(expect.arrayContaining(["--dry-run"]));
     expect(suggestions).not.toEqual(expect.arrayContaining(["--prune"]));
-    expect(suggestions).toEqual(expect.arrayContaining(["--json"]));
+    expect(suggestions).toEqual([]);
   });
 
   it("suggests doctor smoke flags", () => {

--- a/packages/cli/src/completion.ts
+++ b/packages/cli/src/completion.ts
@@ -3,7 +3,6 @@ const TOP_LEVEL_COMMANDS = [
   "setup",
   "doctor",
   "upgrade",
-  "project",
   "repo",
   "config",
   "completion",
@@ -42,8 +41,6 @@ const COMMAND_OPTIONS: Record<string, readonly string[]> = {
   "workflow:preview": ["--file", "--sample", "--attempt", ...GLOBAL_OPTIONS],
   setup: [
     "--non-interactive",
-    "--project",
-    "--workspace-dir",
     "--assigned-only",
     "--output",
     "--skip-skills",
@@ -59,41 +56,15 @@ const COMMAND_OPTIONS: Record<string, readonly string[]> = {
     ...GLOBAL_OPTIONS,
   ],
   upgrade: [...GLOBAL_OPTIONS],
-  project: ["add", "list", "remove", "start", "stop", "switch", "status"],
-  "project:add": [
-    "--non-interactive",
-    "--project",
-    "--workspace-dir",
-    "--assigned-only",
-    ...GLOBAL_OPTIONS,
-  ],
-  "project:list": [...GLOBAL_OPTIONS],
-  "project:remove": [...GLOBAL_OPTIONS],
-  "project:start": [
-    "--project-id",
-    "--project",
-    "--daemon",
-    "-d",
-    ...GLOBAL_OPTIONS,
-  ],
-  "project:stop": ["--project-id", "--project", "--force", ...GLOBAL_OPTIONS],
-  "project:switch": [...GLOBAL_OPTIONS],
-  "project:status": [
-    "--project-id",
-    "--project",
-    "--watch",
-    "-w",
-    ...GLOBAL_OPTIONS,
-  ],
-  repo: ["init", "start", "status", "stop", "list", "add", "remove", "sync"],
+  repo: ["init", "start", "status", "stop", "run", "recover", "logs", "explain"],
   "repo:init": ["--repo-dir", "--workflow-file", ...GLOBAL_OPTIONS],
   "repo:start": ["--daemon", "-d", "--once", "--http", "--web", "--log-level", ...GLOBAL_OPTIONS],
   "repo:status": ["--watch", "-w", ...GLOBAL_OPTIONS],
   "repo:stop": ["--force", ...GLOBAL_OPTIONS],
-  "repo:list": [...GLOBAL_OPTIONS],
-  "repo:add": [...GLOBAL_OPTIONS],
-  "repo:remove": [...GLOBAL_OPTIONS],
-  "repo:sync": [...GLOBAL_OPTIONS],
+  "repo:run": ["--watch", ...GLOBAL_OPTIONS],
+  "repo:recover": ["--dry-run", ...GLOBAL_OPTIONS],
+  "repo:logs": ["--follow", "-f", "--issue", "--run", "--level", ...GLOBAL_OPTIONS],
+  "repo:explain": ["--json", "--workflow", ...GLOBAL_OPTIONS],
   config: ["show", "set", "edit"],
   "config:show": [...GLOBAL_OPTIONS],
   "config:set": [...GLOBAL_OPTIONS],
@@ -114,7 +85,6 @@ function renderBashCasePatterns(): string {
         }
         if (
           command === "workflow" ||
-          command === "project" ||
           command === "repo" ||
           command === "config"
         ) {
@@ -138,12 +108,6 @@ function renderFishLines(): string {
   for (const command of TOP_LEVEL_COMMANDS) {
     lines.push(
       `complete -c gh-symphony -f -n '__fish_use_subcommand' -a '${command}'`
-    );
-  }
-
-  for (const subcommand of COMMAND_OPTIONS.project ?? []) {
-    lines.push(
-      `complete -c gh-symphony -f -n '__fish_seen_subcommand_from project' -a '${subcommand}'`
     );
   }
 
@@ -236,7 +200,7 @@ _gh_symphony_completion() {
     return
   fi
 
-  if [[ "\${path}" == "workflow" || "\${path}" == "project" || "\${path}" == "repo" || "\${path}" == "config" || "\${path}" == "completion" ]]; then
+  if [[ "\${path}" == "workflow" || "\${path}" == "repo" || "\${path}" == "config" || "\${path}" == "completion" ]]; then
     if [[ -n "\${GH_SYMPHONY_SUBCOMMAND}" ]]; then
       path="\${path}:\${GH_SYMPHONY_SUBCOMMAND}"
     fi

--- a/packages/cli/src/config.test.ts
+++ b/packages/cli/src/config.test.ts
@@ -1,0 +1,65 @@
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  DEFAULT_CONFIG_DIR,
+  REPO_RUNTIME_DIR,
+  resolveConfigDir,
+} from "./config.js";
+
+const originalCwd = process.cwd();
+const originalConfigDir = process.env.GH_SYMPHONY_CONFIG_DIR;
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  if (originalConfigDir === undefined) {
+    delete process.env.GH_SYMPHONY_CONFIG_DIR;
+  } else {
+    process.env.GH_SYMPHONY_CONFIG_DIR = originalConfigDir;
+  }
+});
+
+describe("resolveConfigDir", () => {
+  it("prefers an explicit override", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "cli-config-cwd-"));
+    const override = await mkdtemp(join(tmpdir(), "cli-config-override-"));
+    const envDir = await mkdtemp(join(tmpdir(), "cli-config-env-"));
+    process.chdir(cwd);
+    process.env.GH_SYMPHONY_CONFIG_DIR = envDir;
+
+    expect(resolveConfigDir(override)).toBe(override);
+  });
+
+  it("prefers GH_SYMPHONY_CONFIG_DIR over cwd runtime discovery", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "cli-config-cwd-"));
+    const envDir = await mkdtemp(join(tmpdir(), "cli-config-env-"));
+    const runtimeDir = join(cwd, REPO_RUNTIME_DIR);
+    await mkdir(runtimeDir, { recursive: true });
+    await writeFile(join(runtimeDir, "config.json"), "{}\n", "utf8");
+    process.chdir(cwd);
+    process.env.GH_SYMPHONY_CONFIG_DIR = envDir;
+
+    expect(resolveConfigDir()).toBe(envDir);
+  });
+
+  it("uses an initialized cwd repository runtime when no override is set", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "cli-config-cwd-"));
+    const runtimeDir = join(cwd, REPO_RUNTIME_DIR);
+    await mkdir(runtimeDir, { recursive: true });
+    await writeFile(join(runtimeDir, "config.json"), "{}\n", "utf8");
+    process.chdir(cwd);
+    delete process.env.GH_SYMPHONY_CONFIG_DIR;
+
+    expect(resolveConfigDir()).toBe(runtimeDir);
+  });
+
+  it("falls back to the home config when cwd runtime is not initialized", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "cli-config-cwd-"));
+    await mkdir(join(cwd, REPO_RUNTIME_DIR), { recursive: true });
+    process.chdir(cwd);
+    delete process.env.GH_SYMPHONY_CONFIG_DIR;
+
+    expect(resolveConfigDir()).toBe(DEFAULT_CONFIG_DIR);
+  });
+});

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1,5 +1,6 @@
+import { existsSync } from "node:fs";
 import { readFile, writeFile, mkdir } from "node:fs/promises";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { homedir } from "node:os";
 import type {
   OrchestratorProjectConfig,
@@ -11,6 +12,7 @@ export const CONFIG_FILE = "config.json";
 export const DAEMON_PID_FILE = "daemon.pid";
 export const ORCHESTRATOR_LOG_FILE = "orchestrator.log";
 export const HTTP_STATUS_FILE = "http.json";
+export const REPO_RUNTIME_DIR = join(".runtime", "orchestrator");
 
 export type CliGlobalConfig = {
   activeProject: string | null;
@@ -43,7 +45,19 @@ export type StateRole = "active" | "wait" | "terminal";
 export type StateMapping = { role: StateRole; goal?: string };
 
 export function resolveConfigDir(override?: string): string {
-  return override ?? process.env.GH_SYMPHONY_CONFIG_DIR ?? DEFAULT_CONFIG_DIR;
+  if (override) {
+    return override;
+  }
+  if (process.env.GH_SYMPHONY_CONFIG_DIR) {
+    return process.env.GH_SYMPHONY_CONFIG_DIR;
+  }
+
+  const repoRuntimeDir = resolve(process.cwd(), REPO_RUNTIME_DIR);
+  if (existsSync(configFilePath(repoRuntimeDir))) {
+    return repoRuntimeDir;
+  }
+
+  return DEFAULT_CONFIG_DIR;
 }
 
 export function configFilePath(configDir: string): string {

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -131,7 +131,7 @@ describe("Commander CLI entrypoint", () => {
 
     const output = stdout.output();
     expect(output).toContain("complete -F _gh_symphony_completion gh-symphony");
-    expect(output).toContain("workflow setup doctor upgrade project repo");
+    expect(output).toContain("workflow setup doctor upgrade repo");
   });
 
   it.each([

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -62,7 +62,6 @@ type CliOptionValues = Partial<
     repoDir?: string;
     workflowFile?: string;
     workflow?: string;
-    workspaceDir?: string;
     watch?: boolean;
     sample?: string;
     smoke?: boolean;
@@ -307,8 +306,6 @@ function createProgram(): { program: Command; wasInvoked: () => boolean } {
       .command("setup")
       .description("Run the one-command first-run setup flow")
       .option("--non-interactive", "Run without prompts")
-      .option("--project <id>", "GitHub Project ID or URL")
-      .option("--workspace-dir <path>", "Workspace directory")
       .option("--assigned-only", "Limit processing to assigned issues")
       .option("--output <path>", "Write WORKFLOW.md to a custom path")
       .option("--skip-skills", "Skip runtime skill generation")
@@ -319,8 +316,6 @@ function createProgram(): { program: Command; wasInvoked: () => boolean } {
     const values = this.optsWithGlobals<CliOptionValues>();
     const args: string[] = [];
     pushOption(args, "--non-interactive", values.nonInteractive);
-    pushOption(args, "--project", values.project);
-    pushOption(args, "--workspace-dir", values.workspaceDir);
     pushOption(args, "--assigned-only", values.assignedOnly);
     pushOption(args, "--output", values.output);
     pushOption(args, "--skip-skills", values.skipSkills);

--- a/packages/cli/src/orchestrator-runtime.ts
+++ b/packages/cli/src/orchestrator-runtime.ts
@@ -1,9 +1,10 @@
 import { resolve } from "node:path";
+import { REPO_RUNTIME_DIR } from "./config.js";
 
 export function resolveRuntimeRoot(configDir: string): string {
   return resolve(configDir);
 }
 
 export function resolveRepoRuntimeRoot(repoDir = process.cwd()): string {
-  return resolve(repoDir, ".runtime", "orchestrator");
+  return resolve(repoDir, REPO_RUNTIME_DIR);
 }

--- a/packages/cli/src/project-selection.test.ts
+++ b/packages/cli/src/project-selection.test.ts
@@ -98,7 +98,7 @@ describe("resolveManagedProjectConfig", () => {
 
     expect(project).toBeNull();
     expect(stderr.mock.calls.map((call) => String(call[0])).join("")).toContain(
-      "Multiple projects are configured. Re-run with --project-id in non-interactive environments."
+      "Multiple repository runtime configs are present. Run 'gh-symphony repo init' from the target repository to refresh the cwd runtime."
     );
     expect(process.exitCode).toBe(1);
   });
@@ -160,7 +160,7 @@ describe("inspectManagedProjectSelection", () => {
     expect(result).toMatchObject({
       kind: "multiple_projects_require_selection",
       message:
-        "Multiple projects are configured. Re-run with --project-id in non-interactive environments.",
+        "Multiple repository runtime configs are present. Run 'gh-symphony repo init' from the target repository to refresh the cwd runtime.",
     });
   });
 

--- a/packages/cli/src/project-selection.ts
+++ b/packages/cli/src/project-selection.ts
@@ -33,7 +33,7 @@ function isInteractiveTerminal(): boolean {
 }
 
 function explicitProjectRequiredMessage(): string {
-  return "Multiple projects are configured. Re-run with --project-id in non-interactive environments.\n";
+  return "Multiple repository runtime configs are present. Run 'gh-symphony repo init' from the target repository to refresh the cwd runtime.\n";
 }
 
 export async function inspectManagedProjectSelection(
@@ -48,7 +48,7 @@ export async function inspectManagedProjectSelection(
       return {
         kind: "requested_project_missing",
         projectId: input.requestedProjectId,
-        message: `Project "${input.requestedProjectId}" is not configured. Run 'gh-symphony project add' or choose an existing project.`,
+        message: `Project "${input.requestedProjectId}" is not configured. Run 'gh-symphony repo init' from the target repository.`,
       };
     }
 
@@ -63,7 +63,7 @@ export async function inspectManagedProjectSelection(
   if (!global) {
     return {
       kind: "missing_global_config",
-      message: "No CLI configuration found. Run 'gh-symphony project add' first.",
+      message: "No repository runtime config found. Run 'gh-symphony repo init' first.",
     };
   }
 
@@ -71,7 +71,7 @@ export async function inspectManagedProjectSelection(
   if (projectIds.length === 0) {
     return {
       kind: "no_projects",
-      message: "No managed projects are configured. Run 'gh-symphony project add' first.",
+      message: "No repository runtime config is configured. Run 'gh-symphony repo init' first.",
     };
   }
 
@@ -91,7 +91,7 @@ export async function inspectManagedProjectSelection(
       return {
         kind: "active_project_missing",
         projectId: global.activeProject,
-        message: `Active project "${global.activeProject}" is configured in config.json but its project config is missing. Re-run 'gh-symphony project add' or 'gh-symphony project switch'.`,
+        message: `Active project "${global.activeProject}" is configured in config.json but its project config is missing. Re-run 'gh-symphony repo init'.`,
       };
     }
 
@@ -109,7 +109,7 @@ export async function inspectManagedProjectSelection(
       return {
         kind: "configured_project_missing",
         projectId,
-        message: `Configured project "${projectId}" is missing its project config file. Re-run 'gh-symphony project add'.`,
+        message: `Configured project "${projectId}" is missing its project config file. Re-run 'gh-symphony repo init'.`,
       };
     }
 
@@ -123,7 +123,7 @@ export async function inspectManagedProjectSelection(
   return {
     kind: "multiple_projects_require_selection",
     message:
-      "Multiple projects are configured and no active project is set. Run 'gh-symphony project switch' or re-run with --project-id.",
+      "Multiple repository runtime configs are present and no active project is set. Re-run 'gh-symphony repo init' from the target repository.",
   };
 }
 
@@ -188,7 +188,7 @@ export function handleMissingManagedProjectConfig(): void {
   }
 
   process.stderr.write(
-    "No project configured. Run 'gh-symphony project add' first.\n"
+    "No repository runtime config found. Run 'gh-symphony repo init' first.\n"
   );
   process.exitCode = 1;
 }

--- a/packages/cli/src/repo-runtime.ts
+++ b/packages/cli/src/repo-runtime.ts
@@ -24,6 +24,7 @@ import { resolveRepoRuntimeRoot } from "./orchestrator-runtime.js";
 export type RepoInitFlags = {
   repoDir: string;
   workflowFile?: string;
+  assignedOnly?: boolean;
 };
 
 const INTERNAL_PROJECT_ID = "repository";
@@ -76,12 +77,15 @@ export async function initRepoRuntime(flags: RepoInitFlags): Promise<{
   const trackerAdapter = workflow.tracker.kind ?? "github-project";
   const trackerBindingId =
     workflow.tracker.projectId ?? workflow.tracker.projectSlug ?? "";
-  const trackerSettings: Record<string, string> = {
+  const trackerSettings: Record<string, string | boolean> = {
     ...(workflow.tracker.projectId
       ? { projectId: workflow.tracker.projectId }
       : {}),
     repository: `${repository.owner}/${repository.name}`,
   };
+  if (flags.assignedOnly) {
+    trackerSettings.assignedOnly = true;
+  }
   if (trackerAdapter === "file") {
     if (!process.env.GH_SYMPHONY_FILE_TRACKER_ISSUES_PATH) {
       throw new Error(

--- a/packages/orchestrator/src/explain.ts
+++ b/packages/orchestrator/src/explain.ts
@@ -199,7 +199,7 @@ function explainRepositoryLinked(
       id: "repository_linked",
       status: "warn",
       message: "No repository is configured for the active managed project.",
-      hint: "Run 'gh-symphony repo add <owner/name>' or re-run 'gh-symphony project add'.",
+      hint: "Run 'gh-symphony repo init' from the target repository.",
     };
   }
 
@@ -215,7 +215,7 @@ function explainRepositoryLinked(
     details: { configuredRepository: configured, issueRepository: repository },
     hint: linked
       ? undefined
-      : "Run 'gh-symphony repo add <owner/name>' or select the correct project with 'gh-symphony project switch'.",
+      : "Run 'gh-symphony repo init' from the repository that owns this issue.",
   };
 }
 
@@ -232,7 +232,7 @@ function explainProjectItemPresent(
     details: issue ? { itemId: issue.tracker.itemId } : undefined,
     hint: issue
       ? undefined
-      : "Add the issue to the GitHub Project or run 'gh-symphony project status' to confirm the active project.",
+      : "Add the issue to the GitHub Project or run 'gh-symphony repo status' to confirm the repository runtime.",
   };
 }
 
@@ -322,7 +322,7 @@ function explainRuntimeOwnership(
         retryKind: activeRun.retryKind,
         nextRetryAt: activeRun.nextRetryAt,
       },
-      hint: "Run 'gh-symphony status' or 'gh-symphony logs --issue <owner/repo#number>' to inspect the current owner.",
+      hint: "Run 'gh-symphony repo status' or 'gh-symphony repo logs --issue <owner/repo#number>' to inspect the current owner.",
     };
   }
 
@@ -336,7 +336,7 @@ function explainRuntimeOwnership(
         currentRunId: record.currentRunId,
         retryEntry: record.retryEntry,
       },
-      hint: "Run 'gh-symphony status' to inspect active and retrying work.",
+      hint: "Run 'gh-symphony repo status' to inspect active and retrying work.",
     };
   }
 


### PR DESCRIPTION
## Issues

- Fixes #293

## Summary

- Makes `gh-symphony setup` cwd-driven by removing `--project` and `--workspace-dir` from setup registration and wiring setup completion through `repo init`.
- Sweeps CLI docs, remediation hints, completion output, and usage strings to the repo-centric command surface.
- Fixes repo-centric follow-through issues: default config discovery now prefers initialized cwd runtimes, and `doctor --fix` uses `workflow init` for missing/invalid `WORKFLOW.md` remediation.
- Adds the major changeset for the v1 CLI restructure.

## Changes

- Setup now generates workflow artifacts and initializes `.runtime/orchestrator/` for the current repository instead of writing managed-project config under the global config dir.
- Default config resolution now preserves explicit `--config` and `GH_SYMPHONY_CONFIG_DIR`, then uses `<cwd>/.runtime/orchestrator` when it contains `config.json`, then falls back to `~/.gh-symphony`.
- `--config` help and CLI README text now match the initialized-cwd-runtime fallback behavior, and setup unknown-flag errors call out removed project/workspace flags plus supported setup flags.
- `doctor --fix` now reports/spawns `gh-symphony --config <dir> workflow init` for `workflow_file` remediation instead of the removed top-level `init` command.
- README, CLI README, control-plane docs, doctor/workflow/explain hints, completions, and tests now reference `repo ...` and `workflow init` commands.

## Evidence

- `pnpm --filter @gh-symphony/cli test -- doctor`
- New TC: missing `WORKFLOW.md` with `doctor --fix --json` reports `gh-symphony --config <dir> workflow init` for `workflow_file` remediation.
- `pnpm --filter @gh-symphony/cli test -- help -u`
- `pnpm --filter @gh-symphony/cli test -- config setup doctor workflow index`
- Scratch repo TC with file-tracker `WORKFLOW.md`: `repo init` then plain `doctor --json` with `GH_SYMPHONY_CONFIG_DIR` unset resolved `<repo>/.runtime/orchestrator` and passed `managed_project`.
- `pnpm lint && pnpm test && pnpm typecheck && pnpm build`
- `env -u GH_SYMPHONY_CONFIG_DIR pnpm e2e:init`
- `env -u GH_SYMPHONY_CONFIG_DIR bash e2e/run-e2e.sh happy 45`
- Prior validation retained: `node packages/cli/dist/index.js setup --project PVT_xxx` exits with `error: unknown option '--project'`; local cloned E2E repo `repo start --daemon` -> `repo status --json` -> `repo run test-owner/test-repo#1` -> `repo logs` -> `repo stop`.

## Human Validation

- [ ] Confirm `gh-symphony setup` from a cloned GitHub repository writes `WORKFLOW.md` and `.runtime/orchestrator/`.
- [ ] Confirm plain `gh-symphony doctor` after `repo init` uses the cwd runtime unless `--config` or `GH_SYMPHONY_CONFIG_DIR` is set.
- [ ] Confirm `doctor --fix` regenerates a missing/invalid `WORKFLOW.md` through `workflow init`.
- [ ] Confirm removed command examples no longer appear in the public README/CLI README flows.
- [ ] Confirm `repo start --daemon` can be stopped with `repo stop` in a real repository.

## Risks

- `GH_SYMPHONY_CONFIG_DIR` intentionally remains higher precedence than cwd runtime discovery, so users or automation with that env var set must unset it or pass `--config` to exercise repo-local defaults.
- `setup --non-interactive` can only auto-select when exactly one GitHub Project is visible; explicit multi-project selection remains available through `workflow init --project ...` followed by `repo init`.