### PR TITLE
fix(workflow): remove legacy-incompatible PR context

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -46,31 +46,8 @@ You are an AI coding agent working on issue {{issue.identifier}}: "{{issue.title
 
 **Repository:** {{issue.repository}}
 **Current state:** {{issue.state}}
-**Subject type:** {{pull_request_context.subject_type}}
 
-{% if pull_request_context.review_first %}
-
-### Pull Request Context
-
-- Primary PR: {{pull_request_context.primary_pull_request.identifier}}
-- PR URL: {{pull_request_context.primary_pull_request.url}}
-- Head branch: {% if pull_request_context.primary_pull_request.headRefName == null %}unknown{% else %}{{pull_request_context.primary_pull_request.headRefName}}{% endif %}
-- Base branch: {% if pull_request_context.primary_pull_request.baseRefName == null %}unknown{% else %}{{pull_request_context.primary_pull_request.baseRefName}}{% endif %}
-- PR status: {% if pull_request_context.primary_pull_request.state == null %}unknown{% else %}{{pull_request_context.primary_pull_request.state}}{% endif %}
-- Draft: {% if pull_request_context.primary_pull_request.isDraft == null %}unknown{% else %}{{pull_request_context.primary_pull_request.isDraft}}{% endif %}
-- Merged: {% if pull_request_context.primary_pull_request.merged == null %}unknown{% else %}{{pull_request_context.primary_pull_request.merged}}{% endif %}
-- Checkout branch: {% if pull_request_context.checkout_branch == null %}unknown{% else %}{{pull_request_context.checkout_branch}}{% endif %}
-{% if pull_request_context.linked_pull_requests.size > 0 -%}
-- Linked PRs:
-{%- for pr in pull_request_context.linked_pull_requests %}
-  - {{pr.identifier}} — {{pr.url}} — head: {% if pr.headRefName == null %}unknown{% else %}{{pr.headRefName}}{% endif %} — base: {% if pr.baseRefName == null %}unknown{% else %}{{pr.baseRefName}}{% endif %} — status: {% if pr.state == null %}unknown{% else %}{{pr.state}}{% endif %} — draft: {% if pr.isDraft == null %}unknown{% else %}{{pr.isDraft}}{% endif %} — merged: {% if pr.merged == null %}unknown{% else %}{{pr.merged}}{% endif %}
-{%- endfor %}
-{% else -%}
-- Linked PRs: none
-{% endif %}
-
-Before changing code, inspect review comments, failing checks, and unresolved review threads for the primary PR and linked PRs. If this is an Issue with a linked PR, do not create a new branch; checkout and update the existing PR head branch. If this is a PR-only item, perform the rework on the PR branch.
-{% endif %}
+> Temporary compatibility note: this workflow intentionally avoids `pull_request_context` template variables so older installed `gh-symphony` daemons can render prompts until the runtime is upgraded.
 
 ### Task
 
@@ -87,7 +64,7 @@ Before changing code, inspect review comments, failing checks, and unresolved re
 7. Keep code, commands, identifiers, and raw tool output in their original form when translating reports.
 8. **Whenever you transition the issue to a different state, post a comment on the issue** in the report language explaining the transition: what state it is moving to, why, and what was decided or completed. This is mandatory for every state change — do not transition silently.
 9. If the issue re-enters `Ready` or `In progress` while a PR already exists, treat that as a **new work cycle**: inspect the PR's main merge blockers first, then create a new workpad comment with the revised plan before making code changes. Within the same work cycle, always update the existing workpad comment in place instead of creating additional ones.
-10. If the current subject is an Issue and `Pull Request Context` is present, treat the Issue as the canonical project item and treat any PR card as context only.
+10. Treat Issue cards as the canonical project item for planning and state transitions. If an issue already has an open PR, inspect it from the issue timeline or GitHub links before deciding whether to create a new branch.
 
 ### Workflow
 
@@ -112,7 +89,7 @@ Before changing code, inspect review comments, failing checks, and unresolved re
 5. Treat the issue as too large in scope if it would likely require changes to more than 20 files or more than 3 packages.
 6. If the issue is actionable and a PR already exists, inspect the PR review timeline, failing checks, and unresolved comments to identify the major merge blockers before touching the code.
 7. If Step 6 applies, this is a new work cycle — create a new workpad comment in the report language that records the re-entry trigger, the major merge blockers, and the revised implementation plan.
-8. If the issue is actionable and Step 7 did not apply, create or continue the workpad, create a branch if needed, post a comment indicating that triage passed and implementation is starting, and continue to Step 2. If `Pull Request Context` is present, do not create a branch; checkout the existing PR head branch instead.
+8. If the issue is actionable and Step 7 did not apply, create or continue the workpad, create a branch if needed, post a comment indicating that triage passed and implementation is starting, and continue to Step 2. If an existing PR is discovered from the issue timeline, prefer checking out and updating that PR head branch instead of creating a duplicate branch.
 
 #### Step 2: Execution phase
 


### PR DESCRIPTION
## Summary
- Temporarily removes `pull_request_context` Liquid variable usage from the root `WORKFLOW.md` prompt.
- Keeps issue/PR workflow guidance in plain text so older installed `gh-symphony` daemons can render prompts without `template_render_error`.
- Leaves the longer-term runtime upgrade path untouched; this is a compatibility guard for the current production daemon.

## Context
Current deployed daemon reports:

```text
template_render_error: undefined variable: pull_request_context, line:15, col:21
```

The installed daemon is `gh-symphony v0.0.20`, while the latest workflow prompt expects PR context variables introduced later. This blocks dispatch for Ready issues, including #298.

## Layer Assessment
- Affects: Policy Layer / Configuration Layer (`WORKFLOW.md` prompt policy and runtime config surface).
- Does not edit `docs/symphony-spec.md`.
- No intentional divergence from the upstream Symphony spec; this is a repository-local compatibility rollback of prompt variables.

## Validation
- [x] `gh-symphony workflow preview --file WORKFLOW.md --json` renders successfully with the installed legacy CLI.
- [x] `gh-symphony workflow validate --file WORKFLOW.md` passes.
- [x] `pnpm test` passes after refreshing dependencies with `pnpm install --frozen-lockfile`.

## Notes
- The first `pnpm test` attempt failed because local dependencies were stale after fast-forwarding `main` (`react/jsx-dev-runtime` missing). Running `pnpm install --frozen-lockfile` restored the expected workspace dependencies; no lockfile changes were made.
