### PR TITLE
test: cover project PR dry-run orchestration

### DIFF
--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -3024,10 +3024,15 @@ Prefer focused changes.
 
     const first = await service.runOnce();
     const second = await service.runOnce();
+    const workerEnv = spawnImpl.mock.calls[0]?.[2]?.env as
+      | Record<string, string>
+      | undefined;
 
     expect(first.summary.dispatched).toBe(1);
     expect(second.summary.dispatched).toBe(0);
     expect(spawnImpl).toHaveBeenCalledTimes(1);
+    expect(workerEnv?.SYMPHONY_ISSUE_SUBJECT_ID).toBe("issue-1");
+    expect(workerEnv?.SYMPHONY_ISSUE_IDENTIFIER).toBe("acme/platform#1");
   });
 
   it("dispatches only the issue when linked Ready issue and pull request Project items both exist", async () => {
@@ -3106,7 +3111,7 @@ Prefer focused changes.
       fetchImpl: vi.fn().mockResolvedValue(
         createTrackerResponseWithLinkedIssueAndPullRequest(repository, {
           issueState: "In review",
-          pullRequestState: "Todo",
+          pullRequestState: "Ready",
         })
       ),
       spawnImpl: spawnImpl as never,
@@ -3354,7 +3359,7 @@ Prefer focused changes.
       fetchImpl: vi.fn().mockResolvedValue(
         createTrackerResponseWithLinkedIssueAndPullRequest(repository, {
           issueState: "Done",
-          pullRequestState: "Todo",
+          pullRequestState: "Ready",
         })
       ),
       spawnImpl: spawnImpl as never,
@@ -8755,6 +8760,8 @@ tracker:
     - Done
   blocker_check_states:
     - Ready
+hooks:
+  commands: []
 polling:
   interval_ms: 30000
 workspace:

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -2993,7 +2993,44 @@ Prefer focused changes.
     expect(spawnImpl).not.toHaveBeenCalled();
   });
 
-  it("dispatches only the issue when a linked issue and pull request are both active project items", async () => {
+  it("dispatches a single Ready issue-only Project item once", async () => {
+    process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
+    const tempRoot = await mkdtemp(
+      join(tmpdir(), "orchestrator-ready-issue-only-")
+    );
+    const repository = await createRepositoryFixture(
+      tempRoot,
+      "acme",
+      "platform",
+      {
+        rawWorkflow: createReadyStateWorkflow(),
+      }
+    );
+    const store = new OrchestratorFsStore(tempRoot);
+    const projectConfig = createProjectConfig(tempRoot, repository);
+    await store.saveProjectConfig(projectConfig);
+
+    const spawnImpl = vi.fn().mockReturnValue({
+      pid: 4306,
+      unref: vi.fn(),
+    });
+    const service = new OrchestratorService(store, projectConfig, {
+      fetchImpl: vi
+        .fn()
+        .mockResolvedValue(createTrackerResponseWithState(repository, "Ready")),
+      spawnImpl: spawnImpl as never,
+      now: () => new Date("2026-03-08T00:00:00.000Z"),
+    });
+
+    const first = await service.runOnce();
+    const second = await service.runOnce();
+
+    expect(first.summary.dispatched).toBe(1);
+    expect(second.summary.dispatched).toBe(0);
+    expect(spawnImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("dispatches only the issue when linked Ready issue and pull request Project items both exist", async () => {
     process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
     const tempRoot = await mkdtemp(
       join(tmpdir(), "orchestrator-canonical-issue-pr-")
@@ -3003,31 +3040,9 @@ Prefer focused changes.
       "acme",
       "platform",
       {
-        rawWorkflow: `---
-tracker:
-  kind: github-project
-  project_id: project-123
-  state_field: Status
-  active_states:
-    - Todo
-  terminal_states:
-    - Done
-  blocker_check_states:
-    - Todo
-agent:
-  max_concurrent_agents: 10
-polling:
-  interval_ms: 30000
-workspace:
-  root: .runtime/symphony-workspaces
-codex:
-  command: codex app-server
-  read_timeout_ms: 5000
-  stall_timeout_ms: 300000
-  turn_timeout_ms: 3600000
----
-linked={% for pr in issue.linked_pull_requests %}{{ pr.identifier }}:{{ pr.projectState }}{% endfor %}
-`,
+        rawWorkflow: createReadyStateWorkflow(
+          "linked={% for pr in issue.linked_pull_requests %}{{ pr.identifier }}:{{ pr.projectState }}{% endfor %}\n"
+        ),
       }
     );
     const store = new OrchestratorFsStore(tempRoot);
@@ -3042,8 +3057,8 @@ linked={% for pr in issue.linked_pull_requests %}{{ pr.identifier }}:{{ pr.proje
     const service = new OrchestratorService(store, projectConfig, {
       fetchImpl: vi.fn().mockResolvedValue(
         createTrackerResponseWithLinkedIssueAndPullRequest(repository, {
-          issueState: "Todo",
-          pullRequestState: "Todo",
+          issueState: "Ready",
+          pullRequestState: "Ready",
         })
       ),
       spawnImpl: spawnImpl as never,
@@ -3059,7 +3074,7 @@ linked={% for pr in issue.linked_pull_requests %}{{ pr.identifier }}:{{ pr.proje
     expect(spawnImpl).toHaveBeenCalledTimes(1);
     expect(workerEnv?.SYMPHONY_ISSUE_SUBJECT_ID).toBe("issue-1");
     expect(workerEnv?.SYMPHONY_RENDERED_PROMPT).toContain(
-      "linked=acme/platform#2:Todo"
+      "linked=acme/platform#2:Ready"
     );
     expect(
       execSync(
@@ -3104,7 +3119,7 @@ linked={% for pr in issue.linked_pull_requests %}{{ pr.identifier }}:{{ pr.proje
     expect(spawnImpl).not.toHaveBeenCalled();
   });
 
-  it("dispatches a standalone ready pull request subject", async () => {
+  it("dispatches a standalone Ready pull request subject", async () => {
     process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
     const tempRoot = await mkdtemp(
       join(tmpdir(), "orchestrator-canonical-pr-standalone-")
@@ -3112,7 +3127,10 @@ linked={% for pr in issue.linked_pull_requests %}{{ pr.identifier }}:{{ pr.proje
     const repository = await createRepositoryFixture(
       tempRoot,
       "acme",
-      "platform"
+      "platform",
+      {
+        rawWorkflow: createReadyStateWorkflow(),
+      }
     );
     const store = new OrchestratorFsStore(tempRoot);
     const projectConfig = createProjectConfig(tempRoot, repository);
@@ -3127,7 +3145,7 @@ linked={% for pr in issue.linked_pull_requests %}{{ pr.identifier }}:{{ pr.proje
       fetchImpl: vi
         .fn()
         .mockResolvedValue(
-          createTrackerResponseWithPullRequestOnly(repository, "Todo")
+          createTrackerResponseWithPullRequestOnly(repository, "Ready")
         ),
       spawnImpl: spawnImpl as never,
       now: () => new Date("2026-03-08T00:00:00.000Z"),
@@ -8723,6 +8741,33 @@ codex:
 Prefer focused changes.
 `;
   await writeFile(join(repositoryRoot, "WORKFLOW.md"), content, "utf8");
+}
+
+function createReadyStateWorkflow(prompt = "{{ issue.title }}\n"): string {
+  return `---
+tracker:
+  kind: github-project
+  project_id: project-123
+  state_field: Status
+  active_states:
+    - Ready
+  terminal_states:
+    - Done
+  blocker_check_states:
+    - Ready
+polling:
+  interval_ms: 30000
+workspace:
+  root: .runtime/symphony-workspaces
+agent:
+  max_concurrent_agents: 10
+codex:
+  command: codex app-server
+  read_timeout_ms: 5000
+  stall_timeout_ms: 300000
+  turn_timeout_ms: 3600000
+---
+${prompt}`;
 }
 
 function createTrackerResponse(repository: {

--- a/packages/tracker-github/src/tracker-github.test.ts
+++ b/packages/tracker-github/src/tracker-github.test.ts
@@ -265,6 +265,41 @@ describe("resolveTrackerAdapter", () => {
     });
   });
 
+  it("preserves fork head repository metadata when normalizing PullRequest Project items", () => {
+    const issue = normalizeGithubProjectItem(
+      "project-123",
+      makePullRequestProjectItem({
+        itemId: "item-pr-8",
+        pullRequestId: "pr-8",
+        number: 8,
+        title: "Validate fork PR metadata",
+        state: "Ready",
+        headRepository: {
+          name: "platform-fork",
+          url: "https://github.com/contributor/platform-fork",
+          owner: { login: "contributor" },
+        },
+      }),
+      DEFAULT_WORKFLOW_LIFECYCLE
+    );
+
+    expect(issue?.metadata.pullRequest).toMatchObject({
+      id: "pr-8",
+      identifier: "acme/platform#8",
+      headRefName: "feature/pr-metadata",
+      headRepository: {
+        owner: "contributor",
+        name: "platform-fork",
+        url: "https://github.com/contributor/platform-fork",
+        cloneUrl: "https://github.com/contributor/platform-fork.git",
+      },
+      repository: {
+        owner: "acme",
+        name: "platform",
+      },
+    });
+  });
+
   it("attaches Issue linked pull request metadata from closedByPullRequestsReferences", () => {
     const issue = normalizeGithubProjectItem(
       "project-123",
@@ -2981,6 +3016,11 @@ function makePullRequestProjectItem(input: {
   number: number;
   title: string;
   state?: string;
+  headRepository?: {
+    name: string;
+    url: string;
+    owner: { login: string };
+  } | null;
 }) {
   return {
     id: input.itemId,
@@ -3006,11 +3046,14 @@ function makePullRequestProjectItem(input: {
       merged: false,
       headRefName: "feature/pr-metadata",
       baseRefName: "main",
-      headRepository: {
-        name: "platform",
-        url: "https://github.com/acme/platform",
-        owner: { login: "acme" },
-      },
+      headRepository:
+        input.headRepository === undefined
+          ? {
+              name: "platform",
+              url: "https://github.com/acme/platform",
+              owner: { login: "acme" },
+            }
+          : input.headRepository,
       repository: {
         name: "platform",
         url: "https://github.com/acme/platform",

--- a/packages/tracker-github/src/tracker-github.test.ts
+++ b/packages/tracker-github/src/tracker-github.test.ts
@@ -266,6 +266,7 @@ describe("resolveTrackerAdapter", () => {
   });
 
   it("preserves fork head repository metadata when normalizing PullRequest Project items", () => {
+    // Checkout safety for fork PR subjects is enforced at the orchestrator layer.
     const issue = normalizeGithubProjectItem(
       "project-123",
       makePullRequestProjectItem({


### PR DESCRIPTION
## Issues

- Fixes #281

## Summary

- Added and tightened Ready-state orchestration fixtures for issue-only, PR-only, and linked issue+PR Project items.
- Addressed review nits by strengthening issue-only worker env assertions, aligning workflow fixture shape, and documenting fork PR normalize/orchestrator responsibility boundaries.

## Changes

- `packages/orchestrator/src/service.test.ts` validates Ready issue-only dispatch identity, Ready PR-only dispatch, canonical issue dedup for linked Ready issue+PR items, linked PR prompt rendering, and same-repo PR branch checkout.
- The In review and Done canonical issue policy tests now explicitly pair the canonical issue with a Ready PR item, matching #281 scenarios 4 and 5.
- `packages/tracker-github/src/tracker-github.test.ts` verifies normalized PullRequest metadata preserves fork `headRepository` details, with checkout blocking covered at the orchestrator layer.
- Synced the PR branch with latest `origin/main` before revalidation.

## Evidence

- `pnpm --filter @gh-symphony/orchestrator test -- service.test.ts`
- `pnpm --filter @gh-symphony/tracker-github test -- tracker-github.test.ts`
- `pnpm lint && pnpm test && pnpm typecheck && pnpm build`
- Docker E2E from the prior cycle remains applicable for the dry-run fixture: `cp e2e/fixtures/happy-path.json e2e/fixtures/issues.json && docker compose -f docker-compose.e2e.yml up -d`; observed `/api/v1/state` active run for `test-owner/test-repo#1` and stub worker `completed` events in logs; restored `issues.json` to `[]` and ran `docker compose -f docker-compose.e2e.yml down --remove-orphans`.

## Human Validation

- [ ] Confirm Project item dry-run behavior matches expected production policy.
- [ ] Confirm linked PR prompt context remains compatible with installed daemon prompt variables.
- [ ] Confirm fork PR blocker wording is acceptable for operators.

## Risks

- This PR changes tests only; production behavior risk is limited to coverage expectations.
- Docker E2E fixture leaves the issue Ready, so the orchestrator requeues after stub completion; this matches the existing blackbox fixture behavior observed during validation.