### PR TITLE
fix: mark cli repo-centric release as minor

### DIFF
--- a/.changeset/cli-repo-centric-major.md
+++ b/.changeset/cli-repo-centric-major.md
@@ -1,5 +1,5 @@
 ---
-"@gh-symphony/cli": major
+"@gh-symphony/cli": minor
 ---
 
 @gh-symphony/cli: BREAKING — restructure CLI to repo-centric model


### PR DESCRIPTION
## Summary
- Changes the pending `@gh-symphony/cli` changeset from `major` to `minor`
- This makes Changesets calculate `0.0.22` → `0.1.0` instead of `1.0.0`

## Validation
- `pnpm changeset status --output /tmp/github-symphony-changeset-status.json`
- `git diff --check`

Expected Changesets result:
```json
{
  "name": "@gh-symphony/cli",
  "type": "minor",
  "oldVersion": "0.0.22",
  "newVersion": "0.1.0"
}
```
