### PR TITLE
fix(orchestrator): advise on active linked PR cards

### DIFF
--- a/packages/cli/src/commands/repo-explain.ts
+++ b/packages/cli/src/commands/repo-explain.ts
@@ -16,6 +16,7 @@ import {
   findGithubProjectIssue,
   isActiveRunRecordStatus,
   parseIssueIdentifier,
+  resolveCanonicalSubjectIssues,
   resolveTrackerAdapter,
   type DispatchExplainReport,
 } from "@gh-symphony/orchestrator";
@@ -149,6 +150,11 @@ const handler = async (
     readRuns(runtimeRoot, projectConfig.projectId),
     readJsonFile<ProjectStatusSnapshot>(join(runtimeRoot, "status.json")),
   ]);
+  const canonicalIssues = resolveCanonicalSubjectIssues(issues);
+  const canonicalIssue =
+    canonicalIssues.find((candidate) =>
+      matchesExplainIdentifier(candidate, identifier)
+    ) ?? issue;
 
   let workflow: ExplainWorkflowSettings;
   try {
@@ -174,9 +180,9 @@ const handler = async (
   ).length;
   const report = explainIssueDispatch({
     identifier,
-    issue,
+    issue: canonicalIssue,
     projectRepository: projectConfig.repository ?? null,
-    allIssues: issues,
+    allIssues: canonicalIssues,
     lifecycle: workflow.lifecycle,
     issueRecords: issueRecords ?? [],
     runs,
@@ -204,6 +210,33 @@ const handler = async (
 };
 
 export default handler;
+
+function matchesExplainIdentifier(
+  issue: {
+    identifier: string;
+    metadata: {
+      linkedPullRequests?: unknown;
+    };
+  },
+  identifier: string
+): boolean {
+  const normalizedIdentifier = identifier.trim().toLowerCase();
+  if (issue.identifier.trim().toLowerCase() === normalizedIdentifier) {
+    return true;
+  }
+
+  const linkedPullRequests = Array.isArray(issue.metadata.linkedPullRequests)
+    ? issue.metadata.linkedPullRequests
+    : [];
+  return linkedPullRequests.some(
+    (pullRequest) =>
+      typeof pullRequest === "object" &&
+      pullRequest !== null &&
+      "identifier" in pullRequest &&
+      typeof pullRequest.identifier === "string" &&
+      pullRequest.identifier.trim().toLowerCase() === normalizedIdentifier
+  );
+}
 
 type ExplainWorkflowSettings = {
   lifecycle: WorkflowLifecycleConfig;

--- a/packages/core/src/contracts/tracker-adapter.ts
+++ b/packages/core/src/contracts/tracker-adapter.ts
@@ -120,4 +120,13 @@ export type OrchestratorTrackerAdapter = {
     project: OrchestratorProjectConfig,
     run: OrchestratorRunRecord
   ): TrackedIssue;
+  upsertIssueComment?(
+    project: OrchestratorProjectConfig,
+    issue: TrackedIssue,
+    input: {
+      marker: string;
+      body: string;
+    },
+    dependencies?: OrchestratorTrackerDependencies
+  ): Promise<"created" | "updated" | "unchanged">;
 };

--- a/packages/orchestrator/src/dispatch.test.ts
+++ b/packages/orchestrator/src/dispatch.test.ts
@@ -1056,6 +1056,109 @@ describe("targeted canonical subject dispatch", () => {
     }
   );
 
+  it("evaluates linked PR advisory states with each issue repository workflow", async () => {
+    const tempRoot = await mkdtemp(
+      join(tmpdir(), "orchestrator-linked-pr-advisory-per-repo-workflow-")
+    );
+    const defaultRepository = await createRepositoryFixture(
+      tempRoot,
+      "acme",
+      "platform"
+    );
+    const alternateRepository = await createRepositoryFixture(
+      tempRoot,
+      "other",
+      "service",
+      { activeStates: ["Doing"] }
+    );
+    const store = new OrchestratorFsStore(tempRoot);
+    const projectConfig = createProjectConfig(
+      tempRoot,
+      defaultRepository.cloneUrl,
+      defaultRepository.owner,
+      defaultRepository.name
+    );
+    await store.saveProjectConfig(projectConfig);
+
+    const defaultIssue = makeIssue({
+      id: "issue-10",
+      identifier: "acme/platform#10",
+      number: 10,
+      state: "Done",
+      repository: defaultRepository,
+      tracker: {
+        adapter: "github-project",
+        bindingId: "project-123",
+        itemId: "item-issue-10",
+      },
+      metadata: { contentType: "Issue" },
+    });
+    const alternateIssue = makeIssue({
+      id: "issue-11",
+      identifier: "other/service#11",
+      number: 11,
+      state: "Review",
+      repository: alternateRepository,
+      tracker: {
+        adapter: "github-project",
+        bindingId: "project-123",
+        itemId: "item-issue-11",
+      },
+      metadata: {
+        contentType: "Issue",
+        linkedPullRequests: [
+          makePullRequestContext(
+            alternateRepository,
+            111,
+            "feature/pr-111"
+          ),
+        ],
+      },
+    });
+    const alternatePullRequest = makeIssue({
+      id: "pr-111",
+      identifier: "other/service#111",
+      number: 111,
+      state: "Todo",
+      repository: alternateRepository,
+      tracker: {
+        adapter: "github-project",
+        bindingId: "project-123",
+        itemId: "item-pr-111",
+      },
+      metadata: {
+        contentType: "PullRequest",
+        pullRequest: makePullRequestContext(
+          alternateRepository,
+          111,
+          "feature/pr-111"
+        ),
+      },
+    });
+    const adapter = createDispatchAdapter(defaultRepository, [
+      defaultIssue,
+      alternateIssue,
+      alternatePullRequest,
+    ]);
+    const upsertIssueComment = vi.fn().mockResolvedValue("created");
+    adapter.upsertIssueComment = upsertIssueComment;
+    vi.spyOn(trackerAdapters, "resolveTrackerAdapter").mockReturnValue(
+      adapter
+    );
+
+    const spawnImpl = vi.fn().mockReturnValue({ pid: 5410, unref: vi.fn() });
+    const service = new OrchestratorService(store, projectConfig, {
+      spawnImpl: spawnImpl as never,
+      now: () => new Date("2026-03-08T00:00:00.000Z"),
+    });
+
+    const result = await service.runOnce();
+
+    expect(result.summary.dispatched).toBe(0);
+    expect(spawnImpl).not.toHaveBeenCalled();
+    expect(upsertIssueComment).not.toHaveBeenCalled();
+  });
+
   it("dispatches a standalone PR subject when targeting its identifier", async () => {
     const tempRoot = await mkdtemp(
       join(tmpdir(), "orchestrator-targeted-standalone-pr-")
@@ -1328,6 +1431,7 @@ async function createRepositoryFixture(
   owner: string,
   name: string,
   options: {
+    activeStates?: string[];
     maxConcurrentByState?: Record<string, number>;
     codex?: {
       approvalPolicy?: string;
@@ -1367,6 +1471,7 @@ async function createRepositoryFixture(
 async function writeWorkflowFixture(
   repositoryRoot: string,
   options: {
+    activeStates?: string[];
     maxConcurrentByState?: Record<string, number>;
     codex?: {
       approvalPolicy?: string;
@@ -1375,6 +1480,10 @@ async function writeWorkflowFixture(
     };
   } = {}
 ): Promise<void> {
+  const activeStates = options.activeStates ?? ["Todo", "In Progress"];
+  const activeStateLines = activeStates
+    .map((state) => `    - ${state}`)
+    .join("\n");
   const maxConcurrentByState = options.maxConcurrentByState
     ? `  max_concurrent_agents_by_state:\n${Object.entries(
         options.maxConcurrentByState
@@ -1411,8 +1520,7 @@ tracker:
   project_id: project-123
   state_field: Status
   active_states:
-    - Todo
-    - In Progress
+${activeStateLines}
   terminal_states:
     - Done
   blocker_check_states:

--- a/packages/orchestrator/src/dispatch.test.ts
+++ b/packages/orchestrator/src/dispatch.test.ts
@@ -247,6 +247,53 @@ describe("explainIssueDispatch", () => {
     );
   });
 
+  it("explains active linked PR cards when the canonical Issue is inactive", () => {
+    const issue = makeIssue({
+      identifier: "acme/repo#1",
+      state: "In review",
+      metadata: {
+        contentType: "Issue",
+        linkedPullRequests: [
+          {
+            id: "pr-2",
+            number: 2,
+            identifier: "acme/repo#2",
+            url: "https://github.com/acme/repo/pull/2",
+            state: "OPEN",
+            projectState: "In Progress",
+          },
+        ],
+      },
+    });
+    const report = explainIssueDispatch({
+      identifier: issue.identifier,
+      issue,
+      projectRepository,
+      allIssues: [issue],
+      lifecycle,
+      issueRecords: [],
+      runs: [],
+      activeRunCount: 0,
+      maxConcurrentAgents: 3,
+      maxConcurrentAgentsByState: {},
+    });
+
+    expect(report.dispatchable).toBe(false);
+    expect(report.summary).toContain("Linked PR card");
+    expect(report.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "workflow_state",
+          status: "block",
+          message: expect.stringContaining('canonical Issue state "In review"'),
+          hint: expect.stringContaining(
+            "Linked PR card status alone does not trigger dispatch"
+          ),
+        }),
+      ])
+    );
+  });
+
   it("explains unresolved blockers", () => {
     const blocker = makeIssue({
       id: "blocker-1",
@@ -752,9 +799,7 @@ describe("targeted canonical subject dispatch", () => {
   });
 
   it("dispatches the canonical Issue when targeting a linked PR identifier", async () => {
-    const tempRoot = await mkdtemp(
-      join(tmpdir(), "orchestrator-targeted-pr-")
-    );
+    const tempRoot = await mkdtemp(join(tmpdir(), "orchestrator-targeted-pr-"));
     const repository = await createRepositoryFixture(
       tempRoot,
       "acme",
@@ -883,7 +928,11 @@ describe("targeted canonical subject dispatch", () => {
         },
         metadata: {
           contentType: "PullRequest",
-          pullRequest: makePullRequestContext(repository, 108, "feature/pr-108"),
+          pullRequest: makePullRequestContext(
+            repository,
+            108,
+            "feature/pr-108"
+          ),
         },
       });
       vi.spyOn(trackerAdapters, "resolveTrackerAdapter").mockReturnValue(
@@ -902,6 +951,108 @@ describe("targeted canonical subject dispatch", () => {
 
       expect(result.summary.dispatched).toBe(0);
       expect(spawnImpl).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each(["Todo", "In Progress"])(
+    "posts a deduplicated advisory and does not dispatch when linked PR is %s but canonical Issue is inactive",
+    async (pullRequestState) => {
+      const tempRoot = await mkdtemp(
+        join(tmpdir(), "orchestrator-linked-pr-active-advisory-")
+      );
+      const repository = await createRepositoryFixture(
+        tempRoot,
+        "acme",
+        "platform"
+      );
+      const store = new OrchestratorFsStore(tempRoot);
+      const projectConfig = createProjectConfig(
+        tempRoot,
+        repository.cloneUrl,
+        repository.owner,
+        repository.name
+      );
+      await store.saveProjectConfig(projectConfig);
+
+      const issue = makeIssue({
+        id: "issue-9",
+        identifier: "acme/platform#9",
+        number: 9,
+        state: "In review",
+        repository,
+        tracker: {
+          adapter: "github-project",
+          bindingId: "project-123",
+          itemId: "item-issue-9",
+        },
+        metadata: {
+          contentType: "Issue",
+          linkedPullRequests: [
+            makePullRequestContext(repository, 109, "feature/pr-109"),
+          ],
+        },
+      });
+      const linkedPullRequest = makeIssue({
+        id: "pr-109",
+        identifier: "acme/platform#109",
+        number: 109,
+        state: pullRequestState,
+        repository,
+        tracker: {
+          adapter: "github-project",
+          bindingId: "project-123",
+          itemId: "item-pr-109",
+        },
+        metadata: {
+          contentType: "PullRequest",
+          pullRequest: makePullRequestContext(
+            repository,
+            109,
+            "feature/pr-109"
+          ),
+        },
+      });
+      const adapter = createDispatchAdapter(repository, [
+        issue,
+        linkedPullRequest,
+      ]);
+      const upsertIssueComment = vi.fn().mockResolvedValue("created");
+      adapter.upsertIssueComment = upsertIssueComment;
+      vi.spyOn(trackerAdapters, "resolveTrackerAdapter").mockReturnValue(
+        adapter
+      );
+
+      const spawnImpl = vi.fn().mockReturnValue({ pid: 5406, unref: vi.fn() });
+      const service = new OrchestratorService(store, projectConfig, {
+        spawnImpl: spawnImpl as never,
+        now: () => new Date("2026-03-08T00:00:00.000Z"),
+      });
+
+      const result = await service.runOnce({
+        issueIdentifier: "acme/platform#109",
+      });
+
+      expect(result.summary.dispatched).toBe(0);
+      expect(spawnImpl).not.toHaveBeenCalled();
+      expect(upsertIssueComment).toHaveBeenCalledTimes(1);
+      expect(upsertIssueComment).toHaveBeenCalledWith(
+        projectConfig,
+        expect.objectContaining({
+          id: "issue-9",
+          identifier: "acme/platform#9",
+        }),
+        expect.objectContaining({
+          marker:
+            "<!-- gh-symphony:linked-pr-active-while-issue-inactive issue=issue-9 pr=pr-109 -->",
+          body: expect.stringContaining(
+            "Linked PR card status alone does not trigger dispatch."
+          ),
+        }),
+        expect.any(Object)
+      );
+      expect(upsertIssueComment.mock.calls[0]?.[2].body).toContain(
+        "No worker was started for this PR card status change."
+      );
     }
   );
 

--- a/packages/orchestrator/src/explain.ts
+++ b/packages/orchestrator/src/explain.ts
@@ -250,6 +250,24 @@ function explainWorkflowState(
   }
 
   const role = isStateTerminal(issue.state, lifecycle) ? "terminal" : "wait";
+  const linkedPullRequest = findActiveLinkedPullRequest(issue, lifecycle);
+  if (linkedPullRequest) {
+    return {
+      id: "workflow_state",
+      status: "block",
+      message: `Linked PR card ${linkedPullRequest.identifier} is active in project state "${linkedPullRequest.projectState}", but canonical Issue state "${issue.state}" maps to ${role}, not active, in WORKFLOW.md.`,
+      details: {
+        activeStates: lifecycle.activeStates,
+        terminalStates: lifecycle.terminalStates,
+        blockerCheckStates: lifecycle.blockerCheckStates,
+        canonicalIssueState: issue.state,
+        linkedPullRequestIdentifier: linkedPullRequest.identifier,
+        linkedPullRequestProjectState: linkedPullRequest.projectState,
+      },
+      hint: "Linked PR card status alone does not trigger dispatch. Move the canonical Issue card to an active state to request rework.",
+    };
+  }
+
   return {
     id: "workflow_state",
     status: "block",
@@ -261,6 +279,34 @@ function explainWorkflowState(
     },
     hint: "Move the GitHub Project item to an active state or run 'gh-symphony workflow preview' to inspect WORKFLOW.md state mappings.",
   };
+}
+
+export function findActiveLinkedPullRequest(
+  issue: TrackedIssue,
+  lifecycle: WorkflowLifecycleConfig
+): { id: string; identifier: string; projectState: string } | null {
+  if (isStateActive(issue.state, lifecycle)) {
+    return null;
+  }
+
+  const linkedPullRequests = Array.isArray(issue.metadata.linkedPullRequests)
+    ? issue.metadata.linkedPullRequests
+    : [];
+  for (const pullRequest of linkedPullRequests) {
+    const projectState =
+      typeof pullRequest.projectState === "string"
+        ? pullRequest.projectState
+        : null;
+    if (projectState && isStateActive(projectState, lifecycle)) {
+      return {
+        id: pullRequest.id,
+        identifier: pullRequest.identifier,
+        projectState,
+      };
+    }
+  }
+
+  return null;
 }
 
 function explainBlockers(

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -13,6 +13,7 @@ import {
 } from "./lock.js";
 
 export { OrchestratorService, createStore };
+export { resolveCanonicalSubjectIssues } from "./service.js";
 export type { OrchestratorLogLevel };
 export * from "./runtime-factory.js";
 export * from "./explain.js";

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -645,7 +645,6 @@ export class OrchestratorService {
         tenant,
         trackerAdapter,
         filteredIssues,
-        lifecycle,
         trackerDependencies
       );
       const trackedIssuesByIdentifier = new Map<string, TrackedIssue>(
@@ -1186,7 +1185,6 @@ export class OrchestratorService {
     tenant: OrchestratorProjectConfig,
     trackerAdapter: OrchestratorTrackerAdapter,
     issues: readonly TrackedIssue[],
-    lifecycle: WorkflowLifecycleConfig,
     trackerDependencies: OrchestratorTrackerDependencies
   ): Promise<void> {
     if (!trackerAdapter.upsertIssueComment) {
@@ -1197,6 +1195,16 @@ export class OrchestratorService {
       if (issue.metadata.contentType === "PullRequest") {
         continue;
       }
+
+      const resolution = await this.loadProjectWorkflow(
+        tenant,
+        issue.repository
+      );
+      if (!isUsableWorkflowResolution(resolution)) {
+        continue;
+      }
+      const lifecycle = resolution.lifecycle;
+
       if (isStateTerminal(issue.state, lifecycle)) {
         continue;
       }

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -54,6 +54,7 @@ import { OrchestratorFsStore } from "./fs-store.js";
 import { resolveTrackerAdapter } from "./tracker-adapters.js";
 import {
   hasConvergenceLockedRunForIssue,
+  findActiveLinkedPullRequest,
   isActiveRunRecordStatus,
   isIssueCandidateEligibleWithReason,
   isIssueOrchestrationClaimedState,
@@ -67,6 +68,8 @@ const DEFAULT_WORKER_COMMAND = "node packages/worker/dist/index.js";
 const DEFAULT_MAX_NONPRODUCTIVE_TURNS = 3;
 const LOW_RATE_LIMIT_WARNING_THRESHOLD = 0.05;
 const MAX_FAILURE_RETRIES_EXCEEDED_REASON = "max_failure_retries_exceeded";
+const LINKED_PR_ACTIVE_ISSUE_INACTIVE_MARKER_PREFIX =
+  "gh-symphony:linked-pr-active-while-issue-inactive";
 
 type ProjectWorkflowResolution = Awaited<
   ReturnType<typeof loadRepositoryWorkflow>
@@ -116,7 +119,7 @@ function parseFiniteNumber(value: unknown): number | null {
   return null;
 }
 
-function resolveCanonicalSubjectIssues(
+export function resolveCanonicalSubjectIssues(
   issues: readonly TrackedIssue[]
 ): TrackedIssue[] {
   const pullRequestsById = new Map<string, TrackedIssue>();
@@ -244,14 +247,11 @@ function resolvePullRequestBranchCheckoutTarget(
 
   const headRepository = pullRequest.headRepository ?? null;
   const sameOwner =
-    headRepository?.owner.toLowerCase() === issue.repository.owner.toLowerCase();
+    headRepository?.owner.toLowerCase() ===
+    issue.repository.owner.toLowerCase();
   const sameName =
     headRepository?.name.toLowerCase() === issue.repository.name.toLowerCase();
-  if (
-    !headRepository ||
-    !sameOwner ||
-    !sameName
-  ) {
+  if (!headRepository || !sameOwner || !sameName) {
     const source = headRepository
       ? `${headRepository.owner}/${headRepository.name}`
       : "unknown fork";
@@ -261,6 +261,37 @@ function resolvePullRequestBranchCheckoutTarget(
   }
 
   return { headRefName };
+}
+
+function buildLinkedPullRequestActiveAdvisoryMarker(
+  issueId: string,
+  pullRequestId: string
+): string {
+  return `<!-- ${LINKED_PR_ACTIVE_ISSUE_INACTIVE_MARKER_PREFIX} issue=${issueId} pr=${pullRequestId} -->`;
+}
+
+function buildLinkedPullRequestActiveAdvisoryBody(input: {
+  marker: string;
+  issue: TrackedIssue;
+  linkedPullRequest: {
+    identifier: string;
+    projectState: string;
+  };
+  lifecycle: WorkflowLifecycleConfig;
+}): string {
+  const activeStates = input.lifecycle.activeStates
+    .map((state) => `\`${state}\``)
+    .join(" or ");
+
+  return `${input.marker}
+
+Linked PR card status alone does not trigger dispatch.
+
+- Canonical Issue: ${input.issue.identifier} (${input.issue.state})
+- Linked PR card: ${input.linkedPullRequest.identifier} (${input.linkedPullRequest.projectState})
+- No worker was started for this PR card status change.
+
+To request rework, move the canonical Issue card to ${activeStates}.`;
 }
 
 export class OrchestratorService {
@@ -604,13 +635,19 @@ export class OrchestratorService {
       );
       const canonicalIssues = resolveCanonicalSubjectIssues(issues);
       const filteredIssues = issueIdentifier
-        ? canonicalIssues.filter(
-            (issue: TrackedIssue) =>
-              matchesTargetIssueIdentifier(issue, issueIdentifier)
+        ? canonicalIssues.filter((issue: TrackedIssue) =>
+            matchesTargetIssueIdentifier(issue, issueIdentifier)
           )
         : canonicalIssues;
       const { candidates: actionableCandidates, lifecycle } =
         await this.resolveActionableCandidates(tenant, filteredIssues);
+      await this.publishLinkedPullRequestActiveAdvisories(
+        tenant,
+        trackerAdapter,
+        filteredIssues,
+        lifecycle,
+        trackerDependencies
+      );
       const trackedIssuesByIdentifier = new Map<string, TrackedIssue>(
         syncedIssuesByIdentifier
       );
@@ -1143,6 +1180,56 @@ export class OrchestratorService {
   ): boolean {
     return isIssueCandidateEligibleWithReason(issue, lifecycle, issues)
       .eligible;
+  }
+
+  private async publishLinkedPullRequestActiveAdvisories(
+    tenant: OrchestratorProjectConfig,
+    trackerAdapter: OrchestratorTrackerAdapter,
+    issues: readonly TrackedIssue[],
+    lifecycle: WorkflowLifecycleConfig,
+    trackerDependencies: OrchestratorTrackerDependencies
+  ): Promise<void> {
+    if (!trackerAdapter.upsertIssueComment) {
+      return;
+    }
+
+    for (const issue of issues) {
+      if (issue.metadata.contentType === "PullRequest") {
+        continue;
+      }
+      if (isStateTerminal(issue.state, lifecycle)) {
+        continue;
+      }
+
+      const linkedPullRequest = findActiveLinkedPullRequest(issue, lifecycle);
+      if (!linkedPullRequest) {
+        continue;
+      }
+
+      const marker = buildLinkedPullRequestActiveAdvisoryMarker(
+        issue.id,
+        linkedPullRequest.id
+      );
+      const body = buildLinkedPullRequestActiveAdvisoryBody({
+        marker,
+        issue,
+        linkedPullRequest,
+        lifecycle,
+      });
+
+      try {
+        await trackerAdapter.upsertIssueComment(
+          tenant,
+          issue,
+          { marker, body },
+          trackerDependencies
+        );
+      } catch (error) {
+        this.writeStderr(
+          `[orchestrator] failed to publish linked PR active advisory for ${issue.identifier}: ${this.formatErrorMessage(error)}`
+        );
+      }
+    }
   }
 
   private async loadProjectWorkflow(

--- a/packages/tracker-github/src/adapter.ts
+++ b/packages/tracker-github/src/adapter.ts
@@ -171,6 +171,43 @@ type GraphQLIssueProjectItemsConnection = {
   };
 };
 
+type GraphQLIssueCommentNode = {
+  id: string;
+  body: string;
+};
+
+type GraphQLIssueCommentsConnection = {
+  nodes: Array<GraphQLIssueCommentNode | null> | null;
+  pageInfo: {
+    endCursor: string | null;
+    hasNextPage: boolean;
+  };
+};
+
+type GraphQLIssueCommentsByIdResponse = {
+  node:
+    | {
+        __typename: "Issue";
+        comments: GraphQLIssueCommentsConnection;
+      }
+    | { __typename: string }
+    | null;
+};
+
+type GraphQLAddIssueCommentResponse = {
+  addComment: {
+    commentEdge: {
+      node: GraphQLIssueCommentNode | null;
+    } | null;
+  } | null;
+};
+
+type GraphQLUpdateIssueCommentResponse = {
+  updateIssueComment: {
+    issueComment: GraphQLIssueCommentNode | null;
+  } | null;
+};
+
 type GraphQLProjectItemsPage = {
   nodes: Array<GraphQLProjectItem | null> | null;
   pageInfo: {
@@ -372,7 +409,8 @@ function normalizePullRequestProjectItem(
   const pullRequestUpdatedAtMs = parseTimestampMs(content.updatedAt);
   const trackedUpdatedAt =
     itemUpdatedAtMs !== null &&
-    (pullRequestUpdatedAtMs === null || itemUpdatedAtMs > pullRequestUpdatedAtMs)
+    (pullRequestUpdatedAtMs === null ||
+      itemUpdatedAtMs > pullRequestUpdatedAtMs)
       ? item.updatedAt
       : (content.updatedAt ?? item.updatedAt);
 
@@ -634,6 +672,98 @@ export const fetchGithubProjectIssues = fetchProjectIssues;
 export const fetchGithubIssueStatesByIds = fetchIssueStatesByIds;
 export const fetchGithubProjectIssueByRepositoryAndNumber =
   fetchProjectIssueByRepositoryAndNumber;
+export const upsertGithubIssueComment = upsertIssueComment;
+
+async function upsertIssueComment(
+  config: GitHubTrackerConfig,
+  issueId: string,
+  input: {
+    marker: string;
+    body: string;
+  },
+  fetchImpl: FetchLike = fetch
+): Promise<"created" | "updated" | "unchanged"> {
+  const existingComment = await findIssueCommentByMarker(
+    config,
+    issueId,
+    input.marker,
+    fetchImpl
+  );
+
+  if (!existingComment) {
+    await executeGraphQLQuery<GraphQLAddIssueCommentResponse>(
+      config,
+      ADD_ISSUE_COMMENT_MUTATION,
+      {
+        subjectId: issueId,
+        body: input.body,
+      },
+      fetchImpl
+    );
+    return "created";
+  }
+
+  if (existingComment.body === input.body) {
+    return "unchanged";
+  }
+
+  await executeGraphQLQuery<GraphQLUpdateIssueCommentResponse>(
+    config,
+    UPDATE_ISSUE_COMMENT_MUTATION,
+    {
+      commentId: existingComment.id,
+      body: input.body,
+    },
+    fetchImpl
+  );
+  return "updated";
+}
+
+async function findIssueCommentByMarker(
+  config: GitHubTrackerConfig,
+  issueId: string,
+  marker: string,
+  fetchImpl: FetchLike
+): Promise<GraphQLIssueCommentNode | null> {
+  let cursor: string | null = null;
+
+  while (true) {
+    const data: GraphQLIssueCommentsByIdResponse =
+      await executeGraphQLQuery<GraphQLIssueCommentsByIdResponse>(
+        config,
+        ISSUE_COMMENTS_BY_ID_QUERY,
+        {
+          issueId,
+          cursor,
+        },
+        fetchImpl
+      );
+
+    if (data.node?.__typename !== "Issue") {
+      throw new GitHubTrackerQueryError(
+        "GitHub GraphQL response did not include issue comments."
+      );
+    }
+    const issueNode = data.node as Extract<
+      GraphQLIssueCommentsByIdResponse["node"],
+      { __typename: "Issue" }
+    >;
+
+    const match =
+      issueNode.comments.nodes?.find(
+        (comment: GraphQLIssueCommentNode | null) =>
+          comment?.body.includes(marker)
+      ) ?? null;
+    if (match) {
+      return match;
+    }
+
+    if (!issueNode.comments.pageInfo.hasNextPage) {
+      return null;
+    }
+    cursor = issueNode.comments.pageInfo.endCursor;
+  }
+}
 
 async function fetchCurrentUserLogin(
   config: GitHubTrackerConfig,
@@ -814,7 +944,9 @@ function normalizeRepositoryIssueLookup(
 function normalizePullRequestNodes(
   nodes: Array<GraphQLPullRequestNode | null>
 ): GitHubPullRequestMetadata[] {
-  return nodes.flatMap((node) => (node ? [normalizePullRequestNode(node)] : []));
+  return nodes.flatMap((node) =>
+    node ? [normalizePullRequestNode(node)] : []
+  );
 }
 
 function normalizePullRequestNode(
@@ -869,9 +1001,7 @@ function normalizeLabelNames(
 function normalizeAssigneeLogins(
   nodes: Array<{ login: string | null } | null>
 ): string[] {
-  return nodes.flatMap((assignee) =>
-    assignee?.login ? [assignee.login] : []
-  );
+  return nodes.flatMap((assignee) => (assignee?.login ? [assignee.login] : []));
 }
 
 function withGitHubMetadata(
@@ -1635,6 +1765,50 @@ const ISSUE_PROJECT_ITEMS_PAGE_QUERY = `
             hasNextPage
           }
         }
+      }
+    }
+  }
+`;
+
+const ISSUE_COMMENTS_BY_ID_QUERY = `
+  query IssueCommentsById($issueId: ID!, $cursor: String) {
+    node(id: $issueId) {
+      __typename
+      ... on Issue {
+        comments(first: 100, after: $cursor) {
+          nodes {
+            id
+            body
+          }
+          pageInfo {
+            endCursor
+            hasNextPage
+          }
+        }
+      }
+    }
+  }
+`;
+
+const ADD_ISSUE_COMMENT_MUTATION = `
+  mutation AddIssueComment($subjectId: ID!, $body: String!) {
+    addComment(input: { subjectId: $subjectId, body: $body }) {
+      commentEdge {
+        node {
+          id
+          body
+        }
+      }
+    }
+  }
+`;
+
+const UPDATE_ISSUE_COMMENT_MUTATION = `
+  mutation UpdateIssueComment($commentId: ID!, $body: String!) {
+    updateIssueComment(input: { id: $commentId, body: $body }) {
+      issueComment {
+        id
+        body
       }
     }
   }

--- a/packages/tracker-github/src/orchestrator-adapter.ts
+++ b/packages/tracker-github/src/orchestrator-adapter.ts
@@ -8,6 +8,7 @@ import {
   fetchGithubIssueStatesByIds,
   fetchGithubProjectIssueByRepositoryAndNumber,
   fetchGithubProjectIssues,
+  upsertGithubIssueComment,
 } from "./adapter.js";
 
 export const githubProjectTrackerAdapter: OrchestratorTrackerAdapter = {
@@ -68,6 +69,16 @@ export const githubProjectTrackerAdapter: OrchestratorTrackerAdapter = {
       },
       metadata: {},
     };
+  },
+
+  async upsertIssueComment(project, issue, input, dependencies = {}) {
+    const trackerConfig = resolveGitHubTrackerConfig(project, dependencies);
+    return upsertGithubIssueComment(
+      trackerConfig,
+      issue.id,
+      input,
+      dependencies.fetchImpl
+    );
   },
 };
 

--- a/packages/tracker-github/src/tracker-github.test.ts
+++ b/packages/tracker-github/src/tracker-github.test.ts
@@ -732,6 +732,164 @@ describe("resolveTrackerAdapter", () => {
     expect(issue.state).toBe("Ready");
   });
 
+  it("creates advisory comments when the marker is absent", async () => {
+    const adapter = resolveTrackerAdapter({
+      adapter: "github-project",
+      bindingId: "project-123",
+      settings: {
+        projectId: "project-123",
+      },
+    });
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              node: {
+                __typename: "Issue",
+                comments: {
+                  nodes: [],
+                  pageInfo: { endCursor: null, hasNextPage: false },
+                },
+              },
+            },
+          })
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              addComment: {
+                commentEdge: {
+                  node: {
+                    id: "comment-1",
+                    body: "marker body",
+                  },
+                },
+              },
+            },
+          })
+        )
+      );
+
+    const result = await adapter.upsertIssueComment?.(
+      makeProjectConfig(),
+      makeTrackedIssue(),
+      {
+        marker:
+          "<!-- gh-symphony:linked-pr-active-while-issue-inactive issue=issue-1 pr=pr-2 -->",
+        body: "marker body",
+      },
+      { token: "test-token", fetchImpl }
+    );
+
+    expect(result).toBe("created");
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    const mutationBody = JSON.parse(
+      String(fetchImpl.mock.calls[1]?.[1]?.body)
+    ) as { query: string; variables: Record<string, string> };
+    expect(mutationBody.query).toContain("mutation AddIssueComment");
+    expect(mutationBody.variables.subjectId).toBe("issue-1");
+  });
+
+  it("does not update advisory comments when the existing body is unchanged", async () => {
+    const adapter = resolveTrackerAdapter({
+      adapter: "github-project",
+      bindingId: "project-123",
+      settings: {
+        projectId: "project-123",
+      },
+    });
+    const marker =
+      "<!-- gh-symphony:linked-pr-active-while-issue-inactive issue=issue-1 pr=pr-2 -->";
+    const body = `${marker}\n\nLinked PR card status alone does not trigger dispatch.`;
+    const fetchImpl = vi.fn().mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          data: {
+            node: {
+              __typename: "Issue",
+              comments: {
+                nodes: [{ id: "comment-1", body }],
+                pageInfo: { endCursor: null, hasNextPage: false },
+              },
+            },
+          },
+        })
+      )
+    );
+
+    const result = await adapter.upsertIssueComment?.(
+      makeProjectConfig(),
+      makeTrackedIssue(),
+      { marker, body },
+      { token: "test-token", fetchImpl }
+    );
+
+    expect(result).toBe("unchanged");
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("updates advisory comments when the marker exists with a different body", async () => {
+    const adapter = resolveTrackerAdapter({
+      adapter: "github-project",
+      bindingId: "project-123",
+      settings: {
+        projectId: "project-123",
+      },
+    });
+    const marker =
+      "<!-- gh-symphony:linked-pr-active-while-issue-inactive issue=issue-1 pr=pr-2 -->";
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              node: {
+                __typename: "Issue",
+                comments: {
+                  nodes: [{ id: "comment-1", body: `${marker}\nold body` }],
+                  pageInfo: { endCursor: null, hasNextPage: false },
+                },
+              },
+            },
+          })
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              updateIssueComment: {
+                issueComment: {
+                  id: "comment-1",
+                  body: `${marker}\nnew body`,
+                },
+              },
+            },
+          })
+        )
+      );
+
+    const result = await adapter.upsertIssueComment?.(
+      makeProjectConfig(),
+      makeTrackedIssue(),
+      { marker, body: `${marker}\nnew body` },
+      { token: "test-token", fetchImpl }
+    );
+
+    expect(result).toBe("updated");
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    const mutationBody = JSON.parse(
+      String(fetchImpl.mock.calls[1]?.[1]?.body)
+    ) as { query: string; variables: Record<string, string> };
+    expect(mutationBody.query).toContain("mutation UpdateIssueComment");
+    expect(mutationBody.variables.commentId).toBe("comment-1");
+  });
+
   it("throws for unsupported tracker adapters", () => {
     expect(() =>
       resolveTrackerAdapter({
@@ -3164,6 +3322,57 @@ function makePullRequestStateLookupNode(input: {
         endCursor: null,
         hasNextPage: false,
       },
+    },
+  };
+}
+
+function makeProjectConfig() {
+  return {
+    projectId: "tenant-1",
+    slug: "tenant-1",
+    workspaceDir: "/tmp/workspaces/tenant-1",
+    repository: {
+      owner: "acme",
+      name: "platform",
+      cloneUrl: "https://github.com/acme/platform.git",
+    },
+    tracker: {
+      adapter: "github-project" as const,
+      bindingId: "project-123",
+      settings: {
+        projectId: "project-123",
+      },
+    },
+  };
+}
+
+function makeTrackedIssue(): TrackedIssue {
+  return {
+    id: "issue-1",
+    identifier: "acme/platform#1",
+    number: 1,
+    title: "Test issue",
+    description: null,
+    priority: null,
+    state: "In review",
+    branchName: null,
+    url: "https://github.com/acme/platform/issues/1",
+    labels: [],
+    blockedBy: [],
+    createdAt: null,
+    updatedAt: null,
+    repository: {
+      owner: "acme",
+      name: "platform",
+      cloneUrl: "https://github.com/acme/platform.git",
+    },
+    tracker: {
+      adapter: "github-project",
+      bindingId: "project-123",
+      itemId: "item-1",
+    },
+    metadata: {
+      contentType: "Issue",
     },
   };
 }


### PR DESCRIPTION
## Issues

- Fixes #305

## Summary

- canonical Issue가 inactive인데 linked PR card만 active인 상태를 dispatch 전에 감지합니다.
- 이 경우 worker를 시작하지 않고 canonical Issue에 hidden marker 기반 advisory comment를 upsert합니다.
- advisory 판단은 각 canonical Issue의 repository별 `WORKFLOW.md` lifecycle로 평가해 multi-repo Project에서 다른 repo의 state mapping이 섞이지 않도록 했습니다.
- `repo explain`의 workflow_state block reason에도 같은 상황을 노출합니다.

## Changes

- tracker adapter에 optional `upsertIssueComment` 계약을 추가하고 GitHub GraphQL comment create/update 구현을 연결했습니다.
- orchestrator canonical issue merge 결과에서 active linked PR project state를 찾아 advisory를 발행하도록 했습니다. terminal Issue는 advisory 없이 계속 dispatch되지 않습니다.
- advisory 발행 경로가 단일 lifecycle을 공유하지 않고 Issue별 repository workflow를 로드해 linked PR active 여부를 판정합니다.
- `repo explain`이 Project 전체 목록의 canonical merge 결과를 사용해 linked PR project state를 설명할 수 있게 했습니다.
- dispatch, GitHub tracker comment upsert, repo explain, multi-repo lifecycle advisory 회귀 테스트를 추가했습니다.

## Evidence

- `pnpm --filter @gh-symphony/orchestrator test -- dispatch.test.ts`
- `pnpm --filter @gh-symphony/tracker-github test -- tracker-github.test.ts`
- `pnpm --filter @gh-symphony/cli test -- repo-explain.test.ts`
- `pnpm lint && pnpm test && pnpm typecheck && pnpm build`
- Docker E2E blackbox: `docker compose -f docker-compose.e2e.yml -f docker-compose.e2e.events.yml up -d --build`, `/healthz` OK, happy-path fixture 주입 후 dashboard API에서 `activeRuns: 1`, `executionPhase: "implementation"`, `lastEvent: "running"` 확인, 이후 continuation retry 관찰 및 컨테이너 정리

## Human Validation

- [ ] Issue `In review` + linked PR `Ready`에서 worker가 시작되지 않고 advisory comment가 생성/재사용되는지 확인
- [ ] linked PR active state 변경 시 기존 marker comment가 업데이트되는지 확인
- [ ] multi-repo Project에서 linked PR active 여부가 canonical Issue repository의 `WORKFLOW.md` active states 기준으로 판정되는지 확인
- [ ] `gh-symphony repo explain <issue>` 출력에서 linked PR active / canonical Issue inactive 사유가 보이는지 확인

## Risks

- Advisory comment write는 GitHub tracker adapter에서만 지원합니다. 다른 tracker는 optional method가 없으면 기존처럼 comment 없이 dispatch 정책만 유지합니다.
- advisory 실패 구조화 이벤트, stale advisory cleanup, marker search 최적화는 승인 리뷰에서 non-blocking follow-up으로 분리했습니다.