### PR TITLE
feat(tracker): add Linear read adapter

### DIFF
--- a/packages/cli/src/commands/repo.test.ts
+++ b/packages/cli/src/commands/repo.test.ts
@@ -76,7 +76,9 @@ async function createGitRepo(remoteName = "platform"): Promise<string> {
   return repoDir;
 }
 
-async function readRepoProjectConfig(repoDir: string): Promise<CliProjectConfig> {
+async function readRepoProjectConfig(
+  repoDir: string
+): Promise<CliProjectConfig> {
   return JSON.parse(
     await readFile(
       join(
@@ -189,6 +191,51 @@ describe("repo init runtime migration", () => {
 
     expect(process.exitCode).toBeUndefined();
     expect(stdout.output()).toContain("Repository initialized: acme/platform");
+  });
+
+  it("initializes a Linear tracker runtime from WORKFLOW.md", async () => {
+    const repoDir = await createGitRepo();
+    const stdout = captureWrites(process.stdout);
+    const repoCommand = await loadRepoCommand();
+    await writeFile(
+      join(repoDir, "WORKFLOW.md"),
+      `---
+tracker:
+  kind: linear
+  project_slug: symphony-0c79b11b75ea
+  active_states:
+    - Todo
+    - In Progress
+codex:
+  command: codex app-server
+---
+Handle {{issue.identifier}}.
+`,
+      "utf8"
+    );
+
+    try {
+      await repoCommand(
+        ["init", "--repo-dir", repoDir],
+        baseOptions(join(repoDir, "unused"))
+      );
+    } finally {
+      stdout.restore();
+    }
+
+    const projectConfig = await readRepoProjectConfig(repoDir);
+
+    expect(process.exitCode).toBeUndefined();
+    expect(projectConfig.tracker).toMatchObject({
+      adapter: "linear",
+      bindingId: "symphony-0c79b11b75ea",
+      apiUrl: "https://api.linear.app/graphql",
+      settings: {
+        projectSlug: "symphony-0c79b11b75ea",
+        activeStates: "Todo\nIn Progress",
+        repository: "acme/platform",
+      },
+    });
   });
 
   it("resolves a relative --workflow-file against --repo-dir", async () => {

--- a/packages/cli/src/repo-runtime.ts
+++ b/packages/cli/src/repo-runtime.ts
@@ -81,6 +81,12 @@ export async function initRepoRuntime(flags: RepoInitFlags): Promise<{
     ...(workflow.tracker.projectId
       ? { projectId: workflow.tracker.projectId }
       : {}),
+    ...(workflow.tracker.projectSlug
+      ? { projectSlug: workflow.tracker.projectSlug }
+      : {}),
+    ...(trackerAdapter === "linear"
+      ? { activeStates: workflow.tracker.activeStates.join("\n") }
+      : {}),
     repository: `${repository.owner}/${repository.name}`,
   };
   if (flags.assignedOnly) {
@@ -105,6 +111,9 @@ export async function initRepoRuntime(flags: RepoInitFlags): Promise<{
     tracker: {
       adapter: trackerAdapter,
       bindingId: trackerBindingId,
+      ...(workflow.tracker.endpoint
+        ? { apiUrl: workflow.tracker.endpoint }
+        : {}),
       settings: trackerSettings,
     },
   };

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -9,13 +9,18 @@
       "@gh-symphony/control-plane": ["../control-plane/src/index.ts"],
       "@gh-symphony/core": ["../core/src/index.ts"],
       "@gh-symphony/dashboard": ["../dashboard/src/index.ts"],
-      "@gh-symphony/extension-github-workflow": ["../extension-github-workflow/src/index.ts"],
+      "@gh-symphony/extension-github-workflow": [
+        "../extension-github-workflow/src/index.ts"
+      ],
       "@gh-symphony/orchestrator": ["../orchestrator/src/index.ts"],
       "@gh-symphony/runtime-claude": ["../runtime-claude/src/index.ts"],
       "@gh-symphony/runtime-codex": ["../runtime-codex/src/index.ts"],
-      "@gh-symphony/tool-github-graphql": ["../tool-github-graphql/src/index.ts"],
+      "@gh-symphony/tool-github-graphql": [
+        "../tool-github-graphql/src/index.ts"
+      ],
       "@gh-symphony/tracker-file": ["../tracker-file/src/index.ts"],
       "@gh-symphony/tracker-github": ["../tracker-github/src/index.ts"],
+      "@gh-symphony/tracker-linear": ["../tracker-linear/src/index.ts"],
       "@gh-symphony/worker": ["../worker/src/index.ts"]
     }
   },

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -15,7 +15,10 @@ export default defineConfig({
         "../control-plane/src/index.ts"
       ),
       "@gh-symphony/core": resolve(packageRoot, "../core/src/index.ts"),
-      "@gh-symphony/dashboard": resolve(packageRoot, "../dashboard/src/index.ts"),
+      "@gh-symphony/dashboard": resolve(
+        packageRoot,
+        "../dashboard/src/index.ts"
+      ),
       "@gh-symphony/extension-github-workflow": resolve(
         packageRoot,
         "../extension-github-workflow/src/index.ts"
@@ -43,6 +46,10 @@ export default defineConfig({
       "@gh-symphony/tracker-github": resolve(
         packageRoot,
         "../tracker-github/src/index.ts"
+      ),
+      "@gh-symphony/tracker-linear": resolve(
+        packageRoot,
+        "../tracker-linear/src/index.ts"
       ),
       "@gh-symphony/worker": resolve(packageRoot, "../worker/src/index.ts"),
     },

--- a/packages/core/src/workflow-loader.test.ts
+++ b/packages/core/src/workflow-loader.test.ts
@@ -111,7 +111,7 @@ Prompt body.
     expect(workflow.tracker.projectId).toBeNull();
   });
 
-  it.each(["project_id", "projectId", "teamId"])(
+  it.each(["project_id", "projectId", "teamId", "team_id"])(
     "rejects Linear tracker alias %s",
     (key) => {
       expect(() =>
@@ -143,6 +143,39 @@ Prompt body.
 `)
     ).toThrow(
       'Workflow front matter field "tracker.project_slug" is required for tracker.kind "linear".'
+    );
+  });
+
+  it("rejects blank project_slug for Linear tracker config", () => {
+    expect(() =>
+      parseWorkflowMarkdown(`---
+tracker:
+  kind: linear
+  project_slug: ""
+codex:
+  command: codex app-server
+---
+Prompt body.
+`)
+    ).toThrow(
+      'Workflow front matter field "tracker.project_slug" is required for tracker.kind "linear".'
+    );
+  });
+
+  it("rejects blank endpoint for Linear tracker config", () => {
+    expect(() =>
+      parseWorkflowMarkdown(`---
+tracker:
+  kind: linear
+  project_slug: symphony-0c79b11b75ea
+  endpoint: ""
+codex:
+  command: codex app-server
+---
+Prompt body.
+`)
+    ).toThrow(
+      'Workflow front matter field "tracker.endpoint" must be a non-empty string when provided for tracker.kind "linear".'
     );
   });
 

--- a/packages/core/src/workflow-loader.test.ts
+++ b/packages/core/src/workflow-loader.test.ts
@@ -86,6 +86,66 @@ Prompt body.
     expect(workflow.agent.maxFailureRetries).toBe(10);
   });
 
+  it("parses Linear tracker config with default endpoint", () => {
+    const workflow = parseWorkflowMarkdown(
+      `---
+tracker:
+  kind: linear
+  project_slug: symphony-0c79b11b75ea
+  api_key: $LINEAR_API_KEY
+  active_states:
+    - Todo
+    - In Progress
+codex:
+  command: codex app-server
+---
+Prompt body.
+`,
+      { LINEAR_API_KEY: "lin_api_key" } as NodeJS.ProcessEnv
+    );
+
+    expect(workflow.tracker.kind).toBe("linear");
+    expect(workflow.tracker.projectSlug).toBe("symphony-0c79b11b75ea");
+    expect(workflow.tracker.endpoint).toBe("https://api.linear.app/graphql");
+    expect(workflow.tracker.apiKey).toBe("lin_api_key");
+    expect(workflow.tracker.projectId).toBeNull();
+  });
+
+  it.each(["project_id", "projectId", "teamId"])(
+    "rejects Linear tracker alias %s",
+    (key) => {
+      expect(() =>
+        parseWorkflowMarkdown(`---
+tracker:
+  kind: linear
+  project_slug: symphony-0c79b11b75ea
+  ${key}: forbidden
+codex:
+  command: codex app-server
+---
+Prompt body.
+`)
+      ).toThrow(
+        `Workflow front matter field "tracker.${key}" is not supported for tracker.kind "linear"; use "tracker.project_slug".`
+      );
+    }
+  );
+
+  it("requires project_slug for Linear tracker config", () => {
+    expect(() =>
+      parseWorkflowMarkdown(`---
+tracker:
+  kind: linear
+codex:
+  command: codex app-server
+---
+Prompt body.
+`)
+    ).toThrow(
+      'Workflow front matter field "tracker.project_slug" is required for tracker.kind "linear".'
+    );
+  });
+
   it("resolves environment indirection from yaml front matter", () => {
     const workflow = parseWorkflowMarkdown(
       `---
@@ -161,7 +221,9 @@ Prompt body.
 `);
 
     expect(workflow.runtime).toBeNull();
-    expect(workflow.codex.command).toBe("claude -p --output-format stream-json");
+    expect(workflow.codex.command).toBe(
+      "claude -p --output-format stream-json"
+    );
     expect(workflow.agentCommand).toBe("claude -p --output-format stream-json");
   });
 
@@ -289,7 +351,9 @@ runtime:
 ---
 Prompt body.
 `)
-    ).toThrow(/Workflow front matter field "runtime\.isolation" must be an object/);
+    ).toThrow(
+      /Workflow front matter field "runtime\.isolation" must be an object/
+    );
   });
 
   it("reports nested runtime boolean paths clearly", () => {
@@ -404,9 +468,9 @@ Prompt body.
 `);
 
     expect(workflow.runtime?.kind).toBe("claude-print");
-    expect(
-      "session" in (workflow.runtime as Record<string, unknown>)
-    ).toBe(false);
+    expect("session" in (workflow.runtime as Record<string, unknown>)).toBe(
+      false
+    );
   });
 });
 

--- a/packages/core/src/workflow/config.ts
+++ b/packages/core/src/workflow/config.ts
@@ -112,6 +112,7 @@ export type ParsedWorkflow = WorkflowDefinition & {
 export const DEFAULT_CODEX_COMMAND = "codex app-server";
 export const DEFAULT_CLAUDE_COMMAND = "claude";
 export const DEFAULT_AGENT_COMMAND = DEFAULT_CODEX_COMMAND;
+export const DEFAULT_LINEAR_GRAPHQL_URL = "https://api.linear.app/graphql";
 export const DEFAULT_HOOK_TIMEOUT_MS = 60_000;
 export const DEFAULT_POLL_INTERVAL_MS = 30_000;
 export const DEFAULT_MAX_RETRY_BACKOFF_MS = 300_000;

--- a/packages/core/src/workflow/parser.ts
+++ b/packages/core/src/workflow/parser.ts
@@ -2,6 +2,7 @@ import {
   DEFAULT_AGENT_COMMAND,
   DEFAULT_BASE_DELAY_MS,
   DEFAULT_CLAUDE_COMMAND,
+  DEFAULT_LINEAR_GRAPHQL_URL,
   DEFAULT_HOOK_TIMEOUT_MS,
   DEFAULT_MAX_CONCURRENT_AGENTS,
   DEFAULT_MAX_FAILURE_RETRIES,
@@ -62,6 +63,7 @@ export function parseWorkflowMarkdown(
     : readRequiredObject(frontMatter, "codex");
 
   const trackerKind = readRequiredString(tracker, "kind", env);
+  validateTrackerConfig(tracker, trackerKind);
   const activeStates =
     readStringList(tracker, "active_states") ??
     DEFAULT_WORKFLOW_TRACKER.activeStates;
@@ -108,7 +110,9 @@ export function parseWorkflowMarkdown(
     ),
     tracker: {
       kind: trackerKind,
-      endpoint: readOptionalString(tracker, "endpoint", env),
+      endpoint:
+        readOptionalString(tracker, "endpoint", env) ??
+        (trackerKind === "linear" ? DEFAULT_LINEAR_GRAPHQL_URL : null),
       apiKey: readOptionalString(tracker, "api_key", env),
       projectSlug: readOptionalString(tracker, "project_slug", env),
       activeStates,
@@ -171,6 +175,29 @@ export function parseWorkflowMarkdown(
   };
 
   return parsed;
+}
+
+function validateTrackerConfig(
+  tracker: Record<string, WorkflowFrontMatterNode>,
+  trackerKind: string
+): void {
+  if (trackerKind !== "linear") {
+    return;
+  }
+
+  for (const key of ["project_id", "projectId", "teamId"]) {
+    if (key in tracker) {
+      throw new Error(
+        `Workflow front matter field "tracker.${key}" is not supported for tracker.kind "linear"; use "tracker.project_slug".`
+      );
+    }
+  }
+
+  if (!("project_slug" in tracker)) {
+    throw new Error(
+      'Workflow front matter field "tracker.project_slug" is required for tracker.kind "linear".'
+    );
+  }
 }
 
 function parseLegacyWorkflowMarkdown(markdown: string): ParsedWorkflow {
@@ -382,7 +409,9 @@ function splitInlineArrayEntries(inner: string): string[] {
   }
 
   if (quote) {
-    throw new Error("Workflow front matter inline array has an unterminated string.");
+    throw new Error(
+      "Workflow front matter inline array has an unterminated string."
+    );
   }
 
   pushInlineArrayEntry(entries, current, "end");
@@ -397,9 +426,7 @@ function pushInlineArrayEntry(
   const trimmed = entry.trim();
   if (!trimmed) {
     const reason =
-      position === "end"
-        ? "has a trailing comma"
-        : "contains an empty item";
+      position === "end" ? "has a trailing comma" : "contains an empty item";
     throw new Error(`Workflow front matter inline array ${reason}.`);
   }
   entries.push(trimmed);
@@ -669,6 +696,17 @@ function resolveEnvironmentValue(
     if (!resolved) {
       throw new Error(
         `Workflow front matter requires environment variable ${envTokenMatch[1]}.`
+      );
+    }
+    return resolved;
+  }
+
+  const dollarEnvTokenMatch = value.match(/^\$([A-Z0-9_]+)$/);
+  if (dollarEnvTokenMatch) {
+    const resolved = env[dollarEnvTokenMatch[1]];
+    if (!resolved) {
+      throw new Error(
+        `Workflow front matter requires environment variable ${dollarEnvTokenMatch[1]}.`
       );
     }
     return resolved;

--- a/packages/core/src/workflow/parser.ts
+++ b/packages/core/src/workflow/parser.ts
@@ -63,7 +63,7 @@ export function parseWorkflowMarkdown(
     : readRequiredObject(frontMatter, "codex");
 
   const trackerKind = readRequiredString(tracker, "kind", env);
-  validateTrackerConfig(tracker, trackerKind);
+  validateTrackerConfig(tracker, trackerKind, env);
   const activeStates =
     readStringList(tracker, "active_states") ??
     DEFAULT_WORKFLOW_TRACKER.activeStates;
@@ -179,13 +179,14 @@ export function parseWorkflowMarkdown(
 
 function validateTrackerConfig(
   tracker: Record<string, WorkflowFrontMatterNode>,
-  trackerKind: string
+  trackerKind: string,
+  env: NodeJS.ProcessEnv
 ): void {
   if (trackerKind !== "linear") {
     return;
   }
 
-  for (const key of ["project_id", "projectId", "teamId"]) {
+  for (const key of ["project_id", "projectId", "teamId", "team_id"]) {
     if (key in tracker) {
       throw new Error(
         `Workflow front matter field "tracker.${key}" is not supported for tracker.kind "linear"; use "tracker.project_slug".`
@@ -193,10 +194,20 @@ function validateTrackerConfig(
     }
   }
 
-  if (!("project_slug" in tracker)) {
+  const projectSlug = readOptionalString(tracker, "project_slug", env);
+  if (!projectSlug || projectSlug.trim().length === 0) {
     throw new Error(
       'Workflow front matter field "tracker.project_slug" is required for tracker.kind "linear".'
     );
+  }
+
+  if ("endpoint" in tracker) {
+    const endpoint = readOptionalString(tracker, "endpoint", env);
+    if (!endpoint || endpoint.trim().length === 0) {
+      throw new Error(
+        'Workflow front matter field "tracker.endpoint" must be a non-empty string when provided for tracker.kind "linear".'
+      );
+    }
   }
 }
 

--- a/packages/orchestrator/src/tracker-adapters.test.ts
+++ b/packages/orchestrator/src/tracker-adapters.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { resolveTrackerAdapter } from "./tracker-adapters.js";
+
+describe("resolveTrackerAdapter", () => {
+  it("registers the Linear adapter", () => {
+    const adapter = resolveTrackerAdapter({
+      adapter: "linear",
+      bindingId: "project-slug",
+      settings: {
+        projectSlug: "project-slug",
+      },
+    });
+
+    expect(adapter.buildWorkerEnvironment).toBeTypeOf("function");
+  });
+});

--- a/packages/orchestrator/src/tracker-adapters.ts
+++ b/packages/orchestrator/src/tracker-adapters.ts
@@ -1,6 +1,7 @@
 import { resolveTrackerAdapter as resolveGitHubAdapter } from "@gh-symphony/tracker-github";
 export { findGithubProjectIssue } from "@gh-symphony/tracker-github";
 import { fileTrackerAdapter } from "@gh-symphony/tracker-file";
+import { linearTrackerAdapter } from "@gh-symphony/tracker-linear";
 import type {
   OrchestratorTrackerAdapter,
   OrchestratorTrackerConfig,
@@ -8,6 +9,7 @@ import type {
 
 const localAdapters = new Map<string, OrchestratorTrackerAdapter>([
   ["file", fileTrackerAdapter],
+  ["linear", linearTrackerAdapter],
 ]);
 
 export function resolveTrackerAdapter(

--- a/packages/orchestrator/tsconfig.typecheck.json
+++ b/packages/orchestrator/tsconfig.typecheck.json
@@ -12,7 +12,8 @@
         "../tool-github-graphql/src/index.ts"
       ],
       "@gh-symphony/tracker-file": ["../tracker-file/src/index.ts"],
-      "@gh-symphony/tracker-github": ["../tracker-github/src/index.ts"]
+      "@gh-symphony/tracker-github": ["../tracker-github/src/index.ts"],
+      "@gh-symphony/tracker-linear": ["../tracker-linear/src/index.ts"]
     }
   }
 }

--- a/packages/orchestrator/vitest.config.ts
+++ b/packages/orchestrator/vitest.config.ts
@@ -28,6 +28,10 @@ export default defineConfig({
         packageRoot,
         "../tracker-github/src/index.ts"
       ),
+      "@gh-symphony/tracker-linear": resolve(
+        packageRoot,
+        "../tracker-linear/src/index.ts"
+      ),
     },
   },
   test: {

--- a/packages/tracker-linear/README.md
+++ b/packages/tracker-linear/README.md
@@ -1,0 +1,7 @@
+# @gh-symphony/tracker-linear
+
+Linear tracker adapter for GitHub Symphony.
+
+The MVP is read-side only: it polls Linear issues by `project.slugId` and
+workflow state names, normalizes them into `TrackedIssue`, and injects Linear
+context into worker environments.

--- a/packages/tracker-linear/package.json
+++ b/packages/tracker-linear/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "@gh-symphony/orchestrator",
+  "name": "@gh-symphony/tracker-linear",
   "version": "0.0.14",
   "private": true,
   "license": "MIT",
   "author": "hojinzs",
-  "description": "Headless CLI orchestrator with filesystem-backed state management for GitHub Symphony",
+  "description": "Linear tracker adapter implementing the Symphony tracker contract",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -26,7 +26,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/hojinzs/github-symphony.git",
-    "directory": "packages/orchestrator"
+    "directory": "packages/tracker-linear"
   },
   "homepage": "https://github.com/hojinzs/github-symphony#readme",
   "bugs": {
@@ -34,18 +34,11 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "dev": "node --watch src/index.ts",
     "lint": "eslint src --ext .ts",
-    "start": "node dist/index.js",
     "test": "vitest run --passWithNoTests",
     "typecheck": "tsc -p tsconfig.typecheck.json"
   },
   "dependencies": {
-    "@gh-symphony/core": "workspace:*",
-    "@gh-symphony/runtime-claude": "workspace:*",
-    "@gh-symphony/runtime-codex": "workspace:*",
-    "@gh-symphony/tracker-file": "workspace:*",
-    "@gh-symphony/tracker-github": "workspace:*",
-    "@gh-symphony/tracker-linear": "workspace:*"
+    "@gh-symphony/core": "workspace:*"
   }
 }

--- a/packages/tracker-linear/src/index.ts
+++ b/packages/tracker-linear/src/index.ts
@@ -1,0 +1,5 @@
+export {
+  DEFAULT_LINEAR_GRAPHQL_URL,
+  linearTrackerAdapter,
+  normalizeLinearIssue,
+} from "./orchestrator-adapter.js";

--- a/packages/tracker-linear/src/orchestrator-adapter.ts
+++ b/packages/tracker-linear/src/orchestrator-adapter.ts
@@ -1,0 +1,448 @@
+import type {
+  OrchestratorProjectConfig,
+  OrchestratorRunRecord,
+  OrchestratorTrackerAdapter,
+  OrchestratorTrackerConfig,
+  OrchestratorTrackerDependencies,
+  TrackedIssue,
+} from "@gh-symphony/core";
+
+export const DEFAULT_LINEAR_GRAPHQL_URL = "https://api.linear.app/graphql";
+const DEFAULT_PAGE_SIZE = 50;
+const LINEAR_IDENTIFIER_PATTERN = /^[A-Z][A-Z0-9]*-\d+$/;
+
+type LinearGraphqlClient = <TData>(
+  query: string,
+  variables: Record<string, unknown>
+) => Promise<TData>;
+
+type LinearConnection<TNode> = {
+  nodes?: TNode[] | null;
+  pageInfo?: {
+    hasNextPage?: boolean | null;
+    endCursor?: string | null;
+  } | null;
+};
+
+type LinearIssueNode = {
+  id?: string | null;
+  identifier?: string | null;
+  number?: number | null;
+  title?: string | null;
+  description?: string | null;
+  priority?: number | null;
+  url?: string | null;
+  createdAt?: string | null;
+  updatedAt?: string | null;
+  state?: {
+    name?: string | null;
+  } | null;
+  labels?: LinearConnection<{
+    name?: string | null;
+  }> | null;
+  relations?: LinearConnection<{
+    type?: string | null;
+    relatedIssue?: {
+      id?: string | null;
+      identifier?: string | null;
+      state?: {
+        name?: string | null;
+      } | null;
+    } | null;
+  }> | null;
+};
+
+type LinearIssuesResponse = {
+  issues?: LinearConnection<LinearIssueNode> | null;
+};
+
+const LINEAR_ISSUE_FIELDS = /* GraphQL */ `
+  nodes {
+    id
+    identifier
+    number
+    title
+    description
+    priority
+    url
+    createdAt
+    updatedAt
+    state {
+      name
+    }
+    labels {
+      nodes {
+        name
+      }
+    }
+    relations {
+      nodes {
+        type
+        relatedIssue {
+          id
+          identifier
+          state {
+            name
+          }
+        }
+      }
+    }
+  }
+  pageInfo {
+    hasNextPage
+    endCursor
+  }
+`;
+
+const LINEAR_ISSUES_BY_STATES_QUERY = /* GraphQL */ `
+  query SymphonyLinearIssues(
+    $projectSlug: String!
+    $stateNames: [String!]!
+    $first: Int!
+    $after: String
+  ) {
+    issues(
+      first: $first
+      after: $after
+      filter: {
+        project: { slugId: { eq: $projectSlug } }
+        state: { name: { in: $stateNames } }
+      }
+    ) {
+      ${LINEAR_ISSUE_FIELDS}
+    }
+  }
+`;
+
+const LINEAR_ISSUES_BY_IDS_QUERY = /* GraphQL */ `
+  query SymphonyLinearIssueStates(
+    $projectSlug: String!
+    $issueIds: [ID!]!
+    $first: Int!
+    $after: String
+  ) {
+    issues(
+      first: $first
+      after: $after
+      filter: {
+        project: { slugId: { eq: $projectSlug } }
+        id: { in: $issueIds }
+      }
+    ) {
+      ${LINEAR_ISSUE_FIELDS}
+    }
+  }
+`;
+
+export const linearTrackerAdapter: OrchestratorTrackerAdapter = {
+  async listIssues(project, dependencies = {}) {
+    return listLinearIssues(
+      project,
+      project.tracker.settings?.activeStates,
+      dependencies
+    );
+  },
+
+  async listIssuesByStates(project, states, dependencies = {}) {
+    if (states.length === 0) {
+      return [];
+    }
+
+    return listLinearIssues(project, states, dependencies);
+  },
+
+  async fetchIssueStatesByIds(project, issueIds, dependencies = {}) {
+    if (issueIds.length === 0) {
+      return [];
+    }
+
+    return listLinearIssues(project, undefined, dependencies, issueIds);
+  },
+
+  buildWorkerEnvironment(project, issue) {
+    return {
+      LINEAR_GRAPHQL_URL: resolveLinearEndpoint(project.tracker),
+      LINEAR_ISSUE_ID: issue.id,
+      LINEAR_ISSUE_IDENTIFIER: issue.identifier,
+      SYMPHONY_TRACKER_KIND: "linear",
+    };
+  },
+
+  reviveIssue(project, run: OrchestratorRunRecord): TrackedIssue {
+    return {
+      id: run.issueId,
+      identifier: sanitizeLinearIdentifier(run.issueIdentifier),
+      number: parseLinearIssueNumber(run.issueIdentifier),
+      title: run.issueTitle ?? run.issueIdentifier,
+      description: null,
+      priority: null,
+      state: run.issueState,
+      branchName: null,
+      url: null,
+      labels: [],
+      blockedBy: [],
+      createdAt: null,
+      updatedAt: null,
+      repository: project.repository,
+      tracker: {
+        adapter: "linear",
+        bindingId: project.tracker.bindingId,
+        itemId: run.issueId,
+      },
+      metadata: {},
+    };
+  },
+};
+
+async function listLinearIssues(
+  project: OrchestratorProjectConfig,
+  stateNamesInput: unknown,
+  dependencies: OrchestratorTrackerDependencies,
+  issueIds?: readonly string[]
+): Promise<TrackedIssue[]> {
+  const config = resolveLinearTrackerConfig(project, dependencies);
+  const client = createLinearGraphqlClient(config, dependencies.fetchImpl);
+  const stateNames = readStringArray(stateNamesInput);
+  const nodes = await fetchPaginatedLinearIssues(client, {
+    projectSlug: config.projectSlug,
+    stateNames,
+    issueIds: issueIds ? [...issueIds] : undefined,
+    pageSize: config.pageSize,
+  });
+
+  return nodes.map((node) =>
+    normalizeLinearIssue(project, config.projectSlug, node)
+  );
+}
+
+async function fetchPaginatedLinearIssues(
+  client: LinearGraphqlClient,
+  input: {
+    projectSlug: string;
+    stateNames?: string[];
+    issueIds?: string[];
+    pageSize: number;
+  }
+): Promise<LinearIssueNode[]> {
+  const issues: LinearIssueNode[] = [];
+  let after: string | null = null;
+
+  do {
+    const query = input.issueIds
+      ? LINEAR_ISSUES_BY_IDS_QUERY
+      : LINEAR_ISSUES_BY_STATES_QUERY;
+    const response: LinearIssuesResponse = await client<LinearIssuesResponse>(
+      query,
+      {
+        projectSlug: input.projectSlug,
+        ...(input.issueIds
+          ? { issueIds: input.issueIds }
+          : { stateNames: input.stateNames ?? [] }),
+        first: input.pageSize,
+        after,
+      }
+    );
+    const connection: LinearConnection<LinearIssueNode> | null | undefined =
+      response.issues;
+    issues.push(...(connection?.nodes ?? []));
+    after = connection?.pageInfo?.hasNextPage
+      ? (connection.pageInfo.endCursor ?? null)
+      : null;
+  } while (after);
+
+  return issues;
+}
+
+export function normalizeLinearIssue(
+  project: OrchestratorProjectConfig,
+  projectSlug: string,
+  issue: LinearIssueNode
+): TrackedIssue {
+  const id = requireString(issue.id, "Linear issue id");
+  const identifier = sanitizeLinearIdentifier(
+    requireString(issue.identifier, "Linear issue identifier")
+  );
+  const state = requireString(issue.state?.name, "Linear issue state name");
+
+  return {
+    id,
+    identifier,
+    number:
+      typeof issue.number === "number"
+        ? issue.number
+        : parseLinearIssueNumber(identifier),
+    title: issue.title ?? identifier,
+    description: issue.description ?? null,
+    priority: typeof issue.priority === "number" ? issue.priority : null,
+    state,
+    branchName: null,
+    url: issue.url ?? null,
+    labels: (issue.labels?.nodes ?? [])
+      .map((label) => label.name)
+      .filter((label): label is string => typeof label === "string"),
+    blockedBy: (issue.relations?.nodes ?? [])
+      .filter((relation) => relation.type === "blocks")
+      .map((relation) => ({
+        id: relation.relatedIssue?.id ?? null,
+        identifier:
+          typeof relation.relatedIssue?.identifier === "string"
+            ? sanitizeLinearIdentifier(relation.relatedIssue.identifier)
+            : null,
+        state: relation.relatedIssue?.state?.name ?? null,
+      })),
+    createdAt: issue.createdAt ?? null,
+    updatedAt: issue.updatedAt ?? null,
+    repository: project.repository,
+    tracker: {
+      adapter: "linear",
+      bindingId: project.tracker.bindingId,
+      itemId: id,
+    },
+    metadata: {
+      projectSlug,
+    },
+  };
+}
+
+function createLinearGraphqlClient(
+  config: ReturnType<typeof resolveLinearTrackerConfig>,
+  fetchImpl: typeof fetch = fetch
+): LinearGraphqlClient {
+  return async <TData>(
+    query: string,
+    variables: Record<string, unknown>
+  ): Promise<TData> => {
+    const response = await fetchImpl(config.endpoint, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: config.token,
+      },
+      body: JSON.stringify({ query, variables }),
+    });
+
+    if (!response.ok) {
+      throw new Error(
+        `Linear GraphQL request failed with HTTP ${response.status}.`
+      );
+    }
+
+    const payload = (await response.json()) as {
+      data?: TData;
+      errors?: Array<{ message?: string }>;
+    };
+
+    if (payload.errors?.length) {
+      const message =
+        payload.errors
+          .map((error) => error.message)
+          .filter(Boolean)
+          .join("; ") || "Unknown Linear GraphQL error";
+      throw new Error(`Linear GraphQL request failed: ${message}`);
+    }
+
+    if (!payload.data) {
+      throw new Error("Linear GraphQL response did not include data.");
+    }
+
+    return payload.data;
+  };
+}
+
+function resolveLinearTrackerConfig(
+  project: OrchestratorProjectConfig,
+  dependencies: OrchestratorTrackerDependencies
+) {
+  const projectSlug = readRequiredSetting(project.tracker, "projectSlug");
+  const token = dependencies.token ?? process.env.LINEAR_API_KEY;
+
+  if (!token) {
+    throw new Error("LINEAR_API_KEY environment variable is required.");
+  }
+
+  return {
+    endpoint: resolveLinearEndpoint(project.tracker),
+    pageSize:
+      readPositiveIntegerSetting(project.tracker, "pageSize") ??
+      DEFAULT_PAGE_SIZE,
+    projectSlug,
+    token,
+  };
+}
+
+function resolveLinearEndpoint(tracker: OrchestratorTrackerConfig): string {
+  return tracker.apiUrl ?? DEFAULT_LINEAR_GRAPHQL_URL;
+}
+
+function readRequiredSetting(
+  tracker: OrchestratorTrackerConfig,
+  key: string
+): string {
+  const value = tracker.settings?.[key];
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(
+      `Tracker adapter "${tracker.adapter}" requires the "${key}" setting.`
+    );
+  }
+  return value;
+}
+
+function readPositiveIntegerSetting(
+  tracker: OrchestratorTrackerConfig,
+  key: string
+): number | undefined {
+  const value = tracker.settings?.[key];
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value === "number" && Number.isInteger(value) && value > 0) {
+    return value;
+  }
+  if (typeof value === "string") {
+    const parsed = Number(value);
+    if (Number.isInteger(parsed) && parsed > 0) {
+      return parsed;
+    }
+  }
+  throw new Error(
+    `Tracker adapter "${tracker.adapter}" requires the "${key}" setting to be a positive integer when provided.`
+  );
+}
+
+function readStringArray(value: unknown): string[] | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value === "string") {
+    return value
+      .split(/\r?\n|,/)
+      .map((entry) => entry.trim())
+      .filter(Boolean);
+  }
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  return value.filter((entry): entry is string => typeof entry === "string");
+}
+
+function requireString(value: unknown, label: string): string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`${label} is required.`);
+  }
+  return value;
+}
+
+function sanitizeLinearIdentifier(identifier: string): string {
+  const sanitized = identifier.trim().toUpperCase();
+  if (!LINEAR_IDENTIFIER_PATTERN.test(sanitized)) {
+    throw new Error(
+      `Linear issue identifier "${identifier}" must match ${LINEAR_IDENTIFIER_PATTERN.source}.`
+    );
+  }
+  return sanitized;
+}
+
+function parseLinearIssueNumber(identifier: string): number {
+  const sanitized = sanitizeLinearIdentifier(identifier);
+  return Number.parseInt(sanitized.split("-").at(-1) ?? "0", 10);
+}

--- a/packages/tracker-linear/src/orchestrator-adapter.ts
+++ b/packages/tracker-linear/src/orchestrator-adapter.ts
@@ -1,13 +1,14 @@
-import type {
-  OrchestratorProjectConfig,
-  OrchestratorRunRecord,
-  OrchestratorTrackerAdapter,
-  OrchestratorTrackerConfig,
-  OrchestratorTrackerDependencies,
-  TrackedIssue,
+import {
+  DEFAULT_LINEAR_GRAPHQL_URL as CORE_DEFAULT_LINEAR_GRAPHQL_URL,
+  type OrchestratorProjectConfig,
+  type OrchestratorRunRecord,
+  type OrchestratorTrackerAdapter,
+  type OrchestratorTrackerConfig,
+  type OrchestratorTrackerDependencies,
+  type TrackedIssue,
 } from "@gh-symphony/core";
 
-export const DEFAULT_LINEAR_GRAPHQL_URL = "https://api.linear.app/graphql";
+export const DEFAULT_LINEAR_GRAPHQL_URL = CORE_DEFAULT_LINEAR_GRAPHQL_URL;
 const DEFAULT_PAGE_SIZE = 50;
 const LINEAR_IDENTIFIER_PATTERN = /^[A-Z][A-Z0-9]*-\d+$/;
 
@@ -169,10 +170,12 @@ export const linearTrackerAdapter: OrchestratorTrackerAdapter = {
   },
 
   reviveIssue(project, run: OrchestratorRunRecord): TrackedIssue {
+    const revivedIdentifier = reviveLinearIdentifier(run.issueIdentifier);
+
     return {
       id: run.issueId,
-      identifier: sanitizeLinearIdentifier(run.issueIdentifier),
-      number: parseLinearIssueNumber(run.issueIdentifier),
+      identifier: revivedIdentifier,
+      number: parseLinearIssueNumberOrZero(revivedIdentifier),
       title: run.issueTitle ?? run.issueIdentifier,
       description: null,
       priority: null,
@@ -203,6 +206,11 @@ async function listLinearIssues(
   const config = resolveLinearTrackerConfig(project, dependencies);
   const client = createLinearGraphqlClient(config, dependencies.fetchImpl);
   const stateNames = readStringArray(stateNamesInput);
+  if (!issueIds && (!stateNames || stateNames.length === 0)) {
+    throw new Error(
+      'Tracker adapter "linear" requires at least one active state name in the "activeStates" setting.'
+    );
+  }
   const nodes = await fetchPaginatedLinearIssues(client, {
     projectSlug: config.projectSlug,
     stateNames,
@@ -371,7 +379,7 @@ function resolveLinearTrackerConfig(
 }
 
 function resolveLinearEndpoint(tracker: OrchestratorTrackerConfig): string {
-  return tracker.apiUrl ?? DEFAULT_LINEAR_GRAPHQL_URL;
+  return tracker.apiUrl?.trim() || DEFAULT_LINEAR_GRAPHQL_URL;
 }
 
 function readRequiredSetting(
@@ -445,4 +453,20 @@ function sanitizeLinearIdentifier(identifier: string): string {
 function parseLinearIssueNumber(identifier: string): number {
   const sanitized = sanitizeLinearIdentifier(identifier);
   return Number.parseInt(sanitized.split("-").at(-1) ?? "0", 10);
+}
+
+function parseLinearIssueNumberOrZero(identifier: string): number {
+  try {
+    return parseLinearIssueNumber(identifier);
+  } catch {
+    return 0;
+  }
+}
+
+function reviveLinearIdentifier(identifier: string): string {
+  try {
+    return sanitizeLinearIdentifier(identifier);
+  } catch {
+    return identifier;
+  }
 }

--- a/packages/tracker-linear/src/tracker-linear.test.ts
+++ b/packages/tracker-linear/src/tracker-linear.test.ts
@@ -182,6 +182,22 @@ describe("linearTrackerAdapter", () => {
     expect(request.variables.stateNames).toEqual(["Rework"]);
   });
 
+  it("requires active state names when polling Linear candidates", async () => {
+    await expect(
+      linearTrackerAdapter.listIssues(
+        makeProject({
+          settings: { projectSlug: "symphony-0c79b11b75ea", activeStates: "" },
+        }),
+        {
+          fetchImpl: vi.fn(),
+          token: "linear-token",
+        }
+      )
+    ).rejects.toThrow(
+      'Tracker adapter "linear" requires at least one active state name in the "activeStates" setting.'
+    );
+  });
+
   it("fetchIssueStatesByIds filters by Linear ids", async () => {
     const fetchImpl = vi.fn().mockResolvedValue(
       jsonResponse({
@@ -225,6 +241,19 @@ describe("linearTrackerAdapter", () => {
     expect(env).not.toHaveProperty("LINEAR_TEAM_ID");
   });
 
+  it("defaults blank tracker apiUrl to the Linear GraphQL endpoint", () => {
+    const env = linearTrackerAdapter.buildWorkerEnvironment(
+      makeProject({ apiUrl: "   " }),
+      normalizeLinearIssue(makeProject(), "project-slug", {
+        id: "issue-1",
+        identifier: "eng-123",
+        state: { name: "Todo" },
+      })
+    );
+
+    expect(env.LINEAR_GRAPHQL_URL).toBe("https://api.linear.app/graphql");
+  });
+
   it("revives issues with repository routing from the orchestrator project", () => {
     const revived = linearTrackerAdapter.reviveIssue(makeProject(), {
       runId: "run-1",
@@ -258,6 +287,42 @@ describe("linearTrackerAdapter", () => {
 
     expect(revived.identifier).toBe("ENG-123");
     expect(revived.number).toBe(123);
+    expect(revived.repository).toBe(repository);
+  });
+
+  it("revives legacy issue identifiers without blocking recovery", () => {
+    const revived = linearTrackerAdapter.reviveIssue(makeProject(), {
+      runId: "run-1",
+      projectId: "repository",
+      projectSlug: "platform",
+      issueId: "issue-1",
+      issueSubjectId: "issue-1",
+      issueIdentifier: "legacy identifier",
+      issueState: "Todo",
+      repository: {
+        owner: "ignored",
+        name: "ignored",
+        cloneUrl: "https://example.test/ignored.git",
+      },
+      status: "running",
+      attempt: 1,
+      processId: null,
+      port: null,
+      workingDirectory: "/workspace",
+      issueWorkspaceKey: "legacy identifier",
+      workspaceRuntimeDir: "/runtime",
+      workflowPath: null,
+      retryKind: null,
+      createdAt: "2026-05-01T00:00:00.000Z",
+      updatedAt: "2026-05-01T00:00:00.000Z",
+      startedAt: null,
+      completedAt: null,
+      lastError: null,
+      nextRetryAt: null,
+    });
+
+    expect(revived.identifier).toBe("legacy identifier");
+    expect(revived.number).toBe(0);
     expect(revived.repository).toBe(repository);
   });
 

--- a/packages/tracker-linear/src/tracker-linear.test.ts
+++ b/packages/tracker-linear/src/tracker-linear.test.ts
@@ -1,0 +1,273 @@
+import { describe, expect, it, vi } from "vitest";
+import type { OrchestratorProjectConfig } from "@gh-symphony/core";
+import { linearTrackerAdapter, normalizeLinearIssue } from "./index.js";
+
+const repository = {
+  owner: "acme",
+  name: "platform",
+  cloneUrl: "https://github.com/acme/platform.git",
+  path: "/workspace/platform",
+};
+
+function makeProject(
+  overrides: Partial<OrchestratorProjectConfig["tracker"]> = {}
+): OrchestratorProjectConfig {
+  return {
+    projectId: "repository",
+    slug: "platform",
+    workspaceDir: "/workspace/platform",
+    repository,
+    tracker: {
+      adapter: "linear",
+      bindingId: "symphony-0c79b11b75ea",
+      apiUrl: "https://linear.test/graphql",
+      settings: {
+        projectSlug: "symphony-0c79b11b75ea",
+        activeStates: "Todo\nIn Progress",
+        ...overrides.settings,
+      },
+      ...overrides,
+    },
+  };
+}
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("linearTrackerAdapter", () => {
+  it("queries Linear by project slug and state names with cursor pagination", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse({
+          data: {
+            issues: {
+              nodes: [
+                {
+                  id: "issue-1",
+                  identifier: "ENG-1",
+                  number: 1,
+                  title: "First issue",
+                  description: "Description",
+                  priority: 2,
+                  url: "https://linear.app/acme/issue/ENG-1",
+                  createdAt: "2026-05-01T00:00:00.000Z",
+                  updatedAt: "2026-05-02T00:00:00.000Z",
+                  state: { name: "Todo" },
+                  labels: { nodes: [{ name: "tracker" }] },
+                  relations: {
+                    nodes: [
+                      {
+                        type: "blocks",
+                        relatedIssue: {
+                          id: "issue-0",
+                          identifier: "ENG-0",
+                          state: { name: "Done" },
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+              pageInfo: { hasNextPage: true, endCursor: "cursor-1" },
+            },
+          },
+        })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          data: {
+            issues: {
+              nodes: [
+                {
+                  id: "issue-2",
+                  identifier: "OPS-20",
+                  number: 20,
+                  title: "Second issue",
+                  priority: 4,
+                  state: { name: "In Progress" },
+                  labels: { nodes: [] },
+                  relations: { nodes: [] },
+                },
+              ],
+              pageInfo: { hasNextPage: false, endCursor: null },
+            },
+          },
+        })
+      );
+
+    const issues = await linearTrackerAdapter.listIssues(makeProject(), {
+      fetchImpl,
+      token: "linear-token",
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    const firstRequest = JSON.parse(
+      String(fetchImpl.mock.calls[0]?.[1]?.body)
+    ) as { query: string; variables: Record<string, unknown> };
+    const secondRequest = JSON.parse(
+      String(fetchImpl.mock.calls[1]?.[1]?.body)
+    ) as { variables: Record<string, unknown> };
+
+    expect(firstRequest.query).toContain(
+      "project: { slugId: { eq: $projectSlug } }"
+    );
+    expect(firstRequest.query).toContain(
+      "state: { name: { in: $stateNames } }"
+    );
+    expect(firstRequest.variables).toMatchObject({
+      projectSlug: "symphony-0c79b11b75ea",
+      stateNames: ["Todo", "In Progress"],
+      first: 50,
+      after: null,
+    });
+    expect(secondRequest.variables.after).toBe("cursor-1");
+    expect(issues).toMatchObject([
+      {
+        id: "issue-1",
+        identifier: "ENG-1",
+        number: 1,
+        title: "First issue",
+        priority: 2,
+        state: "Todo",
+        url: "https://linear.app/acme/issue/ENG-1",
+        labels: ["tracker"],
+        blockedBy: [{ id: "issue-0", identifier: "ENG-0", state: "Done" }],
+        repository,
+        tracker: {
+          adapter: "linear",
+          bindingId: "symphony-0c79b11b75ea",
+          itemId: "issue-1",
+        },
+      },
+      {
+        id: "issue-2",
+        identifier: "OPS-20",
+        number: 20,
+        state: "In Progress",
+        repository,
+      },
+    ]);
+  });
+
+  it("listIssuesByStates queries Linear directly without using projectItemsCache", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonResponse({
+        data: {
+          issues: {
+            nodes: [],
+            pageInfo: { hasNextPage: false, endCursor: null },
+          },
+        },
+      })
+    );
+    const projectItemsCache = {
+      getOrLoad: vi.fn(),
+    };
+
+    await linearTrackerAdapter.listIssuesByStates(makeProject(), ["Rework"], {
+      fetchImpl,
+      token: "linear-token",
+      projectItemsCache,
+    });
+
+    const request = JSON.parse(String(fetchImpl.mock.calls[0]?.[1]?.body)) as {
+      variables: Record<string, unknown>;
+    };
+    expect(projectItemsCache.getOrLoad).not.toHaveBeenCalled();
+    expect(request.variables.stateNames).toEqual(["Rework"]);
+  });
+
+  it("fetchIssueStatesByIds filters by Linear ids", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonResponse({
+        data: {
+          issues: {
+            nodes: [],
+            pageInfo: { hasNextPage: false, endCursor: null },
+          },
+        },
+      })
+    );
+
+    await linearTrackerAdapter.fetchIssueStatesByIds(
+      makeProject(),
+      ["issue-1", "issue-2"],
+      { fetchImpl, token: "linear-token" }
+    );
+
+    const request = JSON.parse(String(fetchImpl.mock.calls[0]?.[1]?.body)) as {
+      variables: Record<string, unknown>;
+    };
+    expect(request.variables.issueIds).toEqual(["issue-1", "issue-2"]);
+  });
+
+  it("injects worker environment without requiring team id", () => {
+    const env = linearTrackerAdapter.buildWorkerEnvironment(
+      makeProject({ apiUrl: undefined }),
+      normalizeLinearIssue(makeProject(), "project-slug", {
+        id: "issue-1",
+        identifier: "eng-123",
+        state: { name: "Todo" },
+      })
+    );
+
+    expect(env).toEqual({
+      LINEAR_GRAPHQL_URL: "https://api.linear.app/graphql",
+      LINEAR_ISSUE_ID: "issue-1",
+      LINEAR_ISSUE_IDENTIFIER: "ENG-123",
+      SYMPHONY_TRACKER_KIND: "linear",
+    });
+    expect(env).not.toHaveProperty("LINEAR_TEAM_ID");
+  });
+
+  it("revives issues with repository routing from the orchestrator project", () => {
+    const revived = linearTrackerAdapter.reviveIssue(makeProject(), {
+      runId: "run-1",
+      projectId: "repository",
+      projectSlug: "platform",
+      issueId: "issue-1",
+      issueSubjectId: "issue-1",
+      issueIdentifier: "eng-123",
+      issueState: "Todo",
+      repository: {
+        owner: "ignored",
+        name: "ignored",
+        cloneUrl: "https://example.test/ignored.git",
+      },
+      status: "running",
+      attempt: 1,
+      processId: null,
+      port: null,
+      workingDirectory: "/workspace",
+      issueWorkspaceKey: "ENG-123",
+      workspaceRuntimeDir: "/runtime",
+      workflowPath: null,
+      retryKind: null,
+      createdAt: "2026-05-01T00:00:00.000Z",
+      updatedAt: "2026-05-01T00:00:00.000Z",
+      startedAt: null,
+      completedAt: null,
+      lastError: null,
+      nextRetryAt: null,
+    });
+
+    expect(revived.identifier).toBe("ENG-123");
+    expect(revived.number).toBe(123);
+    expect(revived.repository).toBe(repository);
+  });
+
+  it("rejects Linear identifiers that cannot be used as workspace keys", () => {
+    expect(() =>
+      normalizeLinearIssue(makeProject(), "project-slug", {
+        id: "issue-1",
+        identifier: "eng 123",
+        state: { name: "Todo" },
+      })
+    ).toThrow(/must match \^\[A-Z\]\[A-Z0-9\]\*-/);
+  });
+});

--- a/packages/tracker-linear/tsconfig.json
+++ b/packages/tracker-linear/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "noEmit": false,
+    "declaration": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/tracker-linear/tsconfig.typecheck.json
+++ b/packages/tracker-linear/tsconfig.typecheck.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "..",
+    "baseUrl": ".",
+    "paths": {
+      "@gh-symphony/core": ["../core/src/index.ts"]
+    }
+  }
+}

--- a/packages/tracker-linear/vitest.config.ts
+++ b/packages/tracker-linear/vitest.config.ts
@@ -1,0 +1,16 @@
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+const packageRoot = dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@gh-symphony/core": resolve(packageRoot, "../core/src/index.ts"),
+    },
+  },
+  test: {
+    environment: "node",
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -178,6 +178,9 @@ importers:
       '@gh-symphony/tracker-github':
         specifier: workspace:*
         version: link:../tracker-github
+      '@gh-symphony/tracker-linear':
+        specifier: workspace:*
+        version: link:../tracker-linear
 
   packages/runtime-claude:
     dependencies:
@@ -206,6 +209,12 @@ importers:
         version: link:../core
 
   packages/tracker-github:
+    dependencies:
+      '@gh-symphony/core':
+        specifier: workspace:*
+        version: link:../core
+
+  packages/tracker-linear:
     dependencies:
       '@gh-symphony/core':
         specifier: workspace:*


### PR DESCRIPTION
## Issues

- Fixes #313

## Summary

- Adds a read-side Linear tracker adapter and registers it as `tracker.kind: linear`.
- Aligns WORKFLOW.md Linear validation with the ADR: `project_slug` only, default endpoint, explicit alias rejection, and early rejection of empty Linear config values.
- Addresses review feedback for recoverability and runtime defaults without expanding the MVP into Linear write/OAuth scope.

## Changes

- Scaffolded `@gh-symphony/tracker-linear` with injectable GraphQL fetch, server-side `project.slugId` and state-name filtering, cursor pagination, issue-id reconciliation queries, `TrackedIssue` normalization, worker environment injection, and revive support.
- Updated WORKFLOW.md parsing and repo runtime mapping so Linear configs carry `projectSlug`, active state names, and default `https://api.linear.app/graphql` into orchestrator config without storing Linear secrets.
- Registered the Linear adapter in `packages/orchestrator/src/tracker-adapters.ts` and added focused coverage across tracker, core parser, CLI repo init, and orchestrator registry behavior.
- Tightened Linear review-feedback paths: reject blank `project_slug` and blank `endpoint`, reject `team_id`, require non-empty active state names during Linear polling, default blank runtime `apiUrl`, single-source the default Linear endpoint from core, and revive legacy/corrupt persisted identifiers leniently.

## Evidence

- `pnpm --filter @gh-symphony/tracker-linear test`
- `pnpm --filter @gh-symphony/core test -- workflow-loader.test.ts`
- `pnpm --filter @gh-symphony/cli test -- repo.test.ts`
- `pnpm --filter @gh-symphony/orchestrator test -- tracker-adapters.test.ts`
- `pnpm --filter @gh-symphony/tracker-linear test && pnpm --filter @gh-symphony/tracker-linear typecheck`
- `pnpm lint && pnpm test && pnpm typecheck && pnpm build`
- Docker E2E blackbox TC: `./e2e/run-e2e.sh happy 45` verified dashboard readiness, `/api/v1/refresh` accepted fixture injection, one worker dispatched for `test-owner/test-repo#1`, reached `running`, entered continuation retry after completion, and returned to `idle` after fixture reset.

## Human Validation

- [ ] Confirm a repo-local WORKFLOW.md with `tracker.kind: linear` and `tracker.project_slug` starts the orchestrator against a real Linear project.
- [ ] Confirm Linear issue state names in `active_states` match the target workspace workflow.
- [ ] Confirm no Linear API key is persisted in generated runtime project config or reviewer-visible logs.
- [ ] Confirm blank/legacy Linear configuration errors are understandable for operators.

## Risks

- Linear write/tooling remains intentionally out of scope for this MVP; workers receive Linear context but ticket writes still belong to workflow/runtime tooling.
- Linear OAuth remains out of scope; the current adapter continues to target personal API keys through `LINEAR_API_KEY`.
- GraphQL relation semantics for blockers may need real-workspace review if a team relies on nonstandard Linear relation direction conventions.