### PR TITLE
fix(cli): allow local Claude auth preflight

### DIFF
--- a/.changeset/claude-local-auth-preflight.md
+++ b/.changeset/claude-local-auth-preflight.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Allow `gh-symphony init` Claude runtime preflight to pass with Claude Code local authentication instead of requiring `ANTHROPIC_API_KEY`.

--- a/packages/cli/src/commands/workflow-init.test.ts
+++ b/packages/cli/src/commands/workflow-init.test.ts
@@ -326,14 +326,14 @@ describe("init priority field detection", () => {
     expect(payload.priorityFieldName).toBe("Priority");
   });
 
-  it("runs Claude preflight for init --runtime claude-code", async () => {
+  it("allows Claude preflight for init --runtime claude-code with local auth", async () => {
     const configDir = await mkdtemp(join(tmpdir(), "cli-init-claude-preflight-"));
     const binDir = join(configDir, "bin");
     await mkdir(binDir, { recursive: true });
-    const claude = join(binDir, "claude-code");
+    const claude = join(binDir, "claude");
     await writeFile(
       claude,
-      "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then echo 'claude-code 1.0.0'; fi\n",
+      "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then echo 'claude 1.0.0'; fi\n",
       "utf8"
     );
     await chmod(claude, 0o755);
@@ -385,9 +385,12 @@ describe("init priority field detection", () => {
       }
     );
 
-    expect(process.exitCode).toBe(1);
-    expect(p.log.error).toHaveBeenCalledWith(
-      expect.stringContaining("Neither ANTHROPIC_API_KEY")
+    expect(process.exitCode).toBeUndefined();
+    expect(p.log.info).toHaveBeenCalledWith(
+      expect.stringContaining("WARN Claude authentication")
+    );
+    expect(p.log.info).toHaveBeenCalledWith(
+      expect.stringContaining("Claude Code local login")
     );
   });
 
@@ -836,7 +839,7 @@ describe("init ecosystem generation", () => {
     expect(plan.workflowMd).toContain("    - bypassPermissions");
     expect(plan.workflowMd).toContain("    bare: false");
     expect(plan.workflowMd).toContain("    strict_mcp_config: false");
-    expect(plan.workflowMd).toContain("    env: ANTHROPIC_API_KEY");
+    expect(plan.workflowMd).not.toContain("    env: ANTHROPIC_API_KEY");
     expect(plan.workflowMd).toContain("    stall_timeout_ms: 900000");
     expect(plan.workflowMd).toContain("## Runtime Constraints");
     expect(plan.workflowMd).toContain("Runtime trade-off note:");

--- a/packages/cli/src/commands/workflow-init.ts
+++ b/packages/cli/src/commands/workflow-init.ts
@@ -192,6 +192,7 @@ async function runInitRuntimePreflight(runtime: string): Promise<boolean> {
     command:
       resolveClaudeCommandBinary(resolveRuntimeCommand(runtime)) ??
       resolveRuntimeCommand(runtime),
+    authMode: "local-or-api-key",
     includeGhAuth: !hasGitHubGraphqlToken,
   });
   const message = formatClaudePreflightText(report);

--- a/packages/cli/src/workflow/generate-reference-workflow.test.ts
+++ b/packages/cli/src/workflow/generate-reference-workflow.test.ts
@@ -45,7 +45,7 @@ describe("generateReferenceWorkflow", () => {
     });
     expect(output).toContain("kind: claude-print");
     expect(output).toContain("command: claude");
-    expect(output).toContain("    env: ANTHROPIC_API_KEY");
+    expect(output).not.toContain("    env: ANTHROPIC_API_KEY");
     expect(output).toContain("    stall_timeout_ms: 900000");
   });
 

--- a/packages/cli/src/workflow/generate-workflow-md.test.ts
+++ b/packages/cli/src/workflow/generate-workflow-md.test.ts
@@ -114,7 +114,7 @@ describe("generateWorkflowMarkdown", () => {
     expect(markdown).toContain("kind: claude-print");
     expect(markdown).toContain("command: claude");
     expect(markdown).toContain("    - -p");
-    expect(markdown).toContain("    env: ANTHROPIC_API_KEY");
+    expect(markdown).not.toContain("    env: ANTHROPIC_API_KEY");
     expect(markdown).toContain("    stall_timeout_ms: 900000");
   });
 

--- a/packages/cli/src/workflow/workflow-runtime.ts
+++ b/packages/cli/src/workflow/workflow-runtime.ts
@@ -127,8 +127,6 @@ export function buildRuntimeFrontMatter(runtime: string): string[] {
       "  isolation:",
       "    bare: false",
       "    strict_mcp_config: false",
-      "  auth:",
-      "    env: ANTHROPIC_API_KEY",
       "  timeouts:",
       "    read_timeout_ms: 5000",
       "    turn_timeout_ms: 3600000",

--- a/packages/runtime-claude/src/preflight.test.ts
+++ b/packages/runtime-claude/src/preflight.test.ts
@@ -47,7 +47,7 @@ describe("Claude runtime preflight", () => {
     });
   });
 
-  it("reports missing ANTHROPIC_API_KEY with broker guidance", async () => {
+  it("reports missing ANTHROPIC_API_KEY with broker guidance when API key auth is required", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "claude-preflight-key-"));
     const report = await runClaudePreflight(
       { cwd, env: {}, command: "claude" },
@@ -63,6 +63,29 @@ describe("Claude runtime preflight", () => {
       remediation: expect.stringContaining(
         "Set ANTHROPIC_API_KEY or configure"
       ),
+    });
+  });
+
+  it("warns when local Claude Code auth is allowed and no API key or broker is configured", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "claude-preflight-local-"));
+    const report = await runClaudePreflight(
+      {
+        cwd,
+        env: {},
+        command: "claude",
+        authMode: "local-or-api-key",
+      },
+      { execFileSync: vi.fn(execSuccess) as never }
+    );
+
+    expect(report.ok).toBe(true);
+    expect(
+      report.checks.find((check) => check.id === "anthropic_api_key")
+    ).toMatchObject({
+      status: "warn",
+      title: "Claude authentication",
+      summary: expect.stringContaining("Claude Code local login"),
+      details: { source: "local" },
     });
   });
 

--- a/packages/runtime-claude/src/preflight.test.ts
+++ b/packages/runtime-claude/src/preflight.test.ts
@@ -89,6 +89,42 @@ describe("Claude runtime preflight", () => {
     });
   });
 
+  it("fails clearly when credential broker configuration is incomplete", async () => {
+    const cwd = await mkdtemp(
+      join(tmpdir(), "claude-preflight-partial-broker-")
+    );
+    const report = await runClaudePreflight(
+      {
+        cwd,
+        env: {
+          AGENT_CREDENTIAL_BROKER_URL: "https://broker.test/agent",
+        },
+        command: "claude",
+        authMode: "local-or-api-key",
+      },
+      { execFileSync: vi.fn(execSuccess) as never }
+    );
+
+    expect(report.ok).toBe(false);
+    expect(
+      report.checks.find((check) => check.id === "anthropic_api_key")
+    ).toMatchObject({
+      status: "fail",
+      title: "Claude authentication",
+      summary: expect.stringContaining(
+        "AGENT_CREDENTIAL_BROKER_SECRET is not configured"
+      ),
+      remediation: expect.stringContaining(
+        "Set AGENT_CREDENTIAL_BROKER_SECRET"
+      ),
+      details: {
+        source: "broker",
+        brokerUrl: "https://broker.test/agent",
+        missing: "AGENT_CREDENTIAL_BROKER_SECRET",
+      },
+    });
+  });
+
   it("reports gh authentication failure when requested", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "claude-preflight-gh-"));
     const execFileSync = vi.fn(

--- a/packages/runtime-claude/src/preflight.ts
+++ b/packages/runtime-claude/src/preflight.ts
@@ -55,7 +55,9 @@ export type ClaudePreflightOptions = {
   probeCredentialBroker?: boolean;
   /**
    * `local-or-api-key` allows Claude Code's local OAuth/keychain login path
-   * and reports missing API-key/broker credentials as a warning.
+   * and reports entirely missing API-key/broker credentials as a warning.
+   * Partially configured broker credentials still fail because they indicate
+   * an attempted broker setup that cannot work as configured.
    *
    * `api-key-required` is for headless/bare runtime paths where local Claude
    * Code auth is not sufficient.
@@ -271,6 +273,23 @@ async function checkClaudeAuthentication(
         "ANTHROPIC_API_KEY and agent credential broker are not configured; Claude Code local login may be used for this non-bare runtime.",
         "If this runtime will run headlessly or with runtime.isolation.bare: true, set ANTHROPIC_API_KEY or configure AGENT_CREDENTIAL_BROKER_URL and AGENT_CREDENTIAL_BROKER_SECRET.",
         { source: "local" }
+      );
+    }
+
+    if (brokerUrl || brokerSecret) {
+      const missingName = brokerUrl
+        ? "AGENT_CREDENTIAL_BROKER_SECRET"
+        : "AGENT_CREDENTIAL_BROKER_URL";
+      return fail(
+        "anthropic_api_key",
+        "Claude authentication",
+        `Agent credential broker configuration is incomplete: ${missingName} is not configured.`,
+        `Set ${missingName} or remove the partial broker configuration and use ANTHROPIC_API_KEY instead.`,
+        {
+          source: "broker",
+          brokerUrl: brokerUrl ?? null,
+          missing: missingName,
+        }
       );
     }
 

--- a/packages/runtime-claude/src/preflight.ts
+++ b/packages/runtime-claude/src/preflight.ts
@@ -11,6 +11,10 @@ export type ClaudePreflightCheckId =
   | "claude_mcp_config"
   | "gh_authentication";
 
+export type ClaudePreflightAuthMode =
+  | "local-or-api-key"
+  | "api-key-required";
+
 export type ClaudePreflightCheck = {
   id: ClaudePreflightCheckId;
   title: string;
@@ -49,6 +53,14 @@ export type ClaudePreflightOptions = {
    * credentials as sufficient.
    */
   probeCredentialBroker?: boolean;
+  /**
+   * `local-or-api-key` allows Claude Code's local OAuth/keychain login path
+   * and reports missing API-key/broker credentials as a warning.
+   *
+   * `api-key-required` is for headless/bare runtime paths where local Claude
+   * Code auth is not sufficient.
+   */
+  authMode?: ClaudePreflightAuthMode;
 };
 
 const DEFAULT_DEPENDENCIES: ClaudePreflightDependencies = {
@@ -71,7 +83,7 @@ export async function runClaudePreflight(
   const checks: ClaudePreflightCheck[] = [];
 
   checks.push(checkClaudeBinary(command, options.cwd, deps));
-  checks.push(await checkAnthropicApiKey(env, options, deps));
+  checks.push(await checkClaudeAuthentication(env, options, deps));
   checks.push(await checkWorkspaceMcpConfig(options.cwd, deps));
   if (options.includeGhAuth) {
     checks.push(checkGhAuthentication(options.cwd, deps));
@@ -234,15 +246,16 @@ function checkGhAuthentication(
   }
 }
 
-async function checkAnthropicApiKey(
+async function checkClaudeAuthentication(
   env: NodeJS.ProcessEnv,
-  options: Pick<ClaudePreflightOptions, "probeCredentialBroker">,
+  options: Pick<ClaudePreflightOptions, "authMode" | "probeCredentialBroker">,
   deps: Pick<ClaudePreflightDependencies, "fetchImpl">
 ): Promise<ClaudePreflightCheck> {
+  const authMode = options.authMode ?? "api-key-required";
   if (env.ANTHROPIC_API_KEY?.trim()) {
     return pass(
       "anthropic_api_key",
-      "Anthropic API key",
+      "Claude authentication",
       "ANTHROPIC_API_KEY is configured in the environment.",
       { source: "env" }
     );
@@ -251,9 +264,19 @@ async function checkAnthropicApiKey(
   const brokerUrl = env.AGENT_CREDENTIAL_BROKER_URL?.trim();
   const brokerSecret = env.AGENT_CREDENTIAL_BROKER_SECRET?.trim();
   if (!brokerUrl || !brokerSecret) {
+    if (authMode === "local-or-api-key" && !brokerUrl && !brokerSecret) {
+      return warn(
+        "anthropic_api_key",
+        "Claude authentication",
+        "ANTHROPIC_API_KEY and agent credential broker are not configured; Claude Code local login may be used for this non-bare runtime.",
+        "If this runtime will run headlessly or with runtime.isolation.bare: true, set ANTHROPIC_API_KEY or configure AGENT_CREDENTIAL_BROKER_URL and AGENT_CREDENTIAL_BROKER_SECRET.",
+        { source: "local" }
+      );
+    }
+
     return fail(
       "anthropic_api_key",
-      "Anthropic API key",
+      "Claude authentication",
       "Neither ANTHROPIC_API_KEY nor an agent credential broker is configured.",
       "Set ANTHROPIC_API_KEY or configure AGENT_CREDENTIAL_BROKER_URL and AGENT_CREDENTIAL_BROKER_SECRET.",
       { source: "missing" }
@@ -263,7 +286,7 @@ async function checkAnthropicApiKey(
   if (options.probeCredentialBroker === false) {
     return pass(
       "anthropic_api_key",
-      "Anthropic API key",
+      "Claude authentication",
       "Agent credential broker configuration is present.",
       { source: "broker", brokerUrl }
     );
@@ -285,7 +308,7 @@ async function checkAnthropicApiKey(
     if (response.ok && payload.env?.ANTHROPIC_API_KEY?.trim()) {
       return pass(
         "anthropic_api_key",
-        "Anthropic API key",
+        "Claude authentication",
         "Agent credential broker is reachable and returned ANTHROPIC_API_KEY.",
         { source: "broker", brokerUrl }
       );
@@ -293,7 +316,7 @@ async function checkAnthropicApiKey(
 
     return fail(
       "anthropic_api_key",
-      "Anthropic API key",
+      "Claude authentication",
       payload.error
         ? `Agent credential broker did not return ANTHROPIC_API_KEY: ${payload.error}.`
         : "Agent credential broker did not return ANTHROPIC_API_KEY.",
@@ -303,7 +326,7 @@ async function checkAnthropicApiKey(
   } catch (error) {
     return fail(
       "anthropic_api_key",
-      "Anthropic API key",
+      "Claude authentication",
       "Agent credential broker could not be reached.",
       "Set ANTHROPIC_API_KEY or fix AGENT_CREDENTIAL_BROKER_URL and AGENT_CREDENTIAL_BROKER_SECRET.",
       {

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -24,7 +24,6 @@ import {
 } from "@gh-symphony/runtime-codex";
 import {
   formatClaudePreflightText,
-  isClaudeRuntimeCommand,
   resolveClaudeCommandBinary,
   runClaudePreflight,
 } from "@gh-symphony/runtime-claude";
@@ -493,19 +492,20 @@ async function startAssignedRun() {
       launcherEnv
     );
     const route = resolveWorkerRuntimeRoute(workflow);
+    const runtimeCommand = resolveWorkflowRuntimeCommand(workflow);
+    const claudeCommand = resolveClaudeCommandBinary(runtimeCommand);
     if (
       route === "runtime-adapter" &&
       workflow.runtime?.kind === "claude-print" &&
-      isClaudeRuntimeCommand(resolveWorkflowRuntimeCommand(workflow))
+      claudeCommand
     ) {
-      const runtimeCommand = resolveWorkflowRuntimeCommand(workflow);
       const hasGitHubGraphqlToken =
         typeof launcherEnv.GITHUB_GRAPHQL_TOKEN === "string" &&
         launcherEnv.GITHUB_GRAPHQL_TOKEN.trim().length > 0;
       const preflight = await runClaudePreflight({
         cwd: launcherEnv.WORKING_DIRECTORY!,
         env: launcherEnv,
-        command: resolveClaudeCommandBinary(runtimeCommand) ?? runtimeCommand,
+        command: claudeCommand,
         authMode: resolveClaudePreflightAuthMode(workflow),
         includeGhAuth: !hasGitHubGraphqlToken,
       });

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -48,7 +48,10 @@ import {
   type WorkerNonCodexTurnResult,
 } from "./non-codex-runtime.js";
 import { resolveExitRunPhase } from "./run-phase.js";
-import { resolveWorkerRuntimeRoute } from "./runtime-routing.js";
+import {
+  resolveClaudePreflightAuthMode,
+  resolveWorkerRuntimeRoute,
+} from "./runtime-routing.js";
 import { buildContinuationTurnInput } from "./thread-resume.js";
 import { resolveMaxTurns } from "./turn-limits.js";
 import { persistTokenUsageArtifact, type TokenUsage } from "./token-usage.js";
@@ -495,14 +498,15 @@ async function startAssignedRun() {
       workflow.runtime?.kind === "claude-print" &&
       isClaudeRuntimeCommand(resolveWorkflowRuntimeCommand(workflow))
     ) {
+      const runtimeCommand = resolveWorkflowRuntimeCommand(workflow);
       const hasGitHubGraphqlToken =
         typeof launcherEnv.GITHUB_GRAPHQL_TOKEN === "string" &&
         launcherEnv.GITHUB_GRAPHQL_TOKEN.trim().length > 0;
       const preflight = await runClaudePreflight({
         cwd: launcherEnv.WORKING_DIRECTORY!,
         env: launcherEnv,
-        command:
-          resolveClaudeCommandBinary(workflow.codex.command) ?? undefined,
+        command: resolveClaudeCommandBinary(runtimeCommand) ?? runtimeCommand,
+        authMode: resolveClaudePreflightAuthMode(workflow),
         includeGhAuth: !hasGitHubGraphqlToken,
       });
       process.stderr.write(

--- a/packages/worker/src/runtime-routing.test.ts
+++ b/packages/worker/src/runtime-routing.test.ts
@@ -3,7 +3,10 @@ import {
   DEFAULT_WORKFLOW_DEFINITION,
   type WorkflowDefinition,
 } from "@gh-symphony/core";
-import { resolveWorkerRuntimeRoute } from "./runtime-routing.js";
+import {
+  resolveClaudePreflightAuthMode,
+  resolveWorkerRuntimeRoute,
+} from "./runtime-routing.js";
 
 describe("resolveWorkerRuntimeRoute", () => {
   it("keeps legacy codex fallback on the Codex app-server route", () => {
@@ -38,6 +41,32 @@ describe("resolveWorkerRuntimeRoute", () => {
       ).toBe("runtime-adapter");
     }
   );
+
+  it("allows local Claude Code auth for non-bare Claude runtimes", () => {
+    expect(
+      resolveClaudePreflightAuthMode(
+        workflowWithRuntime({
+          kind: "claude-print",
+          command: "claude",
+          args: [],
+          bare: false,
+        })
+      )
+    ).toBe("local-or-api-key");
+  });
+
+  it("requires API-key auth for bare Claude runtimes", () => {
+    expect(
+      resolveClaudePreflightAuthMode(
+        workflowWithRuntime({
+          kind: "claude-print",
+          command: "claude",
+          args: [],
+          bare: true,
+        })
+      )
+    ).toBe("api-key-required");
+  });
 });
 
 function workflowWithRuntime(
@@ -45,6 +74,7 @@ function workflowWithRuntime(
     kind: "codex-app-server" | "claude-print" | "custom";
     command: string;
     args: readonly string[];
+    bare?: boolean;
   }
 ): WorkflowDefinition {
   return {
@@ -57,7 +87,7 @@ function workflowWithRuntime(
             command: runtime.command,
             args: runtime.args,
             isolation: {
-              bare: false,
+              bare: runtime.bare ?? false,
               strictMcpConfig: false,
             },
             auth: {

--- a/packages/worker/src/runtime-routing.ts
+++ b/packages/worker/src/runtime-routing.ts
@@ -1,4 +1,5 @@
 import type { WorkflowDefinition } from "@gh-symphony/core";
+import type { ClaudePreflightAuthMode } from "@gh-symphony/runtime-claude";
 
 export type WorkerRuntimeRoute = "codex-app-server" | "runtime-adapter";
 
@@ -12,4 +13,12 @@ export function resolveWorkerRuntimeRoute(
   }
 
   return "runtime-adapter";
+}
+
+export function resolveClaudePreflightAuthMode(
+  workflow: WorkflowDefinition
+): ClaudePreflightAuthMode {
+  return workflow.runtime?.isolation.bare === true
+    ? "api-key-required"
+    : "local-or-api-key";
 }


### PR DESCRIPTION
## Issues

- Fixes #318

## Summary

- Allows the default `claude-print` init path to pass preflight without `ANTHROPIC_API_KEY` when local Claude Code auth is allowed.
- Keeps strict API-key/broker validation for bare/headless Claude worker startup.
- Clarifies partially configured credential broker failures so users see the exact missing broker setting.

## Changes

- Added mode-aware Claude authentication preflight: `local-or-api-key` warns only when API-key and broker credentials are entirely absent, while `api-key-required` still fails.
- Reports partial broker configuration as a clear failure naming either `AGENT_CREDENTIAL_BROKER_URL` or `AGENT_CREDENTIAL_BROKER_SECRET`.
- Threaded local-compatible auth mode through `gh-symphony init` and derived worker preflight mode from `runtime.isolation.bare`.
- Simplified worker Claude command resolution so the preflight probes the resolved Claude binary once.
- Removed the default generated `auth.env: ANTHROPIC_API_KEY` from `claude-print` scaffolding so default `bare:false` workflows do not imply it is universally required.
- Added regression coverage for local-auth warning, strict-auth failure, partial broker failure, broker pass-through, init behavior, worker auth-mode derivation, and generated workflow output.

## Evidence

- `pnpm --filter @gh-symphony/runtime-claude test -- preflight.test.ts` (9 tests)
- `pnpm --filter @gh-symphony/worker test -- runtime-routing.test.ts` (6 tests)
- `pnpm --filter @gh-symphony/cli test -- workflow-init.test.ts generate-workflow-md.test.ts generate-reference-workflow.test.ts`
- `pnpm lint && pnpm test && pnpm typecheck && pnpm build`
- `pnpm e2e:claude` (Docker blackbox: 5 Claude E2E tests passed)
- TC: default `claude-print` / `bare:false` without `ANTHROPIC_API_KEY` produces a warning-only Claude authentication check; `bare:true` still resolves to `api-key-required` and fails without API key or broker; partial broker configuration fails with the exact missing broker variable.

## Human Validation

- [ ] Confirm `gh-symphony init --runtime claude-print` completes preflight on a machine with local Claude Code auth and no `ANTHROPIC_API_KEY`.
- [ ] Confirm a `runtime.isolation.bare: true` Claude worker reports a clear auth failure when no API key or credential broker is configured.
- [ ] Confirm a partial broker setup reports the exact missing broker variable.
- [ ] Confirm generated `WORKFLOW.md` language matches the intended default local Claude Code auth flow.

## Risks

- Existing callers of `runClaudePreflight` remain strict by default; only init and worker mode derivation changed.
- Partial broker configuration now gets a more specific failure message, but remains a failure in both auth modes because it indicates an attempted broker setup that cannot work as configured.
