### PR TITLE
chore: add Claude auth preflight patch changeset

### DIFF
--- a/.changeset/claude-local-auth-preflight.md
+++ b/.changeset/claude-local-auth-preflight.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Allow `gh-symphony init` Claude runtime preflight to pass with Claude Code local authentication instead of requiring `ANTHROPIC_API_KEY`.


### PR DESCRIPTION
## Summary
- Add a patch changeset for `@gh-symphony/cli` covering the Claude Code local-auth preflight fix.
- Changesets status resolves the CLI release from `0.1.0` to `0.1.1`.

## Symphony layer classification
- Configuration Layer only: release metadata/changeset bookkeeping.
- No upstream spec change or divergence; `docs/symphony-spec.md` was not modified.

## Validation
- `pnpm install --frozen-lockfile` — passed
- `pnpm changeset status --output /tmp/github-symphony-changeset-status.json && python3 -m json.tool /tmp/github-symphony-changeset-status.json` — passed (`@gh-symphony/cli` patch, new version `0.1.1`)
- `git diff --check` — passed
- `pnpm test` — failed in existing CLI tests unrelated to this changeset-only PR:
  - `/private/var/...` vs `/var/...` temp path canonicalization assertions in `src/config.test.ts` and `src/commands/setup.test.ts`
  - two `src/commands/doctor.test.ts` env-token auth assertions returning `report.ok === false`
