### PR TITLE
fix: target release changeset at CLI package

### DIFF
--- a/.changeset/linked-pr-context.md
+++ b/.changeset/linked-pr-context.md
@@ -1,5 +1,5 @@
 ---
-"@gh-symphony/core": patch
+"@gh-symphony/cli": patch
 ---
 
 Expose normalized linked pull request prompt variables, including top-level `issue.linked_pull_requests` entries with missing optional PR fields represented as `null`.


### PR DESCRIPTION
## Summary
- Retarget the remaining changeset from ignored/private `@gh-symphony/core` to published `@gh-symphony/cli`.
- Fixes the Release workflow failure where Changesets tried to create a release PR with no commits between `main` and `changeset-release/main`.

## Validation
- `pnpm changeset status --output /tmp/github-symphony-changeset-status.json` — passed; computes `@gh-symphony/cli` `0.1.1` → `0.1.2` patch release.
- `GITHUB_TOKEN=$(gh auth token) pnpm changeset version` in a temporary copy — passed; generated release diff for CLI package/changelog.
- `pnpm typecheck` — passed.
- `pnpm test` — local environment had unrelated failures in CLI tests (`/var` vs `/private/var` temp path canonicalization and doctor auth mocks); this PR only changes one changeset frontmatter line.

## Notes
After this PR merges to `main`, the existing `Release` workflow should run and create/update the `changeset-release/main` release PR instead of failing with an empty diff.