### PR TITLE
Add Linear GraphQL worker tool

### DIFF
--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -18,6 +18,9 @@
       "@gh-symphony/tool-github-graphql": [
         "../tool-github-graphql/src/index.ts"
       ],
+      "@gh-symphony/tool-linear-graphql": [
+        "../tool-linear-graphql/src/index.ts"
+      ],
       "@gh-symphony/tracker-file": ["../tracker-file/src/index.ts"],
       "@gh-symphony/tracker-github": ["../tracker-github/src/index.ts"],
       "@gh-symphony/tracker-linear": ["../tracker-linear/src/index.ts"],

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -39,6 +39,10 @@ export default defineConfig({
         packageRoot,
         "../tool-github-graphql/src/index.ts"
       ),
+      "@gh-symphony/tool-linear-graphql": resolve(
+        packageRoot,
+        "../tool-linear-graphql/src/index.ts"
+      ),
       "@gh-symphony/tracker-file": resolve(
         packageRoot,
         "../tracker-file/src/index.ts"

--- a/packages/core/src/observability/index.ts
+++ b/packages/core/src/observability/index.ts
@@ -2,4 +2,5 @@ export * from "./structured-events.js";
 export * from "./snapshot-builder.js";
 export * from "./fs-reader.js";
 export * from "./event-formatter.js";
+export * from "./redaction.js";
 export * from "./status-assembler.js";

--- a/packages/core/src/observability/redaction.test.ts
+++ b/packages/core/src/observability/redaction.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { redactObservabilitySecrets } from "./redaction.js";
+
+describe("redactObservabilitySecrets", () => {
+  it("redacts Linear API keys and Authorization headers recursively", () => {
+    const redacted = redactObservabilitySecrets({
+      event: "tool-call",
+      LINEAR_API_KEY: "lin_secret",
+      headers: {
+        authorization: "Bearer lin_secret",
+      },
+      nested: [
+        {
+          token: "lin_secret",
+          value: "safe",
+        },
+      ],
+    });
+
+    expect(redacted).toEqual({
+      event: "tool-call",
+      LINEAR_API_KEY: "[REDACTED]",
+      headers: {
+        authorization: "[REDACTED]",
+      },
+      nested: [
+        {
+          token: "[REDACTED]",
+          value: "safe",
+        },
+      ],
+    });
+    expect(JSON.stringify(redacted)).not.toContain("lin_secret");
+  });
+});

--- a/packages/core/src/observability/redaction.ts
+++ b/packages/core/src/observability/redaction.ts
@@ -1,0 +1,32 @@
+const REDACTED = "[REDACTED]";
+const SENSITIVE_KEY_PATTERN =
+  /(^|_|\b)(authorization|linear_api_key|github_graphql_token|token|api_key|secret)(_|$|\b)/i;
+
+export function redactObservabilitySecrets<T>(value: T): T {
+  return redactValue(value) as T;
+}
+
+function redactValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => redactValue(item));
+  }
+
+  if (!isRecord(value)) {
+    return value;
+  }
+
+  return Object.fromEntries(
+    Object.entries(value).map(([key, nested]) => [
+      key,
+      shouldRedactKey(key) ? REDACTED : redactValue(nested),
+    ])
+  );
+}
+
+function shouldRedactKey(key: string): boolean {
+  return SENSITIVE_KEY_PATTERN.test(key);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value != null && typeof value === "object";
+}

--- a/packages/orchestrator/src/fs-store.test.ts
+++ b/packages/orchestrator/src/fs-store.test.ts
@@ -167,6 +167,72 @@ describe("OrchestratorFsStore.loadRecentRunEvents", () => {
     ]);
   });
 
+  it("redacts tokens from run.json and events.ndjson before persistence", async () => {
+    const runtimeRoot = await mkdtemp(join(tmpdir(), "orchestrator-store-"));
+    const store = new OrchestratorFsStore(runtimeRoot);
+
+    await store.saveRun({
+      runId: "run-1",
+      projectId: "project-1",
+      issueId: "issue-1",
+      issueIdentifier: "ENG-123",
+      issueTitle: "Linear issue",
+      issueState: "Todo",
+      issueSubjectId: "issue-1",
+      repository: {
+        owner: "acme",
+        name: "repo",
+        cloneUrl: "https://github.com/acme/repo.git",
+        url: "https://github.com/acme/repo",
+      },
+      workspaceKey: "ENG-123",
+      workspacePath: "/tmp/workspace",
+      repositoryPath: "/tmp/workspace/repository",
+      status: "active",
+      attempt: 1,
+      maxAttempts: 1,
+      processId: null,
+      sessionId: null,
+      startedAt: "2026-05-14T00:00:00.000Z",
+      updatedAt: "2026-05-14T00:00:00.000Z",
+      completedAt: null,
+      lastError: null,
+      lastWorkerLog: null,
+      lastTurnSummary: null,
+      tokenUsage: undefined,
+      linear: {
+        LINEAR_API_KEY: "lin_secret",
+      },
+    } as never);
+
+    await store.appendRunEvent("run-1", {
+      at: "2026-05-14T00:00:00.000Z",
+      event: "worker-error",
+      projectId: "project-1",
+      runId: "run-1",
+      issueIdentifier: "ENG-123",
+      error: "worker failed",
+      attempt: 1,
+      headers: {
+        authorization: "Bearer lin_secret",
+      },
+    } as never);
+
+    const runJson = await readFile(
+      join(store.runDir("run-1", "project-1"), "run.json"),
+      "utf8"
+    );
+    const eventsNdjson = await readFile(
+      join(store.runDir("run-1", "project-1"), "events.ndjson"),
+      "utf8"
+    );
+
+    expect(runJson).not.toContain("lin_secret");
+    expect(eventsNdjson).not.toContain("lin_secret");
+    expect(runJson).toContain("[REDACTED]");
+    expect(eventsNdjson).toContain("[REDACTED]");
+  });
+
   it("mirrors events to an external directory when configured", async () => {
     const runtimeRoot = await mkdtemp(join(tmpdir(), "orchestrator-store-"));
     const eventsMirrorRoot = await mkdtemp(
@@ -185,15 +251,7 @@ describe("OrchestratorFsStore.loadRecentRunEvents", () => {
     });
 
     await expect(
-      readFile(
-        join(
-          eventsMirrorRoot,
-          "runs",
-          "run-1",
-          "events.ndjson"
-        ),
-        "utf8"
-      )
+      readFile(join(eventsMirrorRoot, "runs", "run-1", "events.ndjson"), "utf8")
     ).resolves.toContain('"event":"hook-failed"');
   });
 
@@ -218,20 +276,10 @@ describe("OrchestratorFsStore.loadRecentRunEvents", () => {
       });
 
       const primaryStats = await stat(
-        join(
-          runtimeRoot,
-          "runs",
-          "run-1",
-          "events.ndjson"
-        )
+        join(runtimeRoot, "runs", "run-1", "events.ndjson")
       );
       const mirroredStats = await stat(
-        join(
-          eventsMirrorRoot,
-          "runs",
-          "run-1",
-          "events.ndjson"
-        )
+        join(eventsMirrorRoot, "runs", "run-1", "events.ndjson")
       );
 
       expect(primaryStats.mode & 0o644).toBe(0o644);
@@ -264,12 +312,7 @@ describe("OrchestratorFsStore.loadRecentRunEvents", () => {
 
       await expect(
         readFile(
-          join(
-            eventsMirrorRoot,
-            "runs",
-            "run-1",
-            "events.ndjson"
-          ),
+          join(eventsMirrorRoot, "runs", "run-1", "events.ndjson"),
           "utf8"
         )
       ).resolves.toContain('"event":"hook-failed"');
@@ -300,15 +343,7 @@ describe("OrchestratorFsStore.loadRecentRunEvents", () => {
       ).resolves.toBeUndefined();
 
       await expect(
-        readFile(
-          join(
-            runtimeRoot,
-            "runs",
-            "run-1",
-            "events.ndjson"
-          ),
-          "utf8"
-        )
+        readFile(join(runtimeRoot, "runs", "run-1", "events.ndjson"), "utf8")
       ).resolves.toContain('"event":"hook-failed"');
       expect(warnSpy).toHaveBeenCalledOnce();
     } finally {

--- a/packages/orchestrator/src/fs-store.ts
+++ b/packages/orchestrator/src/fs-store.ts
@@ -19,6 +19,7 @@ import {
   type OrchestratorStateStore,
   type OrchestratorProjectConfig,
   parseRecentEvents,
+  redactObservabilitySecrets,
   type ProjectStatusSnapshot,
   readJsonFile,
   safeReadDir,
@@ -126,10 +127,7 @@ export class OrchestratorFsStore implements OrchestratorStateStore {
   }
 
   async saveProjectStatus(status: ProjectStatusSnapshot): Promise<void> {
-    await writeJsonFile(
-      join(this.projectDir(), "status.json"),
-      status
-    );
+    await writeJsonFile(join(this.projectDir(), "status.json"), status);
   }
 
   async loadProjectStatus(
@@ -176,14 +174,16 @@ export class OrchestratorFsStore implements OrchestratorStateStore {
   async saveRun(run: OrchestratorRunRecord): Promise<void> {
     await writeJsonFile(
       join(this.runDir(run.runId, run.projectId), "run.json"),
-      run
+      redactObservabilitySecrets(run)
     );
   }
 
   async appendRunEvent(runId: string, event: OrchestratorEvent): Promise<void> {
+    const redactedEvent = redactObservabilitySecrets(event);
     const resolvedProjectId =
-      "projectId" in event && typeof event.projectId === "string"
-        ? event.projectId
+      "projectId" in redactedEvent &&
+      typeof redactedEvent.projectId === "string"
+        ? redactedEvent.projectId
         : undefined;
     const runDirectory =
       resolvedProjectId !== undefined
@@ -197,7 +197,7 @@ export class OrchestratorFsStore implements OrchestratorStateStore {
 
     const path = join(runDirectory, "events.ndjson");
     const resolvedPath = resolve(path);
-    const serializedEvent = JSON.stringify(event) + "\n";
+    const serializedEvent = JSON.stringify(redactedEvent) + "\n";
     await mkdir(dirname(path), { recursive: true });
     await appendFile(path, serializedEvent, {
       encoding: "utf8",

--- a/packages/orchestrator/tsconfig.typecheck.json
+++ b/packages/orchestrator/tsconfig.typecheck.json
@@ -11,6 +11,9 @@
       "@gh-symphony/tool-github-graphql": [
         "../tool-github-graphql/src/index.ts"
       ],
+      "@gh-symphony/tool-linear-graphql": [
+        "../tool-linear-graphql/src/index.ts"
+      ],
       "@gh-symphony/tracker-file": ["../tracker-file/src/index.ts"],
       "@gh-symphony/tracker-github": ["../tracker-github/src/index.ts"],
       "@gh-symphony/tracker-linear": ["../tracker-linear/src/index.ts"]

--- a/packages/orchestrator/vitest.config.ts
+++ b/packages/orchestrator/vitest.config.ts
@@ -20,6 +20,10 @@ export default defineConfig({
         packageRoot,
         "../tool-github-graphql/src/index.ts"
       ),
+      "@gh-symphony/tool-linear-graphql": resolve(
+        packageRoot,
+        "../tool-linear-graphql/src/index.ts"
+      ),
       "@gh-symphony/tracker-file": resolve(
         packageRoot,
         "../tracker-file/src/index.ts"

--- a/packages/runtime-claude/package.json
+++ b/packages/runtime-claude/package.json
@@ -40,6 +40,7 @@
   },
   "dependencies": {
     "@gh-symphony/core": "workspace:*",
-    "@gh-symphony/tool-github-graphql": "workspace:*"
+    "@gh-symphony/tool-github-graphql": "workspace:*",
+    "@gh-symphony/tool-linear-graphql": "workspace:*"
   }
 }

--- a/packages/runtime-claude/src/adapter.ts
+++ b/packages/runtime-claude/src/adapter.ts
@@ -29,10 +29,7 @@ import {
   type ClaudeSpawnTurnResult,
   type ClaudeWireMessage,
 } from "./spawn.js";
-import {
-  ClaudeSessionStore,
-  type ClaudeSessionFile,
-} from "./session-store.js";
+import { ClaudeSessionStore, type ClaudeSessionFile } from "./session-store.js";
 
 export type ClaudeRuntimeConfig = {
   workingDirectory: string;
@@ -643,10 +640,7 @@ function isResumeRejectedWith4xx(result: ClaudeSpawnTurnResult): boolean {
   // constrained to resume-related lines that include an HTTP 4xx code.
   return result.records.some((record) => {
     const text = record.line.toLowerCase();
-    return (
-      text.includes("resume") &&
-      /\b4\d\d\b/.test(text)
-    );
+    return text.includes("resume") && /\b4\d\d\b/.test(text);
   });
 }
 
@@ -678,6 +672,10 @@ function buildClaudeMcpTokenEnvironment(options: {
     GITHUB_TOKEN_BROKER_SECRET: source.GITHUB_TOKEN_BROKER_SECRET,
     GITHUB_TOKEN_CACHE_PATH: source.GITHUB_TOKEN_CACHE_PATH,
     GITHUB_PROJECT_ID: source.GITHUB_PROJECT_ID,
+    LINEAR_API_KEY: source.LINEAR_API_KEY,
+    LINEAR_AUTHORIZATION: source.LINEAR_AUTHORIZATION,
+    LINEAR_GRAPHQL_URL: source.LINEAR_GRAPHQL_URL,
+    SYMPHONY_TRACKER_KIND: source.SYMPHONY_TRACKER_KIND,
     WORKSPACE_RUNTIME_DIR:
       options.runtimeDirectory ?? source.WORKSPACE_RUNTIME_DIR,
   };

--- a/packages/runtime-claude/src/mcp-compose.test.ts
+++ b/packages/runtime-claude/src/mcp-compose.test.ts
@@ -18,10 +18,14 @@ async function readJson(path: string): Promise<Record<string, unknown>> {
 
 describe("composeClaudeMcpConfig", () => {
   afterEach(async () => {
-    await Promise.all(tempRoots.splice(0).map((root) => rm(root, {
-      force: true,
-      recursive: true,
-    })));
+    await Promise.all(
+      tempRoots.splice(0).map((root) =>
+        rm(root, {
+          force: true,
+          recursive: true,
+        })
+      )
+    );
   });
 
   it("creates a workspace .mcp.json with only github_graphql when none exists", async () => {
@@ -98,18 +102,68 @@ describe("composeClaudeMcpConfig", () => {
     });
   });
 
+  it("adds linear_graphql only for Linear tracker sessions", async () => {
+    const workspaceRoot = await createTempWorkspace();
+
+    const result = await composeClaudeMcpConfig(workspaceRoot, false, {
+      SYMPHONY_TRACKER_KIND: "linear",
+      LINEAR_API_KEY: "lin_api_key",
+      LINEAR_GRAPHQL_URL: "https://linear.example/graphql",
+    });
+
+    expect(await readJson(result.finalPath)).toEqual({
+      mcpServers: {
+        github_graphql: {
+          command: "node",
+          args: [expect.stringContaining("mcp-server.js")],
+          env: {
+            GITHUB_GRAPHQL_API_URL: "https://api.github.com/graphql",
+          },
+        },
+        linear_graphql: {
+          command: "node",
+          args: [expect.stringContaining("mcp-server.js")],
+          env: {
+            LINEAR_GRAPHQL_URL: "https://linear.example/graphql",
+          },
+        },
+      },
+    });
+    expect(JSON.stringify(await readJson(result.finalPath))).not.toContain(
+      "lin_api_key"
+    );
+  });
+
+  it("does not add linear_graphql for non-Linear tracker sessions", async () => {
+    const workspaceRoot = await createTempWorkspace();
+
+    const result = await composeClaudeMcpConfig(workspaceRoot, false, {
+      LINEAR_API_KEY: "lin_api_key",
+    });
+    const config = await readJson(result.finalPath);
+
+    expect(
+      (config.mcpServers as Record<string, unknown>).linear_graphql
+    ).toBeUndefined();
+  });
+
   it("writes strict mode config to an ephemeral path without mutating the workspace file", async () => {
     const workspaceRoot = await createTempWorkspace();
     const runtimeRoot = join(workspaceRoot, "runtime-root");
     const workspaceMcpPath = join(workspaceRoot, ".mcp.json");
-    const originalConfig = JSON.stringify({
-      mcpServers: {
-        user_server: {
-          command: "node",
-          args: ["user-server.js"],
+    const originalConfig =
+      JSON.stringify(
+        {
+          mcpServers: {
+            user_server: {
+              command: "node",
+              args: ["user-server.js"],
+            },
+          },
         },
-      },
-    }, null, 2) + "\n";
+        null,
+        2
+      ) + "\n";
     await writeFile(workspaceMcpPath, originalConfig, "utf8");
 
     const result = await composeClaudeMcpConfig(workspaceRoot, true, {

--- a/packages/runtime-claude/src/mcp-compose.ts
+++ b/packages/runtime-claude/src/mcp-compose.ts
@@ -1,6 +1,7 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { basename, dirname, join, resolve } from "node:path";
 import { createGitHubGraphQLMcpServerEntry } from "@gh-symphony/tool-github-graphql";
+import { createLinearGraphQLMcpServerEntry } from "@gh-symphony/tool-linear-graphql";
 
 export type ClaudeMcpTokenEnvironment = {
   GITHUB_GRAPHQL_TOKEN?: string;
@@ -9,6 +10,10 @@ export type ClaudeMcpTokenEnvironment = {
   GITHUB_TOKEN_BROKER_SECRET?: string;
   GITHUB_TOKEN_CACHE_PATH?: string;
   GITHUB_PROJECT_ID?: string;
+  LINEAR_API_KEY?: string;
+  LINEAR_AUTHORIZATION?: string;
+  LINEAR_GRAPHQL_URL?: string;
+  SYMPHONY_TRACKER_KIND?: string;
   WORKSPACE_RUNTIME_DIR?: string;
 };
 
@@ -32,12 +37,16 @@ export async function composeClaudeMcpConfig(
     ? resolveStrictMcpConfigPath(workspaceRoot, symphonyTokenEnv)
     : workspaceMcpPath;
   const baseConfig = await readBaseMcpConfig(workspaceMcpPath);
-  const mergedConfig = mergeGitHubGraphQLMcpServer(baseConfig, symphonyTokenEnv);
+  const mergedConfig = mergeSymphonyMcpServers(baseConfig, symphonyTokenEnv);
 
   // Non-strict mode mutates the workspace .mcp.json in-place so Claude's
   // auto-discovery can pick up both user-authored and Symphony-managed entries.
   await mkdir(dirname(finalPath), { recursive: true });
-  await writeFile(finalPath, JSON.stringify(mergedConfig, null, 2) + "\n", "utf8");
+  await writeFile(
+    finalPath,
+    JSON.stringify(mergedConfig, null, 2) + "\n",
+    "utf8"
+  );
 
   return {
     finalPath,
@@ -62,7 +71,7 @@ async function readBaseMcpConfig(workspaceMcpPath: string): Promise<McpConfig> {
   }
 }
 
-function mergeGitHubGraphQLMcpServer(
+function mergeSymphonyMcpServers(
   baseConfig: McpConfig,
   env: ClaudeMcpTokenEnvironment
 ): McpConfig {
@@ -70,19 +79,27 @@ function mergeGitHubGraphQLMcpServer(
     ? baseConfig.mcpServers
     : {};
 
+  const mergedServers: Record<string, unknown> = {
+    ...mcpServers,
+    github_graphql: createGitHubGraphQLMcpServerEntry({
+      githubToken: env.GITHUB_GRAPHQL_TOKEN,
+      githubGraphqlApiUrl: env.GITHUB_GRAPHQL_API_URL,
+      githubTokenBrokerUrl: env.GITHUB_TOKEN_BROKER_URL,
+      githubTokenBrokerSecret: env.GITHUB_TOKEN_BROKER_SECRET,
+      githubTokenCachePath: env.GITHUB_TOKEN_CACHE_PATH,
+      githubProjectId: env.GITHUB_PROJECT_ID,
+    }),
+  };
+
+  if (env.SYMPHONY_TRACKER_KIND === "linear") {
+    mergedServers.linear_graphql = createLinearGraphQLMcpServerEntry({
+      linearGraphqlUrl: env.LINEAR_GRAPHQL_URL,
+    });
+  }
+
   return {
     ...baseConfig,
-    mcpServers: {
-      ...mcpServers,
-      github_graphql: createGitHubGraphQLMcpServerEntry({
-        githubToken: env.GITHUB_GRAPHQL_TOKEN,
-        githubGraphqlApiUrl: env.GITHUB_GRAPHQL_API_URL,
-        githubTokenBrokerUrl: env.GITHUB_TOKEN_BROKER_URL,
-        githubTokenBrokerSecret: env.GITHUB_TOKEN_BROKER_SECRET,
-        githubTokenCachePath: env.GITHUB_TOKEN_CACHE_PATH,
-        githubProjectId: env.GITHUB_PROJECT_ID,
-      }),
-    },
+    mcpServers: mergedServers,
   };
 }
 
@@ -95,7 +112,11 @@ function resolveStrictMcpConfigPath(
   const normalizedWorkspaceRoot = resolve(workspaceRoot);
   const runtimeDir =
     env.WORKSPACE_RUNTIME_DIR ??
-    join(normalizedWorkspaceRoot, ".runtime", basename(normalizedWorkspaceRoot));
+    join(
+      normalizedWorkspaceRoot,
+      ".runtime",
+      basename(normalizedWorkspaceRoot)
+    );
 
   return join(runtimeDir, "mcp.json");
 }

--- a/packages/runtime-claude/tsconfig.typecheck.json
+++ b/packages/runtime-claude/tsconfig.typecheck.json
@@ -6,7 +6,12 @@
     "baseUrl": ".",
     "paths": {
       "@gh-symphony/core": ["../core/src/index.ts"],
-      "@gh-symphony/tool-github-graphql": ["../tool-github-graphql/src/index.ts"]
+      "@gh-symphony/tool-github-graphql": [
+        "../tool-github-graphql/src/index.ts"
+      ],
+      "@gh-symphony/tool-linear-graphql": [
+        "../tool-linear-graphql/src/index.ts"
+      ]
     }
   }
 }

--- a/packages/runtime-claude/vitest.config.ts
+++ b/packages/runtime-claude/vitest.config.ts
@@ -12,6 +12,10 @@ export default defineConfig({
         packageRoot,
         "../tool-github-graphql/src/index.ts"
       ),
+      "@gh-symphony/tool-linear-graphql": resolve(
+        packageRoot,
+        "../tool-linear-graphql/src/index.ts"
+      ),
     },
   },
   test: {

--- a/packages/runtime-codex/src/launcher.ts
+++ b/packages/runtime-codex/src/launcher.ts
@@ -38,6 +38,10 @@ export function resolveLocalRuntimeLaunchConfig(
     agentCredentialCachePath: env.AGENT_CREDENTIAL_CACHE_PATH,
     githubProjectId: env.GITHUB_PROJECT_ID,
     githubGraphqlApiUrl: env.GITHUB_GRAPHQL_API_URL,
+    enableLinearGraphqlTool: env.SYMPHONY_TRACKER_KIND === "linear",
+    linearApiKey: env.LINEAR_API_KEY,
+    linearAuthorization: env.LINEAR_AUTHORIZATION,
+    linearGraphqlUrl: env.LINEAR_GRAPHQL_URL,
     agentCommand: env.SYMPHONY_AGENT_COMMAND,
   };
 }

--- a/packages/runtime-codex/src/runtime.test.ts
+++ b/packages/runtime-codex/src/runtime.test.ts
@@ -6,6 +6,7 @@ import {
   createCodexRuntimeAdapter,
   createGitCredentialHelperEnvironment,
   createGitHubGraphQLToolDefinition,
+  createLinearGraphQLToolDefinition,
   getCodexObservabilityEventName,
   normalizeCodexRuntimeEvents,
   prepareCodexRuntimePlan,
@@ -39,6 +40,21 @@ describe("createGitHubGraphQLToolDefinition", () => {
   });
 });
 
+describe("createLinearGraphQLToolDefinition", () => {
+  it("builds a runtime tool definition for Linear GraphQL access", () => {
+    const tool = createLinearGraphQLToolDefinition({
+      linearGraphqlUrl: "https://linear.example/graphql",
+    });
+
+    expect(tool.name).toBe("linear_graphql");
+    expect(tool.command).toBe("node");
+    expect(tool.args[0]).toContain("mcp-server.js");
+    expect(tool.env).toEqual({
+      LINEAR_GRAPHQL_URL: "https://linear.example/graphql",
+    });
+  });
+});
+
 describe("buildCodexRuntimePlan", () => {
   it("prepares the codex app-server launch contract", () => {
     const plan = buildCodexRuntimePlan({
@@ -63,14 +79,54 @@ describe("buildCodexRuntimePlan", () => {
     expect(plan.tools).toHaveLength(1);
     expect(plan.env.CODEX_PROJECT_ID).toBe("workspace-123");
     expect(plan.env.GITHUB_GRAPHQL_TOOL_NAME).toBe("github_graphql");
-    expect(plan.env.GITHUB_GRAPHQL_TOOL_COMMAND).toContain(
-      "mcp-server.js"
-    );
+    expect(plan.env.GITHUB_GRAPHQL_TOOL_COMMAND).toContain("mcp-server.js");
     expect(plan.env.GIT_CONFIG_KEY_0).toBe("credential.helper");
     expect(plan.env.GIT_CONFIG_VALUE_0).toContain("git-credential-helper.js");
     expect(plan.env.WORKER_PROFILE).toBe("test");
     expect(plan.env.OPENAI_API_KEY).toBe("sk-ready-runtime");
     expect(plan.env.CODEX_HOME).toBe("/tmp/workspace-123/.codex-agent");
+  });
+
+  it("exposes linear_graphql only when enabled for Linear tracker sessions", () => {
+    const nonLinearPlan = buildCodexRuntimePlan({
+      projectId: "workspace-123",
+      workingDirectory: "/tmp/workspace-123",
+      agentEnv: {
+        OPENAI_API_KEY: "sk-ready-runtime",
+      },
+    });
+    expect(nonLinearPlan.tools.map((tool) => tool.name)).toEqual([
+      "github_graphql",
+    ]);
+    expect(nonLinearPlan.env.LINEAR_GRAPHQL_TOOL_NAME).toBe("");
+
+    const linearPlan = buildCodexRuntimePlan({
+      projectId: "workspace-123",
+      workingDirectory: "/tmp/workspace-123",
+      enableLinearGraphqlTool: true,
+      linearApiKey: "lin_api_key",
+      linearGraphqlUrl: "https://linear.example/graphql",
+      agentEnv: {
+        OPENAI_API_KEY: "sk-ready-runtime",
+      },
+    });
+
+    expect(linearPlan.tools.map((tool) => tool.name)).toEqual([
+      "github_graphql",
+      "linear_graphql",
+    ]);
+    expect(linearPlan.env.LINEAR_GRAPHQL_TOOL_NAME).toBe("linear_graphql");
+    expect(linearPlan.env.LINEAR_GRAPHQL_URL).toBe(
+      "https://linear.example/graphql"
+    );
+    expect(linearPlan.env.LINEAR_API_KEY).toBe("lin_api_key");
+    const linearTool = linearPlan.tools.find(
+      (tool) => tool.name === "linear_graphql"
+    );
+    expect(linearTool?.env).toEqual({
+      LINEAR_GRAPHQL_URL: "https://linear.example/graphql",
+    });
+    expect(JSON.stringify(linearTool)).not.toContain("lin_api_key");
   });
 });
 
@@ -200,18 +256,16 @@ describe("resolveAgentRuntimeEnvironment", () => {
       },
       {
         fetchImpl: fetchImpl as typeof fetch,
-        readFileImpl: vi
-          .fn()
-          .mockResolvedValue(
-            JSON.stringify({
-              env: {
-                OPENAI_API_KEY: "sk-cached-agent",
-                OPENAI_BASE_URL: "https://openai.example.test/v1",
-              },
-              expires_at: "2026-04-22T10:10:00.000Z",
-              cachedAt: "2026-04-22T10:00:00.000Z",
-            })
-          ) as never,
+        readFileImpl: vi.fn().mockResolvedValue(
+          JSON.stringify({
+            env: {
+              OPENAI_API_KEY: "sk-cached-agent",
+              OPENAI_BASE_URL: "https://openai.example.test/v1",
+            },
+            expires_at: "2026-04-22T10:10:00.000Z",
+            cachedAt: "2026-04-22T10:00:00.000Z",
+          })
+        ) as never,
         now: new Date("2026-04-22T10:00:00.000Z"),
       }
     );
@@ -247,17 +301,15 @@ describe("resolveAgentRuntimeEnvironment", () => {
             { status: 200 }
           )
         ) as never,
-        readFileImpl: vi
-          .fn()
-          .mockResolvedValue(
-            JSON.stringify({
-              env: {
-                OPENAI_API_KEY: "sk-stale-agent",
-              },
-              expires_at: "2026-04-22T10:00:30.000Z",
-              cachedAt: "2026-04-22T09:50:00.000Z",
-            })
-          ) as never,
+        readFileImpl: vi.fn().mockResolvedValue(
+          JSON.stringify({
+            env: {
+              OPENAI_API_KEY: "sk-stale-agent",
+            },
+            expires_at: "2026-04-22T10:00:30.000Z",
+            cachedAt: "2026-04-22T09:50:00.000Z",
+          })
+        ) as never,
         writeFileImpl,
         now: new Date("2026-04-22T10:00:00.000Z"),
       }
@@ -283,15 +335,13 @@ describe("resolveAgentRuntimeEnvironment", () => {
       },
       {
         fetchImpl: fetchImpl as typeof fetch,
-        readFileImpl: vi
-          .fn()
-          .mockResolvedValue(
-            JSON.stringify({
-              env: {
-                OPENAI_API_KEY: "sk-legacy-agent",
-              },
-            })
-          ) as never,
+        readFileImpl: vi.fn().mockResolvedValue(
+          JSON.stringify({
+            env: {
+              OPENAI_API_KEY: "sk-legacy-agent",
+            },
+          })
+        ) as never,
         now: new Date("2026-04-22T11:00:00.000Z"),
       }
     );
@@ -610,7 +660,9 @@ describe("createCodexRuntimeAdapter", () => {
     const result = await adapter.spawnTurn();
 
     expect(result.plan.env.OPENAI_API_KEY).toBe("sk-direct-runtime");
-    expect(result.plan.env.CODEX_HOME).toBe(resolveStagedCodexHome("/tmp/workspace-123"));
+    expect(result.plan.env.CODEX_HOME).toBe(
+      resolveStagedCodexHome("/tmp/workspace-123")
+    );
     expect(spawnImpl).toHaveBeenCalledOnce();
 
     await adapter.shutdown();

--- a/packages/runtime-codex/src/runtime.ts
+++ b/packages/runtime-codex/src/runtime.ts
@@ -6,6 +6,7 @@ import { homedir } from "node:os";
 import { fileURLToPath } from "node:url";
 import {
   buildAgentInputRequiredReason,
+  DEFAULT_LINEAR_GRAPHQL_URL,
   readAgentCredentialCache,
   shouldReuseAgentCredentialCache,
   writeAgentCredentialCache,
@@ -15,6 +16,7 @@ import {
   type AgentRuntimeEvent,
 } from "@gh-symphony/core";
 import { createGitHubGraphQLMcpServerEntry } from "@gh-symphony/tool-github-graphql";
+import { createLinearGraphQLMcpServerEntry } from "@gh-symphony/tool-linear-graphql";
 
 const DEFAULT_GITHUB_GIT_HOST = "github.com";
 const DEFAULT_GITHUB_GIT_USERNAME = "x-access-token";
@@ -27,7 +29,7 @@ const DIRECT_AGENT_ENV_KEYS = [
 ] as const;
 
 export type RuntimeToolDefinition = {
-  name: "github_graphql";
+  name: "github_graphql" | "linear_graphql";
   description: string;
   command: string;
   args: string[];
@@ -53,6 +55,10 @@ export type CodexRuntimeConfig = {
   agentCredentialCachePath?: string;
   githubProjectId?: string;
   githubGraphqlApiUrl?: string;
+  enableLinearGraphqlTool?: boolean;
+  linearApiKey?: string;
+  linearAuthorization?: string;
+  linearGraphqlUrl?: string;
   extraEnv?: NodeJS.ProcessEnv;
   /** Shell command to launch codex app-server. Leading "bash -lc " is stripped if present, since the runtime always wraps in bash -lc. */
   agentCommand?: string;
@@ -63,7 +69,7 @@ export type CodexRuntimePlan = {
   command: string;
   args: string[];
   env: NodeJS.ProcessEnv;
-  tools: [RuntimeToolDefinition];
+  tools: RuntimeToolDefinition[];
 };
 
 export class AgentRuntimeResolutionError extends Error {}
@@ -164,16 +170,47 @@ export function createGitHubGraphQLToolDefinition(
   };
 }
 
+export function createLinearGraphQLToolDefinition(
+  config: Pick<CodexRuntimeConfig, "linearGraphqlUrl">
+): RuntimeToolDefinition {
+  const entry = createLinearGraphQLMcpServerEntry(config);
+
+  return {
+    name: "linear_graphql",
+    description:
+      "Execute a single Linear GraphQL query or mutation for the active Linear issue using runtime-managed auth.",
+    command: entry.command,
+    args: entry.args,
+    env: entry.env,
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: {
+          type: "string",
+          description: "Single GraphQL query or mutation document.",
+        },
+        variables: {
+          type: "object",
+          description: "Variables for the GraphQL document.",
+        },
+        operationName: {
+          type: "string",
+          description: "Optional GraphQL operation name.",
+        },
+      },
+      required: ["query"],
+      additionalProperties: false,
+    },
+  };
+}
+
 function asRecord(value: unknown): Record<string, unknown> {
   return value != null && typeof value === "object"
     ? (value as Record<string, unknown>)
     : {};
 }
 
-function hasOwn(
-  record: Record<string, unknown>,
-  key: string
-): boolean {
+function hasOwn(record: Record<string, unknown>, key: string): boolean {
   return Object.prototype.hasOwnProperty.call(record, key);
 }
 
@@ -391,7 +428,9 @@ export function resolvePreparedAgentEnvironment(
   const preparedEnv = Object.fromEntries(
     DIRECT_AGENT_ENV_KEYS.flatMap((key) => {
       const value = env?.[key];
-      return typeof value === "string" && value.length > 0 ? [[key, value]] : [];
+      return typeof value === "string" && value.length > 0
+        ? [[key, value]]
+        : [];
     })
   );
 
@@ -408,7 +447,18 @@ export function resolvePreparedAgentEnvironment(
 export function buildCodexRuntimePlan(
   config: CodexRuntimeConfig
 ): CodexRuntimePlan {
-  const tool = createGitHubGraphQLToolDefinition(config);
+  const githubTool = createGitHubGraphQLToolDefinition(config);
+  const tools = [
+    githubTool,
+    ...(config.enableLinearGraphqlTool
+      ? [
+          createLinearGraphQLToolDefinition({
+            linearGraphqlUrl:
+              config.linearGraphqlUrl ?? DEFAULT_LINEAR_GRAPHQL_URL,
+          }),
+        ]
+      : []),
+  ];
   const gitCredentialHelper = createGitCredentialHelperEnvironment(config);
 
   const shellCmd = (() => {
@@ -430,13 +480,30 @@ export function buildCodexRuntimePlan(
       ...config.agentEnv,
       CODEX_PROJECT_ID: config.projectId,
       GITHUB_PROJECT_ID: config.githubProjectId ?? "",
-      GITHUB_GRAPHQL_TOOL_NAME: tool.name,
-      GITHUB_GRAPHQL_TOOL_COMMAND: [tool.command, ...tool.args].join(" "),
+      GITHUB_GRAPHQL_TOOL_NAME: githubTool.name,
+      GITHUB_GRAPHQL_TOOL_COMMAND: [
+        githubTool.command,
+        ...githubTool.args,
+      ].join(" "),
+      LINEAR_GRAPHQL_TOOL_NAME: config.enableLinearGraphqlTool
+        ? "linear_graphql"
+        : "",
+      LINEAR_GRAPHQL_URL: config.linearGraphqlUrl ?? DEFAULT_LINEAR_GRAPHQL_URL,
+      ...(config.linearAuthorization
+        ? {
+            LINEAR_AUTHORIZATION: config.linearAuthorization,
+          }
+        : {}),
+      ...(config.linearApiKey
+        ? {
+            LINEAR_API_KEY: config.linearApiKey,
+          }
+        : {}),
       ...agentEnv,
       ...gitCredentialHelper,
-      ...tool.env,
+      ...Object.assign({}, ...tools.map((tool) => tool.env)),
     },
-    tools: [tool],
+    tools,
   };
 }
 
@@ -451,16 +518,13 @@ export function launchCodexAppServer(
   });
 }
 
-export class CodexRuntimeAdapter
-  implements
-    AgentRuntimeAdapter<
-      CodexRuntimePrepareContext,
-      CodexRuntimeTurnInput,
-      CodexRuntimeTurnResult,
-      CodexRuntimeEvent,
-      CodexRuntimeCredentialBrokerResponse
-    >
-{
+export class CodexRuntimeAdapter implements AgentRuntimeAdapter<
+  CodexRuntimePrepareContext,
+  CodexRuntimeTurnInput,
+  CodexRuntimeTurnResult,
+  CodexRuntimeEvent,
+  CodexRuntimeCredentialBrokerResponse
+> {
   // Event emission is intentionally deferred until the worker-owned loop is
   // neutralized in #4. Until then, keep handler registration compatible.
   private readonly handlers = new Set<(event: CodexRuntimeEvent) => void>();
@@ -491,7 +555,9 @@ export class CodexRuntimeAdapter
     });
   }
 
-  async spawnTurn(_input?: CodexRuntimeTurnInput): Promise<CodexRuntimeTurnResult> {
+  async spawnTurn(
+    _input?: CodexRuntimeTurnInput
+  ): Promise<CodexRuntimeTurnResult> {
     if (!this.plan) {
       await this.prepare();
     }
@@ -650,10 +716,16 @@ export async function resolveAgentRuntimeEnvironment(
   const now = dependencies.now ?? new Date();
   const readFileImpl = dependencies.readFileImpl ?? readFile;
   const cachedCredentials = config.agentCredentialCachePath
-    ? await readAgentCredentialCache(config.agentCredentialCachePath, readFileImpl)
+    ? await readAgentCredentialCache(
+        config.agentCredentialCachePath,
+        readFileImpl
+      )
     : null;
 
-  if (cachedCredentials && shouldReuseAgentCredentialCache(cachedCredentials, now)) {
+  if (
+    cachedCredentials &&
+    shouldReuseAgentCredentialCache(cachedCredentials, now)
+  ) {
     return resolveRuntimeCredentials(config, cachedCredentials, adapter);
   }
 
@@ -665,10 +737,11 @@ export async function resolveAgentRuntimeEnvironment(
       authorization: `Bearer ${config.agentCredentialBrokerSecret}`,
     },
   });
-  const payload = (await response.json()) as AgentRuntimeCredentialBrokerResponse & {
-    error?: string;
-    expires_at?: string;
-  };
+  const payload =
+    (await response.json()) as AgentRuntimeCredentialBrokerResponse & {
+      error?: string;
+      expires_at?: string;
+    };
   const resolvedEnv =
     payload.env && response.ok
       ? adapter
@@ -720,7 +793,10 @@ function resolveRuntimeCredentials(
 ): Record<string, string> {
   return adapter
     ? adapter.resolveCredentials(brokerResponse)
-    : resolvePreparedAgentEnvironment(config.workingDirectory, brokerResponse.env);
+    : resolvePreparedAgentEnvironment(
+        config.workingDirectory,
+        brokerResponse.env
+      );
 }
 
 async function stageCodexHome(

--- a/packages/runtime-codex/tsconfig.typecheck.json
+++ b/packages/runtime-codex/tsconfig.typecheck.json
@@ -8,6 +8,9 @@
       "@gh-symphony/core": ["../core/src/index.ts"],
       "@gh-symphony/tool-github-graphql": [
         "../tool-github-graphql/src/index.ts"
+      ],
+      "@gh-symphony/tool-linear-graphql": [
+        "../tool-linear-graphql/src/index.ts"
       ]
     }
   }

--- a/packages/runtime-codex/vitest.config.ts
+++ b/packages/runtime-codex/vitest.config.ts
@@ -12,6 +12,10 @@ export default defineConfig({
         packageRoot,
         "../tool-github-graphql/src/index.ts"
       ),
+      "@gh-symphony/tool-linear-graphql": resolve(
+        packageRoot,
+        "../tool-linear-graphql/src/index.ts"
+      ),
     },
   },
   test: {

--- a/packages/tool-linear-graphql/package.json
+++ b/packages/tool-linear-graphql/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "@gh-symphony/runtime-codex",
+  "name": "@gh-symphony/tool-linear-graphql",
   "version": "0.0.14",
   "private": true,
   "license": "MIT",
   "author": "hojinzs",
-  "description": "Codex AI runtime integration for Symphony workers",
+  "description": "Runtime-neutral Linear GraphQL tool and MCP server for Symphony",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -13,6 +13,11 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "default": "./dist/index.js"
+    },
+    "./mcp-server": {
+      "types": "./dist/mcp-server.d.ts",
+      "import": "./dist/mcp-server.js",
+      "default": "./dist/mcp-server.js"
     }
   },
   "files": [
@@ -26,7 +31,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/hojinzs/github-symphony.git",
-    "directory": "packages/runtime-codex"
+    "directory": "packages/tool-linear-graphql"
   },
   "homepage": "https://github.com/hojinzs/github-symphony#readme",
   "bugs": {
@@ -36,11 +41,9 @@
     "build": "tsc -p tsconfig.json",
     "lint": "eslint src --ext .ts",
     "test": "vitest run --passWithNoTests",
-    "typecheck": "tsc -p tsconfig.typecheck.json"
+    "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
-    "@gh-symphony/core": "workspace:*",
-    "@gh-symphony/tool-github-graphql": "workspace:*",
-    "@gh-symphony/tool-linear-graphql": "workspace:*"
+    "graphql": "^16.11.0"
   }
 }

--- a/packages/tool-linear-graphql/src/index.ts
+++ b/packages/tool-linear-graphql/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./tool.js";
+export * from "./mcp-server.js";
+export * from "./mcp-entry.js";

--- a/packages/tool-linear-graphql/src/mcp-entry.ts
+++ b/packages/tool-linear-graphql/src/mcp-entry.ts
@@ -1,0 +1,25 @@
+import { resolveLinearGraphQLMcpServerEntryPoint } from "./mcp-server.js";
+import { DEFAULT_LINEAR_GRAPHQL_API_URL } from "./tool.js";
+
+export type LinearGraphQLMcpServerEntryOptions = {
+  linearGraphqlUrl?: string;
+};
+
+export type LinearGraphQLMcpServerEntry = {
+  command: "node";
+  args: string[];
+  env: Record<string, string>;
+};
+
+export function createLinearGraphQLMcpServerEntry(
+  options: LinearGraphQLMcpServerEntryOptions = {}
+): LinearGraphQLMcpServerEntry {
+  return {
+    command: "node",
+    args: [resolveLinearGraphQLMcpServerEntryPoint()],
+    env: {
+      LINEAR_GRAPHQL_URL:
+        options.linearGraphqlUrl ?? DEFAULT_LINEAR_GRAPHQL_API_URL,
+    },
+  };
+}

--- a/packages/tool-linear-graphql/src/mcp-server.ts
+++ b/packages/tool-linear-graphql/src/mcp-server.ts
@@ -1,0 +1,180 @@
+import { fileURLToPath } from "node:url";
+import { executeLinearGraphQL, type LinearGraphQLInvocation } from "./tool.js";
+
+const TOOL_SCHEMA = {
+  name: "linear_graphql",
+  description:
+    "Execute a single Linear GraphQL query or mutation for the active Linear issue using runtime-managed auth.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      query: {
+        type: "string",
+        description: "Single GraphQL query or mutation document.",
+      },
+      variables: {
+        type: "object",
+        description: "Variables for the GraphQL document.",
+      },
+      operationName: {
+        type: "string",
+        description: "Optional GraphQL operation name.",
+      },
+    },
+    required: ["query"],
+    additionalProperties: false,
+  },
+};
+
+let lineBuffer = "";
+
+export function resolveLinearGraphQLMcpServerEntryPoint(): string {
+  return fileURLToPath(new URL("./mcp-server.js", import.meta.url));
+}
+
+function sendResponse(id: string | number | null, result: unknown): void {
+  process.stdout.write(`${JSON.stringify({ jsonrpc: "2.0", id, result })}\n`);
+}
+
+function sendError(
+  id: string | number | null,
+  code: number,
+  message: string
+): void {
+  process.stdout.write(
+    `${JSON.stringify({ jsonrpc: "2.0", id, error: { code, message } })}\n`
+  );
+}
+
+async function handleRequest(msg: {
+  jsonrpc: string;
+  id?: string | number | null;
+  method: string;
+  params?: unknown;
+}): Promise<void> {
+  const id = msg.id ?? null;
+
+  switch (msg.method) {
+    case "initialize": {
+      sendResponse(id, {
+        protocolVersion: "2024-11-05",
+        capabilities: { tools: {} },
+        serverInfo: {
+          name: "github-symphony-linear-graphql",
+          version: "0.1.0",
+        },
+      });
+      process.stdout.write(
+        `${JSON.stringify({
+          jsonrpc: "2.0",
+          method: "notifications/initialized",
+        })}\n`
+      );
+      break;
+    }
+
+    case "tools/list": {
+      sendResponse(id, { tools: [TOOL_SCHEMA] });
+      break;
+    }
+
+    case "tools/call": {
+      const params = msg.params as {
+        name: string;
+        arguments?: Record<string, unknown>;
+      };
+
+      if (params.name !== "linear_graphql") {
+        sendError(id, -32602, `Unknown tool: ${params.name}`);
+        return;
+      }
+
+      const args = params.arguments ?? {};
+      const invocation: LinearGraphQLInvocation = {
+        query: args.query as string,
+        variables: args.variables as Record<string, unknown> | undefined,
+        operationName: args.operationName as string | undefined,
+      };
+
+      try {
+        const result = await executeLinearGraphQL(invocation, {
+          apiKey: process.env.LINEAR_API_KEY,
+          apiUrl: process.env.LINEAR_GRAPHQL_URL,
+          authorizationHeader: process.env.LINEAR_AUTHORIZATION,
+        });
+
+        sendResponse(id, {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(result, null, 2),
+            },
+          ],
+        });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        sendResponse(id, {
+          content: [{ type: "text", text: message }],
+          isError: true,
+        });
+      }
+      break;
+    }
+
+    case "notifications/initialized":
+    case "ping": {
+      if (id !== null && id !== undefined) {
+        sendResponse(id, {});
+      }
+      break;
+    }
+
+    default: {
+      if (id !== null && id !== undefined) {
+        sendError(id, -32601, `Method not found: ${msg.method}`);
+      }
+    }
+  }
+}
+
+async function main(): Promise<void> {
+  process.stdin.setEncoding("utf8");
+
+  process.stdin.on("data", (chunk: string) => {
+    lineBuffer += chunk;
+    const lines = lineBuffer.split("\n");
+    lineBuffer = lines.pop() ?? "";
+
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+
+      try {
+        const msg = JSON.parse(trimmed) as {
+          jsonrpc: string;
+          id?: string | number | null;
+          method: string;
+          params?: unknown;
+        };
+        void handleRequest(msg);
+      } catch (err) {
+        process.stderr.write(
+          `[linear-graphql-mcp] parse error: ${err instanceof Error ? err.message : String(err)}\n`
+        );
+      }
+    }
+  });
+
+  process.stdin.on("end", () => {
+    process.exit(0);
+  });
+}
+
+if (import.meta.url === new URL(process.argv[1] ?? "", "file:").href) {
+  main().catch((err: unknown) => {
+    process.stderr.write(
+      `[linear-graphql-mcp] fatal: ${err instanceof Error ? err.message : String(err)}\n`
+    );
+    process.exitCode = 1;
+  });
+}

--- a/packages/tool-linear-graphql/src/tool.test.ts
+++ b/packages/tool-linear-graphql/src/tool.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  DEFAULT_LINEAR_GRAPHQL_API_URL,
+  createLinearGraphQLMcpServerEntry,
+  executeLinearGraphQL,
+  resolveLinearAuthorizationHeader,
+  validateLinearGraphQLInvocation,
+} from "./index.js";
+
+describe("validateLinearGraphQLInvocation", () => {
+  it("accepts a single query operation", () => {
+    expect(() =>
+      validateLinearGraphQLInvocation({
+        query: "query Issue($id: String!) { issue(id: $id) { id identifier } }",
+        variables: { id: "issue-1" },
+        operationName: "Issue",
+      })
+    ).not.toThrow();
+  });
+
+  it("accepts a single mutation for status transitions", () => {
+    expect(() =>
+      validateLinearGraphQLInvocation({
+        query:
+          "mutation TransitionIssue($id: String!, $stateId: String!) { issueUpdate(id: $id, input: { stateId: $stateId }) { success issue { id } } }",
+      })
+    ).not.toThrow();
+  });
+
+  it("accepts a single mutation for workpad and PR-link comments", () => {
+    expect(() =>
+      validateLinearGraphQLInvocation({
+        query:
+          "mutation WriteComment($issueId: String!, $body: String!) { commentCreate(input: { issueId: $issueId, body: $body }) { success comment { id } } }",
+      })
+    ).not.toThrow();
+  });
+
+  it("rejects multi-operation documents using the GraphQL AST", () => {
+    expect(() =>
+      validateLinearGraphQLInvocation({
+        query: "query Q1 { viewer { id } } query Q2 { viewer { name } }",
+      })
+    ).toThrow(/exactly one GraphQL operation/);
+  });
+});
+
+describe("executeLinearGraphQL", () => {
+  it("posts a single operation with runtime-managed Authorization", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ data: { ok: true } }), { status: 200 })
+      );
+
+    await expect(
+      executeLinearGraphQL(
+        {
+          query:
+            "mutation LinkPr($issueId: String!, $body: String!) { commentCreate(input: { issueId: $issueId, body: $body }) { success } }",
+          variables: {
+            issueId: "issue-1",
+            body: "PR: https://github.com/acme/repo/pull/1",
+          },
+          operationName: "LinkPr",
+        },
+        {
+          authorizationHeader: "Bearer runtime-linear-token",
+          apiUrl: "https://linear.example/graphql",
+        },
+        fetchImpl as typeof fetch
+      )
+    ).resolves.toEqual({ data: { ok: true } });
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://linear.example/graphql",
+      expect.objectContaining({
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: "Bearer runtime-linear-token",
+        },
+      })
+    );
+  });
+
+  it("rejects multi-operation documents before HTTP", async () => {
+    const fetchImpl = vi.fn();
+
+    await expect(
+      executeLinearGraphQL(
+        {
+          query: "query Q1 { viewer { id } } query Q2 { viewer { name } }",
+        },
+        {
+          apiKey: "lin_api_key",
+        },
+        fetchImpl as typeof fetch
+      )
+    ).rejects.toThrow(/exactly one GraphQL operation/);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+});
+
+describe("resolveLinearAuthorizationHeader", () => {
+  it("prefers the runtime-provided Authorization header", () => {
+    expect(
+      resolveLinearAuthorizationHeader({
+        authorizationHeader: "Bearer brokered-token",
+        apiKey: "fallback-token",
+      })
+    ).toBe("Bearer brokered-token");
+  });
+
+  it("supports LINEAR_API_KEY fallback", () => {
+    expect(resolveLinearAuthorizationHeader({ apiKey: "lin_api_key" })).toBe(
+      "Bearer lin_api_key"
+    );
+  });
+});
+
+describe("createLinearGraphQLMcpServerEntry", () => {
+  it("creates a default MCP server entry without optional auth env", () => {
+    expect(createLinearGraphQLMcpServerEntry()).toEqual({
+      command: "node",
+      args: [expect.stringContaining("mcp-server.js")],
+      env: {
+        LINEAR_GRAPHQL_URL: DEFAULT_LINEAR_GRAPHQL_API_URL,
+      },
+    });
+  });
+
+  it("keeps auth out of the MCP server entry environment", () => {
+    expect(
+      createLinearGraphQLMcpServerEntry({
+        linearGraphqlUrl: "https://linear.example/graphql",
+      })
+    ).toEqual({
+      command: "node",
+      args: [expect.stringContaining("mcp-server.js")],
+      env: {
+        LINEAR_GRAPHQL_URL: "https://linear.example/graphql",
+      },
+    });
+  });
+});

--- a/packages/tool-linear-graphql/src/tool.ts
+++ b/packages/tool-linear-graphql/src/tool.ts
@@ -1,0 +1,119 @@
+import { parse } from "graphql";
+
+export const DEFAULT_LINEAR_GRAPHQL_API_URL = "https://api.linear.app/graphql";
+
+export type LinearGraphQLInvocation = {
+  query: string;
+  variables?: Record<string, unknown>;
+  operationName?: string;
+};
+
+export type LinearGraphQLToolConfig = {
+  apiKey?: string;
+  apiUrl?: string;
+  authorizationHeader?: string;
+};
+
+export async function executeLinearGraphQL(
+  invocation: LinearGraphQLInvocation,
+  config: LinearGraphQLToolConfig,
+  fetchImpl: typeof fetch = fetch
+): Promise<unknown> {
+  validateLinearGraphQLInvocation(invocation);
+  const authorization = resolveLinearAuthorizationHeader(config);
+  const response = await fetchImpl(
+    config.apiUrl ?? DEFAULT_LINEAR_GRAPHQL_API_URL,
+    {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization,
+      },
+      body: JSON.stringify(invocation),
+    }
+  );
+
+  const payload = (await response.json()) as {
+    errors?: Array<{ message: string }>;
+  };
+
+  if (!response.ok) {
+    throw new Error(
+      `Linear GraphQL request failed with status ${response.status}: ${JSON.stringify(payload)}`
+    );
+  }
+
+  if (payload.errors?.length) {
+    throw new Error(payload.errors.map((error) => error.message).join("; "));
+  }
+
+  return payload;
+}
+
+export function validateLinearGraphQLInvocation(
+  invocation: LinearGraphQLInvocation
+): void {
+  if (typeof invocation.query !== "string" || invocation.query.trim() === "") {
+    throw new Error(
+      "linear_graphql requires a non-empty GraphQL query string."
+    );
+  }
+
+  const document = parse(invocation.query);
+  const operationCount = document.definitions.filter(
+    (definition) => definition.kind === "OperationDefinition"
+  ).length;
+
+  if (operationCount > 1) {
+    throw new Error(
+      "linear_graphql accepts exactly one GraphQL operation per request; split multi-operation documents before calling Linear."
+    );
+  }
+}
+
+export function resolveLinearAuthorizationHeader(
+  config: LinearGraphQLToolConfig
+): string {
+  if (config.authorizationHeader) {
+    return config.authorizationHeader;
+  }
+
+  if (config.apiKey) {
+    return `Bearer ${config.apiKey}`;
+  }
+
+  throw new Error(
+    "Linear GraphQL auth is not configured; provide runtime LINEAR_AUTHORIZATION or LINEAR_API_KEY."
+  );
+}
+
+async function readStdin(): Promise<string> {
+  const chunks: Uint8Array[] = [];
+
+  for await (const chunk of process.stdin) {
+    chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+  }
+
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+async function main(): Promise<void> {
+  const rawInput = await readStdin();
+  const invocation = JSON.parse(rawInput) as LinearGraphQLInvocation;
+
+  const result = await executeLinearGraphQL(invocation, {
+    apiKey: process.env.LINEAR_API_KEY,
+    apiUrl: process.env.LINEAR_GRAPHQL_URL,
+    authorizationHeader: process.env.LINEAR_AUTHORIZATION,
+  });
+
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+}
+
+if (import.meta.url === new URL(process.argv[1] ?? "", "file:").href) {
+  main().catch((error: unknown) => {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    process.stderr.write(`${message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/packages/tool-linear-graphql/tsconfig.json
+++ b/packages/tool-linear-graphql/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "noEmit": false,
+    "declaration": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/tool-linear-graphql/vitest.config.ts
+++ b/packages/tool-linear-graphql/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+});

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -49,6 +49,7 @@ import {
 import { resolveExitRunPhase } from "./run-phase.js";
 import {
   resolveClaudePreflightAuthMode,
+  shouldExposeLinearGraphQLTool,
   resolveWorkerRuntimeRoute,
 } from "./runtime-routing.js";
 import { buildContinuationTurnInput } from "./thread-resume.js";
@@ -533,6 +534,13 @@ async function startAssignedRun() {
 
     const config = resolveLocalRuntimeLaunchConfig(launcherEnv);
     config.agentCommand = resolveWorkflowRuntimeCommand(workflow);
+    config.enableLinearGraphqlTool = shouldExposeLinearGraphQLTool(
+      workflow,
+      launcherEnv
+    );
+    config.linearApiKey = launcherEnv.LINEAR_API_KEY;
+    config.linearAuthorization = launcherEnv.LINEAR_AUTHORIZATION;
+    config.linearGraphqlUrl = launcherEnv.LINEAR_GRAPHQL_URL;
     const plan = await prepareCodexRuntimePlan(config);
     childProcess = launchCodexAppServer(plan);
     runtimeState.status = "running";

--- a/packages/worker/src/runtime-routing.test.ts
+++ b/packages/worker/src/runtime-routing.test.ts
@@ -5,6 +5,7 @@ import {
 } from "@gh-symphony/core";
 import {
   resolveClaudePreflightAuthMode,
+  shouldExposeLinearGraphQLTool,
   resolveWorkerRuntimeRoute,
 } from "./runtime-routing.js";
 
@@ -66,6 +67,43 @@ describe("resolveWorkerRuntimeRoute", () => {
         })
       )
     ).toBe("api-key-required");
+  });
+});
+
+describe("shouldExposeLinearGraphQLTool", () => {
+  it("enables the Linear tool for Linear tracker workflow sessions", () => {
+    expect(
+      shouldExposeLinearGraphQLTool({
+        ...DEFAULT_WORKFLOW_DEFINITION,
+        tracker: {
+          ...DEFAULT_WORKFLOW_DEFINITION.tracker,
+          kind: "linear",
+        },
+      })
+    ).toBe(true);
+  });
+
+  it("keeps the Linear tool hidden for non-Linear tracker sessions", () => {
+    expect(
+      shouldExposeLinearGraphQLTool(
+        {
+          ...DEFAULT_WORKFLOW_DEFINITION,
+          tracker: {
+            ...DEFAULT_WORKFLOW_DEFINITION.tracker,
+            kind: "github",
+          },
+        },
+        {}
+      )
+    ).toBe(false);
+  });
+
+  it("recognizes runtime Linear tracker env injected by tracker adapters", () => {
+    expect(
+      shouldExposeLinearGraphQLTool(DEFAULT_WORKFLOW_DEFINITION, {
+        SYMPHONY_TRACKER_KIND: "linear",
+      })
+    ).toBe(true);
   });
 });
 

--- a/packages/worker/src/runtime-routing.ts
+++ b/packages/worker/src/runtime-routing.ts
@@ -22,3 +22,14 @@ export function resolveClaudePreflightAuthMode(
     ? "api-key-required"
     : "local-or-api-key";
 }
+
+export function shouldExposeLinearGraphQLTool(
+  workflow: WorkflowDefinition,
+  env: NodeJS.ProcessEnv = process.env
+): boolean {
+  return (
+    workflow.tracker.kind === "linear" ||
+    env.SYMPHONY_TRACKER_KIND === "linear" ||
+    env.SYMPHONY_TRACKER_ADAPTER === "linear"
+  );
+}

--- a/packages/worker/tsconfig.typecheck.json
+++ b/packages/worker/tsconfig.typecheck.json
@@ -6,10 +6,17 @@
     "baseUrl": ".",
     "paths": {
       "@gh-symphony/core": ["../core/src/index.ts"],
-      "@gh-symphony/extension-github-workflow": ["../extension-github-workflow/src/index.ts"],
+      "@gh-symphony/extension-github-workflow": [
+        "../extension-github-workflow/src/index.ts"
+      ],
       "@gh-symphony/runtime-claude": ["../runtime-claude/src/index.ts"],
       "@gh-symphony/runtime-codex": ["../runtime-codex/src/index.ts"],
-      "@gh-symphony/tool-github-graphql": ["../tool-github-graphql/src/index.ts"],
+      "@gh-symphony/tool-github-graphql": [
+        "../tool-github-graphql/src/index.ts"
+      ],
+      "@gh-symphony/tool-linear-graphql": [
+        "../tool-linear-graphql/src/index.ts"
+      ],
       "@gh-symphony/tracker-github": ["../tracker-github/src/index.ts"]
     }
   }

--- a/packages/worker/vitest.config.ts
+++ b/packages/worker/vitest.config.ts
@@ -24,6 +24,10 @@ export default defineConfig({
         packageRoot,
         "../tool-github-graphql/src/index.ts"
       ),
+      "@gh-symphony/tool-linear-graphql": resolve(
+        packageRoot,
+        "../tool-linear-graphql/src/index.ts"
+      ),
       "@gh-symphony/tracker-github": resolve(
         packageRoot,
         "../tracker-github/src/index.ts"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -190,6 +190,9 @@ importers:
       '@gh-symphony/tool-github-graphql':
         specifier: workspace:*
         version: link:../tool-github-graphql
+      '@gh-symphony/tool-linear-graphql':
+        specifier: workspace:*
+        version: link:../tool-linear-graphql
 
   packages/runtime-codex:
     dependencies:
@@ -199,8 +202,17 @@ importers:
       '@gh-symphony/tool-github-graphql':
         specifier: workspace:*
         version: link:../tool-github-graphql
+      '@gh-symphony/tool-linear-graphql':
+        specifier: workspace:*
+        version: link:../tool-linear-graphql
 
   packages/tool-github-graphql: {}
+
+  packages/tool-linear-graphql:
+    dependencies:
+      graphql:
+        specifier: ^16.11.0
+        version: 16.14.0
 
   packages/tracker-file:
     dependencies:
@@ -2518,6 +2530,10 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  graphql@16.14.0:
+    resolution: {integrity: sha512-BBvQ/406p+4CZbTpCbVPSxfzrZrbnuWSP1ELYgyS6B+hNeKzgrdB4JczCa5VZUBQrDa9hUngm0KnexY6pJRN5Q==}
+    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -6040,6 +6056,8 @@ snapshots:
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
+
+  graphql@16.14.0: {}
 
   has-flag@4.0.0: {}
 


### PR DESCRIPTION
## Issues

- Fixes #314

## Summary

- Adds a `linear_graphql` worker tool for Linear tracker sessions only.
- Keeps Linear auth runtime-managed while supporting the `LINEAR_API_KEY` fallback.
- Tightens review feedback around non-Linear secret exposure, stale Claude MCP entries, zero-operation GraphQL documents, and camelCase secret redaction.

## Changes

- Added `@gh-symphony/tool-linear-graphql` with `{ query, variables, operationName }` input, GraphQL AST single-operation validation, MCP wrapper, and write-flow mutation examples in tests.
- Wired Codex and Claude runtimes to expose `linear_graphql` only when the active tracker is Linear, without embedding Linear secrets in MCP tool definitions.
- Gated Linear credential env injection so non-Linear Codex sessions clear inherited Linear auth env, and removed stale Claude `linear_graphql` MCP entries for non-Linear sessions.
- Passed Linear issue env through worker runtime launch and added persisted observability redaction for Linear tokens, Authorization headers, camelCase auth keys, and run/event snapshots without redacting normal `tokenUsage` counters.
- Refreshed the branch against `origin/main` and resolved the Claude MCP runtime config merge conflict.

## Evidence

- `pnpm --filter @gh-symphony/tool-linear-graphql test`
- `pnpm --filter @gh-symphony/runtime-codex test -- runtime.test.ts`
- `pnpm --filter @gh-symphony/runtime-claude test -- mcp-compose.test.ts`
- `pnpm --filter @gh-symphony/core test -- redaction.test.ts`
- `pnpm --filter @gh-symphony/orchestrator test -- service.test.ts`
- `pnpm lint && pnpm test && pnpm typecheck && pnpm build`
- Docker E2E: `docker compose -f docker-compose.e2e.yml -f docker-compose.e2e.events.yml up -d --build`, health check, happy-path issue injection, refresh, state/event polling through worker `completed` / continuation retry, fixture cleanup, and compose down.

## Human Validation

- [ ] Confirm a Linear tracker worker session receives `linear_graphql` and a GitHub/file tracker session does not.
- [ ] Confirm Linear status transition and comment mutations work with a real `LINEAR_API_KEY`.
- [ ] Confirm no Linear token appears in reviewer-visible logs, run state, or workpad comments.

## Risks

- Real Linear mutation behavior depends on valid workspace state IDs and issue IDs; automated coverage uses parser/runtime examples rather than live Linear API credentials.
