### PR TITLE
fix(runtime-claude): keep MCP config out of checkout

### DIFF
--- a/.changeset/quiet-claude-mcp-runtime.md
+++ b/.changeset/quiet-claude-mcp-runtime.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Keep Symphony-managed Claude MCP config in the issue runtime directory so retries do not fail on a generated workspace `.mcp.json` dirty status. Fixes #325.

--- a/docs/adr/2026-04-15_claude-print-runtime-support.md
+++ b/docs/adr/2026-04-15_claude-print-runtime-support.md
@@ -165,12 +165,12 @@ v1은 **`permissive` 동작만 지원**한다. Claude는 `--permission-mode bypa
 
 #### 4.6.2 MCP config 합성 (Claude 전용)
 
-Worker 초기화 단계에서 symphony-required MCP (`github_graphql`) 를 사용자 `.mcp.json` 과 병합한다. 최종 파일 위치와 argv 는 `runtime.isolation.strict_mcp_config` 에 따라 분기:
+Worker 초기화 단계에서 symphony-required MCP (`github_graphql`) 를 사용자 `.mcp.json` 과 병합한다. 병합 결과는 체크아웃 루트를 오염시키지 않도록 항상 worker runtime directory 의 ephemeral 파일에 기록한다. `runtime.isolation.strict_mcp_config` 는 auto-discovery 차단 여부만 제어한다:
 
 | `strict_mcp_config` | 병합 결과 위치 | argv 추가 |
 |---|---|---|
-| **false (default)** | 워크스페이스 루트 `.mcp.json` 에 mutation 으로 merge. 워크스페이스는 throwaway clone 이므로 오염 영향 없음. | 없음 (Claude auto-discovery 가 픽업) |
-| true | `.runtime/<workspace>/mcp.json` (ephemeral) | `--strict-mcp-config --mcp-config <path>` |
+| **false (default)** | `WORKSPACE_RUNTIME_DIR/mcp.json` (ephemeral) | `--mcp-config <path>` |
+| true | `WORKSPACE_RUNTIME_DIR/mcp.json` (ephemeral) | `--strict-mcp-config --mcp-config <path>` |
 
 병합 규칙:
 - Base: 워크스페이스 루트 `.mcp.json` 이 있으면 그 내용, 없으면 `{ mcpServers: {} }`.
@@ -201,7 +201,7 @@ Codex 런타임 prompt는 현행 유지.
 | Knob | off (default) — Claude Code 네이티브 | on — 격리 |
 |---|---|---|
 | `runtime.isolation.bare` | `CLAUDE.md` 자동 주입, skills/hooks/plugins discovery 활성 | argv 에 `--bare` 추가 — discovery 모두 스킵 |
-| `runtime.isolation.strict_mcp_config` | 사용자 `.mcp.json` + `~/.claude` MCP 모두 로드. Symphony MCP 는 워크스페이스 `.mcp.json` merge 로 공급 (§4.6.2) | argv 에 `--strict-mcp-config --mcp-config <ephemeral>` 추가. Symphony-merged ephemeral 만 로드 |
+| `runtime.isolation.strict_mcp_config` | 사용자 `.mcp.json` + `~/.claude` MCP 모두 로드. Symphony MCP 는 `--mcp-config <ephemeral>` 로 공급 (§4.6.2) | argv 에 `--strict-mcp-config --mcp-config <ephemeral>` 추가. Symphony-merged ephemeral 만 로드 |
 
 Default 근거:
 - `bypassPermissions` 를 v1 default 로 놓은 §4.4 와 동일 철학: "넓게 시작, 좁힐 팀이 명시 opt-in".

--- a/packages/runtime-claude/src/adapter.test.ts
+++ b/packages/runtime-claude/src/adapter.test.ts
@@ -411,13 +411,64 @@ describe("ClaudePrintRuntimeAdapter", () => {
     });
   });
 
+  it("prepares non-strict MCP config argv without writing workspace .mcp.json", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "claude-adapter-"));
+    const runtimeRoot = join(workspaceRoot, "runtime");
+    tempRoots.push(workspaceRoot);
+    const calls: Array<{
+      args: ReadonlyArray<string>;
+    }> = [];
+    const { child, stdout, stderr } = createStubChild();
+
+    const spawnImpl: SpawnLike = (_command, args) => {
+      calls.push({ args });
+
+      queueMicrotask(() => {
+        stdout.end();
+        stderr.end();
+        child.emit("close", 0, null);
+      });
+
+      return child;
+    };
+
+    const adapter = new ClaudePrintRuntimeAdapter(
+      {
+        workingDirectory: workspaceRoot,
+        runtimeDirectory: runtimeRoot,
+        env: {
+          GITHUB_GRAPHQL_TOKEN: "runtime-token",
+        },
+      },
+      { spawnImpl }
+    );
+
+    await adapter.prepare({ runId: "run-1" });
+    await adapter.spawnTurn({
+      messages: [],
+    });
+
+    const mcpConfigPath = join(runtimeRoot, "mcp.json");
+    expect(calls[0]?.args).toContain("--mcp-config");
+    expect(calls[0]?.args).toContain(mcpConfigPath);
+    expect(calls[0]?.args).not.toContain("--strict-mcp-config");
+    expect(await readFile(mcpConfigPath, "utf8")).toContain("github_graphql");
+    await expect(
+      readFile(join(workspaceRoot, ".mcp.json"), "utf8")
+    ).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
   it("does not inherit host MCP credentials during prepare unless enabled", async () => {
     process.env.GITHUB_GRAPHQL_TOKEN = "host-token";
     const workspaceRoot = await mkdtemp(join(tmpdir(), "claude-adapter-"));
+    const runtimeRoot = join(workspaceRoot, "runtime");
     tempRoots.push(workspaceRoot);
 
     const adapter = new ClaudePrintRuntimeAdapter({
       workingDirectory: workspaceRoot,
+      runtimeDirectory: runtimeRoot,
       env: {
         GITHUB_PROJECT_ID: "project-from-config",
       },
@@ -426,7 +477,7 @@ describe("ClaudePrintRuntimeAdapter", () => {
     await adapter.prepare({ runId: "run-1" });
 
     const config = JSON.parse(
-      await readFile(join(workspaceRoot, ".mcp.json"), "utf8")
+      await readFile(join(runtimeRoot, "mcp.json"), "utf8")
     ) as {
       mcpServers?: {
         github_graphql?: {
@@ -446,16 +497,18 @@ describe("ClaudePrintRuntimeAdapter", () => {
   it("can opt in to inheriting host MCP credentials during prepare", async () => {
     process.env.GITHUB_GRAPHQL_TOKEN = "host-token";
     const workspaceRoot = await mkdtemp(join(tmpdir(), "claude-adapter-"));
+    const runtimeRoot = join(workspaceRoot, "runtime");
     tempRoots.push(workspaceRoot);
 
     const adapter = new ClaudePrintRuntimeAdapter({
       workingDirectory: workspaceRoot,
+      runtimeDirectory: runtimeRoot,
       inheritProcessEnv: true,
     });
 
     await adapter.prepare({ runId: "run-1" });
 
-    expect(await readFile(join(workspaceRoot, ".mcp.json"), "utf8")).toContain(
+    expect(await readFile(join(runtimeRoot, "mcp.json"), "utf8")).toContain(
       "host-token"
     );
   });

--- a/packages/runtime-claude/src/mcp-compose.test.ts
+++ b/packages/runtime-claude/src/mcp-compose.test.ts
@@ -202,7 +202,7 @@ describe("composeClaudeMcpConfig", () => {
 
   it("keeps an existing git workspace clean after non-strict preparation", async () => {
     const workspaceRoot = await createTempWorkspace();
-    const runtimeRoot = join(workspaceRoot, "..", "runtime");
+    const runtimeRoot = await createTempWorkspace();
     const workspaceMcpPath = join(workspaceRoot, ".mcp.json");
     const userConfig = JSON.stringify({
       mcpServers: {
@@ -218,6 +218,8 @@ describe("composeClaudeMcpConfig", () => {
     await execFileAsync(
       "git",
       [
+        "-c",
+        "commit.gpgsign=false",
         "-c",
         "user.email=test@example.com",
         "-c",

--- a/packages/runtime-claude/src/mcp-compose.test.ts
+++ b/packages/runtime-claude/src/mcp-compose.test.ts
@@ -1,10 +1,13 @@
+import { execFile } from "node:child_process";
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { promisify } from "node:util";
 import { afterEach, describe, expect, it } from "vitest";
 import { composeClaudeMcpConfig } from "./mcp-compose.js";
 
 const tempRoots: string[] = [];
+const execFileAsync = promisify(execFile);
 
 async function createTempWorkspace(): Promise<string> {
   const workspaceRoot = await mkdtemp(join(tmpdir(), "claude-mcp-compose-"));
@@ -24,16 +27,19 @@ describe("composeClaudeMcpConfig", () => {
     })));
   });
 
-  it("creates a workspace .mcp.json with only github_graphql when none exists", async () => {
+  it("creates a runtime mcp config with only github_graphql when none exists", async () => {
     const workspaceRoot = await createTempWorkspace();
+    const runtimeRoot = join(workspaceRoot, "runtime");
 
     const result = await composeClaudeMcpConfig(workspaceRoot, false, {
       GITHUB_GRAPHQL_TOKEN: "token-1",
+      WORKSPACE_RUNTIME_DIR: runtimeRoot,
     });
 
     expect(result).toEqual({
-      finalPath: join(workspaceRoot, ".mcp.json"),
-      extraArgv: [],
+      finalPath: join(runtimeRoot, "mcp.json"),
+      extraArgv: ["--mcp-config", join(runtimeRoot, "mcp.json")],
+      cleanupPath: join(runtimeRoot, "mcp.json"),
     });
     expect(await readJson(result.finalPath)).toEqual({
       mcpServers: {
@@ -51,34 +57,42 @@ describe("composeClaudeMcpConfig", () => {
 
   it("preserves user-authored keys and overwrites github_graphql", async () => {
     const workspaceRoot = await createTempWorkspace();
+    const runtimeRoot = join(workspaceRoot, "runtime");
     const workspaceMcpPath = join(workspaceRoot, ".mcp.json");
-    await writeFile(
-      workspaceMcpPath,
-      JSON.stringify({
-        customTopLevel: true,
-        mcpServers: {
-          user_server: {
-            command: "node",
-            args: ["user-server.js"],
-          },
-          github_graphql: {
-            command: "old",
-            env: {
-              GITHUB_GRAPHQL_TOKEN: "old-token",
-            },
+    const originalConfig = JSON.stringify({
+      customTopLevel: true,
+      mcpServers: {
+        user_server: {
+          command: "node",
+          args: ["user-server.js"],
+        },
+        github_graphql: {
+          command: "old",
+          env: {
+            GITHUB_GRAPHQL_TOKEN: "old-token",
           },
         },
-      }),
+      },
+    }, null, 2) + "\n";
+    await writeFile(
+      workspaceMcpPath,
+      originalConfig,
       "utf8"
     );
 
     const result = await composeClaudeMcpConfig(workspaceRoot, false, {
       GITHUB_GRAPHQL_TOKEN: "token-2",
       GITHUB_PROJECT_ID: "project-1",
+      WORKSPACE_RUNTIME_DIR: runtimeRoot,
     });
 
-    expect(result.finalPath).toBe(workspaceMcpPath);
-    expect(await readJson(workspaceMcpPath)).toEqual({
+    expect(result).toEqual({
+      finalPath: join(runtimeRoot, "mcp.json"),
+      extraArgv: ["--mcp-config", join(runtimeRoot, "mcp.json")],
+      cleanupPath: join(runtimeRoot, "mcp.json"),
+    });
+    expect(await readFile(workspaceMcpPath, "utf8")).toBe(originalConfig);
+    expect(await readJson(result.finalPath)).toEqual({
       customTopLevel: true,
       mcpServers: {
         user_server: {
@@ -156,25 +170,84 @@ describe("composeClaudeMcpConfig", () => {
 
   it("treats a non-object mcpServers value as empty", async () => {
     const workspaceRoot = await createTempWorkspace();
+    const runtimeRoot = join(workspaceRoot, "runtime");
     const workspaceMcpPath = join(workspaceRoot, ".mcp.json");
+    const originalConfig = JSON.stringify({
+      mcpServers: null,
+    }) + "\n";
     await writeFile(
       workspaceMcpPath,
-      JSON.stringify({
-        mcpServers: null,
-      }),
+      originalConfig,
       "utf8"
     );
 
-    const result = await composeClaudeMcpConfig(workspaceRoot, false, {});
+    const result = await composeClaudeMcpConfig(workspaceRoot, false, {
+      WORKSPACE_RUNTIME_DIR: runtimeRoot,
+    });
 
-    expect(result.finalPath).toBe(workspaceMcpPath);
-    expect(await readJson(workspaceMcpPath)).toEqual({
+    expect(result.finalPath).toBe(join(runtimeRoot, "mcp.json"));
+    expect(await readFile(workspaceMcpPath, "utf8")).toBe(originalConfig);
+    expect(await readJson(result.finalPath)).toEqual({
       mcpServers: {
         github_graphql: {
           command: "node",
           args: [expect.stringContaining("mcp-server.js")],
           env: {
             GITHUB_GRAPHQL_API_URL: "https://api.github.com/graphql",
+          },
+        },
+      },
+    });
+  });
+
+  it("keeps an existing git workspace clean after non-strict preparation", async () => {
+    const workspaceRoot = await createTempWorkspace();
+    const runtimeRoot = join(workspaceRoot, "..", "runtime");
+    const workspaceMcpPath = join(workspaceRoot, ".mcp.json");
+    const userConfig = JSON.stringify({
+      mcpServers: {
+        user_server: {
+          command: "node",
+          args: ["user-server.js"],
+        },
+      },
+    }, null, 2) + "\n";
+    await writeFile(workspaceMcpPath, userConfig, "utf8");
+    await execFileAsync("git", ["init"], { cwd: workspaceRoot });
+    await execFileAsync("git", ["add", ".mcp.json"], { cwd: workspaceRoot });
+    await execFileAsync(
+      "git",
+      [
+        "-c",
+        "user.email=test@example.com",
+        "-c",
+        "user.name=Test User",
+        "commit",
+        "-m",
+        "initial",
+      ],
+      { cwd: workspaceRoot }
+    );
+
+    const result = await composeClaudeMcpConfig(workspaceRoot, false, {
+      GITHUB_GRAPHQL_TOKEN: "token-clean",
+      WORKSPACE_RUNTIME_DIR: runtimeRoot,
+    });
+    const { stdout } = await execFileAsync("git", ["status", "--porcelain"], {
+      cwd: workspaceRoot,
+    });
+
+    expect(stdout).toBe("");
+    expect(await readFile(workspaceMcpPath, "utf8")).toBe(userConfig);
+    expect(await readJson(result.finalPath)).toMatchObject({
+      mcpServers: {
+        user_server: {
+          command: "node",
+          args: ["user-server.js"],
+        },
+        github_graphql: {
+          env: {
+            GITHUB_GRAPHQL_TOKEN: "token-clean",
           },
         },
       },

--- a/packages/runtime-claude/src/mcp-compose.ts
+++ b/packages/runtime-claude/src/mcp-compose.ts
@@ -28,14 +28,13 @@ export async function composeClaudeMcpConfig(
   symphonyTokenEnv: ClaudeMcpTokenEnvironment = {}
 ): Promise<ClaudeMcpCompositionResult> {
   const workspaceMcpPath = join(workspaceRoot, ".mcp.json");
-  const finalPath = strictMode
-    ? resolveStrictMcpConfigPath(workspaceRoot, symphonyTokenEnv)
-    : workspaceMcpPath;
+  const finalPath = resolveRuntimeMcpConfigPath(
+    workspaceRoot,
+    symphonyTokenEnv
+  );
   const baseConfig = await readBaseMcpConfig(workspaceMcpPath);
   const mergedConfig = mergeGitHubGraphQLMcpServer(baseConfig, symphonyTokenEnv);
 
-  // Non-strict mode mutates the workspace .mcp.json in-place so Claude's
-  // auto-discovery can pick up both user-authored and Symphony-managed entries.
   await mkdir(dirname(finalPath), { recursive: true });
   await writeFile(finalPath, JSON.stringify(mergedConfig, null, 2) + "\n", "utf8");
 
@@ -43,8 +42,8 @@ export async function composeClaudeMcpConfig(
     finalPath,
     extraArgv: strictMode
       ? ["--strict-mcp-config", "--mcp-config", finalPath]
-      : [],
-    ...(strictMode ? { cleanupPath: finalPath } : {}),
+      : ["--mcp-config", finalPath],
+    cleanupPath: finalPath,
   };
 }
 
@@ -86,16 +85,20 @@ function mergeGitHubGraphQLMcpServer(
   };
 }
 
-function resolveStrictMcpConfigPath(
+function resolveRuntimeMcpConfigPath(
   workspaceRoot: string,
   env: ClaudeMcpTokenEnvironment
 ): string {
   // Direct package tests and ad-hoc callers may not have the worker runtime
-  // directory yet; keep their strict config inside the workspace fallback path.
+  // directory yet; keep fallback artifacts next to, not inside, the checkout.
   const normalizedWorkspaceRoot = resolve(workspaceRoot);
   const runtimeDir =
     env.WORKSPACE_RUNTIME_DIR ??
-    join(normalizedWorkspaceRoot, ".runtime", basename(normalizedWorkspaceRoot));
+    join(
+      dirname(normalizedWorkspaceRoot),
+      ".runtime",
+      basename(normalizedWorkspaceRoot)
+    );
 
   return join(runtimeDir, "mcp.json");
 }


### PR DESCRIPTION
## Issues

- Fixes #325

## Summary

- Writes Symphony-composed Claude MCP config to the worker runtime directory instead of the issue repository checkout.
- Passes the runtime config explicitly with `--mcp-config` in non-strict mode and preserves `--strict-mcp-config --mcp-config` in strict mode.
- Hardens the regression test so its runtime directory is unique, cleaned up, and independent of global git signing settings.

## Changes

- Updated `composeClaudeMcpConfig()` to always use `WORKSPACE_RUNTIME_DIR/mcp.json` with a sibling fallback outside the checkout.
- Preserved user-authored workspace `.mcp.json` as merge input without mutating it.
- Added regression coverage for clean `git status --porcelain` after non-strict MCP preparation.
- Updated the Claude runtime ADR and added the required patch Changeset for `@gh-symphony/cli`.
- Addressed review feedback by using a cleaned-up temp runtime directory in the regression test and disabling git commit signing for the test commit.

## Evidence

- `pnpm --filter @gh-symphony/runtime-claude test -- mcp-compose adapter`
- `pnpm lint && pnpm test && pnpm typecheck && pnpm build`
- `pnpm e2e:claude`

## Human Validation

- [ ] Confirm a Claude runtime retry/restart reuses a preserved issue workspace without `?? .mcp.json`.
- [ ] Confirm user-authored workspace `.mcp.json` entries remain available alongside `github_graphql`.
- [ ] Confirm strict MCP config behavior still loads only the composed ephemeral config.

## Risks

- Non-strict Claude runs now receive Symphony MCP config through explicit `--mcp-config`; reviewers should confirm this matches the installed Claude CLI version expected in production.