### PR TITLE
feat(cli): add Linear workflow validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,19 @@ gh-symphony repo recover --dry-run       # Preview what would be recovered
 
 `gh-symphony repo init` binds the orchestrator to the cwd repository. It reads `WORKFLOW.md`, infers `owner/name` from the Git remote, and writes per-repo runtime state under `.runtime/orchestrator/`.
 
+For Linear tracker repositories, `WORKFLOW.md` remains the source of truth:
+
+```yaml
+tracker:
+  kind: linear
+  api_key: $LINEAR_API_KEY
+  project_slug: symphony-0c79b11b75ea
+```
+
+`gh-symphony repo init` validates that `tracker.project_slug` is present and that the `tracker.api_key` reference resolves, for example through `LINEAR_API_KEY`. Linear config aliases such as `tracker.project_id`, `projectId`, `project_id`, and `teamId` are rejected. The legacy `.gh-symphony/config.json` file is not used as the Linear source of truth.
+
+Linear orchestration is polling-only. There is intentionally no Linear webhook setup command; state transitions, workpad comments, and PR handoff policy belong in `WORKFLOW.md`. See `docs/examples/linear-WORKFLOW.md` for a complete example.
+
 ### Configuration
 
 ```bash
@@ -517,7 +530,7 @@ gh-symphony workflow init --non-interactive --project PVT_xxx --dry-run
 
 `gh-symphony workflow validate` parses the target file, strictly renders the prompt body and continuation guidance with canonical sample variables, and prints a compact runtime/lifecycle summary.
 
-`gh-symphony workflow preview --issue owner/repo#123` is the fastest validation step after `workflow init`: it resolves the active managed project (or `--project-id`) and renders the exact worker prompt from the live GitHub Project issue. Keep `--sample <path-to-json>` for fixture-based debugging, and use `--attempt <n>` to inspect retry prompts before changing policy files.
+`gh-symphony workflow preview --issue owner/repo#123` is the fastest validation step after `workflow init`: it resolves the active managed project (or `--project-id`) and renders the exact worker prompt from the live GitHub Project issue. Linear workflows can preview a single issue with `gh-symphony workflow preview ENG-123`, which routes through the configured Linear tracker adapter and `LINEAR_API_KEY`. Keep `--sample <path-to-json>` for fixture-based debugging, and use `--attempt <n>` to inspect retry prompts before changing policy files.
 
 ### Resolution order
 

--- a/docs/examples/linear-WORKFLOW.md
+++ b/docs/examples/linear-WORKFLOW.md
@@ -1,0 +1,73 @@
+---
+tracker:
+  kind: linear
+  endpoint: https://api.linear.app/graphql
+  api_key: $LINEAR_API_KEY
+  project_slug: symphony-0c79b11b75ea
+  active_states:
+    - Todo
+    - In Progress
+    - Rework
+  terminal_states:
+    - Done
+    - Canceled
+    - Cancelled
+    - Duplicate
+polling:
+  interval_ms: 30000
+workspace:
+  root: .runtime/symphony-workspaces
+agent:
+  max_concurrent_agents: 4
+  max_turns: 20
+runtime:
+  kind: codex-app-server
+  command: codex
+  args:
+    - app-server
+  isolation:
+    bare: false
+    strict_mcp_config: false
+  timeouts:
+    read_timeout_ms: 5000
+    turn_timeout_ms: 3600000
+    stall_timeout_ms: 300000
+---
+
+## Status Map
+
+- **Todo** [active]: create a workpad comment, move the Linear issue to `In Progress`, and start implementation.
+- **In Progress** [active]: continue the current work cycle, updating the existing workpad comment in place.
+- **Rework** [active]: inspect PR review feedback first, then update the workpad with the revised plan before editing code.
+- **Human Review** [wait]: a PR has been opened and human review is required; do not continue unless review feedback asks for changes.
+- **Done**, **Canceled**, **Cancelled**, **Duplicate** [terminal]: exit immediately.
+
+## Linear Tracker Policy
+
+`WORKFLOW.md` is the source of truth for Linear tracker setup. Use `tracker.kind: linear` with `tracker.project_slug`; do not use `tracker.project_id`, `projectId`, `project_id`, `teamId`, or `.gh-symphony/config.json` as Linear configuration inputs.
+
+`LINEAR_API_KEY` must be available when running `gh-symphony repo init`, `gh-symphony repo start`, or `gh-symphony workflow preview ENG-123`. The orchestrator reads Linear by polling the configured project. Linear webhook setup is a non-goal and no webhook command is expected.
+
+## Workpad Policy
+
+1. Read the Linear issue body and comments before making changes.
+2. Create exactly one workpad comment per active work cycle.
+3. If the issue returns from `Human Review` to `Rework` or another active state, start a new workpad comment and record the review trigger.
+4. Within a work cycle, update the existing workpad comment instead of creating duplicates.
+5. Do not write secrets, tokens, or raw `LINEAR_API_KEY` values into comments, logs, commits, or PR bodies.
+
+## Execution Policy
+
+1. Create a branch for the Linear issue identifier, for example `eng-123-description`.
+2. Implement only the issue scope.
+3. Run the repository validation commands required by this repository.
+4. Commit logical units of work.
+5. Open a GitHub PR against the configured repository.
+
+## PR Handoff Policy
+
+1. Add the GitHub PR URL to the Linear issue comment thread.
+2. Move the Linear issue to `Human Review`.
+3. Record validation evidence and the PR URL in the workpad.
+4. If review changes are requested, move the issue to `Rework`, address the feedback, update the PR, and return the issue to `Human Review`.
+5. When the PR is merged and validation is complete, move the Linear issue to `Done`.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -107,6 +107,25 @@ You can further customize the agent's behavior by editing `WORKFLOW.md` — this
 
 > Currently supported runtimes: **Codex**, **Claude Code**
 
+### Linear Tracker Repositories
+
+For Linear, configure the tracker in `WORKFLOW.md` and initialize the repository runtime from the target GitHub repository:
+
+```yaml
+tracker:
+  kind: linear
+  api_key: $LINEAR_API_KEY
+  project_slug: symphony-0c79b11b75ea
+```
+
+`gh-symphony repo init` validates `tracker.project_slug` and resolves `tracker.api_key`, so `LINEAR_API_KEY` must be set before initialization. Linear aliases such as `tracker.project_id`, `projectId`, `project_id`, and `teamId` are rejected, and `.gh-symphony/config.json` is not a Linear source of truth.
+
+Linear runs are polling-only. There is no webhook setup command. Put state transition, workpad comment, and PR handoff policy in `WORKFLOW.md`; see `docs/examples/linear-WORKFLOW.md` in the repository for a complete example. Preview a Linear issue prompt with:
+
+```bash
+gh-symphony workflow preview ENG-123
+```
+
 ### Repository `.env` Mapping
 
 If your hooks or worker runs need staging hosts, database URLs, Playwright base URLs, or other runtime-only values, store them in the repository runtime directory instead of hardcoding them in `WORKFLOW.md`.

--- a/packages/cli/src/commands/repo.test.ts
+++ b/packages/cli/src/commands/repo.test.ts
@@ -197,11 +197,13 @@ describe("repo init runtime migration", () => {
     const repoDir = await createGitRepo();
     const stdout = captureWrites(process.stdout);
     const repoCommand = await loadRepoCommand();
+    const originalLinearApiKey = process.env.LINEAR_API_KEY;
     await writeFile(
       join(repoDir, "WORKFLOW.md"),
       `---
 tracker:
   kind: linear
+  api_key: $LINEAR_API_KEY
   project_slug: symphony-0c79b11b75ea
   active_states:
     - Todo
@@ -213,6 +215,7 @@ Handle {{issue.identifier}}.
 `,
       "utf8"
     );
+    process.env.LINEAR_API_KEY = "lin_test_token";
 
     try {
       await repoCommand(
@@ -220,6 +223,11 @@ Handle {{issue.identifier}}.
         baseOptions(join(repoDir, "unused"))
       );
     } finally {
+      if (originalLinearApiKey === undefined) {
+        delete process.env.LINEAR_API_KEY;
+      } else {
+        process.env.LINEAR_API_KEY = originalLinearApiKey;
+      }
       stdout.restore();
     }
 
@@ -236,6 +244,80 @@ Handle {{issue.identifier}}.
         repository: "acme/platform",
       },
     });
+  });
+
+  it("fails Linear repo init when tracker.api_key is missing", async () => {
+    const repoDir = await createGitRepo();
+    const stderr = captureWrites(process.stderr);
+    const repoCommand = await loadRepoCommand();
+    await writeFile(
+      join(repoDir, "WORKFLOW.md"),
+      `---
+tracker:
+  kind: linear
+  project_slug: symphony-0c79b11b75ea
+codex:
+  command: codex app-server
+---
+Handle {{issue.identifier}}.
+`,
+      "utf8"
+    );
+
+    try {
+      await repoCommand(
+        ["init", "--repo-dir", repoDir],
+        baseOptions(join(repoDir, "unused"))
+      );
+    } finally {
+      stderr.restore();
+    }
+
+    expect(process.exitCode).toBe(1);
+    expect(stderr.output()).toContain(
+      'Linear tracker repo init requires WORKFLOW.md field "tracker.api_key"'
+    );
+  });
+
+  it("fails Linear repo init when LINEAR_API_KEY reference is unresolved", async () => {
+    const repoDir = await createGitRepo();
+    const stderr = captureWrites(process.stderr);
+    const repoCommand = await loadRepoCommand();
+    const originalLinearApiKey = process.env.LINEAR_API_KEY;
+    await writeFile(
+      join(repoDir, "WORKFLOW.md"),
+      `---
+tracker:
+  kind: linear
+  api_key: $LINEAR_API_KEY
+  project_slug: symphony-0c79b11b75ea
+codex:
+  command: codex app-server
+---
+Handle {{issue.identifier}}.
+`,
+      "utf8"
+    );
+    delete process.env.LINEAR_API_KEY;
+
+    try {
+      await repoCommand(
+        ["init", "--repo-dir", repoDir],
+        baseOptions(join(repoDir, "unused"))
+      );
+    } finally {
+      if (originalLinearApiKey === undefined) {
+        delete process.env.LINEAR_API_KEY;
+      } else {
+        process.env.LINEAR_API_KEY = originalLinearApiKey;
+      }
+      stderr.restore();
+    }
+
+    expect(process.exitCode).toBe(1);
+    expect(stderr.output()).toContain(
+      "Workflow front matter requires environment variable LINEAR_API_KEY"
+    );
   });
 
   it("resolves a relative --workflow-file against --repo-dir", async () => {

--- a/packages/cli/src/commands/repo.test.ts
+++ b/packages/cli/src/commands/repo.test.ts
@@ -279,6 +279,39 @@ Handle {{issue.identifier}}.
     );
   });
 
+  it("fails Linear repo init when tracker.project_slug is missing", async () => {
+    const repoDir = await createGitRepo();
+    const stderr = captureWrites(process.stderr);
+    const repoCommand = await loadRepoCommand();
+    await writeFile(
+      join(repoDir, "WORKFLOW.md"),
+      `---
+tracker:
+  kind: linear
+  api_key: lin_test_token
+codex:
+  command: codex app-server
+---
+Handle {{issue.identifier}}.
+`,
+      "utf8"
+    );
+
+    try {
+      await repoCommand(
+        ["init", "--repo-dir", repoDir],
+        baseOptions(join(repoDir, "unused"))
+      );
+    } finally {
+      stderr.restore();
+    }
+
+    expect(process.exitCode).toBe(1);
+    expect(stderr.output()).toContain(
+      'Workflow front matter field "tracker.project_slug" is required for tracker.kind "linear".'
+    );
+  });
+
   it("fails Linear repo init when LINEAR_API_KEY reference is unresolved", async () => {
     const repoDir = await createGitRepo();
     const stderr = captureWrites(process.stderr);

--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -386,6 +386,82 @@ describe("workflow command handler", () => {
     expect(stdout.output()).toContain("ENG-123: Add Linear preview");
   });
 
+  it("rejects Linear preview when the active runtime is not bound to the workflow project", async () => {
+    const root = await mkdtemp(
+      join(tmpdir(), "workflow-preview-linear-mismatch-")
+    );
+    const workflowPath = join(root, "WORKFLOW.md");
+    const stderr = captureWrites(process.stderr);
+    const resolveTrackerAdapter = vi.fn();
+
+    await writeFile(workflowPath, LINEAR_WORKFLOW, "utf8");
+
+    setWorkflowCommandDependenciesForTest({
+      loadActiveProjectConfig: vi.fn().mockResolvedValue({
+        projectId: "tenant-a",
+        slug: "tenant-a",
+        workspaceDir: root,
+        repository: {
+          owner: "acme",
+          name: "api",
+          cloneUrl: "https://github.com/acme/api.git",
+        },
+        tracker: {
+          adapter: "github-project",
+          bindingId: "PVT_project_123",
+          settings: {
+            projectId: "PVT_project_123",
+          },
+        },
+      }),
+      resolveTrackerAdapter,
+    });
+
+    try {
+      await workflowCommand(["preview", "--file", workflowPath, "ENG-123"], {
+        configDir: root,
+        verbose: false,
+        json: false,
+        noColor: false,
+      });
+    } finally {
+      stderr.restore();
+    }
+
+    expect(stderr.output()).toContain(
+      'Linear live issue preview requires an active repository runtime initialized for project "symphony-0c79b11b75ea".'
+    );
+    expect(resolveTrackerAdapter).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("rejects duplicate preview issue identifiers regardless of argument order", async () => {
+    const root = await mkdtemp(join(tmpdir(), "workflow-preview-duplicate-"));
+    const workflowPath = join(root, "WORKFLOW.md");
+    const stderr = captureWrites(process.stderr);
+
+    await writeFile(workflowPath, LINEAR_WORKFLOW, "utf8");
+
+    try {
+      await workflowCommand(
+        ["preview", "--file", workflowPath, "ENG-123", "--issue", "ENG-124"],
+        {
+          configDir: root,
+          verbose: false,
+          json: false,
+          noColor: false,
+        }
+      );
+    } finally {
+      stderr.restore();
+    }
+
+    expect(stderr.output()).toContain(
+      "Only one preview issue identifier can be provided."
+    );
+    expect(process.exitCode).toBe(1);
+  });
+
   it("fails live preview when the repository is not linked to the bound GitHub Project", async () => {
     const root = await mkdtemp(
       join(tmpdir(), "workflow-preview-live-missing-repo-")

--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -47,6 +47,25 @@ Attempt={{ attempt }}
 Labels={% for label in issue.labels %}{{ label }} {% endfor %}
 `;
 
+const LINEAR_WORKFLOW = `---
+tracker:
+  kind: linear
+  api_key: lin_test_token
+  project_slug: symphony-0c79b11b75ea
+  active_states:
+    - Todo
+  terminal_states:
+    - Done
+runtime:
+  kind: codex-app-server
+  command: codex
+  args:
+    - app-server
+---
+# Issue
+{{ issue.identifier }}: {{ issue.title }}
+`;
+
 afterEach(() => {
   vi.restoreAllMocks();
   resetWorkflowCommandDependenciesForTest();
@@ -268,6 +287,103 @@ describe("workflow command handler", () => {
     expect(stdout.output()).toContain("Sample: live:acme/api#9");
     expect(stdout.output()).toContain("acme/api#9: Fix preview rendering");
     expect(stdout.output()).toContain("Attempt=2");
+  });
+
+  it("routes Linear identifiers through the active tracker adapter", async () => {
+    const root = await mkdtemp(join(tmpdir(), "workflow-preview-linear-"));
+    const workflowPath = join(root, "WORKFLOW.md");
+    const stdout = captureWrites(process.stdout);
+    const fetchIssueStatesByIds = vi.fn().mockResolvedValue([
+      {
+        id: "linear-issue-id",
+        identifier: "ENG-123",
+        number: 123,
+        title: "Add Linear preview",
+        description: "Preview should fetch through Linear.",
+        priority: 2,
+        state: "Todo",
+        branchName: null,
+        url: "https://linear.app/acme/issue/ENG-123",
+        labels: ["cli"],
+        blockedBy: [],
+        createdAt: "2026-05-01T00:00:00Z",
+        updatedAt: "2026-05-02T00:00:00Z",
+        repository: {
+          owner: "acme",
+          name: "api",
+          cloneUrl: "https://github.com/acme/api.git",
+        },
+        tracker: {
+          adapter: "linear",
+          bindingId: "symphony-0c79b11b75ea",
+          itemId: "linear-issue-id",
+        },
+        metadata: {},
+      },
+    ]);
+    const resolveTrackerAdapter = vi.fn().mockReturnValue({
+      listIssues: vi.fn(),
+      listIssuesByStates: vi.fn(),
+      fetchIssueStatesByIds,
+      buildWorkerEnvironment: vi.fn(),
+      reviveIssue: vi.fn(),
+    });
+
+    await writeFile(workflowPath, LINEAR_WORKFLOW, "utf8");
+
+    setWorkflowCommandDependenciesForTest({
+      loadActiveProjectConfig: vi.fn().mockResolvedValue({
+        projectId: "repository",
+        slug: "api",
+        workspaceDir: root,
+        repository: {
+          owner: "acme",
+          name: "api",
+          cloneUrl: "https://github.com/acme/api.git",
+        },
+        tracker: {
+          adapter: "linear",
+          bindingId: "symphony-0c79b11b75ea",
+          settings: {
+            projectSlug: "symphony-0c79b11b75ea",
+          },
+        },
+      }),
+      resolveTrackerAdapter,
+    });
+
+    try {
+      await workflowCommand(["preview", "--file", workflowPath, "ENG-123"], {
+        configDir: root,
+        verbose: false,
+        json: false,
+        noColor: false,
+      });
+    } finally {
+      stdout.restore();
+    }
+
+    expect(resolveTrackerAdapter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        adapter: "linear",
+        bindingId: "symphony-0c79b11b75ea",
+        settings: expect.objectContaining({
+          projectSlug: "symphony-0c79b11b75ea",
+        }),
+      })
+    );
+    expect(fetchIssueStatesByIds).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repository: expect.objectContaining({
+          owner: "acme",
+          name: "api",
+        }),
+      }),
+      ["ENG-123"],
+      { token: "lin_test_token" }
+    );
+    expect(stdout.output()).toContain("Sample: live:ENG-123");
+    expect(stdout.output()).toContain("ENG-123: Add Linear preview");
   });
 
   it("fails live preview when the repository is not linked to the bound GitHub Project", async () => {

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -252,6 +252,9 @@ function parsePreviewFlags(args: string[]): PreviewFlags {
         if (!value || value.startsWith("-")) {
           throw new Error("Option '--issue' argument missing");
         }
+        if (flags.issue) {
+          throw new Error("Only one preview issue identifier can be provided.");
+        }
         flags.issue = value;
         i += 1;
         break;
@@ -708,7 +711,8 @@ async function loadLinearIssue(
     );
   }
 
-  if (!workflow.tracker.projectSlug?.trim()) {
+  const workflowProjectSlug = workflow.tracker.projectSlug?.trim();
+  if (!workflowProjectSlug) {
     throw new Error(
       'Linear live issue preview requires WORKFLOW.md field "tracker.project_slug".'
     );
@@ -720,25 +724,24 @@ async function loadLinearIssue(
     );
   }
 
-  const tracker = {
-    adapter: "linear",
-    bindingId: workflow.tracker.projectSlug,
-    ...(workflow.tracker.endpoint ? { apiUrl: workflow.tracker.endpoint } : {}),
-    settings: {
-      projectSlug: workflow.tracker.projectSlug,
-      activeStates: workflow.tracker.activeStates.join("\n"),
-      repository: `${projectConfig.repository.owner}/${projectConfig.repository.name}`,
-    },
-  };
+  if (
+    projectConfig.tracker.adapter !== "linear" ||
+    projectConfig.tracker.bindingId !== workflowProjectSlug
+  ) {
+    throw new Error(
+      `Linear live issue preview requires an active repository runtime initialized for project "${workflowProjectSlug}". Run 'gh-symphony repo init' from this repository, then re-run the preview.`
+    );
+  }
+
   const orchestratorProject: OrchestratorProjectConfig = {
     projectId: projectConfig.projectId,
     slug: projectConfig.slug,
     workspaceDir: projectConfig.workspaceDir,
     repository: projectConfig.repository,
-    tracker,
+    tracker: projectConfig.tracker,
   };
   const trackerAdapter =
-    workflowCommandDependencies.resolveTrackerAdapter(tracker);
+    workflowCommandDependencies.resolveTrackerAdapter(projectConfig.tracker);
   const [issue] = await trackerAdapter.fetchIssueStatesByIds(
     orchestratorProject,
     [issueIdentifier.trim().toUpperCase()],

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -2,12 +2,14 @@ import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import {
   buildPromptVariables,
+  type OrchestratorProjectConfig,
   parseWorkflowMarkdown,
   renderPrompt,
   type TrackedIssue,
 } from "@gh-symphony/core";
+import { resolveTrackerAdapter } from "@gh-symphony/orchestrator";
 import { fetchGithubProjectIssueByRepositoryAndNumber } from "@gh-symphony/tracker-github";
-import type { CliProjectConfig } from "../config.js";
+import { loadActiveProjectConfig, type CliProjectConfig } from "../config.js";
 import {
   createClient,
   findLinkedRepository,
@@ -55,7 +57,9 @@ type WorkflowCommandDependencies = {
   fetchLiveIssue: typeof fetchGithubProjectIssueByRepositoryAndNumber;
   getGitHubProjectDetail: typeof getProjectDetail;
   getGitHubTokenWithSource: typeof getGhTokenWithSource;
+  loadActiveProjectConfig: typeof loadActiveProjectConfig;
   resolveManagedProjectSelection: typeof inspectManagedProjectSelection;
+  resolveTrackerAdapter: typeof resolveTrackerAdapter;
   validateGitHubToken: typeof validateGitHubToken;
 };
 
@@ -146,7 +150,9 @@ const workflowCommandDependencies: WorkflowCommandDependencies = {
   fetchLiveIssue: fetchGithubProjectIssueByRepositoryAndNumber,
   getGitHubProjectDetail: getProjectDetail,
   getGitHubTokenWithSource: getGhTokenWithSource,
+  loadActiveProjectConfig,
   resolveManagedProjectSelection: inspectManagedProjectSelection,
+  resolveTrackerAdapter,
   validateGitHubToken,
 };
 
@@ -162,8 +168,10 @@ export function resetWorkflowCommandDependenciesForTest(): void {
     fetchGithubProjectIssueByRepositoryAndNumber;
   workflowCommandDependencies.getGitHubProjectDetail = getProjectDetail;
   workflowCommandDependencies.getGitHubTokenWithSource = getGhTokenWithSource;
+  workflowCommandDependencies.loadActiveProjectConfig = loadActiveProjectConfig;
   workflowCommandDependencies.resolveManagedProjectSelection =
     inspectManagedProjectSelection;
+  workflowCommandDependencies.resolveTrackerAdapter = resolveTrackerAdapter;
   workflowCommandDependencies.validateGitHubToken = validateGitHubToken;
 }
 
@@ -266,6 +274,10 @@ function parsePreviewFlags(args: string[]): PreviewFlags {
         if (arg?.startsWith("-")) {
           throw new Error(`Unknown option '${arg}'`);
         }
+        if (flags.issue) {
+          throw new Error("Only one preview issue identifier can be provided.");
+        }
+        flags.issue = arg;
         break;
     }
   }
@@ -294,7 +306,9 @@ Commands:
 Options:
   workflow init [--non-interactive] [--project <id>] [--output <path>] [--skip-skills] [--skip-context] [--dry-run]
   workflow validate [--file <path>]
-  workflow preview [--file <path>] [--issue <owner/repo#number>] [--project-id <projectId>] [--sample <json>] [--attempt <n>]
+  workflow preview [issue] [--file <path>] [--issue <owner/repo#number|ENG-123>] [--project-id <projectId>] [--sample <json>] [--attempt <n>]
+
+Linear workflows use polling through the configured tracker adapter. No Linear webhook setup command is provided.
 `);
 }
 
@@ -669,6 +683,80 @@ async function loadLiveIssue(
   };
 }
 
+const LINEAR_IDENTIFIER_PATTERN = /^[A-Z][A-Z0-9]*-\d+$/;
+
+function isLinearIssueIdentifier(value: string): boolean {
+  return LINEAR_IDENTIFIER_PATTERN.test(value.trim().toUpperCase());
+}
+
+async function loadLinearIssue(
+  issueIdentifier: string,
+  workflow: ReturnType<typeof parseWorkflowMarkdown>,
+  options: GlobalOptions
+): Promise<{
+  issue: TrackedIssue;
+  sampleSource: string;
+}> {
+  const projectConfig =
+    await workflowCommandDependencies.loadActiveProjectConfig(
+      options.configDir
+    );
+
+  if (!projectConfig?.repository) {
+    throw new Error(
+      "Linear live issue preview requires a repository runtime initialized with 'gh-symphony repo init'."
+    );
+  }
+
+  if (!workflow.tracker.projectSlug?.trim()) {
+    throw new Error(
+      'Linear live issue preview requires WORKFLOW.md field "tracker.project_slug".'
+    );
+  }
+
+  if (!workflow.tracker.apiKey?.trim()) {
+    throw new Error(
+      'Linear live issue preview requires WORKFLOW.md field "tracker.api_key" to resolve, for example "$LINEAR_API_KEY".'
+    );
+  }
+
+  const tracker = {
+    adapter: "linear",
+    bindingId: workflow.tracker.projectSlug,
+    ...(workflow.tracker.endpoint ? { apiUrl: workflow.tracker.endpoint } : {}),
+    settings: {
+      projectSlug: workflow.tracker.projectSlug,
+      activeStates: workflow.tracker.activeStates.join("\n"),
+      repository: `${projectConfig.repository.owner}/${projectConfig.repository.name}`,
+    },
+  };
+  const orchestratorProject: OrchestratorProjectConfig = {
+    projectId: projectConfig.projectId,
+    slug: projectConfig.slug,
+    workspaceDir: projectConfig.workspaceDir,
+    repository: projectConfig.repository,
+    tracker,
+  };
+  const trackerAdapter =
+    workflowCommandDependencies.resolveTrackerAdapter(tracker);
+  const [issue] = await trackerAdapter.fetchIssueStatesByIds(
+    orchestratorProject,
+    [issueIdentifier.trim().toUpperCase()],
+    { token: workflow.tracker.apiKey }
+  );
+
+  if (!issue) {
+    throw new Error(
+      `Linear issue ${issueIdentifier} was not found in project "${workflow.tracker.projectSlug}".`
+    );
+  }
+
+  return {
+    issue,
+    sampleSource: `live:${issue.identifier}`,
+  };
+}
+
 function validateWorkflow(
   workflowPath: string,
   markdown: string
@@ -801,13 +889,19 @@ async function runPreview(
   }
   const { workflowPath, markdown } = await loadWorkflowMarkdown(flags.file);
   const workflow = parseWorkflowMarkdown(markdown);
-  if (flags.issue && workflow.tracker.kind !== "github-project") {
+  if (
+    flags.issue &&
+    workflow.tracker.kind !== "github-project" &&
+    !(workflow.tracker.kind === "linear" && isLinearIssueIdentifier(flags.issue))
+  ) {
     throw new Error(
-      "Live issue preview requires 'tracker.kind: github-project' in WORKFLOW.md."
+      "Live issue preview requires 'tracker.kind: github-project' with owner/repo#number or 'tracker.kind: linear' with a Linear identifier such as ENG-123."
     );
   }
   const { issue, sampleSource } = flags.issue
-    ? await loadLiveIssue(flags.issue, flags.projectId, options)
+    ? workflow.tracker.kind === "linear"
+      ? await loadLinearIssue(flags.issue, workflow, options)
+      : await loadLiveIssue(flags.issue, flags.projectId, options)
     : await loadSampleIssue(flags.sample);
   const renderedPrompt = renderIssueWorkflowPreview({
     workflow,

--- a/packages/cli/src/repo-runtime.ts
+++ b/packages/cli/src/repo-runtime.ts
@@ -150,12 +150,6 @@ function validateRepoInitWorkflow(
     return;
   }
 
-  if (!workflow.tracker.projectSlug?.trim()) {
-    throw new Error(
-      'Linear tracker repo init requires WORKFLOW.md field "tracker.project_slug".'
-    );
-  }
-
   if (!workflow.tracker.apiKey?.trim()) {
     throw new Error(
       'Linear tracker repo init requires WORKFLOW.md field "tracker.api_key" to reference a resolvable environment variable such as "$LINEAR_API_KEY".'

--- a/packages/cli/src/repo-runtime.ts
+++ b/packages/cli/src/repo-runtime.ts
@@ -73,6 +73,7 @@ export async function initRepoRuntime(flags: RepoInitFlags): Promise<{
 
   const workflowPath = resolve(repoDir, flags.workflowFile ?? "WORKFLOW.md");
   const workflow = parseWorkflowMarkdown(await readFile(workflowPath, "utf8"));
+  validateRepoInitWorkflow(workflow);
   const repository = resolveRepository(repoDir);
   const trackerAdapter = workflow.tracker.kind ?? "github-project";
   const trackerBindingId =
@@ -140,6 +141,26 @@ export async function initRepoRuntime(flags: RepoInitFlags): Promise<{
     workflowPath,
     repository,
   };
+}
+
+function validateRepoInitWorkflow(
+  workflow: ReturnType<typeof parseWorkflowMarkdown>
+): void {
+  if (workflow.tracker.kind !== "linear") {
+    return;
+  }
+
+  if (!workflow.tracker.projectSlug?.trim()) {
+    throw new Error(
+      'Linear tracker repo init requires WORKFLOW.md field "tracker.project_slug".'
+    );
+  }
+
+  if (!workflow.tracker.apiKey?.trim()) {
+    throw new Error(
+      'Linear tracker repo init requires WORKFLOW.md field "tracker.api_key" to reference a resolvable environment variable such as "$LINEAR_API_KEY".'
+    );
+  }
 }
 
 export async function migrateLegacyRuntime(runtimeRoot: string): Promise<void> {

--- a/packages/cli/src/workflow/generate-reference-workflow.test.ts
+++ b/packages/cli/src/workflow/generate-reference-workflow.test.ts
@@ -145,6 +145,20 @@ describe("generateReferenceWorkflow", () => {
     expect(output).toContain("project_id: PVT_abc123");
   });
 
+  it("includes a Linear tracker example without webhook setup", () => {
+    const output = generateReferenceWorkflow(defaultInput);
+
+    expect(output).toContain("# Linear tracker example:");
+    expect(output).toContain("#   kind: linear");
+    expect(output).toContain("#   api_key: $LINEAR_API_KEY");
+    expect(output).toContain("#   project_slug: symphony-0c79b11b75ea");
+    expect(output).toContain(
+      "# a Linear webhook setup command."
+    );
+    expect(output).not.toContain("#   project_id:");
+    expect(output).not.toContain("#   teamId:");
+  });
+
   it("includes priority_field in front matter when configured", () => {
     const output = generateReferenceWorkflow(defaultInput);
     expect(output).toContain("priority_field: Priority");

--- a/packages/cli/src/workflow/generate-reference-workflow.ts
+++ b/packages/cli/src/workflow/generate-reference-workflow.ts
@@ -85,6 +85,22 @@ export function generateReferenceWorkflow(
   }
 
   lines.push("");
+  lines.push("# Linear tracker example:");
+  lines.push("# tracker:");
+  lines.push("#   kind: linear");
+  lines.push("#   endpoint: https://api.linear.app/graphql");
+  lines.push("#   api_key: $LINEAR_API_KEY");
+  lines.push("#   project_slug: symphony-0c79b11b75ea");
+  lines.push("#   active_states:");
+  lines.push("#     - Todo");
+  lines.push("#     - In Progress");
+  lines.push("#   terminal_states:");
+  lines.push("#     - Done");
+  lines.push("#     - Canceled");
+  lines.push("#     - Duplicate");
+  lines.push("# Linear uses repository-local polling; gh-symphony does not provide");
+  lines.push("# a Linear webhook setup command.");
+  lines.push("");
 
   lines.push("polling:");
   lines.push("  interval_ms: 30000");

--- a/packages/tracker-linear/src/orchestrator-adapter.ts
+++ b/packages/tracker-linear/src/orchestrator-adapter.ts
@@ -135,6 +135,26 @@ const LINEAR_ISSUES_BY_IDS_QUERY = /* GraphQL */ `
   }
 `;
 
+const LINEAR_ISSUES_BY_IDENTIFIERS_QUERY = /* GraphQL */ `
+  query SymphonyLinearIssueStatesByIdentifier(
+    $projectSlug: String!
+    $issueIdentifiers: [String!]!
+    $first: Int!
+    $after: String
+  ) {
+    issues(
+      first: $first
+      after: $after
+      filter: {
+        project: { slugId: { eq: $projectSlug } }
+        identifier: { in: $issueIdentifiers }
+      }
+    ) {
+      ${LINEAR_ISSUE_FIELDS}
+    }
+  }
+`;
+
 export const linearTrackerAdapter: OrchestratorTrackerAdapter = {
   async listIssues(project, dependencies = {}) {
     return listLinearIssues(
@@ -214,7 +234,14 @@ async function listLinearIssues(
   const nodes = await fetchPaginatedLinearIssues(client, {
     projectSlug: config.projectSlug,
     stateNames,
-    issueIds: issueIds ? [...issueIds] : undefined,
+    issueIds:
+      issueIds && !issueIds.every(isLinearIdentifier)
+        ? [...issueIds]
+        : undefined,
+    issueIdentifiers:
+      issueIds && issueIds.every(isLinearIdentifier)
+        ? issueIds.map((identifier) => identifier.trim().toUpperCase())
+        : undefined,
     pageSize: config.pageSize,
   });
 
@@ -229,6 +256,7 @@ async function fetchPaginatedLinearIssues(
     projectSlug: string;
     stateNames?: string[];
     issueIds?: string[];
+    issueIdentifiers?: string[];
     pageSize: number;
   }
 ): Promise<LinearIssueNode[]> {
@@ -236,16 +264,20 @@ async function fetchPaginatedLinearIssues(
   let after: string | null = null;
 
   do {
-    const query = input.issueIds
-      ? LINEAR_ISSUES_BY_IDS_QUERY
-      : LINEAR_ISSUES_BY_STATES_QUERY;
+    const query = input.issueIdentifiers
+      ? LINEAR_ISSUES_BY_IDENTIFIERS_QUERY
+      : input.issueIds
+        ? LINEAR_ISSUES_BY_IDS_QUERY
+        : LINEAR_ISSUES_BY_STATES_QUERY;
     const response: LinearIssuesResponse = await client<LinearIssuesResponse>(
       query,
       {
         projectSlug: input.projectSlug,
-        ...(input.issueIds
-          ? { issueIds: input.issueIds }
-          : { stateNames: input.stateNames ?? [] }),
+        ...(input.issueIdentifiers
+          ? { issueIdentifiers: input.issueIdentifiers }
+          : input.issueIds
+            ? { issueIds: input.issueIds }
+            : { stateNames: input.stateNames ?? [] }),
         first: input.pageSize,
         after,
       }
@@ -259,6 +291,13 @@ async function fetchPaginatedLinearIssues(
   } while (after);
 
   return issues;
+}
+
+function isLinearIdentifier(value: string): boolean {
+  const trimmed = value.trim();
+  return (
+    trimmed === trimmed.toUpperCase() && LINEAR_IDENTIFIER_PATTERN.test(trimmed)
+  );
 }
 
 export function normalizeLinearIssue(

--- a/packages/tracker-linear/src/tracker-linear.test.ts
+++ b/packages/tracker-linear/src/tracker-linear.test.ts
@@ -222,6 +222,34 @@ describe("linearTrackerAdapter", () => {
     expect(request.variables.issueIds).toEqual(["issue-1", "issue-2"]);
   });
 
+  it("fetchIssueStatesByIds routes Linear identifiers through an identifier filter", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonResponse({
+        data: {
+          issues: {
+            nodes: [],
+            pageInfo: { hasNextPage: false, endCursor: null },
+          },
+        },
+      })
+    );
+
+    await linearTrackerAdapter.fetchIssueStatesByIds(makeProject(), ["ENG-123"], {
+      fetchImpl,
+      token: "linear-token",
+    });
+
+    const request = JSON.parse(String(fetchImpl.mock.calls[0]?.[1]?.body)) as {
+      query: string;
+      variables: Record<string, unknown>;
+    };
+    expect(request.query).toContain(
+      "identifier: { in: $issueIdentifiers }"
+    );
+    expect(request.variables.issueIdentifiers).toEqual(["ENG-123"]);
+    expect(request.variables).not.toHaveProperty("issueIds");
+  });
+
   it("injects worker environment without requiring team id", () => {
     const env = linearTrackerAdapter.buildWorkerEnvironment(
       makeProject({ apiUrl: undefined }),


### PR DESCRIPTION
## Issues

- Fixes #315

## Summary

- Adds Linear-specific `repo init` validation for resolved API key configuration while relying on strict WORKFLOW.md parsing for `tracker.project_slug`.
- Allows `gh-symphony workflow preview ENG-123` to route through the active Linear repository runtime and rejects mismatched active runtimes.
- Documents Linear polling, state transition policy, workpad policy, PR handoff, and webhook non-goals with a full `WORKFLOW.md` example.

## Changes

- Added CLI preview routing for Linear identifiers and active repo runtime lookup for Linear single-issue prompt previews.
- Tightened Linear preview so the active runtime must be a Linear binding for the WORKFLOW.md `tracker.project_slug` before resolving the adapter.
- Made duplicate preview issue identifier validation order-independent for positional and `--issue` arguments.
- Extended the Linear tracker adapter to fetch uppercase Linear identifiers through an identifier filter while preserving existing ID-based reconciliation fetches.
- Added docs and reference workflow guidance that keep `WORKFLOW.md` as the Linear source of truth and avoid `.gh-symphony/config.json` revival.
- Added regression tests for repo init validation, Linear preview routing, runtime mismatch rejection, duplicate identifier rejection, reference workflow guidance, and identifier-based Linear fetches.

## Evidence

- `pnpm --filter @gh-symphony/cli test -- src/commands/repo.test.ts src/commands/workflow.test.ts src/workflow/generate-reference-workflow.test.ts`
- `pnpm --filter @gh-symphony/tracker-linear test -- src/tracker-linear.test.ts`
- `pnpm lint && pnpm test && pnpm typecheck && pnpm build`
- Docker E2E TC: start `docker-compose.e2e.yml` with events override, health check, inject `e2e/fixtures/happy-path.json`, POST `/api/v1/refresh`, poll `/api/v1/state` until `health=running` and `activeRuns=1`, then cleanup.

## Human Validation

- [ ] Confirm `gh-symphony repo init` gives actionable errors for missing `tracker.project_slug` or unresolved `LINEAR_API_KEY`.
- [ ] Confirm `gh-symphony workflow preview ENG-123` renders a Linear issue prompt in a repository initialized for the same Linear project.
- [ ] Confirm the Linear `WORKFLOW.md` example matches the intended state transition and PR handoff policy.

## Risks

- Linear identifier preview depends on Linear GraphQL accepting `identifier: { in: [...] }`; ID-based reconciliation remains on the existing `id: { in: [...] }` query path.