### PR TITLE
Fix Claude stream-json input envelope

### DIFF
--- a/.changeset/claude-stream-json-envelope.patch.md
+++ b/.changeset/claude-stream-json-envelope.patch.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Fix claude-print worker turns for issue #329 by sending Claude Code 2.1.x-compatible stream-json user messages and surfacing Claude stderr in runtime failure reports.

--- a/packages/runtime-claude/src/adapter.test.ts
+++ b/packages/runtime-claude/src/adapter.test.ts
@@ -109,7 +109,15 @@ describe("ClaudePrintRuntimeAdapter", () => {
     );
 
     const result = await adapter.spawnTurn({
-      messages: [{ type: "user", text: "hello" }],
+      messages: [
+        {
+          type: "user",
+          message: {
+            role: "user",
+            content: [{ type: "text", text: "hello" }],
+          },
+        },
+      ],
       session: {
         mode: "start",
         sessionId: "session-1",

--- a/packages/runtime-claude/src/spawn.test.ts
+++ b/packages/runtime-claude/src/spawn.test.ts
@@ -59,7 +59,15 @@ describe("spawnClaudeTurn", () => {
       {
         cwd: "/workspace",
         args: ["-p"],
-        stdinMessages: [{ type: "user", text: "hello" }],
+        stdinMessages: [
+          {
+            type: "user",
+            message: {
+              role: "user",
+              content: [{ type: "text", text: "hello" }],
+            },
+          },
+        ],
       },
       {
         spawnImpl,
@@ -69,7 +77,9 @@ describe("spawnClaudeTurn", () => {
       }
     );
 
-    expect(writtenStdin).toBe('{"type":"user","text":"hello"}\n');
+    expect(writtenStdin).toBe(
+      '{"type":"user","message":{"role":"user","content":[{"type":"text","text":"hello"}]}}\n'
+    );
     expect(result.result).toBe("success");
     expect(result.classification.kind).toBe("success");
     expect(events).toEqual(["agent.turnStarted", "agent.turnCompleted"]);
@@ -206,6 +216,71 @@ describe("spawnClaudeTurn", () => {
       reason: "exit_1",
     });
     expect(eventNames).toEqual(["agent.error"]);
+  });
+
+  it("includes stderr in process-exit error events", async () => {
+    const stdin = new PassThrough();
+    const stdout = new PassThrough();
+    const stderr = new PassThrough();
+
+    const { EventEmitter } = await import("node:events");
+    const emitter = new EventEmitter();
+
+    const child = {
+      stdin,
+      stdout,
+      stderr,
+      emit(event: string, ...args: unknown[]) {
+        emitter.emit(event, ...args);
+      },
+      once(event: string, listener: (...args: unknown[]) => void) {
+        emitter.once(event, listener);
+        return child;
+      },
+      on(event: string, listener: (...args: unknown[]) => void) {
+        emitter.on(event, listener);
+        return child;
+      },
+      removeListener(event: string, listener: (...args: unknown[]) => void) {
+        emitter.removeListener(event, listener);
+        return child;
+      },
+    } as unknown as ReturnType<SpawnLike>;
+
+    const spawnImpl: SpawnLike = () => {
+      queueMicrotask(() => {
+        stderr.write(
+          'Error parsing streaming input line: {"type":"user","text":"hi"}\n'
+        );
+        stdout.end();
+        stderr.end();
+        child.emit("close", 1, null);
+      });
+
+      return child;
+    };
+    const errors: string[] = [];
+
+    const result = await spawnClaudeTurn(
+      {
+        cwd: "/workspace",
+        args: ["-p"],
+        stdinMessages: [],
+      },
+      {
+        spawnImpl,
+        onEvent: (event) => {
+          if (event.name === "agent.error") {
+            errors.push(event.payload.error);
+          }
+        },
+      }
+    );
+
+    expect(result.result).toBe("process-error");
+    expect(errors).toEqual([
+      'exit_1: Error parsing streaming input line: {"type":"user","text":"hi"}',
+    ]);
   });
 
   it("records stderr JSON without emitting neutral events or mutating stdout state", async () => {
@@ -533,7 +608,15 @@ describe("spawnClaudeTurn", () => {
       {
         cwd: "/workspace",
         args: ["-p"],
-        stdinMessages: [{ type: "user", text: "hello" }],
+        stdinMessages: [
+          {
+            type: "user",
+            message: {
+              role: "user",
+              content: [{ type: "text", text: "hello" }],
+            },
+          },
+        ],
       },
       { spawnImpl }
     );

--- a/packages/runtime-claude/src/spawn.ts
+++ b/packages/runtime-claude/src/spawn.ts
@@ -134,6 +134,7 @@ export async function spawnClaudeTurn(
       classification.kind === "process-error") &&
     !emittedErrorEvent
   ) {
+    const stderrSummary = summarizeClaudeStderr(records);
     emitEvent({
       name: "agent.error",
       payload: {
@@ -147,8 +148,11 @@ export async function spawnClaudeTurn(
           classification,
           errorMessage:
             "errorMessage" in outcome ? outcome.errorMessage : undefined,
+          stderr: stderrSummary ?? undefined,
         },
-        error: classification.reason,
+        error: stderrSummary
+          ? `${classification.reason}: ${stderrSummary}`
+          : classification.reason,
       },
     });
   }
@@ -164,6 +168,20 @@ export async function spawnClaudeTurn(
     classification,
     errorMessage: "errorMessage" in outcome ? outcome.errorMessage : undefined,
   };
+}
+
+function summarizeClaudeStderr(records: ClaudeSpawnRecord[]): string | null {
+  const stderrLines = records
+    .filter((record) => record.stream === "stderr")
+    .map((record) => record.line || record.parseError)
+    .filter((line): line is string => Boolean(line?.trim()))
+    .map((line) => line.trim());
+
+  if (stderrLines.length === 0) {
+    return null;
+  }
+
+  return stderrLines.slice(-3).join(" | ").slice(0, 1000);
 }
 
 export function classifyClaudeTurnResult(

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -766,13 +766,27 @@ async function spawnNonCodexRuntimeTurn(
     return await (
       adapter as {
         spawnTurn(input: {
-          messages: Array<{ type: "user"; text: string }>;
+          messages: Array<{
+            type: "user";
+            message: {
+              role: "user";
+              content: Array<{ type: "text"; text: string }>;
+            };
+          }>;
           cwd?: string;
           env?: NodeJS.ProcessEnv;
         }): Promise<WorkerNonCodexTurnResult>;
       }
     ).spawnTurn({
-      messages: [{ type: "user", text: renderedPrompt }],
+      messages: [
+        {
+          type: "user",
+          message: {
+            role: "user",
+            content: [{ type: "text", text: renderedPrompt }],
+          },
+        },
+      ],
       cwd: env.WORKING_DIRECTORY,
       env,
     });
@@ -850,10 +864,51 @@ function isNonCodexTurnFailure(result: WorkerNonCodexTurnResult): boolean {
 }
 
 function describeNonCodexTurnFailure(result: WorkerNonCodexTurnResult): string {
+  const stderrSummary = extractRuntimeStderrSummary(result);
+  if (stderrSummary) {
+    return (
+      result.errorMessage ??
+      `${result.command} exited with ${result.signal ?? result.exitCode ?? "unknown"}: ${stderrSummary}`
+    );
+  }
+
   return (
     result.errorMessage ??
     `${result.command} exited with ${result.signal ?? result.exitCode ?? "unknown"}`
   );
+}
+
+function extractRuntimeStderrSummary(
+  result: WorkerNonCodexTurnResult
+): string | null {
+  if ("stderr" in result) {
+    return summarizeRuntimeStderr(result.stderr);
+  }
+
+  if ("records" in result) {
+    return summarizeRuntimeStderr(
+      result.records
+        .filter((record) => record.stream === "stderr")
+        .map((record) => record.line || record.parseError)
+        .filter((line): line is string => Boolean(line))
+        .join("\n")
+    );
+  }
+
+  return null;
+}
+
+function summarizeRuntimeStderr(stderr: string): string | null {
+  const lines = stderr
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+
+  if (lines.length === 0) {
+    return null;
+  }
+
+  return lines.slice(-3).join(" | ").slice(0, 1000);
 }
 
 async function exitWorkerStartupFailure(message: string): Promise<void> {

--- a/packages/worker/src/non-codex-runtime.test.ts
+++ b/packages/worker/src/non-codex-runtime.test.ts
@@ -85,7 +85,15 @@ describe("createWorkerNonCodexRuntimeAdapter", () => {
 
     await adapter.prepare({ runId: "run-1" });
     const resultPromise = adapter.spawnTurn({
-      messages: [{ type: "user", text: "rendered prompt" }],
+      messages: [
+        {
+          type: "user",
+          message: {
+            role: "user",
+            content: [{ type: "text", text: "rendered prompt" }],
+          },
+        },
+      ],
     });
     fake.stdout.end(
       `${JSON.stringify({ type: "result", subtype: "success", session_id: "session-1" })}\n`
@@ -103,7 +111,13 @@ describe("createWorkerNonCodexRuntimeAdapter", () => {
       })
     );
     expect(fake.stdinText()).toBe(
-      `${JSON.stringify({ type: "user", text: "rendered prompt" })}\n`
+      `${JSON.stringify({
+        type: "user",
+        message: {
+          role: "user",
+          content: [{ type: "text", text: "rendered prompt" }],
+        },
+      })}\n`
     );
     expect(result.result).toBe("success");
   });


### PR DESCRIPTION
## Issues

- Fixes #329

## Summary

- Sends `claude-print` worker prompts using Claude Code 2.1.x stream-json `message.role`/`message.content` envelopes.
- Includes Claude stderr details in process-exit failure reports so input parser failures are visible in worker/orchestrator logs.

## Changes

- Wrapped worker-rendered prompts as `{ type: "user", message: { role: "user", content: [{ type: "text", text }] } }` before calling the Claude adapter.
- Added stderr summarization to Claude process-error events and worker non-Codex failure descriptions.
- Updated runtime/worker tests and added a patch changeset for `@gh-symphony/cli`.

## Evidence

- `pnpm --filter @gh-symphony/runtime-claude test -- spawn.test.ts adapter.test.ts`
- `pnpm --filter @gh-symphony/worker test -- non-codex-runtime.test.ts`
- `pnpm lint && pnpm test && pnpm typecheck && pnpm build`
- `pnpm e2e:claude` (`test/e2e/claude/claude-docker.spec.ts`, 5 tests)

## Human Validation

- [ ] Confirm `claude-print` runs against Claude Code 2.1.x no longer exit immediately on the first turn.
- [ ] Confirm worker logs expose Claude stderr for malformed input or parser failures.
- [ ] Confirm release notes/changelog wording is acceptable for the patch changeset.

## Risks

- Low runtime compatibility risk: the adapter still accepts generic wire records, but the worker now emits the newer Claude Code input envelope expected by 2.1.x.