### PR TITLE
Harden Linear reconciliation observability

### DIFF
--- a/AGENT_TEST.md
+++ b/AGENT_TEST.md
@@ -346,6 +346,7 @@ idle → [inject issue + refresh]
 | `e2e/scenarios/03-stall-detection.md` | stall → SIGTERM → retry |
 | `e2e/scenarios/04-fail-retry.md` | 실패 → 재시도 스케줄링 |
 | `e2e/scenarios/08-evidence-permissions.md` | 이벤트 미러 evidence 파일 권한 및 cleanup 검증 |
+| `e2e/scenarios/09-linear-sandbox.md` | Linear sandbox `Todo → In Progress → Human Review/Done` 및 reconciliation edge case 검증 |
 
 ## TC 작성 가이드
 

--- a/e2e/scenarios/09-linear-sandbox.md
+++ b/e2e/scenarios/09-linear-sandbox.md
@@ -1,0 +1,47 @@
+# TC-09: Linear Sandbox State Flow And Reconciliation
+
+## Setup
+
+Use a dedicated Linear sandbox workspace/project with a disposable issue and a repository whose `WORKFLOW.md` uses:
+
+```yaml
+tracker:
+  kind: linear
+  project_slug: symphony-sandbox
+  active_states:
+    - Todo
+    - In Progress
+  terminal_states:
+    - Human Review
+    - Done
+    - Cancelled
+    - Duplicate
+```
+
+Start the runtime with `LINEAR_API_KEY` set and the `linear_graphql` worker tool available. Do not use webhook delivery for this TC; reconciliation must happen through polling or `/api/v1/refresh`.
+
+## Steps
+
+1. Create a sandbox Linear issue in `Todo`.
+2. Start `gh-symphony repo start --http 4680`.
+3. Trigger reconciliation with `curl -X POST http://localhost:4680/api/v1/refresh`.
+4. Verify the worker, not orchestrator coordination code, moves the issue from `Todo` to `In Progress` using `linear_graphql`.
+5. Let the worker complete and move the issue to `Human Review` or `Done` using `linear_graphql`.
+6. Inspect `/api/v1/state` and the run `events.ndjson`.
+7. Repeat with an active worker and move the issue directly from `Todo` or `In Progress` to `Cancelled` or `Duplicate`.
+8. Repeat with an active worker and delete the issue or move it out of the sandbox project.
+9. Repeat with an active worker and concurrently edit the issue state while the worker is running.
+
+## Expected
+
+- The golden path observes `Todo -> In Progress -> Human Review/Done`.
+- State writes are performed by the worker through `linear_graphql`; the orchestrator only dispatches and reconciles.
+- `tracker.list` and `tracker.fetchByIds` structured events include `tracker.adapter="linear"`, `tracker.projectSlug`, `issue.identifier`, and `issue.id`.
+- Linear rate-limit headers appear in the project `rateLimits` snapshot with `source="linear"`.
+- Direct terminal-state jumps stop active workers on the next polling/reconciliation tick.
+- Deleted or moved issues stop active workers on the next polling/reconciliation tick.
+- Concurrent state changes are reconciled by `fetchIssueStatesByIds` before the next candidate list is dispatched.
+
+## Cleanup
+
+Stop the runtime, remove the sandbox Linear issue, and clear any local `.runtime/` directory created during the run.

--- a/packages/core/src/contracts/tracker-adapter.ts
+++ b/packages/core/src/contracts/tracker-adapter.ts
@@ -84,6 +84,10 @@ export type TrackedIssue = {
   rateLimits?: Record<string, unknown> | null;
 };
 
+export type TrackedIssueList = TrackedIssue[] & {
+  rateLimits?: Record<string, unknown> | null;
+};
+
 export type ProjectItemsCache = {
   getOrLoad(
     key: string,
@@ -101,17 +105,17 @@ export type OrchestratorTrackerAdapter = {
   listIssues(
     project: OrchestratorProjectConfig,
     dependencies?: OrchestratorTrackerDependencies
-  ): Promise<TrackedIssue[]>;
+  ): Promise<TrackedIssueList>;
   listIssuesByStates(
     project: OrchestratorProjectConfig,
     states: readonly string[],
     dependencies?: OrchestratorTrackerDependencies
-  ): Promise<TrackedIssue[]>;
+  ): Promise<TrackedIssueList>;
   fetchIssueStatesByIds(
     project: OrchestratorProjectConfig,
     issueIds: readonly string[],
     dependencies?: OrchestratorTrackerDependencies
-  ): Promise<TrackedIssue[]>;
+  ): Promise<TrackedIssueList>;
   buildWorkerEnvironment(
     project: OrchestratorProjectConfig,
     issue: TrackedIssue

--- a/packages/core/src/observability/event-formatter.test.ts
+++ b/packages/core/src/observability/event-formatter.test.ts
@@ -9,6 +9,38 @@ describe("event-formatter", () => {
   it("formats supported orchestrator events", () => {
     expect(
       formatEventMessage({
+        at: "2026-05-17T00:00:00.000Z",
+        event: "tracker.list",
+        projectId: "project-1",
+        tracker: {
+          adapter: "linear",
+          projectSlug: "symphony-0c79b11b75ea",
+        },
+        issue: {
+          identifier: "ENG-1",
+          id: "linear-issue-1",
+        },
+      })
+    ).toBe("Tracker list saw ENG-1");
+
+    expect(
+      formatEventMessage({
+        at: "2026-05-17T00:01:00.000Z",
+        event: "tracker.fetchByIds",
+        projectId: "project-1",
+        tracker: {
+          adapter: "linear",
+          projectSlug: "symphony-0c79b11b75ea",
+        },
+        issue: {
+          identifier: "ENG-1",
+          id: "linear-issue-1",
+        },
+      })
+    ).toBe("Tracker fetch refreshed ENG-1");
+
+    expect(
+      formatEventMessage({
         at: "2026-03-16T00:00:00.000Z",
         event: "run-dispatched",
         projectId: "project-1",

--- a/packages/core/src/observability/event-formatter.ts
+++ b/packages/core/src/observability/event-formatter.ts
@@ -3,6 +3,10 @@ import type { OrchestratorEvent } from "./structured-events.js";
 
 export function formatEventMessage(event: OrchestratorEvent): string | null {
   switch (event.event) {
+    case "tracker.list":
+      return `Tracker list saw ${event.issue.identifier}`;
+    case "tracker.fetchByIds":
+      return `Tracker fetch refreshed ${event.issue.identifier}`;
     case "run-dispatched":
       return event.issueState
         ? `Dispatched from ${event.issueState}`

--- a/packages/core/src/observability/structured-events.ts
+++ b/packages/core/src/observability/structured-events.ts
@@ -7,6 +7,34 @@
  * without coupling consumers to internal implementation details.
  */
 
+export type TrackerEventMetadata = {
+  adapter: string;
+  projectSlug?: string;
+};
+
+export type IssueEventMetadata = {
+  identifier: string;
+  id?: string;
+};
+
+export type TrackerListEvent = {
+  at: string;
+  event: "tracker.list";
+  projectId: string;
+  tracker: TrackerEventMetadata;
+  issue: IssueEventMetadata;
+  rateLimits?: Record<string, unknown> | null;
+};
+
+export type TrackerFetchByIdsEvent = {
+  at: string;
+  event: "tracker.fetchByIds";
+  projectId: string;
+  tracker: TrackerEventMetadata;
+  issue: IssueEventMetadata;
+  rateLimits?: Record<string, unknown> | null;
+};
+
 export type RunDispatchedEvent = {
   at: string;
   event: "run-dispatched";
@@ -15,6 +43,8 @@ export type RunDispatchedEvent = {
   issueState?: string;
   issueId?: string;
   sessionId?: string;
+  tracker?: TrackerEventMetadata;
+  issue?: IssueEventMetadata;
 };
 
 export type RunRecoveredEvent = {
@@ -164,6 +194,8 @@ export type SessionInvalidatedEvent = {
  * Union of all structured orchestration events. Discriminated on `event`.
  */
 export type OrchestratorEvent =
+  | TrackerListEvent
+  | TrackerFetchByIdsEvent
   | RunDispatchedEvent
   | RunRecoveredEvent
   | RunRetriedEvent

--- a/packages/core/src/observability/structured-events.ts
+++ b/packages/core/src/observability/structured-events.ts
@@ -14,7 +14,7 @@ export type TrackerEventMetadata = {
 
 export type IssueEventMetadata = {
   identifier: string;
-  id?: string;
+  id: string;
 };
 
 export type TrackerListEvent = {

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -7656,6 +7656,239 @@ Prefer focused changes.
     expect(snapshot.activeRuns).toHaveLength(0);
   });
 
+  it("records Linear tracker and issue metadata on structured tracker events", async () => {
+    const tempRoot = await mkdtemp(join(tmpdir(), "orchestrator-linear-events-"));
+    const repository = await createRepositoryFixture(
+      tempRoot,
+      "acme",
+      "platform"
+    );
+    await commitWorkflowFixture(repository.path, {
+      rawWorkflow: `---
+tracker:
+  kind: linear
+  project_slug: symphony-0c79b11b75ea
+  active_states:
+    - Todo
+    - In Progress
+  terminal_states:
+    - Done
+hooks:
+  after_create: ""
+  after_remove: ""
+codex:
+  command: node ${join(tempRoot, "worker.js")}
+---
+Handle Linear issue.`,
+    });
+    await writeFile(join(tempRoot, "worker.js"), "setTimeout(() => {}, 1000);\n");
+    await chmod(join(tempRoot, "worker.js"), 0o755);
+
+    const store = new OrchestratorFsStore(tempRoot);
+    const projectConfig = {
+      ...createProjectConfig(tempRoot, repository),
+      tracker: {
+        adapter: "linear" as const,
+        bindingId: "symphony-0c79b11b75ea",
+        settings: {
+          projectSlug: "symphony-0c79b11b75ea",
+          activeStates: "Todo\nIn Progress",
+        },
+      },
+    };
+    await store.saveProjectConfig(projectConfig);
+    const issue = {
+      id: "linear-issue-1",
+      identifier: "ENG-1",
+      number: 1,
+      title: "Linear issue",
+      description: null,
+      priority: null,
+      state: "Todo",
+      branchName: null,
+      url: "https://linear.app/acme/issue/ENG-1",
+      labels: [],
+      blockedBy: [],
+      createdAt: "2026-03-08T00:00:00.000Z",
+      updatedAt: "2026-03-08T00:00:00.000Z",
+      repository,
+      tracker: {
+        adapter: "linear" as const,
+        bindingId: "symphony-0c79b11b75ea",
+        itemId: "linear-issue-1",
+      },
+      metadata: {
+        projectSlug: "symphony-0c79b11b75ea",
+      },
+      rateLimits: {
+        source: "linear",
+        limit: 1500,
+        remaining: 1499,
+        resource: "graphql",
+      },
+    };
+    vi.spyOn(trackerAdapters, "resolveTrackerAdapter").mockReturnValue({
+      listIssues: vi.fn().mockResolvedValue([issue]),
+      listIssuesByStates: vi.fn().mockResolvedValue([]),
+      fetchIssueStatesByIds: vi.fn().mockResolvedValue([]),
+      buildWorkerEnvironment: vi.fn().mockReturnValue({
+        LINEAR_ISSUE_ID: "linear-issue-1",
+      }),
+      reviveIssue: vi.fn(),
+    });
+
+    const service = new OrchestratorService(store, projectConfig, {
+      spawnImpl: vi.fn().mockReturnValue({
+        pid: 4207,
+        unref: vi.fn(),
+      }) as never,
+      now: () => new Date("2026-03-08T00:05:00.000Z"),
+    });
+
+    await service.runOnce();
+
+    const runs = await store.loadAllRuns();
+    const run = runs.find((candidate) => candidate.issueId === "linear-issue-1");
+    expect(run).toBeDefined();
+    const rawEvents = (
+      await readFile(
+        join(store.runDir(run?.runId ?? "", projectConfig.projectId), "events.ndjson"),
+        "utf8"
+      )
+    )
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    const events = rawEvents;
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          event: "tracker.list",
+          tracker: {
+            adapter: "linear",
+            projectSlug: "symphony-0c79b11b75ea",
+          },
+          issue: {
+            identifier: "ENG-1",
+            id: "linear-issue-1",
+          },
+          rateLimits: expect.objectContaining({
+            source: "linear",
+            remaining: 1499,
+          }),
+        }),
+        expect.objectContaining({
+          event: "run-dispatched",
+          tracker: {
+            adapter: "linear",
+            projectSlug: "symphony-0c79b11b75ea",
+          },
+          issue: {
+            identifier: "ENG-1",
+            id: "linear-issue-1",
+          },
+          issueIdentifier: "ENG-1",
+          issueId: "linear-issue-1",
+        }),
+      ])
+    );
+  });
+
+  it("stops active runs when the tracker issue is deleted or moved out of scope", async () => {
+    process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
+    const tempRoot = await mkdtemp(
+      join(tmpdir(), "orchestrator-deleted-reconciliation-")
+    );
+    const repository = await createRepositoryFixture(
+      tempRoot,
+      "acme",
+      "platform"
+    );
+    const store = new OrchestratorFsStore(tempRoot);
+    const projectConfig = createProjectConfig(tempRoot, repository);
+    await store.saveProjectConfig(projectConfig);
+    await store.saveProjectIssueOrchestrations("tenant-1", [
+      {
+        issueId: "issue-1",
+        identifier: "acme/platform#1",
+        workspaceKey: "acme_platform_1",
+        completedOnce: false,
+        failureRetryCount: 0,
+        state: "running",
+        currentRunId: "run-1",
+        retryEntry: null,
+        updatedAt: "2026-03-08T00:00:00.000Z",
+      },
+    ]);
+    await store.saveRun({
+      runId: "run-1",
+      projectId: "tenant-1",
+      projectSlug: "tenant-1",
+      issueId: "issue-1",
+      issueSubjectId: "issue-1",
+      issueIdentifier: "acme/platform#1",
+      issueState: "In Progress",
+      repository,
+      status: "running",
+      attempt: 1,
+      processId: 4208,
+      port: 4603,
+      workingDirectory: join(tempRoot, "active-run"),
+      issueWorkspaceKey: null,
+      workspaceRuntimeDir: join(tempRoot, "active-run", "workspace-runtime"),
+      workflowPath: null,
+      retryKind: null,
+      createdAt: "2026-03-08T00:00:00.000Z",
+      updatedAt: "2026-03-08T00:00:00.000Z",
+      startedAt: "2026-03-08T00:00:00.000Z",
+      completedAt: null,
+      lastError: null,
+      nextRetryAt: null,
+    });
+
+    const listIssues = vi.fn().mockResolvedValue([]);
+    const fetchIssueStatesByIds = vi.fn().mockResolvedValue([]);
+    const killImpl = vi.fn();
+    vi.spyOn(trackerAdapters, "resolveTrackerAdapter").mockReturnValue({
+      listIssues,
+      listIssuesByStates: vi.fn().mockResolvedValue([]),
+      fetchIssueStatesByIds,
+      buildWorkerEnvironment: vi.fn().mockReturnValue({}),
+      reviveIssue: vi.fn(),
+    });
+
+    const service = new OrchestratorService(store, projectConfig, {
+      fetchImpl: vi
+        .fn()
+        .mockResolvedValue(createEmptyTrackerResponse()) as never,
+      now: () => new Date("2026-03-08T00:05:00.000Z"),
+      killImpl,
+      isProcessRunning: vi.fn().mockReturnValue(true),
+    });
+
+    const snapshot = await service.runOnce();
+    const updatedRun = await store.loadRun("run-1");
+    const issueRecords = await store.loadProjectIssueOrchestrations("tenant-1");
+
+    expect(fetchIssueStatesByIds).toHaveBeenCalledWith(
+      projectConfig,
+      ["issue-1"],
+      expect.objectContaining({
+        fetchImpl: expect.any(Function),
+      })
+    );
+    expect(killImpl).toHaveBeenCalledWith(4208, "SIGTERM");
+    expect(updatedRun).toMatchObject({
+      status: "suppressed",
+      processId: null,
+      runPhase: "canceled_by_reconciliation",
+      lastError:
+        "Run suppressed because the tracker issue is no longer tracked.",
+    });
+    expect(issueRecords[0]?.state).toBe("released");
+    expect(snapshot.activeRuns).toHaveLength(0);
+  });
+
   it("releases the iterated orchestration record when suppression matches by identifier", async () => {
     process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
     const tempRoot = await mkdtemp(

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -17,6 +17,7 @@ import {
   resolveIssueWorkspaceDirectory,
   type OrchestratorProjectConfig,
   type RepositoryRef,
+  type TrackedIssueList,
   type WorkflowResolution,
 } from "@gh-symphony/core";
 import { OrchestratorFsStore } from "./fs-store.js";
@@ -7595,6 +7596,34 @@ Prefer focused changes.
       lastError: null,
       nextRetryAt: null,
     });
+    const workspaceKey = deriveIssueWorkspaceKey(
+      {
+        adapter: "github-project",
+        issueSubjectId: "issue-1",
+      },
+      "acme/platform#1"
+    );
+    const workspacePath = resolveIssueWorkspaceDirectory(
+      store.projectDir(projectConfig.projectId),
+      workspaceKey
+    );
+    const repositoryPath = join(workspacePath, "repository");
+    const sentinelPath = join(workspacePath, "sentinel.txt");
+    await mkdir(repositoryPath, { recursive: true });
+    await writeFile(sentinelPath, "cleanup me", "utf8");
+    await store.saveIssueWorkspace({
+      workspaceKey,
+      projectId: "tenant-1",
+      adapter: "github-project",
+      issueSubjectId: "issue-1",
+      issueIdentifier: "acme/platform#1",
+      workspacePath,
+      repositoryPath,
+      status: "active",
+      createdAt: "2026-03-08T00:00:00.000Z",
+      updatedAt: "2026-03-08T00:00:00.000Z",
+      lastError: null,
+    });
 
     const listIssues = vi.fn().mockResolvedValue([]);
     const fetchIssueStatesByIds = vi.fn().mockResolvedValue([
@@ -7644,6 +7673,10 @@ Prefer focused changes.
     const snapshot = await service.runOnce();
     const updatedRun = await store.loadRun("run-1");
     const issueRecords = await store.loadProjectIssueOrchestrations("tenant-1");
+    const workspaceRecord = await store.loadIssueWorkspace(
+      "tenant-1",
+      workspaceKey
+    );
 
     expect(fetchIssueStatesByIds).toHaveBeenCalledTimes(1);
     expect(fetchIssueStatesByIds.mock.invocationCallOrder[0]).toBeLessThan(
@@ -7652,7 +7685,12 @@ Prefer focused changes.
     expect(killImpl).toHaveBeenCalledWith(4205, "SIGTERM");
     expect(updatedRun?.status).toBe("suppressed");
     expect(updatedRun?.issueState).toBe("Done");
+    expect(updatedRun?.lastError).toBe(
+      "Run suppressed because the tracker issue moved to a terminal state."
+    );
     expect(issueRecords[0]?.state).toBe("released");
+    await expect(readFile(sentinelPath, "utf8")).rejects.toThrow();
+    expect(workspaceRecord?.status).toBe("removed");
     expect(snapshot.activeRuns).toHaveLength(0);
   });
 
@@ -7792,6 +7830,175 @@ Handle Linear issue.`,
         }),
       ])
     );
+  });
+
+  it("records tracker.fetchByIds metadata when active Linear runs are refreshed", async () => {
+    const tempRoot = await mkdtemp(
+      join(tmpdir(), "orchestrator-linear-fetch-events-")
+    );
+    const repository = await createRepositoryFixture(
+      tempRoot,
+      "acme",
+      "platform"
+    );
+    const store = new OrchestratorFsStore(tempRoot);
+    const projectConfig = {
+      ...createProjectConfig(tempRoot, repository),
+      tracker: {
+        adapter: "linear" as const,
+        bindingId: "symphony-0c79b11b75ea",
+        settings: {
+          projectSlug: "symphony-0c79b11b75ea",
+          activeStates: "Todo\nIn Progress",
+        },
+      },
+    };
+    await store.saveProjectConfig(projectConfig);
+    await store.saveRun({
+      runId: "run-1",
+      projectId: "tenant-1",
+      projectSlug: "tenant-1",
+      issueId: "linear-issue-1",
+      issueSubjectId: "linear-issue-1",
+      issueIdentifier: "ENG-1",
+      issueState: "Todo",
+      repository,
+      status: "running",
+      attempt: 1,
+      processId: null,
+      port: 4603,
+      workingDirectory: join(tempRoot, "active-run"),
+      issueWorkspaceKey: null,
+      workspaceRuntimeDir: join(tempRoot, "active-run", "workspace-runtime"),
+      workflowPath: null,
+      retryKind: null,
+      createdAt: "2026-03-08T00:00:00.000Z",
+      updatedAt: "2026-03-08T00:00:00.000Z",
+      startedAt: "2026-03-08T00:00:00.000Z",
+      completedAt: null,
+      lastError: null,
+      nextRetryAt: null,
+    });
+
+    const issue = {
+      id: "linear-issue-1",
+      identifier: "ENG-1",
+      number: 1,
+      title: "Linear issue",
+      description: null,
+      priority: null,
+      state: "In Progress",
+      branchName: null,
+      url: "https://linear.app/acme/issue/ENG-1",
+      labels: [],
+      blockedBy: [],
+      createdAt: "2026-03-08T00:00:00.000Z",
+      updatedAt: "2026-03-08T00:05:00.000Z",
+      repository,
+      tracker: {
+        adapter: "linear" as const,
+        bindingId: "symphony-0c79b11b75ea",
+        itemId: "linear-issue-1",
+      },
+      metadata: {
+        projectSlug: "symphony-0c79b11b75ea",
+      },
+      rateLimits: {
+        source: "linear",
+        limit: 1500,
+        remaining: 1498,
+        resource: "graphql",
+      },
+    };
+    vi.spyOn(trackerAdapters, "resolveTrackerAdapter").mockReturnValue({
+      listIssues: vi.fn().mockResolvedValue([]),
+      listIssuesByStates: vi.fn().mockResolvedValue([]),
+      fetchIssueStatesByIds: vi.fn().mockResolvedValue([issue]),
+      buildWorkerEnvironment: vi.fn().mockReturnValue({
+        LINEAR_ISSUE_ID: "linear-issue-1",
+      }),
+      reviveIssue: vi.fn(),
+    });
+
+    const service = new OrchestratorService(store, projectConfig, {
+      now: () => new Date("2026-03-08T00:05:00.000Z"),
+    });
+
+    await service.runOnce();
+
+    const rawEvents = (
+      await readFile(
+        join(store.runDir("run-1", projectConfig.projectId), "events.ndjson"),
+        "utf8"
+      )
+    )
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    expect(rawEvents).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          event: "tracker.fetchByIds",
+          tracker: {
+            adapter: "linear",
+            projectSlug: "symphony-0c79b11b75ea",
+          },
+          issue: {
+            identifier: "ENG-1",
+            id: "linear-issue-1",
+          },
+          rateLimits: expect.objectContaining({
+            source: "linear",
+            remaining: 1498,
+          }),
+        }),
+      ])
+    );
+  });
+
+  it("uses empty tracker list rate limits in project snapshots", async () => {
+    process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
+    const tempRoot = await mkdtemp(
+      join(tmpdir(), "orchestrator-empty-list-rate-limits-")
+    );
+    const repository = await createRepositoryFixture(
+      tempRoot,
+      "acme",
+      "platform"
+    );
+    const store = new OrchestratorFsStore(tempRoot);
+    const projectConfig = createProjectConfig(tempRoot, repository);
+    await store.saveProjectConfig(projectConfig);
+    const listedIssues = [] as TrackedIssueList;
+    listedIssues.rateLimits = {
+      source: "linear",
+      limit: 1500,
+      remaining: 1496,
+      resource: "graphql",
+    };
+    vi.spyOn(trackerAdapters, "resolveTrackerAdapter").mockReturnValue({
+      listIssues: vi.fn().mockResolvedValue(listedIssues),
+      listIssuesByStates: vi.fn().mockResolvedValue([]),
+      fetchIssueStatesByIds: vi.fn().mockResolvedValue([]),
+      buildWorkerEnvironment: vi.fn().mockReturnValue({}),
+      reviveIssue: vi.fn(),
+    });
+
+    const service = new OrchestratorService(store, projectConfig, {
+      fetchImpl: vi
+        .fn()
+        .mockResolvedValue(createEmptyTrackerResponse()) as never,
+      now: () => new Date("2026-03-08T00:05:00.000Z"),
+    });
+
+    const snapshot = await service.runOnce();
+
+    expect(snapshot.rateLimits).toEqual({
+      source: "linear",
+      limit: 1500,
+      remaining: 1496,
+      resource: "graphql",
+    });
   });
 
   it("stops active runs when the tracker issue is deleted or moved out of scope", async () => {

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -781,11 +781,19 @@ export class OrchestratorService {
         await this.store.saveRun(run);
         await this.store.appendRunEvent(run.runId, {
           at: now.toISOString(),
+          event: "tracker.list",
+          projectId: tenant.projectId,
+          ...buildStructuredTrackerEventMetadata(tenant, issue),
+          rateLimits: issue.rateLimits ?? null,
+        });
+        await this.store.appendRunEvent(run.runId, {
+          at: now.toISOString(),
           event: "run-dispatched",
           projectId: tenant.projectId,
           issueIdentifier: issue.identifier,
           issueId: run.issueId,
           issueState: issue.state,
+          ...buildStructuredTrackerEventMetadata(tenant, issue),
         });
         this.logVerbose(
           `[dispatch] Issue ${issue.identifier} → run ${run.runId}`
@@ -803,11 +811,6 @@ export class OrchestratorService {
           continue;
         }
 
-        const issue = trackedIssuesByIdentifier.get(issueRecord.identifier);
-        if (!issue) {
-          continue;
-        }
-
         const persistedRun = issueRecord.currentRunId
           ? await this.store.loadRun(issueRecord.currentRunId, tenant.projectId)
           : null;
@@ -815,6 +818,40 @@ export class OrchestratorService {
           syncedActiveRuns.find((run) =>
             isMatchingIssueRun(run, issueRecord.issueId, issueRecord.identifier)
           ) ?? persistedRun;
+        const issue = trackedIssuesByIdentifier.get(issueRecord.identifier);
+        if (!issue) {
+          if (
+            !activeRun ||
+            activeRun.processId === null ||
+            !this.isProcessRunning(activeRun.processId)
+          ) {
+            continue;
+          }
+          const activeWorkerPid = activeRun.processId;
+          this.sendSignal(activeWorkerPid, "SIGTERM");
+          this.retireWorkerPid(activeWorkerPid);
+          const suppressedRun: OrchestratorRunRecord = {
+            ...activeRun,
+            status: "suppressed",
+            processId: null,
+            completedAt: now.toISOString(),
+            updatedAt: now.toISOString(),
+            runPhase: "canceled_by_reconciliation",
+            lastError:
+              "Run suppressed because the tracker issue is no longer tracked.",
+          };
+          await this.store.saveRun(suppressedRun);
+          this.logVerbose(
+            `[run-completed] ${suppressedRun.runId} status=${suppressedRun.status}`
+          );
+          issueRecords = releaseIssueOrchestration(
+            issueRecords,
+            issueRecord.issueId,
+            now
+          );
+          suppressed += 1;
+          continue;
+        }
         const resolvedIssue = actionableCandidates.find(
           (candidate) => candidate.identifier === issue.identifier
         );
@@ -874,9 +911,18 @@ export class OrchestratorService {
       effectivePollIntervalMs > pollIntervalMs &&
       isLowRateLimit(trackerRateLimits, LOW_RATE_LIMIT_WARNING_THRESHOLD)
     ) {
+      const observedTrackerRateLimits = trackerRateLimits ?? {};
+      const rateLimitSource =
+        observedTrackerRateLimits.source === "github"
+          ? "GitHub"
+          : observedTrackerRateLimits.source === "linear"
+            ? "Linear"
+            : typeof observedTrackerRateLimits.source === "string"
+              ? observedTrackerRateLimits.source
+              : "tracker";
       this.writeStderr(
-        `[orchestrator] low GitHub rate limit for ${tenant.projectId}: interval=${effectivePollIntervalMs}ms rateLimits=${JSON.stringify(
-          trackerRateLimits
+        `[orchestrator] low ${rateLimitSource} rate limit for ${tenant.projectId}: interval=${effectivePollIntervalMs}ms rateLimits=${JSON.stringify(
+          observedTrackerRateLimits
         )}`
       );
     }
@@ -1683,6 +1729,16 @@ export class OrchestratorService {
 
     const syncedRuns: OrchestratorRunRecord[] = [];
     for (const run of activeRuns) {
+      const currentIssue = issuesByIdentifier.get(run.issueIdentifier);
+      if (currentIssue) {
+        await this.store.appendRunEvent(run.runId, {
+          at: now.toISOString(),
+          event: "tracker.fetchByIds",
+          projectId: tenant.projectId,
+          ...buildStructuredTrackerEventMetadata(tenant, currentIssue),
+          rateLimits: currentIssue.rateLimits ?? null,
+        });
+      }
       const currentTrackerState = issueStateByIdentifier.get(
         run.issueIdentifier
       );
@@ -3136,11 +3192,38 @@ function resolveProjectRateLimits(
   return null;
 }
 
+function buildStructuredTrackerEventMetadata(
+  tenant: OrchestratorProjectConfig,
+  issue: TrackedIssue
+): {
+  tracker: { adapter: string; projectSlug?: string };
+  issue: { identifier: string; id: string };
+} {
+  const projectSlug =
+    typeof issue.metadata.projectSlug === "string"
+      ? issue.metadata.projectSlug
+      : tenant.tracker.adapter === "linear" &&
+          typeof tenant.tracker.settings?.projectSlug === "string"
+        ? tenant.tracker.settings.projectSlug
+        : undefined;
+
+  return {
+    tracker: {
+      adapter: issue.tracker.adapter,
+      ...(projectSlug ? { projectSlug } : {}),
+    },
+    issue: {
+      identifier: issue.identifier,
+      id: issue.id,
+    },
+  };
+}
+
 function resolveTrackerRateLimits(
   issues: Iterable<TrackedIssue>
 ): Record<string, unknown> | null {
   for (const issue of issues) {
-    if (isGitHubTrackerRateLimits(issue.rateLimits)) {
+    if (isTrackerGraphqlRateLimits(issue.rateLimits)) {
       return issue.rateLimits;
     }
   }
@@ -3188,10 +3271,13 @@ function extractRateLimitRatio(
   return remaining / limit;
 }
 
-function isGitHubTrackerRateLimits(
+function isTrackerGraphqlRateLimits(
   rateLimits: Record<string, unknown> | null | undefined
 ): rateLimits is Record<string, unknown> {
-  if (!isRecord(rateLimits) || rateLimits.source !== "github") {
+  if (
+    !isRecord(rateLimits) ||
+    (rateLimits.source !== "github" && rateLimits.source !== "linear")
+  ) {
     return false;
   }
 

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -43,6 +43,7 @@ import {
   type RuntimeSessionRow,
   type SessionExitClassification,
   type TrackedIssue,
+  type TrackedIssueList,
   type WorkflowLifecycleConfig,
   type WorkflowResolution,
 } from "@gh-symphony/core";
@@ -672,10 +673,12 @@ export class OrchestratorService {
       }
       rateLimits = resolveProjectRateLimits(
         syncedActiveRuns,
-        trackedIssuesByIdentifier.values()
+        trackedIssuesByIdentifier.values(),
+        getTrackedIssueListRateLimits(issues)
       );
       trackerRateLimits = resolveTrackerRateLimits(
-        trackedIssuesByIdentifier.values()
+        trackedIssuesByIdentifier.values(),
+        getTrackedIssueListRateLimits(issues)
       );
       const concurrency = await this.getProjectConcurrency(tenant);
       const currentlyActive = issueRecords.filter((record) =>
@@ -864,6 +867,7 @@ export class OrchestratorService {
           this.retireWorkerPid(activeRun.processId);
         }
         if (activeRun) {
+          const terminalState = isStateTerminal(issue.state, lifecycle);
           const suppressedRun: OrchestratorRunRecord = {
             ...activeRun,
             status: "suppressed",
@@ -871,8 +875,9 @@ export class OrchestratorService {
             completedAt: now.toISOString(),
             updatedAt: now.toISOString(),
             runPhase: "canceled_by_reconciliation",
-            lastError:
-              "Run suppressed because the tracker state is no longer actionable.",
+            lastError: terminalState
+              ? "Run suppressed because the tracker issue moved to a terminal state."
+              : "Run suppressed because the tracker state is no longer actionable.",
           };
           await this.store.saveRun(suppressedRun);
           this.logVerbose(
@@ -3157,9 +3162,17 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value);
 }
 
+function getTrackedIssueListRateLimits(
+  issues: readonly TrackedIssue[]
+): Record<string, unknown> | null {
+  const rateLimits = (issues as TrackedIssueList).rateLimits;
+  return isRecord(rateLimits) ? rateLimits : null;
+}
+
 function resolveProjectRateLimits(
   runs: Iterable<OrchestratorRunRecord>,
-  issues: Iterable<TrackedIssue>
+  issues: Iterable<TrackedIssue>,
+  fallbackRateLimits: Record<string, unknown> | null = null
 ): Record<string, unknown> | null {
   let latestRunRateLimits: Record<string, unknown> | null = null;
   let latestRunTimestamp = -Infinity;
@@ -3189,7 +3202,7 @@ function resolveProjectRateLimits(
     }
   }
 
-  return null;
+  return fallbackRateLimits;
 }
 
 function buildStructuredTrackerEventMetadata(
@@ -3220,7 +3233,8 @@ function buildStructuredTrackerEventMetadata(
 }
 
 function resolveTrackerRateLimits(
-  issues: Iterable<TrackedIssue>
+  issues: Iterable<TrackedIssue>,
+  fallbackRateLimits: Record<string, unknown> | null = null
 ): Record<string, unknown> | null {
   for (const issue of issues) {
     if (isTrackerGraphqlRateLimits(issue.rateLimits)) {
@@ -3228,7 +3242,9 @@ function resolveTrackerRateLimits(
     }
   }
 
-  return null;
+  return isTrackerGraphqlRateLimits(fallbackRateLimits)
+    ? fallbackRateLimits
+    : null;
 }
 
 function resolveAdaptivePollIntervalMs(

--- a/packages/tracker-linear/src/orchestrator-adapter.ts
+++ b/packages/tracker-linear/src/orchestrator-adapter.ts
@@ -6,6 +6,7 @@ import {
   type OrchestratorTrackerConfig,
   type OrchestratorTrackerDependencies,
   type TrackedIssue,
+  type TrackedIssueList,
 } from "@gh-symphony/core";
 
 export const DEFAULT_LINEAR_GRAPHQL_URL = CORE_DEFAULT_LINEAR_GRAPHQL_URL;
@@ -236,7 +237,7 @@ async function listLinearIssues(
   stateNamesInput: unknown,
   dependencies: OrchestratorTrackerDependencies,
   issueIds?: readonly string[]
-): Promise<TrackedIssue[]> {
+): Promise<TrackedIssueList> {
   const config = resolveLinearTrackerConfig(project, dependencies);
   const client = createLinearGraphqlClient(config, dependencies.fetchImpl);
   const stateNames = readStringArray(stateNamesInput);
@@ -259,9 +260,16 @@ async function listLinearIssues(
     pageSize: config.pageSize,
   });
 
-  return result.nodes.map((node) =>
+  const issues = result.nodes.map((node) =>
     normalizeLinearIssue(project, config.projectSlug, node, result.rateLimits)
-  );
+  ) as TrackedIssueList;
+  Object.defineProperty(issues, "rateLimits", {
+    configurable: true,
+    enumerable: false,
+    value: result.rateLimits,
+    writable: true,
+  });
+  return issues;
 }
 
 async function fetchPaginatedLinearIssues(

--- a/packages/tracker-linear/src/orchestrator-adapter.ts
+++ b/packages/tracker-linear/src/orchestrator-adapter.ts
@@ -12,10 +12,24 @@ export const DEFAULT_LINEAR_GRAPHQL_URL = CORE_DEFAULT_LINEAR_GRAPHQL_URL;
 const DEFAULT_PAGE_SIZE = 50;
 const LINEAR_IDENTIFIER_PATTERN = /^[A-Z][A-Z0-9]*-\d+$/;
 
+type LinearRateLimitPayload = {
+  source: "linear";
+  limit: number | null;
+  remaining: number | null;
+  used: number | null;
+  reset: number | null;
+  resetAt: string | null;
+  retryAfter: number | null;
+  resource: "graphql";
+};
+
 type LinearGraphqlClient = <TData>(
   query: string,
   variables: Record<string, unknown>
-) => Promise<TData>;
+) => Promise<{
+  data: TData;
+  rateLimits: LinearRateLimitPayload | null;
+}>;
 
 type LinearConnection<TNode> = {
   nodes?: TNode[] | null;
@@ -231,7 +245,7 @@ async function listLinearIssues(
       'Tracker adapter "linear" requires at least one active state name in the "activeStates" setting.'
     );
   }
-  const nodes = await fetchPaginatedLinearIssues(client, {
+  const result = await fetchPaginatedLinearIssues(client, {
     projectSlug: config.projectSlug,
     stateNames,
     issueIds:
@@ -245,8 +259,8 @@ async function listLinearIssues(
     pageSize: config.pageSize,
   });
 
-  return nodes.map((node) =>
-    normalizeLinearIssue(project, config.projectSlug, node)
+  return result.nodes.map((node) =>
+    normalizeLinearIssue(project, config.projectSlug, node, result.rateLimits)
   );
 }
 
@@ -259,8 +273,12 @@ async function fetchPaginatedLinearIssues(
     issueIdentifiers?: string[];
     pageSize: number;
   }
-): Promise<LinearIssueNode[]> {
+): Promise<{
+  nodes: LinearIssueNode[];
+  rateLimits: LinearRateLimitPayload | null;
+}> {
   const issues: LinearIssueNode[] = [];
+  let latestRateLimits: LinearRateLimitPayload | null = null;
   let after: string | null = null;
 
   do {
@@ -269,28 +287,32 @@ async function fetchPaginatedLinearIssues(
       : input.issueIds
         ? LINEAR_ISSUES_BY_IDS_QUERY
         : LINEAR_ISSUES_BY_STATES_QUERY;
-    const response: LinearIssuesResponse = await client<LinearIssuesResponse>(
-      query,
-      {
-        projectSlug: input.projectSlug,
-        ...(input.issueIdentifiers
-          ? { issueIdentifiers: input.issueIdentifiers }
-          : input.issueIds
-            ? { issueIds: input.issueIds }
-            : { stateNames: input.stateNames ?? [] }),
-        first: input.pageSize,
-        after,
-      }
-    );
+    const response: {
+      data: LinearIssuesResponse;
+      rateLimits: LinearRateLimitPayload | null;
+    } = await client<LinearIssuesResponse>(query, {
+      projectSlug: input.projectSlug,
+      ...(input.issueIdentifiers
+        ? { issueIdentifiers: input.issueIdentifiers }
+        : input.issueIds
+          ? { issueIds: input.issueIds }
+          : { stateNames: input.stateNames ?? [] }),
+      first: input.pageSize,
+      after,
+    });
+    latestRateLimits = response.rateLimits ?? latestRateLimits;
     const connection: LinearConnection<LinearIssueNode> | null | undefined =
-      response.issues;
+      response.data.issues;
     issues.push(...(connection?.nodes ?? []));
     after = connection?.pageInfo?.hasNextPage
       ? (connection.pageInfo.endCursor ?? null)
       : null;
   } while (after);
 
-  return issues;
+  return {
+    nodes: issues,
+    rateLimits: latestRateLimits,
+  };
 }
 
 function isLinearIdentifier(value: string): boolean {
@@ -303,7 +325,8 @@ function isLinearIdentifier(value: string): boolean {
 export function normalizeLinearIssue(
   project: OrchestratorProjectConfig,
   projectSlug: string,
-  issue: LinearIssueNode
+  issue: LinearIssueNode,
+  rateLimits: Record<string, unknown> | null = null
 ): TrackedIssue {
   const id = requireString(issue.id, "Linear issue id");
   const identifier = sanitizeLinearIdentifier(
@@ -348,6 +371,7 @@ export function normalizeLinearIssue(
     metadata: {
       projectSlug,
     },
+    rateLimits,
   };
 }
 
@@ -358,7 +382,10 @@ function createLinearGraphqlClient(
   return async <TData>(
     query: string,
     variables: Record<string, unknown>
-  ): Promise<TData> => {
+  ): Promise<{
+    data: TData;
+    rateLimits: LinearRateLimitPayload | null;
+  }> => {
     const response = await fetchImpl(config.endpoint, {
       method: "POST",
       headers: {
@@ -367,10 +394,16 @@ function createLinearGraphqlClient(
       },
       body: JSON.stringify({ query, variables }),
     });
+    const rateLimits = extractLinearRateLimits(response.headers);
 
     if (!response.ok) {
+      const retryAfter = rateLimits?.retryAfter;
+      const retrySuffix =
+        typeof retryAfter === "number"
+          ? ` Retry after ${retryAfter} seconds.`
+          : "";
       throw new Error(
-        `Linear GraphQL request failed with HTTP ${response.status}.`
+        `Linear GraphQL request failed with HTTP ${response.status}.${retrySuffix}`
       );
     }
 
@@ -392,8 +425,79 @@ function createLinearGraphqlClient(
       throw new Error("Linear GraphQL response did not include data.");
     }
 
-    return payload.data;
+    return {
+      data: payload.data,
+      rateLimits,
+    };
   };
+}
+
+function extractLinearRateLimits(
+  headers: Pick<Headers, "get"> | null | undefined
+): LinearRateLimitPayload | null {
+  if (!headers || typeof headers.get !== "function") {
+    return null;
+  }
+
+  const limit =
+    parseIntegerHeader(headers.get("x-ratelimit-requests-limit")) ??
+    parseIntegerHeader(headers.get("x-ratelimit-limit"));
+  const remaining =
+    parseIntegerHeader(headers.get("x-ratelimit-requests-remaining")) ??
+    parseIntegerHeader(headers.get("x-ratelimit-remaining"));
+  const reset =
+    parseIntegerHeader(headers.get("x-ratelimit-requests-reset")) ??
+    parseIntegerHeader(headers.get("x-ratelimit-reset"));
+  const retryAfter = parseIntegerHeader(headers.get("retry-after"));
+  const used =
+    limit !== null && remaining !== null
+      ? Math.max(0, limit - remaining)
+      : null;
+
+  if (
+    limit === null &&
+    remaining === null &&
+    reset === null &&
+    retryAfter === null
+  ) {
+    return null;
+  }
+
+  return {
+    source: "linear",
+    limit,
+    remaining,
+    used,
+    reset,
+    resetAt: resolveRateLimitResetAt(reset),
+    retryAfter,
+    resource: "graphql",
+  };
+}
+
+function resolveRateLimitResetAt(reset: number | null): string | null {
+  if (reset === null) {
+    return null;
+  }
+
+  if (reset > 1_000_000_000_000) {
+    return new Date(reset).toISOString();
+  }
+
+  if (reset > 1_000_000_000) {
+    return new Date(reset * 1000).toISOString();
+  }
+
+  return new Date(Date.now() + reset * 1000).toISOString();
+}
+
+function parseIntegerHeader(value: string | null): number | null {
+  if (value === null) {
+    return null;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) ? parsed : null;
 }
 
 function resolveLinearTrackerConfig(

--- a/packages/tracker-linear/src/tracker-linear.test.ts
+++ b/packages/tracker-linear/src/tracker-linear.test.ts
@@ -38,6 +38,16 @@ function jsonResponse(body: unknown): Response {
   });
 }
 
+function jsonResponseWithHeaders(
+  body: unknown,
+  headers: Record<string, string>
+): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json", ...headers },
+  });
+}
+
 describe("linearTrackerAdapter", () => {
   it("queries Linear by project slug and state names with cursor pagination", async () => {
     const fetchImpl = vi
@@ -180,6 +190,81 @@ describe("linearTrackerAdapter", () => {
     };
     expect(projectItemsCache.getOrLoad).not.toHaveBeenCalled();
     expect(request.variables.stateNames).toEqual(["Rework"]);
+  });
+
+  it("normalizes Linear rate-limit headers onto listed issues", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonResponseWithHeaders(
+        {
+          data: {
+            issues: {
+              nodes: [
+                {
+                  id: "issue-1",
+                  identifier: "ENG-1",
+                  number: 1,
+                  title: "First issue",
+                  state: { name: "Todo" },
+                  labels: { nodes: [] },
+                  relations: { nodes: [] },
+                },
+              ],
+              pageInfo: { hasNextPage: false, endCursor: null },
+            },
+          },
+        },
+        {
+          "x-ratelimit-requests-limit": "1500",
+          "x-ratelimit-requests-remaining": "1498",
+          "x-ratelimit-requests-reset": "1773892800",
+        }
+      )
+    );
+
+    const issues = await linearTrackerAdapter.listIssues(makeProject(), {
+      fetchImpl,
+      token: "linear-token",
+    });
+
+    expect(issues[0]?.rateLimits).toEqual({
+      source: "linear",
+      limit: 1500,
+      remaining: 1498,
+      used: 2,
+      reset: 1773892800,
+      resetAt: "2026-03-19T04:00:00.000Z",
+      retryAfter: null,
+      resource: "graphql",
+    });
+  });
+
+  it("surfaces Linear 429 retry metadata without leaking auth", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ errors: [{ message: "rate limited" }] }), {
+        status: 429,
+        headers: {
+          "content-type": "application/json",
+          "retry-after": "30",
+          "x-ratelimit-requests-limit": "1500",
+          "x-ratelimit-requests-remaining": "0",
+        },
+      })
+    );
+
+    await expect(
+      linearTrackerAdapter.listIssues(makeProject(), {
+        fetchImpl,
+        token: "linear-token",
+      })
+    ).rejects.toThrow(
+      "Linear GraphQL request failed with HTTP 429. Retry after 30 seconds."
+    );
+    await expect(
+      linearTrackerAdapter.listIssues(makeProject(), {
+        fetchImpl,
+        token: "linear-token",
+      })
+    ).rejects.not.toThrow("linear-token");
   });
 
   it("requires active state names when polling Linear candidates", async () => {

--- a/packages/tracker-linear/src/tracker-linear.test.ts
+++ b/packages/tracker-linear/src/tracker-linear.test.ts
@@ -238,6 +238,43 @@ describe("linearTrackerAdapter", () => {
     });
   });
 
+  it("preserves Linear rate-limit headers when no issues are returned", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonResponseWithHeaders(
+        {
+          data: {
+            issues: {
+              nodes: [],
+              pageInfo: { hasNextPage: false, endCursor: null },
+            },
+          },
+        },
+        {
+          "x-ratelimit-requests-limit": "1500",
+          "x-ratelimit-requests-remaining": "1497",
+          "x-ratelimit-requests-reset": "1773892800",
+        }
+      )
+    );
+
+    const issues = await linearTrackerAdapter.listIssues(makeProject(), {
+      fetchImpl,
+      token: "linear-token",
+    });
+
+    expect(issues).toHaveLength(0);
+    expect(issues.rateLimits).toEqual({
+      source: "linear",
+      limit: 1500,
+      remaining: 1497,
+      used: 3,
+      reset: 1773892800,
+      resetAt: "2026-03-19T04:00:00.000Z",
+      retryAfter: null,
+      resource: "graphql",
+    });
+  });
+
   it("surfaces Linear 429 retry metadata without leaking auth", async () => {
     const fetchImpl = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({ errors: [{ message: "rate limited" }] }), {


### PR DESCRIPTION
## Issues

- Fixes #316

## Summary

- Normalizes Linear GraphQL rate-limit headers into `TrackedIssue.rateLimits`, including list-level snapshots for empty Linear responses.
- Adds structured tracker events with Linear adapter, project slug, issue identifier, and required issue id metadata.
- Stops live workers when tracked issues disappear, move out of scope, or jump to terminal states on reconciliation, and verifies terminal cleanup for direct terminal jumps.
- Documents the Linear sandbox E2E flow and extends `AGENT_TEST.md` coverage notes.

## Changes

- Added Linear rate-limit extraction for standard and Linear-specific response headers, including 429 retry metadata without auth leakage.
- Carries Linear list/fetch rate-limit metadata on returned issue lists so empty snapshots can still feed project observability and adaptive polling.
- Added `tracker.list` and `tracker.fetchByIds` structured event types, formatter support, and assertions for both event messages.
- Reused `fetchIssueStatesByIds` synchronization to refresh active run states before candidate listing and suppress live workers for removed/moved/terminal issues.
- Tightened structured event metadata so tracker events require `issue.id`.
- Added unit coverage for Linear headers, empty rate-limit snapshots, structured metadata, terminal jumps with cleanup, deleted/moved issues, and current-state synchronization.
- Added `e2e/scenarios/09-linear-sandbox.md` for `Todo -> In Progress -> Human Review/Done` plus deletion, move, concurrent edit, and terminal jump checks.

## Evidence

- `pnpm --filter @gh-symphony/tracker-linear test`
- `pnpm --filter @gh-symphony/core test -- event-formatter.test.ts`
- `pnpm --filter @gh-symphony/orchestrator test -- service.test.ts`
- `pnpm typecheck`
- `pnpm lint && pnpm test && pnpm typecheck && pnpm build`
- `bash e2e/run-e2e.sh happy 60`

## Human Validation

- [ ] Confirm the Linear sandbox issue flow reaches `Todo -> In Progress -> Human Review/Done` through worker `linear_graphql` writes.
- [ ] Confirm direct terminal-state jumps stop active workers and run terminal cleanup on the next reconciliation tick.
- [ ] Confirm deleted or moved Linear issues stop active workers on the next reconciliation tick.
- [ ] Confirm no auth headers or tokens appear in Linear error output.

## Risks

- Real Linear sandbox validation still depends on external `LINEAR_API_KEY` credentials and a disposable Linear project; the repository Docker E2E path uses the file tracker stub for black-box runtime validation.
