### PR TITLE
chore(changeset): record Linear tracker release

### DIFF
--- a/.changeset/linear-tracker-runtime.md
+++ b/.changeset/linear-tracker-runtime.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": minor
+---
+
+Add Linear tracker support for issue #312, including WORKFLOW.md validation for `tracker.kind: linear` and `tracker.project_slug`, orchestrator polling through the Linear adapter, and runtime-managed `linear_graphql` worker access.


### PR DESCRIPTION
## Issues

- Fixes #312

## Summary

- Records the required minor changeset for the Linear tracker integration.
- Confirms the landed Linear adapter, WORKFLOW.md validation, runtime `linear_graphql` exposure, docs, and observability coverage against the issue scope.

## Changes

- Adds `.changeset/linear-tracker-runtime.md` for `@gh-symphony/cli` with a minor bump.
- Leaves implementation code unchanged after the final quality audit found no scoped defect in this pass.

## Evidence

- `pnpm --filter @gh-symphony/core test` — passed, 133 tests.
- `pnpm --filter @gh-symphony/tracker-linear test` — passed, 13 tests.
- `pnpm --filter @gh-symphony/tool-linear-graphql test` — passed, 12 tests.
- `pnpm --filter @gh-symphony/runtime-codex test` — passed, 44 tests.
- `pnpm --filter @gh-symphony/worker test` — passed, 122 tests.
- `pnpm lint && pnpm test && pnpm typecheck && pnpm build` — passed.
- `bash e2e/run-e2e.sh happy 45` — passed; worker dispatched, ran, entered continuation retry, and returned to idle.
- Manual check: reviewed `e2e/scenarios/09-linear-sandbox.md`; not executed here because `LINEAR_API_KEY` is missing in this environment.

## Human Validation

- [ ] Confirm a Linear `WORKFLOW.md` using `tracker.kind: linear` and `tracker.project_slug` initializes as expected.
- [ ] Confirm a sandbox Linear worker can use `linear_graphql` for status/comment writes with runtime-managed auth.
- [ ] Confirm release notes generated from the changeset describe the CLI/runtime behavior accurately.

## Risks

- Real Linear sandbox coverage still depends on a valid `LINEAR_API_KEY` and disposable Linear project; this environment did not include those credentials.