### PR TITLE
feat(core): apply explicit priority mappings

### DIFF
--- a/packages/cli/src/commands/repo.test.ts
+++ b/packages/cli/src/commands/repo.test.ts
@@ -193,6 +193,53 @@ describe("repo init runtime migration", () => {
     expect(stdout.output()).toContain("Repository initialized: acme/platform");
   });
 
+  it("persists explicit priority mapping from WORKFLOW.md into tracker settings", async () => {
+    const repoDir = await createGitRepo();
+    const stdout = captureWrites(process.stdout);
+    const repoCommand = await loadRepoCommand();
+    await writeFile(
+      join(repoDir, "WORKFLOW.md"),
+      `---
+tracker:
+  kind: github-project
+  project_id: PVT_project_123
+  state_field: Status
+  priority_field: Legacy Priority
+  priority:
+    source: labels
+    labels:
+      P0: 0
+      P1: 1
+codex:
+  command: codex app-server
+---
+Handle {{issue.identifier}}.
+`,
+      "utf8"
+    );
+
+    try {
+      await repoCommand(
+        ["init", "--repo-dir", repoDir],
+        baseOptions(join(repoDir, "unused"))
+      );
+    } finally {
+      stdout.restore();
+    }
+
+    const projectConfig = await readRepoProjectConfig(repoDir);
+    expect(projectConfig.tracker.priority).toEqual({
+      source: "labels",
+      labels: {
+        P0: 0,
+        P1: 1,
+      },
+    });
+    expect(projectConfig.tracker.settings?.priorityFieldName).toBe(
+      "Legacy Priority"
+    );
+  });
+
   it("initializes a Linear tracker runtime from WORKFLOW.md", async () => {
     const repoDir = await createGitRepo();
     const stdout = captureWrites(process.stdout);

--- a/packages/cli/src/repo-runtime.ts
+++ b/packages/cli/src/repo-runtime.ts
@@ -93,6 +93,9 @@ export async function initRepoRuntime(flags: RepoInitFlags): Promise<{
   if (flags.assignedOnly) {
     trackerSettings.assignedOnly = true;
   }
+  if (workflow.tracker.priorityFieldName) {
+    trackerSettings.priorityFieldName = workflow.tracker.priorityFieldName;
+  }
   if (trackerAdapter === "file") {
     if (!process.env.GH_SYMPHONY_FILE_TRACKER_ISSUES_PATH) {
       throw new Error(
@@ -115,6 +118,7 @@ export async function initRepoRuntime(flags: RepoInitFlags): Promise<{
       ...(workflow.tracker.endpoint
         ? { apiUrl: workflow.tracker.endpoint }
         : {}),
+      priority: workflow.tracker.priority,
       settings: trackerSettings,
     },
   };

--- a/packages/core/src/contracts/status-surface.ts
+++ b/packages/core/src/contracts/status-surface.ts
@@ -1,5 +1,8 @@
 import type { RepositoryRef } from "../domain/workspace.js";
-import type { WorkflowDefinition } from "../workflow/config.js";
+import type {
+  WorkflowDefinition,
+  WorkflowPriorityConfig,
+} from "../workflow/config.js";
 import type { WorkflowLifecycleConfig } from "../workflow/lifecycle.js";
 import type { TrackerAdapterKind } from "./tracker-adapter.js";
 import type { RunAttemptPhase } from "./run-attempt-phase.js";
@@ -9,6 +12,7 @@ export type OrchestratorTrackerConfig = {
   adapter: TrackerAdapterKind;
   bindingId: string;
   apiUrl?: string;
+  priority?: WorkflowPriorityConfig | null;
   settings?: Record<string, string | number | boolean>;
 };
 

--- a/packages/core/src/observability/structured-events.ts
+++ b/packages/core/src/observability/structured-events.ts
@@ -190,6 +190,26 @@ export type SessionInvalidatedEvent = {
   reason: string;
 };
 
+export type PriorityLabelConflictResolvedEvent = {
+  at: string;
+  event: "priority.label_conflict_resolved";
+  issue: IssueEventMetadata;
+  matched: Array<{
+    label: string;
+    value: number;
+  }>;
+  chosenValue: number;
+  chosenLabels: string[];
+};
+
+export type PriorityUnmappedEvent = {
+  at: string;
+  event: "priority.unmapped";
+  issue: IssueEventMetadata;
+  source: "project-field" | "labels";
+  rawValues: string[];
+};
+
 /**
  * Union of all structured orchestration events. Discriminated on `event`.
  */
@@ -208,4 +228,6 @@ export type OrchestratorEvent =
   | TurnStartedEvent
   | TurnCompletedEvent
   | TurnFailedEvent
-  | SessionInvalidatedEvent;
+  | SessionInvalidatedEvent
+  | PriorityLabelConflictResolvedEvent
+  | PriorityUnmappedEvent;

--- a/packages/core/src/workflow-loader.test.ts
+++ b/packages/core/src/workflow-loader.test.ts
@@ -67,10 +67,152 @@ describe("parseWorkflowMarkdown", () => {
       format: "front-matter",
     });
     expect(workflow.tracker.kind).toBe("github-project");
+    expect(workflow.tracker.priority).toBeNull();
     expect(workflow.tracker.priorityFieldName).toBe("Priority");
     expect(workflow.polling.intervalMs).toBe(30000);
     expect(workflow.agent.maxFailureRetries).toBe(6);
     expect(workflow.agent.maxConcurrentAgentsByState).toEqual({ Todo: 1 });
+  });
+
+  it("parses explicit project-field priority mapping", () => {
+    const workflow = parseWorkflowMarkdown(`---
+tracker:
+  kind: github-project
+  priority:
+    source: project-field
+    field: Priority
+    values:
+      Urgent: 0
+      High: 1
+      Later: -1
+codex:
+  command: codex app-server
+---
+Prompt body.
+`);
+
+    expect(workflow.tracker.priority).toEqual({
+      source: "project-field",
+      field: "Priority",
+      values: {
+        Urgent: 0,
+        High: 1,
+        Later: -1,
+      },
+    });
+  });
+
+  it("parses explicit label priority mapping", () => {
+    const workflow = parseWorkflowMarkdown(`---
+tracker:
+  kind: github-project
+  priority:
+    source: labels
+    labels:
+      P0: 0
+      P1: 1
+codex:
+  command: codex app-server
+---
+Prompt body.
+`);
+
+    expect(workflow.tracker.priority).toEqual({
+      source: "labels",
+      labels: {
+        P0: 0,
+        P1: 1,
+      },
+    });
+  });
+
+  it("parses disabled priority source without rejecting legacy priority_field", () => {
+    const workflow = parseWorkflowMarkdown(`---
+tracker:
+  kind: github-project
+  priority_field: Priority
+  priority:
+    source: disabled
+codex:
+  command: codex app-server
+---
+Prompt body.
+`);
+
+    expect(workflow.tracker.priority).toEqual({ source: "disabled" });
+    expect(workflow.tracker.priorityFieldName).toBe("Priority");
+  });
+
+  it.each([
+    [
+      "project-field without field",
+      `priority:
+    source: project-field
+    values:
+      P0: 0`,
+      'Workflow front matter field "field" is required.',
+    ],
+    [
+      "project-field without values",
+      `priority:
+    source: project-field
+    field: Priority`,
+      'Workflow front matter field "tracker.priority.values" must be a non-empty object for tracker.priority.source "project-field".',
+    ],
+    [
+      "labels without labels",
+      `priority:
+    source: labels`,
+      'Workflow front matter field "tracker.priority.labels" must be a non-empty object for tracker.priority.source "labels".',
+    ],
+    [
+      "project-field with labels",
+      `priority:
+    source: project-field
+    field: Priority
+    values:
+      P0: 0
+    labels:
+      P1: 1`,
+      'Workflow front matter field "tracker.priority.labels" is not supported for tracker.priority.source "project-field".',
+    ],
+    [
+      "labels with field",
+      `priority:
+    source: labels
+    field: Priority
+    labels:
+      P0: 0`,
+      'Workflow front matter field "tracker.priority.field" is not supported for tracker.priority.source "labels".',
+    ],
+    [
+      "disabled with values",
+      `priority:
+    source: disabled
+    values:
+      P0: 0`,
+      'Workflow front matter field "tracker.priority.values" is not supported for tracker.priority.source "disabled".',
+    ],
+    [
+      "unknown source",
+      `priority:
+    source: project-labels
+    labels:
+      P0: 0`,
+      'Unsupported workflow tracker.priority.source "project-labels". Supported values: project-field, labels, disabled.',
+    ],
+  ])("rejects invalid priority config: %s", (_name, priorityYaml, message) => {
+    expect(() =>
+      parseWorkflowMarkdown(`---
+tracker:
+  kind: github-project
+  ${priorityYaml}
+codex:
+  command: codex app-server
+---
+Prompt body.
+`)
+    ).toThrow(message);
   });
 
   it("defaults max_failure_retries to 10 when unset", () => {

--- a/packages/core/src/workflow/config.ts
+++ b/packages/core/src/workflow/config.ts
@@ -20,9 +20,24 @@ export type WorkflowTrackerConfig = {
   terminalStates: string[];
   projectId: string | null;
   stateFieldName: string;
+  priority: WorkflowPriorityConfig | null;
   priorityFieldName: string | null;
   blockerCheckStates: string[];
 };
+
+export type WorkflowPriorityConfig =
+  | {
+      source: "project-field";
+      field: string;
+      values: Record<string, number>;
+    }
+  | {
+      source: "labels";
+      labels: Record<string, number>;
+    }
+  | {
+      source: "disabled";
+    };
 
 export type WorkflowWorkspaceConfig = {
   root: string | null;
@@ -142,6 +157,7 @@ export const DEFAULT_WORKFLOW_TRACKER: WorkflowTrackerConfig = {
   terminalStates: DEFAULT_WORKFLOW_LIFECYCLE.terminalStates,
   projectId: null,
   stateFieldName: DEFAULT_WORKFLOW_LIFECYCLE.stateFieldName,
+  priority: null,
   priorityFieldName: null,
   blockerCheckStates: DEFAULT_WORKFLOW_LIFECYCLE.blockerCheckStates,
 };

--- a/packages/core/src/workflow/parser.ts
+++ b/packages/core/src/workflow/parser.ts
@@ -15,6 +15,7 @@ import {
   DEFAULT_WORKFLOW_DEFINITION,
   DEFAULT_WORKFLOW_TRACKER,
   type ParsedWorkflow,
+  type WorkflowPriorityConfig,
   type WorkflowRuntimeConfig,
   type WorkflowRuntimeKind,
   resolveWorkflowRuntimeCommand,
@@ -121,6 +122,7 @@ export function parseWorkflowMarkdown(
       stateFieldName:
         readOptionalString(tracker, "state_field", env) ??
         DEFAULT_WORKFLOW_TRACKER.stateFieldName,
+      priority: readPriorityConfig(tracker, env),
       priorityFieldName: readOptionalString(tracker, "priority_field", env),
       blockerCheckStates,
     },
@@ -206,6 +208,66 @@ function validateTrackerConfig(
     if (!endpoint || endpoint.trim().length === 0) {
       throw new Error(
         'Workflow front matter field "tracker.endpoint" must be a non-empty string when provided for tracker.kind "linear".'
+      );
+    }
+  }
+}
+
+function readPriorityConfig(
+  tracker: Record<string, WorkflowFrontMatterNode>,
+  env: NodeJS.ProcessEnv
+): WorkflowPriorityConfig | null {
+  if (tracker.priority === undefined || tracker.priority === null) {
+    return null;
+  }
+
+  const priority = readObject(tracker, "priority", "tracker.priority");
+  const source = readRequiredString(priority, "source", env);
+  const keys = new Set(Object.keys(priority));
+
+  if (source === "project-field") {
+    rejectPriorityKeys(keys, ["source", "field", "values"], source);
+    const field = readRequiredString(priority, "field", env);
+    const values = readNumberMap(priority, "values", "tracker.priority.values");
+    if (Object.keys(values).length === 0) {
+      throw new Error(
+        'Workflow front matter field "tracker.priority.values" must be a non-empty object for tracker.priority.source "project-field".'
+      );
+    }
+    return { source, field, values };
+  }
+
+  if (source === "labels") {
+    rejectPriorityKeys(keys, ["source", "labels"], source);
+    const labels = readNumberMap(priority, "labels", "tracker.priority.labels");
+    if (Object.keys(labels).length === 0) {
+      throw new Error(
+        'Workflow front matter field "tracker.priority.labels" must be a non-empty object for tracker.priority.source "labels".'
+      );
+    }
+    return { source, labels };
+  }
+
+  if (source === "disabled") {
+    rejectPriorityKeys(keys, ["source"], source);
+    return { source };
+  }
+
+  throw new Error(
+    `Unsupported workflow tracker.priority.source "${source}". Supported values: project-field, labels, disabled.`
+  );
+}
+
+function rejectPriorityKeys(
+  keys: Set<string>,
+  allowedKeys: string[],
+  source: string
+): void {
+  const allowed = new Set(allowedKeys);
+  for (const key of keys) {
+    if (!allowed.has(key)) {
+      throw new Error(
+        `Workflow front matter field "tracker.priority.${key}" is not supported for tracker.priority.source "${source}".`
       );
     }
   }
@@ -670,14 +732,15 @@ function readOptionalIntegerLike(
 
 function readNumberMap(
   input: Record<string, WorkflowFrontMatterNode>,
-  key: string
+  key: string,
+  path = key
 ): Record<string, number> {
   const value = input[key];
   if (value === undefined || value === null) {
     return {};
   }
   if (typeof value !== "object" || Array.isArray(value)) {
-    throw new Error(`Workflow front matter field "${key}" must be an object.`);
+    throw new Error(`Workflow front matter field "${path}" must be an object.`);
   }
 
   const result: Record<string, number> = {};
@@ -686,12 +749,12 @@ function readNumberMap(
       result[entryKey] = entryValue;
       continue;
     }
-    if (typeof entryValue === "string" && /^\d+$/.test(entryValue)) {
+    if (typeof entryValue === "string" && /^-?\d+$/.test(entryValue)) {
       result[entryKey] = Number.parseInt(entryValue, 10);
       continue;
     }
     throw new Error(
-      `Workflow front matter field "${key}.${entryKey}" must be an integer.`
+      `Workflow front matter field "${path}.${entryKey}" must be an integer.`
     );
   }
   return result;

--- a/packages/orchestrator/src/dispatch.test.ts
+++ b/packages/orchestrator/src/dispatch.test.ts
@@ -144,6 +144,22 @@ describe("sortCandidatesForDispatch", () => {
     ]);
   });
 
+  it("orders explicit tracker priority values before null priorities", () => {
+    const sorted = sortCandidatesForDispatch([
+      makeIssue({ identifier: "acme/repo#null", priority: null }),
+      makeIssue({ identifier: "acme/repo#high", priority: 1 }),
+      makeIssue({ identifier: "acme/repo#urgent", priority: 0 }),
+      makeIssue({ identifier: "acme/repo#low", priority: 3 }),
+    ]);
+
+    expect(sorted.map((issue) => issue.identifier)).toEqual([
+      "acme/repo#urgent",
+      "acme/repo#high",
+      "acme/repo#low",
+      "acme/repo#null",
+    ]);
+  });
+
   it("breaks ties by createdAt oldest first", () => {
     const sorted = sortCandidatesForDispatch([
       makeIssue({

--- a/packages/tracker-github/src/adapter.ts
+++ b/packages/tracker-github/src/adapter.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import {
   DEFAULT_WORKFLOW_LIFECYCLE,
   type TrackedIssue,
+  type WorkflowPriorityConfig,
   type WorkflowLifecycleConfig,
 } from "@gh-symphony/core";
 
@@ -19,6 +20,7 @@ export type GitHubTrackerConfig = {
   pageSize?: number;
   assignedOnly?: boolean;
   timeoutMs?: number;
+  priority?: WorkflowPriorityConfig | null;
   priorityFieldName?: string;
 };
 
@@ -272,6 +274,23 @@ type GraphQLResponse<TData> = {
 
 type PriorityMap = Record<string, number>;
 
+type PriorityResolutionConfig = {
+  explicit?: WorkflowPriorityConfig | null;
+  legacy?: {
+    fieldName?: string;
+    optionIds?: PriorityMap;
+  };
+};
+
+type LegacyPriorityResolutionConfig = {
+  fieldName?: string;
+  optionIds?: PriorityMap;
+};
+
+type PriorityResolutionInput =
+  | PriorityResolutionConfig
+  | LegacyPriorityResolutionConfig;
+
 export class GitHubTrackerError extends Error {}
 
 export class GitHubTrackerHttpError extends GitHubTrackerError {
@@ -305,10 +324,7 @@ export function normalizeProjectItem(
   projectId: string,
   item: GraphQLProjectItem,
   lifecycle: WorkflowLifecycleConfig = DEFAULT_WORKFLOW_LIFECYCLE,
-  priority: {
-    fieldName?: string;
-    optionIds?: PriorityMap;
-  } = {},
+  priority: PriorityResolutionInput = {},
   rateLimits: Record<string, unknown> | null = null
 ): GitHubTrackedIssue | null {
   if (
@@ -398,10 +414,7 @@ function normalizePullRequestProjectItem(
   content: GraphQLPullRequestNode,
   fieldValues: Record<string, string>,
   state: string,
-  priority: {
-    fieldName?: string;
-    optionIds?: PriorityMap;
-  },
+  priority: PriorityResolutionInput,
   rateLimits: Record<string, unknown> | null
 ): GitHubTrackedIssue {
   const pullRequest = normalizePullRequestNode(content);
@@ -451,7 +464,7 @@ export async function fetchProjectIssues(
   // state, so callers must fetch the project items and filter in memory.
   const issues: GitHubTrackedIssue[] = [];
   let cursor: string | null = null;
-  const priorityOptionIds = config.priorityFieldName
+  const priorityOptionIds = !config.priority && config.priorityFieldName
     ? await fetchPriorityOptionOrder(
         config,
         config.priorityFieldName,
@@ -478,8 +491,11 @@ export async function fetchProjectIssues(
         item,
         config.lifecycle,
         {
-          fieldName: config.priorityFieldName,
-          optionIds: priorityOptionIds,
+          explicit: config.priority,
+          legacy: {
+            fieldName: config.priorityFieldName,
+            optionIds: priorityOptionIds,
+          },
         },
         latestRateLimits
       );
@@ -586,7 +602,7 @@ export async function fetchProjectIssueByRepositoryAndNumber(
   issueNumber: number,
   fetchImpl: FetchLike = fetch
 ): Promise<GitHubTrackedIssue | null> {
-  const priorityOptionIds = config.priorityFieldName
+  const priorityOptionIds = !config.priority && config.priorityFieldName
     ? await fetchPriorityOptionOrder(
         config,
         config.priorityFieldName,
@@ -626,8 +642,11 @@ export async function fetchProjectIssueByRepositoryAndNumber(
     projectItem,
     config.lifecycle,
     {
-      fieldName: config.priorityFieldName,
-      optionIds: priorityOptionIds,
+      explicit: config.priority,
+      legacy: {
+        fieldName: config.priorityFieldName,
+        optionIds: priorityOptionIds,
+      },
     },
     result.rateLimits
   );
@@ -917,10 +936,7 @@ function normalizeRepositoryIssueLookup(
   issue: GraphQLRepositoryIssueLookupNode | null,
   projectItem: GraphQLIssueProjectItemNode | null,
   lifecycle: WorkflowLifecycleConfig = DEFAULT_WORKFLOW_LIFECYCLE,
-  priority: {
-    fieldName?: string;
-    optionIds?: PriorityMap;
-  } = {},
+  priority: PriorityResolutionInput = {},
   rateLimits: Record<string, unknown> | null = null
 ): GitHubTrackedIssue | null {
   if (!issue || !projectItem) {
@@ -1103,26 +1119,184 @@ function findProjectItemByProjectId(
 
 function resolvePriority(
   item: GraphQLProjectItem,
-  priority: {
-    fieldName?: string;
-    optionIds?: PriorityMap;
-  }
+  priority: PriorityResolutionInput
 ): number | null {
-  if (!priority.fieldName || !priority.optionIds) {
+  const normalizedPriority = normalizePriorityResolutionConfig(priority);
+
+  if (normalizedPriority.explicit) {
+    return resolveExplicitPriority(item, normalizedPriority.explicit);
+  }
+
+  if (
+    !normalizedPriority.legacy?.fieldName ||
+    !normalizedPriority.legacy.optionIds
+  ) {
     return null;
   }
 
   for (const node of item.fieldValues?.nodes ?? []) {
     if (
       node?.__typename === "ProjectV2ItemFieldSingleSelectValue" &&
-      node.field?.name === priority.fieldName &&
+      node.field?.name === normalizedPriority.legacy.fieldName &&
       node.optionId
     ) {
-      return priority.optionIds[node.optionId] ?? null;
+      return normalizedPriority.legacy.optionIds[node.optionId] ?? null;
     }
   }
 
   return null;
+}
+
+function normalizePriorityResolutionConfig(
+  priority: PriorityResolutionInput
+): PriorityResolutionConfig {
+  if ("explicit" in priority || "legacy" in priority) {
+    return priority;
+  }
+
+  return {
+    legacy: priority as LegacyPriorityResolutionConfig,
+  };
+}
+
+function resolveExplicitPriority(
+  item: GraphQLProjectItem,
+  priority: WorkflowPriorityConfig
+): number | null {
+  if (priority.source === "disabled") {
+    return null;
+  }
+
+  if (priority.source === "project-field") {
+    return resolveProjectFieldPriority(item, priority);
+  }
+
+  return resolveLabelPriority(item, priority);
+}
+
+function resolveProjectFieldPriority(
+  item: GraphQLProjectItem,
+  priority: Extract<WorkflowPriorityConfig, { source: "project-field" }>
+): number | null {
+  for (const node of item.fieldValues?.nodes ?? []) {
+    if (
+      node?.__typename === "ProjectV2ItemFieldSingleSelectValue" &&
+      node.field?.name === priority.field &&
+      node.name
+    ) {
+      const resolved = priority.values[node.name] ?? null;
+      if (resolved === null) {
+        emitPriorityUnmapped(item, "project-field", [node.name]);
+      }
+      return resolved;
+    }
+  }
+
+  return null;
+}
+
+function resolveLabelPriority(
+  item: GraphQLProjectItem,
+  priority: Extract<WorkflowPriorityConfig, { source: "labels" }>
+): number | null {
+  if (
+    item.content?.__typename !== "Issue" &&
+    item.content?.__typename !== "PullRequest"
+  ) {
+    return null;
+  }
+
+  const labels = rawLabelNames(item.content.labels?.nodes ?? []);
+  const matches = labels.flatMap((label) => {
+    const value = priority.labels[label];
+    return typeof value === "number" ? [{ label, value }] : [];
+  });
+
+  if (matches.length === 0) {
+    if (labels.length > 0) {
+      emitPriorityUnmapped(item, "labels", labels);
+    }
+    return null;
+  }
+
+  const chosenValue = Math.min(...matches.map((match) => match.value));
+  if (matches.length > 1) {
+    const chosenLabels = matches
+      .filter((match) => match.value === chosenValue)
+      .map((match) => match.label);
+    emitPriorityLabelConflictResolved(item, matches, chosenValue, chosenLabels);
+  }
+
+  return chosenValue;
+}
+
+function rawLabelNames(
+  nodes: Array<{ name: string | null } | null>
+): string[] {
+  return nodes.flatMap((label) => (label?.name ? [label.name] : []));
+}
+
+function emitPriorityLabelConflictResolved(
+  item: GraphQLProjectItem,
+  matched: Array<{ label: string; value: number }>,
+  chosenValue: number,
+  chosenLabels: string[]
+): void {
+  const issue = issueEventMetadata(item);
+  if (!issue) {
+    return;
+  }
+
+  console.info(
+    JSON.stringify({
+      at: new Date().toISOString(),
+      event: "priority.label_conflict_resolved",
+      issue,
+      matched,
+      chosenValue,
+      chosenLabels,
+    })
+  );
+}
+
+function emitPriorityUnmapped(
+  item: GraphQLProjectItem,
+  source: "project-field" | "labels",
+  rawValues: string[]
+): void {
+  const issue = issueEventMetadata(item);
+  if (!issue) {
+    return;
+  }
+
+  console.info(
+    JSON.stringify({
+      at: new Date().toISOString(),
+      event: "priority.unmapped",
+      issue,
+      source,
+      rawValues,
+    })
+  );
+}
+
+function issueEventMetadata(item: GraphQLProjectItem):
+  | {
+      identifier: string;
+      id: string;
+    }
+  | null {
+  if (
+    item.content?.__typename !== "Issue" &&
+    item.content?.__typename !== "PullRequest"
+  ) {
+    return null;
+  }
+
+  return {
+    identifier: `${item.content.repository.owner.login}/${item.content.repository.name}#${item.content.number}`,
+    id: item.content.id,
+  };
 }
 
 function extractPriorityOptionOrder(

--- a/packages/tracker-github/src/orchestrator-adapter.ts
+++ b/packages/tracker-github/src/orchestrator-adapter.ts
@@ -152,6 +152,7 @@ function resolveGitHubTrackerConfig(
     token,
     apiUrl: project.tracker.apiUrl,
     assignedOnly: readBooleanTrackerSetting(project.tracker, "assignedOnly"),
+    priority: project.tracker.priority ?? null,
     priorityFieldName: readOptionalStringTrackerSetting(
       project.tracker,
       "priorityFieldName"
@@ -168,6 +169,7 @@ function buildProjectItemsCacheKey(
     adapter: "github-project",
     apiUrl: config.apiUrl,
     assignedOnly: config.assignedOnly ?? false,
+    priority: config.priority ?? null,
     priorityFieldName: config.priorityFieldName ?? null,
     projectId: config.projectId,
     timeoutMs: config.timeoutMs,

--- a/packages/tracker-github/src/tracker-github.test.ts
+++ b/packages/tracker-github/src/tracker-github.test.ts
@@ -155,6 +155,171 @@ describe("resolveTrackerAdapter", () => {
     expect(issue?.priority).toBe(1);
   });
 
+  it("maps explicit project-field priority by field display value instead of option order", () => {
+    const issue = normalizeGithubProjectItem(
+      "project-123",
+      makeProjectItem({
+        itemId: "item-1",
+        issueId: "issue-1",
+        number: 1,
+        title: "Explicit field priority",
+        assignees: [],
+        priorityName: "High",
+        priorityOptionId: "priority-p2",
+      }),
+      DEFAULT_WORKFLOW_LIFECYCLE,
+      {
+        explicit: {
+          source: "project-field",
+          field: "Priority",
+          values: {
+            Low: 3,
+            High: 1,
+            Urgent: 0,
+          },
+        },
+        legacy: {
+          fieldName: "Priority",
+          optionIds: {
+            "priority-p2": 2,
+          },
+        },
+      }
+    );
+
+    expect(issue?.priority).toBe(1);
+  });
+
+  it("maps explicit labels priority using exact configured label names", () => {
+    const issue = normalizeGithubProjectItem(
+      "project-123",
+      makeProjectItem({
+        itemId: "item-1",
+        issueId: "issue-1",
+        number: 1,
+        title: "Label priority",
+        assignees: [],
+        labels: ["P1", "enhancement"],
+      }),
+      DEFAULT_WORKFLOW_LIFECYCLE,
+      {
+        explicit: {
+          source: "labels",
+          labels: {
+            P0: 0,
+            P1: 1,
+          },
+        },
+      }
+    );
+
+    expect(issue?.priority).toBe(1);
+  });
+
+  it("chooses the lowest numeric priority when multiple configured labels match", () => {
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+
+    try {
+      const issue = normalizeGithubProjectItem(
+        "project-123",
+        makeProjectItem({
+          itemId: "item-1",
+          issueId: "issue-1",
+          number: 1,
+          title: "Conflicting labels",
+          assignees: [],
+          labels: ["P2", "P0"],
+        }),
+        DEFAULT_WORKFLOW_LIFECYCLE,
+        {
+          explicit: {
+            source: "labels",
+            labels: {
+              P0: 0,
+              P2: 2,
+            },
+          },
+        }
+      );
+
+      expect(issue?.priority).toBe(0);
+      expect(infoSpy).toHaveBeenCalledWith(
+        expect.stringContaining('"event":"priority.label_conflict_resolved"')
+      );
+      expect(infoSpy).toHaveBeenCalledWith(
+        expect.stringContaining('"chosenValue":0')
+      );
+    } finally {
+      infoSpy.mockRestore();
+    }
+  });
+
+  it("keeps explicit priority null for unmapped project field values and emits an event", () => {
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+
+    try {
+      const issue = normalizeGithubProjectItem(
+        "project-123",
+        makeProjectItem({
+          itemId: "item-1",
+          issueId: "issue-1",
+          number: 1,
+          title: "Unmapped field priority",
+          assignees: [],
+          priorityName: "Medium",
+          priorityOptionId: "priority-medium",
+        }),
+        DEFAULT_WORKFLOW_LIFECYCLE,
+        {
+          explicit: {
+            source: "project-field",
+            field: "Priority",
+            values: {
+              Urgent: 0,
+              High: 1,
+            },
+          },
+        }
+      );
+
+      expect(issue?.priority).toBeNull();
+      expect(infoSpy).toHaveBeenCalledWith(
+        expect.stringContaining('"event":"priority.unmapped"')
+      );
+      expect(infoSpy).toHaveBeenCalledWith(
+        expect.stringContaining('"rawValues":["Medium"]')
+      );
+    } finally {
+      infoSpy.mockRestore();
+    }
+  });
+
+  it("keeps explicit priority null when disabled even if legacy priority_field is present", () => {
+    const issue = normalizeGithubProjectItem(
+      "project-123",
+      makeProjectItem({
+        itemId: "item-1",
+        issueId: "issue-1",
+        number: 1,
+        title: "Disabled priority",
+        assignees: [],
+        priorityOptionId: "priority-p0",
+      }),
+      DEFAULT_WORKFLOW_LIFECYCLE,
+      {
+        explicit: { source: "disabled" },
+        legacy: {
+          fieldName: "Priority",
+          optionIds: {
+            "priority-p0": 0,
+          },
+        },
+      }
+    );
+
+    expect(issue?.priority).toBeNull();
+  });
+
   it("keeps existing Issue content normalization unchanged", () => {
     const issue = normalizeGithubProjectItem(
       "project-123",
@@ -2083,6 +2248,94 @@ describe("resolveTrackerAdapter", () => {
     expect(issues.map((issue) => issue.priority)).toEqual([0, 1]);
   });
 
+  it("uses explicit project-field mapping during listing without fetching option order", async () => {
+    const adapter = resolveTrackerAdapter({
+      adapter: "github-project",
+      bindingId: "project-123",
+      priority: {
+        source: "project-field",
+        field: "Priority",
+        values: {
+          High: 1,
+          Low: 3,
+        },
+      },
+      settings: {
+        projectId: "project-123",
+        priorityFieldName: "Priority",
+      },
+    });
+
+    const fetchImpl = vi.fn(async (_url, init) => {
+      const body = JSON.parse(String(init?.body)) as { query: string };
+      expect(body.query).not.toContain("query ProjectFields");
+
+      return new Response(
+        JSON.stringify({
+          data: {
+            node: {
+              __typename: "ProjectV2",
+              items: {
+                nodes: [
+                  makeProjectItem({
+                    itemId: "item-1",
+                    issueId: "issue-1",
+                    number: 1,
+                    title: "Explicit priority issue",
+                    assignees: [],
+                    priorityName: "High",
+                    priorityOptionId: "priority-low-order",
+                  }),
+                ],
+                pageInfo: { endCursor: null, hasNextPage: false },
+              },
+            },
+          },
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }
+      );
+    });
+
+    const issues = await adapter.listIssues(
+      {
+        projectId: "workspace-1",
+        slug: "workspace-1",
+        workspaceDir: "/tmp/workspace-1",
+        repository: {
+          owner: "acme",
+          name: "platform",
+          cloneUrl: "https://github.com/acme/platform.git",
+        },
+        tracker: {
+          adapter: "github-project",
+          bindingId: "project-123",
+          priority: {
+            source: "project-field",
+            field: "Priority",
+            values: {
+              High: 1,
+              Low: 3,
+            },
+          },
+          settings: {
+            projectId: "project-123",
+            priorityFieldName: "Priority",
+          },
+        },
+      },
+      {
+        token: "dependencies-token",
+        fetchImpl,
+      }
+    );
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(issues[0]?.priority).toBe(1);
+  });
+
   it("resolves the REST user endpoint from a graphql URL with a trailing slash", async () => {
     const adapter = resolveTrackerAdapter({
       adapter: "github-project",
@@ -3122,6 +3375,8 @@ function makeProjectItem(input: {
   title: string;
   assignees: string[];
   state?: string;
+  labels?: string[];
+  priorityName?: string;
   priorityOptionId?: string;
 }) {
   return {
@@ -3138,7 +3393,7 @@ function makeProjectItem(input: {
           ? [
               {
                 __typename: "ProjectV2ItemFieldSingleSelectValue" as const,
-                name: "P1",
+                name: input.priorityName ?? "P1",
                 optionId: input.priorityOptionId,
                 field: { name: "Priority" },
               },
@@ -3155,7 +3410,9 @@ function makeProjectItem(input: {
       url: `https://github.com/acme/platform/issues/${input.number}`,
       createdAt: "2026-03-14T00:00:00.000Z",
       updatedAt: "2026-03-14T00:00:00.000Z",
-      labels: { nodes: [] },
+      labels: {
+        nodes: (input.labels ?? []).map((name) => ({ name })),
+      },
       assignees: {
         nodes: input.assignees.map((login) => ({ login })),
       },


### PR DESCRIPTION
## Issues

- Fixes #336

## Summary

- Adds explicit `tracker.priority` parsing and validation for `project-field`, `labels`, and `disabled` sources.
- Makes the GitHub Project V2 adapter resolve priority only from the configured explicit source when present, while preserving legacy `priority_field` behavior.

## Changes

- Added `WorkflowPriorityConfig` and load-time validation for singular-source priority configuration.
- Wired parsed priority config into repo runtime tracker config so `WORKFLOW.md` mappings reach the GitHub adapter.
- Added explicit GitHub priority resolution by project field display value and exact label name, including lowest-value multi-label conflict handling.
- Added typed structured-event surface plus adapter emissions for `priority.label_conflict_resolved` and `priority.unmapped`.
- Added parser/config, GitHub adapter, repo init persistence, and dispatch ordering regression coverage.

## Evidence

- `pnpm --filter @gh-symphony/core test -- workflow-loader`
- `pnpm --filter @gh-symphony/tracker-github test -- tracker-github`
- `pnpm --filter @gh-symphony/orchestrator test -- dispatch`
- `pnpm --filter @gh-symphony/cli test -- repo`
- `pnpm lint && pnpm test && pnpm typecheck && pnpm build`
- Docker E2E TC: started `docker-compose.e2e.yml` with events override, injected `e2e/fixtures/happy-path.json`, triggered `/api/v1/refresh`, confirmed `/api/v1/state` reported `activeRuns: 1` for `test-owner/test-repo#1`, then cleared the fixture and tore the container down.

## Human Validation

- [ ] Confirm explicit project-field mappings remain stable when Project option order changes.
- [ ] Confirm explicit label mappings match the expected repository label names exactly.
- [ ] Confirm legacy `tracker.priority_field` workflows still behave as before.

## Risks

- `priority.unmapped` for label source emits when an issue has labels but none match the configured priority labels; this is intentionally observable but may be noisy until C3 adds drift/doctor filtering.
