### PR TITLE
feat(cli): add doctor support bundle export

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ gh-symphony doctor
 gh-symphony doctor --fix
 gh-symphony doctor --json
 gh-symphony doctor --smoke
+gh-symphony doctor --bundle
 ```
 
 Token-only validation works without `gh`:
@@ -284,6 +285,7 @@ Repository commands:
 gh-symphony doctor                   # Validate local prerequisites, auth, config, WORKFLOW.md, and runtime command
 gh-symphony doctor --fix             # Create safe missing paths and print/run remediation follow-ups
 gh-symphony doctor --smoke           # Final preflight: validate a live issue without dispatching work
+gh-symphony doctor --bundle          # Export a redacted support bundle for bug reports
 gh-symphony repo init                # Bind .runtime/orchestrator to the cwd repository
 gh-symphony repo status              # Show current repository orchestration status
 gh-symphony repo explain owner/repo#123  # Explain why one issue is not dispatching
@@ -313,6 +315,20 @@ gh-symphony repo logs --issue org/repo#1 # Filter by issue
 gh-symphony repo logs --run <run-id>     # Read events for a specific run
 gh-symphony repo logs --level <level>    # Filter by log level
 ```
+
+Create a shareable support bundle when reporting setup or orchestration
+failures:
+
+```bash
+gh-symphony doctor --bundle
+gh-symphony doctor --bundle ./tmp/support-bundle
+gh-symphony doctor --bundle --project-id your-project-id
+```
+
+The bundle includes `manifest.json`, `doctor.json`, redacted config and project
+metadata, `WORKFLOW.md`, runtime status files when present, and bounded tails of
+recent run logs/events. Optional missing files are recorded in the manifest
+instead of failing the export.
 
 Dispatch a single issue:
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -37,6 +37,7 @@ gh-symphony doctor
 gh-symphony doctor --fix
 gh-symphony doctor --json
 gh-symphony doctor --smoke
+gh-symphony doctor --bundle
 GITHUB_GRAPHQL_TOKEN=ghp_your_classic_token gh-symphony doctor --json
 ```
 
@@ -303,6 +304,22 @@ Without `--issue`, doctor auto-selects one active live issue from the managed pr
 - launches `gh-symphony setup` when repository runtime setup or GitHub Project binding must be repaired
 - prints concrete runtime install guidance when the configured command is missing on `PATH`
 
+`gh-symphony doctor --bundle` creates a redacted support bundle for bug reports:
+
+```bash
+gh-symphony doctor --bundle
+gh-symphony doctor --bundle ./tmp/support-bundle
+gh-symphony doctor --bundle --project-id your-project-id
+gh-symphony doctor --bundle --json
+```
+
+The bundle writes a deterministic directory containing `manifest.json`,
+`doctor.json`, redacted CLI/project config, `WORKFLOW.md`, runtime
+`status.json`/`issues.json` when available, and bounded recent run
+`events.ndjson`, `worker.log`, and `orchestrator.log` tails. Missing optional
+artifacts are listed in `manifest.missing`; redaction and truncation counts are
+reported in the command summary.
+
 The diagnostic checks cover:
 
 - the active GitHub auth source (`GITHUB_GRAPHQL_TOKEN` first, otherwise `gh`) and required scopes
@@ -321,6 +338,7 @@ Use JSON output for scripts and CI smoke checks. `--fix --json` includes a remed
 gh-symphony doctor --json
 gh-symphony doctor --fix --json
 gh-symphony doctor --smoke --json
+gh-symphony doctor --bundle --json
 gh-symphony repo start --once
 ```
 

--- a/packages/cli/src/commands/doctor.test.ts
+++ b/packages/cli/src/commands/doctor.test.ts
@@ -1,4 +1,12 @@
-import { access, chmod, mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import {
+  access,
+  chmod,
+  mkdtemp,
+  mkdir,
+  readdir,
+  readFile,
+  writeFile,
+} from "node:fs/promises";
 import { constants } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -7,6 +15,7 @@ import type { TrackedIssue } from "@gh-symphony/core";
 import type { CliProjectConfig } from "../config.js";
 import type { GlobalOptions } from "../index.js";
 import { resolveRuntimeRoot } from "../orchestrator-runtime.js";
+import { orchestratorLogPath } from "../config.js";
 import doctorCommand, {
   type DoctorDependencies,
   runDoctorCommand,
@@ -214,6 +223,128 @@ async function prepareDoctorPaths(
   if (workspaceDir) {
     await mkdir(workspaceDir, { recursive: true });
   }
+}
+
+async function prepareBundleRuntimeFixture(input: {
+  configDir: string;
+  workspaceDir: string;
+  projectId?: string;
+}): Promise<void> {
+  const projectId = input.projectId ?? "tenant-a";
+  await mkdir(join(input.configDir, "projects", projectId), {
+    recursive: true,
+  });
+  await writeFile(
+    join(input.configDir, "config.json"),
+    JSON.stringify(
+      {
+        activeProject: projectId,
+        projects: [projectId],
+        GITHUB_TOKEN: "ghp_xxx",
+      },
+      null,
+      2
+    ),
+    "utf8"
+  );
+  await writeFile(
+    join(input.configDir, "projects", projectId, "project.json"),
+    JSON.stringify(
+      {
+        ...createProjectConfig(input.workspaceDir),
+        projectId,
+        tracker: {
+          adapter: "github-project",
+          bindingId: "PVT_test",
+          settings: {
+            GITHUB_GRAPHQL_TOKEN: "ghp_xxx",
+            LINEAR_API_KEY: "lin_xxx",
+          },
+        },
+      },
+      null,
+      2
+    ),
+    "utf8"
+  );
+  await writeFile(
+    join(input.configDir, "status.json"),
+    JSON.stringify(
+      {
+        health: "running",
+        token: "xxx",
+        repository: { owner: "acme", name: "widgets" },
+      },
+      null,
+      2
+    ),
+    "utf8"
+  );
+  await writeFile(
+    join(input.configDir, "issues.json"),
+    JSON.stringify([{ id: "issue-1", secret: "xxx" }], null, 2),
+    "utf8"
+  );
+  await mkdir(join(input.configDir, "runs", "run-1"), { recursive: true });
+  await writeFile(
+    join(input.configDir, "runs", "run-1", "run.json"),
+    JSON.stringify(
+      {
+        runId: "run-1",
+        status: "running",
+        startedAt: "2026-05-18T00:00:00.000Z",
+        updatedAt: "2026-05-18T00:01:00.000Z",
+        apiKey: "xxx",
+      },
+      null,
+      2
+    ),
+    "utf8"
+  );
+  await writeFile(
+    join(input.configDir, "runs", "run-1", "events.ndjson"),
+    [
+      JSON.stringify({
+        at: "2026-05-18T00:00:00.000Z",
+        event: "worker",
+        message: "Authorization: Bearer abc123",
+      }),
+      "OPENAI_API_KEY=sk-xxx",
+    ].join("\n") + "\n",
+    "utf8"
+  );
+  await writeFile(
+    join(input.configDir, "runs", "run-1", "worker.log"),
+    Array.from({ length: 650 }, (_, index) =>
+      index === 649 ? "X-API-Key: xxx" : `worker line ${index}`
+    ).join("\n"),
+    "utf8"
+  );
+  await mkdir(join(input.configDir, "projects", projectId), {
+    recursive: true,
+  });
+  await writeFile(
+    orchestratorLogPath(input.configDir, projectId),
+    "GITHUB_TOKEN=ghp_xxx\norchestrator ready\n",
+    "utf8"
+  );
+}
+
+async function readBundleFiles(root: string): Promise<string> {
+  const chunks: string[] = [];
+  async function visit(dir: string): Promise<void> {
+    const entries = await readdir(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      const path = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        await visit(path);
+      } else {
+        chunks.push(await readFile(path, "utf8"));
+      }
+    }
+  }
+  await visit(root);
+  return chunks.join("\n");
 }
 
 afterEach(() => {
@@ -1282,7 +1413,8 @@ describe("doctor command handler", () => {
               projectId: "tenant-a",
               projectConfig: createProjectConfig(workspaceDir),
             }),
-            getProjectDetail: (async () => createProjectDetail() as never) as never,
+            getProjectDetail: (async () =>
+              createProjectDetail() as never) as never,
             pathEnv: binDir,
           }
         )
@@ -1411,6 +1543,224 @@ describe("doctor command handler", () => {
     );
   });
 
+  it("creates a redacted support bundle at an explicit path", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "doctor-bundle-config-"));
+    const workspaceDir = join(configDir, "workspaces");
+    await prepareDoctorPaths(configDir, workspaceDir);
+    await prepareBundleRuntimeFixture({ configDir, workspaceDir });
+    const { repoDir, pathEnv } = await createWorkflowFixture();
+    await writeFile(
+      join(repoDir, "WORKFLOW.md"),
+      "---\ntracker:\n  kind: github-project\ncodex:\n  command: fake-agent\n---\nAuthorization: Bearer abc123\n",
+      "utf8"
+    );
+    const outputPath = join(repoDir, "tmp", "support-bundle");
+    const stdout = captureWrites(process.stdout);
+
+    try {
+      await withCwd(repoDir, () =>
+        runDoctorCommand(
+          ["--bundle", outputPath],
+          { ...baseOptions(configDir), json: true },
+          {
+            ...authDependencies(),
+            inspectManagedProjectSelection: async (input) => ({
+              kind: "resolved",
+              projectId: input.requestedProjectId ?? "tenant-a",
+              projectConfig: createProjectConfig(workspaceDir),
+            }),
+            getProjectDetail: (async () =>
+              createProjectDetail() as never) as never,
+            execFileSync: (() => "git version 2.43.0") as never,
+            pathEnv,
+          }
+        )
+      );
+    } finally {
+      stdout.restore();
+    }
+
+    const summary = JSON.parse(stdout.output()) as {
+      outputPath: string;
+      includedCount: number;
+      missingCount: number;
+      redactionCount: number;
+      redactionClasses: Array<{ class: string; count: number }>;
+      truncationCount: number;
+    };
+    expect(summary.outputPath).toBe(outputPath);
+    expect(summary.includedCount).toBeGreaterThanOrEqual(9);
+    expect(summary.missingCount).toBe(0);
+    expect(summary.redactionCount).toBeGreaterThan(0);
+    expect(summary.redactionClasses.map((entry) => entry.class)).toEqual(
+      expect.arrayContaining([
+        "authorization_header",
+        "env_token",
+        "api_key",
+        "secret_key",
+      ])
+    );
+    expect(summary.truncationCount).toBeGreaterThanOrEqual(1);
+
+    const manifest = JSON.parse(
+      await readFile(join(outputPath, "manifest.json"), "utf8")
+    ) as {
+      projectId: string;
+      included: string[];
+      truncations: Array<{ path: string }>;
+    };
+    expect(manifest.projectId).toBe("tenant-a");
+    expect(manifest.included).toEqual(
+      expect.arrayContaining([
+        "doctor.json",
+        "config/config.json",
+        "config/project.json",
+        "repo/WORKFLOW.md",
+        "runtime/status.json",
+        "runtime/issues.json",
+        "runtime/orchestrator.log.tail",
+        "runs/run-1/run.json",
+        "runs/run-1/events.ndjson.tail",
+        "runs/run-1/worker.log.tail",
+      ])
+    );
+    expect(manifest.truncations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ path: "runs/run-1/worker.log.tail" }),
+      ])
+    );
+
+    const bundleContent = await readBundleFiles(outputPath);
+    for (const secret of ["abc123", "ghp_xxx", "lin_xxx", "sk-xxx"]) {
+      expect(bundleContent).not.toContain(secret);
+    }
+  });
+
+  it("creates a timestamped support bundle by default and records missing optional artifacts", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "doctor-bundle-default-"));
+    const workspaceDir = join(configDir, "workspaces");
+    await prepareDoctorPaths(configDir, workspaceDir);
+    await mkdir(join(configDir, "projects", "tenant-a"), { recursive: true });
+    await writeFile(
+      join(configDir, "config.json"),
+      JSON.stringify({ activeProject: "tenant-a", projects: ["tenant-a"] }),
+      "utf8"
+    );
+    await writeFile(
+      join(configDir, "projects", "tenant-a", "project.json"),
+      JSON.stringify(createProjectConfig(workspaceDir)),
+      "utf8"
+    );
+    const { repoDir, pathEnv } = await createWorkflowFixture();
+    const stdout = captureWrites(process.stdout);
+
+    try {
+      await withCwd(repoDir, () =>
+        runDoctorCommand(
+          ["--bundle"],
+          { ...baseOptions(configDir), json: true },
+          {
+            ...authDependencies(),
+            inspectManagedProjectSelection: async () => ({
+              kind: "resolved",
+              projectId: "tenant-a",
+              projectConfig: createProjectConfig(workspaceDir),
+            }),
+            getProjectDetail: (async () =>
+              createProjectDetail() as never) as never,
+            execFileSync: (() => "git version 2.43.0") as never,
+            pathEnv,
+          }
+        )
+      );
+    } finally {
+      stdout.restore();
+    }
+
+    const summary = JSON.parse(stdout.output()) as {
+      outputPath: string;
+      missingCount: number;
+    };
+    expect(summary.outputPath).toContain("gh-symphony-support-bundle-");
+    expect(summary.missingCount).toBeGreaterThan(0);
+    const manifest = JSON.parse(
+      await readFile(join(summary.outputPath, "manifest.json"), "utf8")
+    ) as { missing: Array<{ path: string }> };
+    expect(manifest.missing.map((entry) => entry.path)).toEqual(
+      expect.arrayContaining([
+        "runtime/status.json",
+        "runtime/issues.json",
+        "runtime/orchestrator.log.tail",
+        "runs",
+      ])
+    );
+  });
+
+  it("honors explicit project selection for support bundles", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "doctor-bundle-project-"));
+    const workspaceDir = join(configDir, "workspaces");
+    await prepareDoctorPaths(configDir, workspaceDir);
+    await prepareBundleRuntimeFixture({
+      configDir,
+      workspaceDir,
+      projectId: "project-b",
+    });
+    const { repoDir, pathEnv } = await createWorkflowFixture();
+    const outputPath = join(repoDir, "bundle-project-b");
+    const requestedProjectIds: Array<string | undefined> = [];
+    const stdout = captureWrites(process.stdout);
+
+    try {
+      await withCwd(repoDir, () =>
+        runDoctorCommand(
+          ["--bundle", outputPath, "--project-id", "project-b"],
+          { ...baseOptions(configDir), json: true },
+          {
+            ...authDependencies(),
+            inspectManagedProjectSelection: async (input) => {
+              requestedProjectIds.push(input.requestedProjectId);
+              return {
+                kind: "resolved",
+                projectId: input.requestedProjectId ?? "tenant-a",
+                projectConfig: createProjectConfig(workspaceDir),
+              };
+            },
+            getProjectDetail: (async () =>
+              createProjectDetail() as never) as never,
+            execFileSync: (() => "git version 2.43.0") as never,
+            pathEnv,
+          }
+        )
+      );
+    } finally {
+      stdout.restore();
+    }
+
+    const summary = JSON.parse(stdout.output()) as { projectId: string };
+    expect(summary.projectId).toBe("project-b");
+    expect(requestedProjectIds).toContain("project-b");
+    const manifest = JSON.parse(
+      await readFile(join(outputPath, "manifest.json"), "utf8")
+    ) as { projectId: string };
+    expect(manifest.projectId).toBe("project-b");
+  });
+
+  it("rejects --fix with support bundle export", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "doctor-bundle-fix-"));
+    const stderr = captureWrites(process.stderr);
+
+    try {
+      await doctorCommand(["--bundle", "--fix"], baseOptions(configDir));
+    } finally {
+      stderr.restore();
+    }
+
+    expect(process.exitCode).toBe(2);
+    expect(stderr.output()).toContain(
+      "Option '--fix' cannot be used with '--bundle'"
+    );
+  });
+
   it("reports no managed project for smoke checks", async () => {
     const configDir = await mkdtemp(join(tmpdir(), "doctor-config-"));
     const { repoDir, pathEnv } = await createWorkflowFixture();
@@ -1536,23 +1886,28 @@ describe("doctor command handler", () => {
     const { repoDir, pathEnv } = await createWorkflowFixture();
 
     const report = await withCwd(repoDir, () =>
-      runDoctorDiagnostics(baseOptions(configDir), ["--smoke", "--issue", "garbage"], {
-        ...authDependencies(),
-        inspectManagedProjectSelection: async () => ({
-          kind: "resolved",
-          projectId: "tenant-a",
-          projectConfig: createProjectConfig(workspaceDir, "PVT_test", [
-            {
-              owner: "acme",
-              name: "widgets",
-              url: "https://github.com/acme/widgets",
-              cloneUrl: "https://github.com/acme/widgets.git",
-            },
-          ]),
-        }),
-        getProjectDetail: (async () => createProjectDetail() as never) as never,
-        pathEnv,
-      })
+      runDoctorDiagnostics(
+        baseOptions(configDir),
+        ["--smoke", "--issue", "garbage"],
+        {
+          ...authDependencies(),
+          inspectManagedProjectSelection: async () => ({
+            kind: "resolved",
+            projectId: "tenant-a",
+            projectConfig: createProjectConfig(workspaceDir, "PVT_test", [
+              {
+                owner: "acme",
+                name: "widgets",
+                url: "https://github.com/acme/widgets",
+                cloneUrl: "https://github.com/acme/widgets.git",
+              },
+            ]),
+          }),
+          getProjectDetail: (async () =>
+            createProjectDetail() as never) as never,
+          pathEnv,
+        }
+      )
     );
 
     expect(report.ok).toBe(false);

--- a/packages/cli/src/commands/doctor.test.ts
+++ b/packages/cli/src/commands/doctor.test.ts
@@ -21,6 +21,7 @@ import doctorCommand, {
   runDoctorCommand,
   runDoctorDiagnostics,
 } from "./doctor.js";
+import { SUPPORT_BUNDLE_LIMITS } from "../support/bundle.js";
 
 const DOCTOR_TEST_NODE_VERSION = "v24.0.0";
 
@@ -308,6 +309,13 @@ async function prepareBundleRuntimeFixture(input: {
         at: "2026-05-18T00:00:00.000Z",
         event: "worker",
         message: "Authorization: Bearer abc123",
+      }),
+      JSON.stringify({
+        at: "2026-05-18T00:00:01.000Z",
+        event: "worker",
+        token: "json_token_value",
+        secret: "json_secret_value",
+        apiKey: "json_api_key_value",
       }),
       "OPENAI_API_KEY=sk-xxx",
     ].join("\n") + "\n",
@@ -1631,9 +1639,73 @@ describe("doctor command handler", () => {
     );
 
     const bundleContent = await readBundleFiles(outputPath);
-    for (const secret of ["abc123", "ghp_xxx", "lin_xxx", "sk-xxx"]) {
+    for (const secret of [
+      "abc123",
+      "ghp_xxx",
+      "lin_xxx",
+      "sk-xxx",
+      "json_token_value",
+      "json_secret_value",
+      "json_api_key_value",
+    ]) {
       expect(bundleContent).not.toContain(secret);
     }
+  });
+
+  it("preserves bounded tails for oversized single-line logs", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "doctor-bundle-tail-"));
+    const workspaceDir = join(configDir, "workspaces");
+    await prepareDoctorPaths(configDir, workspaceDir);
+    await prepareBundleRuntimeFixture({ configDir, workspaceDir });
+    await writeFile(
+      join(configDir, "runs", "run-1", "worker.log"),
+      "x".repeat(SUPPORT_BUNDLE_LIMITS.maxLogBytes + 1024) + "tail-marker",
+      "utf8"
+    );
+    const { repoDir, pathEnv } = await createWorkflowFixture();
+    const outputPath = join(repoDir, "bundle-single-line-tail");
+    const stdout = captureWrites(process.stdout);
+
+    try {
+      await withCwd(repoDir, () =>
+        runDoctorCommand(
+          ["--bundle", outputPath],
+          { ...baseOptions(configDir), json: true },
+          {
+            ...authDependencies(),
+            inspectManagedProjectSelection: async () => ({
+              kind: "resolved",
+              projectId: "tenant-a",
+              projectConfig: createProjectConfig(workspaceDir),
+            }),
+            getProjectDetail: (async () =>
+              createProjectDetail() as never) as never,
+            execFileSync: (() => "git version 2.43.0") as never,
+            pathEnv,
+          }
+        )
+      );
+    } finally {
+      stdout.restore();
+    }
+
+    const tail = await readFile(
+      join(outputPath, "runs", "run-1", "worker.log.tail"),
+      "utf8"
+    );
+    expect(tail).toContain("tail-marker");
+    expect(tail.length).toBeGreaterThan(0);
+    const manifest = JSON.parse(
+      await readFile(join(outputPath, "manifest.json"), "utf8")
+    ) as { truncations: Array<{ path: string; reason: string }> };
+    expect(manifest.truncations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          path: "runs/run-1/worker.log.tail",
+          reason: expect.stringContaining("partialLine"),
+        }),
+      ])
+    );
   });
 
   it("creates a timestamped support bundle by default and records missing optional artifacts", async () => {
@@ -1692,6 +1764,57 @@ describe("doctor command handler", () => {
         "runtime/issues.json",
         "runtime/orchestrator.log.tail",
         "runs",
+      ])
+    );
+  });
+
+  it("records malformed optional JSON artifacts as missing", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "doctor-bundle-bad-json-"));
+    const workspaceDir = join(configDir, "workspaces");
+    await prepareDoctorPaths(configDir, workspaceDir);
+    await mkdir(join(configDir, "projects", "tenant-a"), { recursive: true });
+    await writeFile(join(configDir, "config.json"), "{ bad json", "utf8");
+    await writeFile(
+      join(configDir, "projects", "tenant-a", "project.json"),
+      "{ also bad json",
+      "utf8"
+    );
+    const { repoDir, pathEnv } = await createWorkflowFixture();
+    const outputPath = join(repoDir, "bundle-bad-json");
+    const stdout = captureWrites(process.stdout);
+
+    try {
+      await withCwd(repoDir, () =>
+        runDoctorCommand(
+          ["--bundle", outputPath],
+          { ...baseOptions(configDir), json: true },
+          {
+            ...authDependencies(),
+            inspectManagedProjectSelection: async () => ({
+              kind: "resolved",
+              projectId: "tenant-a",
+              projectConfig: createProjectConfig(workspaceDir),
+            }),
+            getProjectDetail: (async () =>
+              createProjectDetail() as never) as never,
+            execFileSync: (() => "git version 2.43.0") as never,
+            pathEnv,
+          }
+        )
+      );
+    } finally {
+      stdout.restore();
+    }
+
+    const summary = JSON.parse(stdout.output()) as { missingCount: number };
+    expect(summary.missingCount).toBeGreaterThanOrEqual(2);
+    const manifest = JSON.parse(
+      await readFile(join(outputPath, "manifest.json"), "utf8")
+    ) as { missing: Array<{ path: string; reason: string }> };
+    expect(manifest.missing).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ path: "config/config.json" }),
+        expect.objectContaining({ path: "config/project.json" }),
       ])
     );
   });

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -42,6 +42,10 @@ import type { GlobalOptions } from "../index.js";
 import { resolveRuntimeRoot } from "../orchestrator-runtime.js";
 import { inspectManagedProjectSelection } from "../project-selection.js";
 import {
+  createSupportBundle,
+  type SupportBundleSummary,
+} from "../support/bundle.js";
+import {
   parseIssueReference,
   readGitHubProjectBinding,
   renderIssueWorkflowPreview,
@@ -122,6 +126,8 @@ type ParsedDoctorArgs = {
   projectId?: string;
   fix: boolean;
   smoke: boolean;
+  bundle: boolean;
+  bundlePath?: string;
   issue?: string;
   error?: string;
 };
@@ -217,7 +223,7 @@ const DEFAULT_DEPENDENCIES: DoctorDependencies = {
 const MINIMUM_NODE_MAJOR = 24;
 const MINIMUM_NODE_VERSION = `v${MINIMUM_NODE_MAJOR}.0.0`;
 const DOCTOR_USAGE =
-  "Usage: gh-symphony doctor [--project-id <project-id>] [--fix] [--smoke] [--issue <owner/repo#number>]";
+  "Usage: gh-symphony doctor [--project-id <project-id>] [--fix] [--smoke] [--issue <owner/repo#number>] [--bundle [path]]";
 
 type GitInstallationState =
   | {
@@ -230,7 +236,7 @@ type GitInstallationState =
     };
 
 function parseDoctorArgs(args: string[]): ParsedDoctorArgs {
-  const parsed: ParsedDoctorArgs = { fix: false, smoke: false };
+  const parsed: ParsedDoctorArgs = { fix: false, smoke: false, bundle: false };
 
   for (let i = 0; i < args.length; i += 1) {
     const arg = args[i];
@@ -255,6 +261,16 @@ function parseDoctorArgs(args: string[]): ParsedDoctorArgs {
       continue;
     }
 
+    if (arg === "--bundle") {
+      parsed.bundle = true;
+      const value = args[i + 1];
+      if (value && !value.startsWith("-")) {
+        parsed.bundlePath = value;
+        i += 1;
+      }
+      continue;
+    }
+
     if (arg === "--issue") {
       const value = args[i + 1];
       if (!value || value.startsWith("-")) {
@@ -270,10 +286,16 @@ function parseDoctorArgs(args: string[]): ParsedDoctorArgs {
       parsed.error = `Unknown option '${arg}'`;
       return parsed;
     }
+
+    parsed.error = `Unexpected argument '${arg}'`;
+    return parsed;
   }
 
   if (parsed.issue && !parsed.smoke) {
     parsed.error = "Option '--issue' requires '--smoke'";
+  }
+  if (parsed.bundle && parsed.fix) {
+    parsed.error = "Option '--fix' cannot be used with '--bundle'";
   }
 
   return parsed;
@@ -760,7 +782,13 @@ async function buildHookChecks(
         "Workflow hook paths",
         `Unresolved WORKFLOW.md hook path${unresolved.length === 1 ? "" : "s"}: ${unresolved.map((entry) => `${entry.hook}=${entry.command}`).join(", ")}.`,
         "Create the referenced hook script(s), fix the hook path(s), or replace them with inline commands.",
-        { configured: configured.length, pathsChecked: checked.length, inline, unresolved, checked }
+        {
+          configured: configured.length,
+          pathsChecked: checked.length,
+          inline,
+          unresolved,
+          checked,
+        }
       ),
     ];
   }
@@ -779,7 +807,12 @@ async function buildHookChecks(
       "workflow_hooks",
       "Workflow hook paths",
       `${pathSummary}${inlineSummary}`,
-      { configured: configured.length, pathsChecked: checked.length, inline, checked }
+      {
+        configured: configured.length,
+        pathsChecked: checked.length,
+        inline,
+        checked,
+      }
     ),
   ];
 }
@@ -2067,6 +2100,25 @@ function renderTextReport(report: DoctorReport): string {
   return lines.join("\n");
 }
 
+function renderBundleSummary(summary: SupportBundleSummary): string {
+  const redactionClasses =
+    summary.redactionClasses.length === 0
+      ? "none"
+      : summary.redactionClasses
+          .map((entry) => `${entry.class}:${entry.count}`)
+          .join(", ");
+  return [
+    "gh-symphony doctor support bundle",
+    `Output path: ${summary.outputPath}`,
+    `Project: ${summary.projectId}`,
+    `Included artifacts: ${summary.includedCount}`,
+    `Missing artifacts: ${summary.missingCount}`,
+    `Redactions: ${summary.redactionCount} (${redactionClasses})`,
+    `Truncations: ${summary.truncationCount}`,
+    `Manifest: ${summary.manifestPath}`,
+  ].join("\n");
+}
+
 export async function runDoctorCommand(
   args: string[],
   options: GlobalOptions,
@@ -2080,6 +2132,28 @@ export async function runDoctorCommand(
     }
 
     const initialReport = await runDoctorDiagnostics(options, args, deps);
+    if (parsedArgs.bundle) {
+      if (!initialReport.projectId) {
+        throw new Error(
+          "Cannot create a support bundle because no managed project was resolved."
+        );
+      }
+      const summary = await createSupportBundle({
+        configDir: options.configDir,
+        projectId: initialReport.projectId,
+        repoRoot: process.cwd(),
+        outputPath: parsedArgs.bundlePath,
+        doctorReport: initialReport,
+      });
+      if (options.json) {
+        process.stdout.write(JSON.stringify(summary, null, 2) + "\n");
+      } else {
+        process.stdout.write(renderBundleSummary(summary) + "\n");
+      }
+      process.exitCode = initialReport.ok ? 0 : 1;
+      return;
+    }
+
     if (parsedArgs.fix) {
       const remediation = {
         attempted: true,

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -308,6 +308,7 @@ describe("Commander CLI entrypoint", () => {
     const output = stdout.output() + stderr.output();
     expect(output).toContain("--fix");
     expect(output).toContain("--smoke");
+    expect(output).toContain("--bundle");
     expect(output).toContain("--issue");
     expect(output).toContain("remediation");
   });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -65,6 +65,7 @@ type CliOptionValues = Partial<
     watch?: boolean;
     sample?: string;
     smoke?: boolean;
+    bundle?: string | boolean;
     attempt?: string;
   }
 >;
@@ -336,6 +337,10 @@ function createProgram(): { program: Command; wasInvoked: () => boolean } {
         "--smoke",
         "Run a safe live issue readiness check without dispatching work"
       )
+      .option(
+        "--bundle [path]",
+        "Export a redacted support bundle for shareable diagnostics"
+      )
       .option("--issue <owner/repo#number>", "Live issue to validate")
       .addOption(new Option("--project <projectId>").hideHelp())
       .allowExcessArguments(false)
@@ -346,6 +351,7 @@ function createProgram(): { program: Command; wasInvoked: () => boolean } {
     pushOption(args, "--project-id", resolveProjectId(values));
     pushOption(args, "--fix", values.fix);
     pushOption(args, "--smoke", values.smoke);
+    pushOption(args, "--bundle", values.bundle);
     pushOption(args, "--issue", values.issue);
     await invokeHandler("doctor", args, values);
   });
@@ -412,9 +418,7 @@ function createProgram(): { program: Command; wasInvoked: () => boolean } {
   });
 
   const repo = addGlobalOptions(
-    program
-      .command("repo")
-      .description("Manage the current repository runtime")
+    program.command("repo").description("Manage the current repository runtime")
   );
 
   repo.action(async function (this: Command) {

--- a/packages/cli/src/support/bundle.ts
+++ b/packages/cli/src/support/bundle.ts
@@ -1,0 +1,507 @@
+import { constants } from "node:fs";
+import { open } from "node:fs/promises";
+import {
+  access,
+  mkdir,
+  readdir,
+  readFile,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import { dirname, join, relative, resolve, sep } from "node:path";
+import {
+  redactObservabilitySecretsWithStats,
+  redactObservabilityTextWithStats,
+  type RedactionSummary,
+} from "@gh-symphony/core";
+import {
+  configFilePath,
+  orchestratorLogPath,
+  projectConfigPath,
+} from "../config.js";
+
+export const SUPPORT_BUNDLE_LIMITS = {
+  maxRuns: 3,
+  maxLogBytes: 64 * 1024,
+  maxLogLines: 500,
+  maxBundleBytes: 5 * 1024 * 1024,
+} as const;
+
+export type SupportBundleMissing = {
+  path: string;
+  reason: string;
+};
+
+export type SupportBundleTruncation = {
+  path: string;
+  originalBytes?: number;
+  writtenBytes: number;
+  maxBytes?: number;
+  maxLines?: number;
+  reason: string;
+};
+
+export type SupportBundleManifest = {
+  version: 1;
+  createdAt: string;
+  projectId: string;
+  configDir: string;
+  included: string[];
+  missing: SupportBundleMissing[];
+  redactions: RedactionSummary[];
+  truncations: SupportBundleTruncation[];
+  limits: typeof SUPPORT_BUNDLE_LIMITS;
+};
+
+export type SupportBundleSummary = {
+  outputPath: string;
+  projectId: string;
+  includedCount: number;
+  missingCount: number;
+  redactionCount: number;
+  redactionClasses: RedactionSummary[];
+  truncationCount: number;
+  manifestPath: string;
+};
+
+type SupportBundleInput = {
+  configDir: string;
+  projectId: string;
+  repoRoot: string;
+  outputPath?: string;
+  doctorReport: unknown;
+  now?: Date;
+};
+
+type BundleState = {
+  root: string;
+  manifest: SupportBundleManifest;
+};
+
+type RecentRun = {
+  runId: string;
+  runDir: string;
+  run: Record<string, unknown> | null;
+  updatedAt: string;
+  active: boolean;
+};
+
+export async function createSupportBundle(
+  input: SupportBundleInput
+): Promise<SupportBundleSummary> {
+  const createdAt = (input.now ?? new Date()).toISOString();
+  const root = resolveBundleRoot(input.outputPath, input.repoRoot, createdAt);
+  await ensureWritableBundleRoot(root);
+
+  const state: BundleState = {
+    root,
+    manifest: {
+      version: 1,
+      createdAt,
+      projectId: input.projectId,
+      configDir: resolve(input.configDir),
+      included: [],
+      missing: [],
+      redactions: [],
+      truncations: [],
+      limits: SUPPORT_BUNDLE_LIMITS,
+    },
+  };
+
+  await writeJsonArtifact(state, "doctor.json", input.doctorReport);
+  await copyJsonArtifact(
+    state,
+    configFilePath(input.configDir),
+    "config/config.json"
+  );
+  await copyJsonArtifact(
+    state,
+    projectConfigPath(input.configDir, input.projectId),
+    "config/project.json"
+  );
+  await copyTextArtifact(
+    state,
+    join(input.repoRoot, "WORKFLOW.md"),
+    "repo/WORKFLOW.md",
+    { bounded: false }
+  );
+
+  const runtimeRoot = await resolveRuntimeArtifactRoot(
+    input.configDir,
+    input.projectId
+  );
+  await copyJsonArtifact(
+    state,
+    join(runtimeRoot, "status.json"),
+    "runtime/status.json"
+  );
+  await copyJsonArtifact(
+    state,
+    join(runtimeRoot, "issues.json"),
+    "runtime/issues.json"
+  );
+  await copyTextArtifact(
+    state,
+    orchestratorLogPath(input.configDir, input.projectId),
+    "runtime/orchestrator.log.tail",
+    { bounded: true }
+  );
+
+  const recentRuns = await listRecentRuns(input.configDir, input.projectId);
+  if (recentRuns.length === 0) {
+    state.manifest.missing.push({
+      path: "runs",
+      reason: "No run records were found for the selected project.",
+    });
+  }
+  for (const recentRun of recentRuns) {
+    const destinationDir = `runs/${sanitizePathSegment(recentRun.runId)}`;
+    if (recentRun.run) {
+      await writeJsonArtifact(
+        state,
+        `${destinationDir}/run.json`,
+        recentRun.run
+      );
+    } else {
+      state.manifest.missing.push({
+        path: `${destinationDir}/run.json`,
+        reason: "Run metadata is missing or unreadable.",
+      });
+    }
+    await copyTextArtifact(
+      state,
+      join(recentRun.runDir, "events.ndjson"),
+      `${destinationDir}/events.ndjson.tail`,
+      { bounded: true }
+    );
+    await copyTextArtifact(
+      state,
+      join(recentRun.runDir, "worker.log"),
+      `${destinationDir}/worker.log.tail`,
+      { bounded: true }
+    );
+  }
+
+  await writeManifest(state);
+  return buildSummary(state);
+}
+
+function resolveBundleRoot(
+  outputPath: string | undefined,
+  repoRoot: string,
+  createdAt: string
+): string {
+  if (outputPath) {
+    return resolve(repoRoot, outputPath);
+  }
+
+  const timestamp = createdAt.replace(/[:.]/g, "").replace("T", "-");
+  return resolve(repoRoot, `gh-symphony-support-bundle-${timestamp}`);
+}
+
+async function ensureWritableBundleRoot(root: string): Promise<void> {
+  await mkdir(root, { recursive: true });
+  const target = await stat(root);
+  if (!target.isDirectory()) {
+    throw new Error(`Bundle output path is not a directory: ${root}`);
+  }
+  await access(root, constants.W_OK);
+}
+
+async function writeJsonArtifact(
+  state: BundleState,
+  relativePath: string,
+  value: unknown
+): Promise<void> {
+  const redacted = redactObservabilitySecretsWithStats(value);
+  addRedactions(state, redacted.redactions);
+  await writeBundleFile(
+    state,
+    relativePath,
+    JSON.stringify(redacted.value, null, 2) + "\n"
+  );
+}
+
+async function copyJsonArtifact(
+  state: BundleState,
+  sourcePath: string,
+  destinationPath: string
+): Promise<void> {
+  let raw: string;
+  try {
+    raw = await readFile(sourcePath, "utf8");
+  } catch (error) {
+    recordMissing(state, destinationPath, sourcePath, error);
+    return;
+  }
+
+  try {
+    await writeJsonArtifact(state, destinationPath, JSON.parse(raw));
+  } catch (error) {
+    throw new Error(
+      `Failed to redact/write JSON artifact ${sourcePath}: ${formatError(error)}`
+    );
+  }
+}
+
+async function copyTextArtifact(
+  state: BundleState,
+  sourcePath: string,
+  destinationPath: string,
+  options: { bounded: boolean }
+): Promise<void> {
+  let captured: CapturedText;
+  try {
+    captured = options.bounded
+      ? await readBoundedTail(sourcePath)
+      : { text: await readFile(sourcePath, "utf8"), truncated: false };
+  } catch (error) {
+    recordMissing(state, destinationPath, sourcePath, error);
+    return;
+  }
+
+  const redacted = redactObservabilityTextWithStats(captured.text);
+  addRedactions(state, redacted.redactions);
+  await writeBundleFile(state, destinationPath, redacted.value);
+  if (captured.truncated) {
+    state.manifest.truncations.push({
+      path: destinationPath,
+      originalBytes: captured.originalBytes,
+      writtenBytes: Buffer.byteLength(redacted.value, "utf8"),
+      maxBytes: SUPPORT_BUNDLE_LIMITS.maxLogBytes,
+      maxLines: SUPPORT_BUNDLE_LIMITS.maxLogLines,
+      reason: captured.reason ?? "bounded_tail",
+    });
+  }
+}
+
+type CapturedText = {
+  text: string;
+  truncated: boolean;
+  originalBytes?: number;
+  reason?: string;
+};
+
+async function readBoundedTail(sourcePath: string): Promise<CapturedText> {
+  const handle = await open(sourcePath, "r");
+  try {
+    const stats = await handle.stat();
+    const start = Math.max(0, stats.size - SUPPORT_BUNDLE_LIMITS.maxLogBytes);
+    const length = stats.size - start;
+    const buffer = Buffer.alloc(length);
+    if (length > 0) {
+      await handle.read(buffer, 0, length, start);
+    }
+
+    let text = buffer.toString("utf8");
+    let truncated = start > 0;
+    const reasons: string[] = [];
+    if (start > 0) {
+      reasons.push("maxLogBytes");
+      const firstNewline = text.indexOf("\n");
+      text = firstNewline >= 0 ? text.slice(firstNewline + 1) : "";
+    }
+
+    const lines = text.split(/\r?\n/);
+    if (lines.length > SUPPORT_BUNDLE_LIMITS.maxLogLines) {
+      text = lines.slice(-SUPPORT_BUNDLE_LIMITS.maxLogLines).join("\n");
+      truncated = true;
+      reasons.push("maxLogLines");
+    }
+
+    return {
+      text,
+      truncated,
+      originalBytes: stats.size,
+      reason: reasons.join(",") || undefined,
+    };
+  } finally {
+    await handle.close();
+  }
+}
+
+async function writeBundleFile(
+  state: BundleState,
+  relativePath: string,
+  content: string
+): Promise<void> {
+  const target = resolveBundlePath(state.root, relativePath);
+  await mkdir(dirname(target), { recursive: true });
+  await writeFile(target, content, "utf8");
+  state.manifest.included.push(relativePath);
+}
+
+async function writeManifest(state: BundleState): Promise<void> {
+  if (!state.manifest.included.includes("manifest.json")) {
+    state.manifest.included.push("manifest.json");
+  }
+  const target = resolveBundlePath(state.root, "manifest.json");
+  await writeFile(
+    target,
+    JSON.stringify(state.manifest, null, 2) + "\n",
+    "utf8"
+  );
+}
+
+function resolveBundlePath(root: string, relativePath: string): string {
+  const target = resolve(root, relativePath);
+  const relativeTarget = relative(root, target);
+  if (
+    relativeTarget === "" ||
+    relativeTarget.startsWith("..") ||
+    relativeTarget.includes(`..${sep}`)
+  ) {
+    throw new Error(`Refusing to write outside bundle root: ${relativePath}`);
+  }
+  return target;
+}
+
+function recordMissing(
+  state: BundleState,
+  destinationPath: string,
+  sourcePath: string,
+  error: unknown
+): void {
+  state.manifest.missing.push({
+    path: destinationPath,
+    reason: `${sourcePath}: ${formatError(error)}`,
+  });
+}
+
+function addRedactions(
+  state: BundleState,
+  redactions: RedactionSummary[]
+): void {
+  const existing = new Map(
+    state.manifest.redactions.map((entry) => [entry.class, entry.count])
+  );
+  for (const redaction of redactions) {
+    existing.set(
+      redaction.class,
+      (existing.get(redaction.class) ?? 0) + redaction.count
+    );
+  }
+  state.manifest.redactions = Array.from(existing.entries())
+    .map(([redactionClass, count]) => ({ class: redactionClass, count }))
+    .sort((left, right) => left.class.localeCompare(right.class));
+}
+
+async function resolveRuntimeArtifactRoot(
+  configDir: string,
+  projectId: string
+): Promise<string> {
+  const candidates = [
+    resolve(configDir),
+    resolve(configDir, "projects", projectId),
+  ];
+  for (const candidate of candidates) {
+    try {
+      await access(join(candidate, "status.json"), constants.R_OK);
+      return candidate;
+    } catch {
+      continue;
+    }
+  }
+  return candidates[0]!;
+}
+
+async function listRecentRuns(
+  configDir: string,
+  projectId: string
+): Promise<RecentRun[]> {
+  const runsDirs = [
+    resolve(configDir, "runs"),
+    resolve(configDir, "projects", projectId, "runs"),
+  ];
+  const seen = new Set<string>();
+  const runs: RecentRun[] = [];
+  for (const runsDir of runsDirs) {
+    let entries: string[];
+    try {
+      entries = await readdir(runsDir);
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      const runId = sanitizePathSegment(entry);
+      if (seen.has(runId)) {
+        continue;
+      }
+      const runDir = join(runsDir, entry);
+      const runJsonPath = join(runDir, "run.json");
+      let run: Record<string, unknown> | null = null;
+      let updatedAt = "";
+      let active = false;
+      try {
+        const raw = await readFile(runJsonPath, "utf8");
+        run = JSON.parse(raw) as Record<string, unknown>;
+        updatedAt =
+          stringField(run, "updatedAt") ??
+          stringField(run, "endedAt") ??
+          stringField(run, "startedAt") ??
+          "";
+        const statusValue = stringField(run, "status");
+        active = statusValue === "running" || statusValue === "retrying";
+      } catch {
+        try {
+          const metadata = await stat(runDir);
+          updatedAt = metadata.mtime.toISOString();
+        } catch {
+          updatedAt = "";
+        }
+      }
+      seen.add(runId);
+      runs.push({ runId, runDir, run, updatedAt, active });
+    }
+  }
+
+  return runs
+    .sort((left, right) => {
+      if (left.active !== right.active) {
+        return left.active ? -1 : 1;
+      }
+      return right.updatedAt.localeCompare(left.updatedAt);
+    })
+    .slice(0, SUPPORT_BUNDLE_LIMITS.maxRuns);
+}
+
+function stringField(
+  value: Record<string, unknown>,
+  key: string
+): string | null {
+  const field = value[key];
+  return typeof field === "string" ? field : null;
+}
+
+function sanitizePathSegment(value: string): string {
+  return value.replace(/[^A-Za-z0-9._-]/g, "_");
+}
+
+function buildSummary(state: BundleState): SupportBundleSummary {
+  const redactionCount = state.manifest.redactions.reduce(
+    (sum, entry) => sum + entry.count,
+    0
+  );
+  return {
+    outputPath: state.root,
+    projectId: state.manifest.projectId,
+    includedCount: state.manifest.included.length,
+    missingCount: state.manifest.missing.length,
+    redactionCount,
+    redactionClasses: state.manifest.redactions,
+    truncationCount: state.manifest.truncations.length,
+    manifestPath: join(state.root, "manifest.json"),
+  };
+}
+
+function formatError(error: unknown): string {
+  if (
+    error &&
+    typeof error === "object" &&
+    "code" in error &&
+    typeof error.code === "string"
+  ) {
+    return error.code;
+  }
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/cli/src/support/bundle.ts
+++ b/packages/cli/src/support/bundle.ts
@@ -10,7 +10,7 @@ import {
 } from "node:fs/promises";
 import { dirname, join, relative, resolve, sep } from "node:path";
 import {
-  redactObservabilitySecretsWithStats,
+  redactObservabilityDiagnosticsWithStats,
   redactObservabilityTextWithStats,
   type RedactionSummary,
 } from "@gh-symphony/core";
@@ -51,6 +51,11 @@ export type SupportBundleManifest = {
   redactions: RedactionSummary[];
   truncations: SupportBundleTruncation[];
   limits: typeof SUPPORT_BUNDLE_LIMITS;
+  bundleBytes: {
+    written: number;
+    softMax: number;
+    exceeded: boolean;
+  };
 };
 
 export type SupportBundleSummary = {
@@ -76,6 +81,7 @@ type SupportBundleInput = {
 type BundleState = {
   root: string;
   manifest: SupportBundleManifest;
+  writtenBytes: number;
 };
 
 type RecentRun = {
@@ -95,6 +101,7 @@ export async function createSupportBundle(
 
   const state: BundleState = {
     root,
+    writtenBytes: 0,
     manifest: {
       version: 1,
       createdAt,
@@ -105,6 +112,11 @@ export async function createSupportBundle(
       redactions: [],
       truncations: [],
       limits: SUPPORT_BUNDLE_LIMITS,
+      bundleBytes: {
+        written: 0,
+        softMax: SUPPORT_BUNDLE_LIMITS.maxBundleBytes,
+        exceeded: false,
+      },
     },
   };
 
@@ -213,7 +225,7 @@ async function writeJsonArtifact(
   relativePath: string,
   value: unknown
 ): Promise<void> {
-  const redacted = redactObservabilitySecretsWithStats(value);
+  const redacted = redactObservabilityDiagnosticsWithStats(value);
   addRedactions(state, redacted.redactions);
   await writeBundleFile(
     state,
@@ -236,8 +248,13 @@ async function copyJsonArtifact(
   }
 
   try {
-    await writeJsonArtifact(state, destinationPath, JSON.parse(raw));
+    const parsed = JSON.parse(raw);
+    await writeJsonArtifact(state, destinationPath, parsed);
   } catch (error) {
+    if (error instanceof SyntaxError) {
+      recordMissing(state, destinationPath, sourcePath, error);
+      return;
+    }
     throw new Error(
       `Failed to redact/write JSON artifact ${sourcePath}: ${formatError(error)}`
     );
@@ -299,7 +316,11 @@ async function readBoundedTail(sourcePath: string): Promise<CapturedText> {
     if (start > 0) {
       reasons.push("maxLogBytes");
       const firstNewline = text.indexOf("\n");
-      text = firstNewline >= 0 ? text.slice(firstNewline + 1) : "";
+      if (firstNewline >= 0) {
+        text = text.slice(firstNewline + 1);
+      } else {
+        reasons.push("partialLine");
+      }
     }
 
     const lines = text.split(/\r?\n/);
@@ -328,6 +349,7 @@ async function writeBundleFile(
   const target = resolveBundlePath(state.root, relativePath);
   await mkdir(dirname(target), { recursive: true });
   await writeFile(target, content, "utf8");
+  state.writtenBytes += Buffer.byteLength(content, "utf8");
   state.manifest.included.push(relativePath);
 }
 
@@ -335,6 +357,11 @@ async function writeManifest(state: BundleState): Promise<void> {
   if (!state.manifest.included.includes("manifest.json")) {
     state.manifest.included.push("manifest.json");
   }
+  state.manifest.bundleBytes = {
+    written: state.writtenBytes,
+    softMax: SUPPORT_BUNDLE_LIMITS.maxBundleBytes,
+    exceeded: state.writtenBytes > SUPPORT_BUNDLE_LIMITS.maxBundleBytes,
+  };
   const target = resolveBundlePath(state.root, "manifest.json");
   await writeFile(
     target,

--- a/packages/core/src/observability/redaction.test.ts
+++ b/packages/core/src/observability/redaction.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  redactObservabilityDiagnosticsWithStats,
   redactObservabilitySecrets,
   redactObservabilitySecretsWithStats,
   redactObservabilityTextWithStats,
@@ -57,8 +58,20 @@ describe("redactObservabilitySecrets", () => {
     expect(JSON.stringify(redacted)).not.toContain("lin_secret");
   });
 
+  it("keeps shared structured redaction key-focused", () => {
+    const redacted = redactObservabilitySecrets({
+      event: "worker",
+      message: "token: ordinary-diagnostic-text",
+    });
+
+    expect(redacted).toEqual({
+      event: "worker",
+      message: "token: ordinary-diagnostic-text",
+    });
+  });
+
   it("redacts structured and raw support diagnostics secrets with class counts", () => {
-    const structured = redactObservabilitySecretsWithStats({
+    const structured = redactObservabilityDiagnosticsWithStats({
       token: "ghp_xxx",
       secret: "top-secret",
       apiKey: "sk-xxx",
@@ -78,11 +91,21 @@ describe("redactObservabilitySecrets", () => {
         "token: xxx",
         "secret: xxx",
         "apiKey: xxx",
+        '{"token":"json_token_value","secret":"json_secret_value","apiKey":"json_api_key_value"}',
       ].join("\n")
     );
     const output = JSON.stringify(structured.value) + raw.value;
 
-    for (const secret of ["abc123", "ghp_xxx", "lin_xxx", "sk-xxx", "xxx"]) {
+    for (const secret of [
+      "abc123",
+      "ghp_xxx",
+      "lin_xxx",
+      "sk-xxx",
+      "xxx",
+      "json_token_value",
+      "json_secret_value",
+      "json_api_key_value",
+    ]) {
       expect(output).not.toContain(secret);
     }
     expect([...structured.redactions, ...raw.redactions]).toEqual(
@@ -93,5 +116,18 @@ describe("redactObservabilitySecrets", () => {
         expect.objectContaining({ class: "secret_key" }),
       ])
     );
+  });
+
+  it("reports key-only structured redaction stats without scanning strings", () => {
+    const structured = redactObservabilitySecretsWithStats({
+      token: "ghp_xxx",
+      message: "Authorization: Bearer abc123",
+    });
+
+    expect(structured.value).toEqual({
+      token: "[REDACTED]",
+      message: "Authorization: Bearer abc123",
+    });
+    expect(structured.redactions).toEqual([{ class: "env_token", count: 1 }]);
   });
 });

--- a/packages/core/src/observability/redaction.test.ts
+++ b/packages/core/src/observability/redaction.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { redactObservabilitySecrets } from "./redaction.js";
+import {
+  redactObservabilitySecrets,
+  redactObservabilitySecretsWithStats,
+  redactObservabilityTextWithStats,
+} from "./redaction.js";
 
 describe("redactObservabilitySecrets", () => {
   it("redacts Linear API keys and Authorization headers recursively", () => {
@@ -51,5 +55,43 @@ describe("redactObservabilitySecrets", () => {
       ],
     });
     expect(JSON.stringify(redacted)).not.toContain("lin_secret");
+  });
+
+  it("redacts structured and raw support diagnostics secrets with class counts", () => {
+    const structured = redactObservabilitySecretsWithStats({
+      token: "ghp_xxx",
+      secret: "top-secret",
+      apiKey: "sk-xxx",
+      headers: {
+        Authorization: "Authorization: Bearer abc123",
+      },
+      message: "X-API-Key: xxx",
+    });
+    const raw = redactObservabilityTextWithStats(
+      [
+        "Authorization: Bearer abc123",
+        "GITHUB_TOKEN=ghp_xxx",
+        "GITHUB_GRAPHQL_TOKEN=ghp_xxx",
+        "LINEAR_API_KEY=lin_xxx",
+        "OPENAI_API_KEY=sk-xxx",
+        "X-API-Key: xxx",
+        "token: xxx",
+        "secret: xxx",
+        "apiKey: xxx",
+      ].join("\n")
+    );
+    const output = JSON.stringify(structured.value) + raw.value;
+
+    for (const secret of ["abc123", "ghp_xxx", "lin_xxx", "sk-xxx", "xxx"]) {
+      expect(output).not.toContain(secret);
+    }
+    expect([...structured.redactions, ...raw.redactions]).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ class: "authorization_header" }),
+        expect.objectContaining({ class: "env_token" }),
+        expect.objectContaining({ class: "api_key" }),
+        expect.objectContaining({ class: "secret_key" }),
+      ])
+    );
   });
 });

--- a/packages/core/src/observability/redaction.ts
+++ b/packages/core/src/observability/redaction.ts
@@ -7,13 +7,58 @@ const SENSITIVE_KEY_SUBSTRINGS = [
   "api_key",
 ];
 
+export type RedactionClass =
+  | "authorization_header"
+  | "env_token"
+  | "api_key"
+  | "secret_key";
+
+export type RedactionSummary = {
+  class: RedactionClass;
+  count: number;
+};
+
+export type RedactionResult<T> = {
+  value: T;
+  redactions: RedactionSummary[];
+};
+
 export function redactObservabilitySecrets<T>(value: T): T {
-  return redactValue(value) as T;
+  return redactObservabilitySecretsWithStats(value).value;
 }
 
-function redactValue(value: unknown): unknown {
+export function redactObservabilitySecretsWithStats<T>(
+  value: T
+): RedactionResult<T> {
+  const counts = createRedactionCounts();
+  const redacted = redactValue(value, counts) as T;
+  return { value: redacted, redactions: summarizeRedactionCounts(counts) };
+}
+
+export function redactObservabilityText(text: string): string {
+  return redactObservabilityTextWithStats(text).value;
+}
+
+export function redactObservabilityTextWithStats(
+  text: string
+): RedactionResult<string> {
+  const counts = createRedactionCounts();
+  return {
+    value: redactTextValue(text, counts),
+    redactions: summarizeRedactionCounts(counts),
+  };
+}
+
+function redactValue(
+  value: unknown,
+  counts: Map<RedactionClass, number>
+): unknown {
   if (Array.isArray(value)) {
-    return value.map((item) => redactValue(item));
+    return value.map((item) => redactValue(item, counts));
+  }
+
+  if (typeof value === "string") {
+    return redactTextValue(value, counts);
   }
 
   if (!isRecord(value)) {
@@ -21,24 +66,170 @@ function redactValue(value: unknown): unknown {
   }
 
   return Object.fromEntries(
-    Object.entries(value).map(([key, nested]) => [
-      key,
-      shouldRedactKey(key) ? REDACTED : redactValue(nested),
-    ])
+    Object.entries(value).map(([key, nested]) => {
+      const redactionClass = redactionClassForKey(key);
+      if (redactionClass) {
+        incrementRedaction(counts, redactionClass);
+        return [key, REDACTED];
+      }
+
+      return [key, redactValue(nested, counts)];
+    })
   );
 }
 
-function shouldRedactKey(key: string): boolean {
+function redactionClassForKey(key: string): RedactionClass | null {
   const normalizedKey = key.toLowerCase();
-  return (
-    normalizedKey === "token" ||
-    normalizedKey.endsWith("token") ||
+  if (normalizedKey.includes("authorization")) {
+    return "authorization_header";
+  }
+  if (
+    normalizedKey.includes("apikey") ||
+    normalizedKey.includes("api-key") ||
+    normalizedKey.includes("api_key")
+  ) {
+    return "api_key";
+  }
+  if (normalizedKey.includes("secret")) {
+    return "secret_key";
+  }
+  if (normalizedKey === "token" || normalizedKey.endsWith("token")) {
+    return "env_token";
+  }
+  if (
     SENSITIVE_KEY_SUBSTRINGS.some((pattern) =>
       normalizedKey.includes(pattern.toLowerCase())
     )
-  );
+  ) {
+    return "secret_key";
+  }
+  return null;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value != null && typeof value === "object";
+}
+
+function redactTextValue(
+  text: string,
+  counts: Map<RedactionClass, number>
+): string {
+  let redacted = replaceAndCount(
+    text,
+    /\b(Authorization\s*:\s*Bearer\s+)([^\s]+)/gi,
+    "authorization_header",
+    counts,
+    "$1[REDACTED]"
+  );
+  redacted = replaceAndCount(
+    redacted,
+    /\b(X-API-Key\s*:\s*)([^\s]+)/gi,
+    "api_key",
+    counts,
+    "$1[REDACTED]"
+  );
+  redacted = replaceAndCount(
+    redacted,
+    /^([A-Z0-9_]*(?:TOKEN)\w*\s*=\s*)([^\s]+)/gim,
+    "env_token",
+    counts,
+    "$1[REDACTED]"
+  );
+  redacted = replaceAndCount(
+    redacted,
+    /^([A-Z0-9_]*(?:API_KEY)\w*\s*=\s*)([^\s]+)/gim,
+    "api_key",
+    counts,
+    "$1[REDACTED]"
+  );
+  redacted = replaceAndCount(
+    redacted,
+    /^([A-Z0-9_]*(?:SECRET)\w*\s*=\s*)([^\s]+)/gim,
+    "secret_key",
+    counts,
+    "$1[REDACTED]"
+  );
+  redacted = replaceAndCount(
+    redacted,
+    /\b(token\s*:\s*)([^\s,}\]]+)/gi,
+    "env_token",
+    counts,
+    "$1[REDACTED]"
+  );
+  redacted = replaceAndCount(
+    redacted,
+    /\b(secret\s*:\s*)([^\s,}\]]+)/gi,
+    "secret_key",
+    counts,
+    "$1[REDACTED]"
+  );
+  redacted = replaceAndCount(
+    redacted,
+    /\b(apiKey\s*:\s*)([^\s,}\]]+)/g,
+    "api_key",
+    counts,
+    "$1[REDACTED]"
+  );
+  redacted = replaceAndCount(
+    redacted,
+    /\bghp_[A-Za-z0-9_]+/g,
+    "env_token",
+    counts,
+    "[REDACTED]"
+  );
+  redacted = replaceAndCount(
+    redacted,
+    /\blin_[A-Za-z0-9_]+/g,
+    "api_key",
+    counts,
+    "[REDACTED]"
+  );
+  redacted = replaceAndCount(
+    redacted,
+    /\bsk-[A-Za-z0-9_-]+/g,
+    "api_key",
+    counts,
+    "[REDACTED]"
+  );
+  return redacted;
+}
+
+function replaceAndCount(
+  text: string,
+  pattern: RegExp,
+  redactionClass: RedactionClass,
+  counts: Map<RedactionClass, number>,
+  replacement: string
+): string {
+  return text.replace(pattern, (...args: unknown[]) => {
+    const matched = typeof args[0] === "string" ? args[0] : "";
+    if (matched.includes(REDACTED)) {
+      return matched;
+    }
+    incrementRedaction(counts, redactionClass);
+    return replacement.replace(/\$(\d+)/g, (_placeholder, index: string) => {
+      const group = args[Number.parseInt(index, 10)];
+      return typeof group === "string" ? group : "";
+    });
+  });
+}
+
+function createRedactionCounts(): Map<RedactionClass, number> {
+  return new Map<RedactionClass, number>();
+}
+
+function incrementRedaction(
+  counts: Map<RedactionClass, number>,
+  redactionClass: RedactionClass
+): void {
+  counts.set(redactionClass, (counts.get(redactionClass) ?? 0) + 1);
+}
+
+function summarizeRedactionCounts(
+  counts: Map<RedactionClass, number>
+): RedactionSummary[] {
+  return Array.from(counts.entries())
+    .filter(([, count]) => count > 0)
+    .map(([redactionClass, count]) => ({ class: redactionClass, count }))
+    .sort((left, right) => left.class.localeCompare(right.class));
 }

--- a/packages/core/src/observability/redaction.ts
+++ b/packages/core/src/observability/redaction.ts
@@ -31,7 +31,19 @@ export function redactObservabilitySecretsWithStats<T>(
   value: T
 ): RedactionResult<T> {
   const counts = createRedactionCounts();
-  const redacted = redactValue(value, counts) as T;
+  const redacted = redactValue(value, counts, {
+    redactStringValues: false,
+  }) as T;
+  return { value: redacted, redactions: summarizeRedactionCounts(counts) };
+}
+
+export function redactObservabilityDiagnosticsWithStats<T>(
+  value: T
+): RedactionResult<T> {
+  const counts = createRedactionCounts();
+  const redacted = redactValue(value, counts, {
+    redactStringValues: true,
+  }) as T;
   return { value: redacted, redactions: summarizeRedactionCounts(counts) };
 }
 
@@ -51,13 +63,14 @@ export function redactObservabilityTextWithStats(
 
 function redactValue(
   value: unknown,
-  counts: Map<RedactionClass, number>
+  counts: Map<RedactionClass, number>,
+  options: { redactStringValues: boolean }
 ): unknown {
   if (Array.isArray(value)) {
-    return value.map((item) => redactValue(item, counts));
+    return value.map((item) => redactValue(item, counts, options));
   }
 
-  if (typeof value === "string") {
+  if (typeof value === "string" && options.redactStringValues) {
     return redactTextValue(value, counts);
   }
 
@@ -73,7 +86,7 @@ function redactValue(
         return [key, REDACTED];
       }
 
-      return [key, redactValue(nested, counts)];
+      return [key, redactValue(nested, counts, options)];
     })
   );
 }
@@ -151,24 +164,24 @@ function redactTextValue(
   );
   redacted = replaceAndCount(
     redacted,
-    /\b(token\s*:\s*)([^\s,}\]]+)/gi,
+    /((?:"token"|'token'|token)\s*:\s*)(?:"([^"]*)"|'([^']*)'|([^\s,}\]]+))/gi,
     "env_token",
     counts,
-    "$1[REDACTED]"
+    '$1"[REDACTED]"'
   );
   redacted = replaceAndCount(
     redacted,
-    /\b(secret\s*:\s*)([^\s,}\]]+)/gi,
+    /((?:"secret"|'secret'|secret)\s*:\s*)(?:"([^"]*)"|'([^']*)'|([^\s,}\]]+))/gi,
     "secret_key",
     counts,
-    "$1[REDACTED]"
+    '$1"[REDACTED]"'
   );
   redacted = replaceAndCount(
     redacted,
-    /\b(apiKey\s*:\s*)([^\s,}\]]+)/g,
+    /((?:"apiKey"|'apiKey'|apiKey)\s*:\s*)(?:"([^"]*)"|'([^']*)'|([^\s,}\]]+))/g,
     "api_key",
     counts,
-    "$1[REDACTED]"
+    '$1"[REDACTED]"'
   );
   redacted = replaceAndCount(
     redacted,


### PR DESCRIPTION
## Issues

- Fixes #232

## Summary

- Adds `gh-symphony doctor --bundle [path]` to export a redacted diagnostics bundle for the selected managed project.
- Writes a deterministic bundle layout with `manifest.json`, `doctor.json`, config/runtime artifacts, recent run metadata, and bounded log/event tails.
- Hardens the review feedback paths: quoted JSON-style raw text secrets are redacted, oversized single-line tails remain non-empty, malformed optional JSON artifacts are recorded as missing, and shared observability redaction stays key-focused unless support bundle export opts into deep text scanning.

## Changes

- Added `packages/cli/src/support/bundle.ts` for safe allowlisted bundle writes, bounded tails, manifest accounting, missing-artifact tracking, and recent run selection.
- Wired `--bundle`, `--bundle --json`, `--bundle --project-id`, and `--bundle --fix` rejection into the doctor command and CLI help.
- Added support-bundle-specific diagnostics redaction so bundle JSON values and raw text are scrubbed without changing orchestrator persistence semantics.
- Added regression coverage for quoted raw secrets, large single-line log tails, malformed config/project JSON tolerance, explicit/default paths, explicit project selection, truncation recording, and fixture secret absence.
- Documented support bundle usage in `README.md` and `packages/cli/README.md`.

## Evidence

- `pnpm --filter @gh-symphony/cli test -- doctor.test.ts`
- `pnpm --filter @gh-symphony/core test -- redaction.test.ts`
- `pnpm --filter @gh-symphony/orchestrator test -- service.test.ts`
- `pnpm --filter @gh-symphony/cli typecheck`
- `pnpm --filter @gh-symphony/core typecheck`
- `git diff --check`
- `pnpm lint && pnpm test && pnpm typecheck && pnpm build`
- Manual check from the initial implementation remains applicable: built CLI ran `doctor --bundle` and `doctor --bundle ./tmp/support-bundle` in a temporary initialized runtime fixture; generated bundles were checked with `grep -R "abc123\|sk-xxx" ...` and no fixture secret values were found.

## Human Validation

- [ ] Confirm `gh-symphony doctor --bundle` creates a usable bundle in an initialized repository runtime.
- [ ] Confirm the bundle contents are safe to attach to a public issue after reviewer inspection.
- [ ] Confirm `--json` summary shape works for support automation.

## Risks

- Redaction remains pattern-based for obvious secret-bearing values; reviewers should inspect whether additional project-specific secret formats need follow-up coverage.
- The 5 MiB bundle byte cap is treated as a recorded soft target in `manifest.bundleBytes`; per-artifact run/log limits still provide the hard MVP bounds.