### PR TITLE
feat(cli): warn on priority mapping drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,57 @@ The generated skill files (under `.codex/skills/` or `.claude/skills/`) define h
 
 > Currently supported runtimes: **Codex**, **Claude Code**
 
+#### Explicit GitHub Priority Mapping
+
+GitHub Project V2 priority is repository policy in `WORKFLOW.md`. The runtime uses exactly one configured source and never falls back or guesses renamed labels, Project fields, or option values. Anything unmapped resolves to `priority = null`.
+
+Use a Project single-select field:
+
+```yaml
+tracker:
+  kind: github-project
+  project_id: PVT_kwDOxxxxxx
+  state_field: Status
+  priority:
+    source: project-field
+    field: Priority
+    values:
+      Urgent: 0
+      High: 1
+      Medium: 2
+      Low: 3
+```
+
+Or use exact repository labels:
+
+```yaml
+tracker:
+  kind: github-project
+  project_id: PVT_kwDOxxxxxx
+  state_field: Status
+  priority:
+    source: labels
+    labels:
+      P0: 0
+      P1: 1
+      P2: 2
+```
+
+Or disable priority dispatch explicitly:
+
+```yaml
+tracker:
+  kind: github-project
+  priority:
+    source: disabled
+```
+
+Lower numbers dispatch first. If an issue has multiple configured priority labels, Symphony uses the lowest numeric value and emits `priority.label_conflict_resolved`. If an active issue carries an unmapped configured-source value, it resolves to `priority = null` and emits `priority.unmapped`.
+
+Legacy `tracker.priority_field: Priority` remains supported for existing workflows, but it is deprecated because it uses live Project option order. To migrate, replace it with `tracker.priority.source: project-field`, copy the exact field name, and write explicit option-name-to-number mappings. If both legacy and explicit config are present, explicit `tracker.priority` wins and diagnostics warn about the conflict.
+
+`gh-symphony workflow validate` reports local config errors and legacy priority warnings. `gh-symphony doctor` additionally checks live Project/repository drift: missing fields, missing labels, unmapped live options, stale configured mappings, and active issues that currently resolve to `priority = null` because their priority-like value is unmapped.
+
 ### 4. Set Orchestrator Runner (Repository)
 
 From inside the cloned repository that should run orchestration, initialize the workflow and repository runtime:

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -107,6 +107,56 @@ You can further customize the agent's behavior by editing `WORKFLOW.md` — this
 
 > Currently supported runtimes: **Codex**, **Claude Code**
 
+### Explicit Priority Mapping
+
+GitHub Project V2 does not have a native issue priority. For GitHub Project workflows, dispatch priority is controlled only by the explicit `tracker.priority` policy in `WORKFLOW.md`; there is no fallback from Project fields to labels and no guessed label naming convention. Unmapped values resolve to `priority = null`, so dispatch falls back to created time and identifier.
+
+Project field source:
+
+```yaml
+tracker:
+  kind: github-project
+  project_id: PVT_kwDOxxxxxx
+  state_field: Status
+  priority:
+    source: project-field
+    field: Priority
+    values:
+      Urgent: 0
+      High: 1
+      Medium: 2
+      Low: 3
+```
+
+Label source:
+
+```yaml
+tracker:
+  kind: github-project
+  project_id: PVT_kwDOxxxxxx
+  state_field: Status
+  priority:
+    source: labels
+    labels:
+      P0: 0
+      P1: 1
+      P2: 2
+      P3: 3
+```
+
+Disabled:
+
+```yaml
+tracker:
+  kind: github-project
+  priority:
+    source: disabled
+```
+
+Legacy `tracker.priority_field: Priority` still works, but it is deprecated because it derives numeric priority from the live Project option order. Migrate by copying the field name into `tracker.priority.field` and writing each option display name under `values` with the intended number. If both keys are present, `tracker.priority` wins and `gh-symphony doctor` reports a warning.
+
+Run `gh-symphony workflow validate` for local schema errors and `gh-symphony doctor` for live drift warnings such as missing Project fields, missing labels, unmapped live options, stale mappings, and active issues whose priority-like value resolves to `priority = null`.
+
 ### Linear Tracker Repositories
 
 For Linear, configure the tracker in `WORKFLOW.md` and initialize the repository runtime from the target GitHub repository:

--- a/packages/cli/src/commands/doctor.test.ts
+++ b/packages/cli/src/commands/doctor.test.ts
@@ -2416,7 +2416,7 @@ describe("doctor command handler", () => {
         fetchProjectIssues: (async () => [
           createTrackedIssue({
             state: "In progress",
-            labels: ["P0", "P1", "P2"],
+            labels: ["p0", "p1", "p2"],
           }),
         ]) as never,
         pathEnv,
@@ -2443,6 +2443,9 @@ describe("doctor command handler", () => {
         expect.objectContaining({
           status: "warn",
           title: "Active issues with unmapped priority labels",
+          details: {
+            activeUnmapped: [{ issue: "acme/widgets#1", labels: ["p2"] }],
+          },
         }),
       ])
     );
@@ -2474,7 +2477,7 @@ describe("doctor command handler", () => {
         fetchProjectIssues: (async () => [
           createTrackedIssue({
             state: "In progress",
-            labels: ["P0", "P1", "P2"],
+            labels: ["p0", "p1", "p2"],
           }),
         ]) as never,
         pathEnv,
@@ -2498,6 +2501,9 @@ describe("doctor command handler", () => {
         expect.objectContaining({
           status: "warn",
           title: "Active issues with unmapped priority labels",
+          details: {
+            activeUnmapped: [{ issue: "acme/widgets#1", labels: ["p2"] }],
+          },
         }),
       ])
     );
@@ -2505,6 +2511,57 @@ describe("doctor command handler", () => {
       expect.arrayContaining([
         expect.objectContaining({ title: "Missing configured priority labels" }),
         expect.objectContaining({ title: "Stale priority label mappings" }),
+      ])
+    );
+  });
+
+  it("does not report mapped priority labels as unmapped when active issue labels are normalized", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "doctor-config-"));
+    const workspaceDir = join(configDir, "workspaces");
+    await prepareDoctorPaths(configDir, workspaceDir);
+    const { repoDir, pathEnv } = await createWorkflowFixture();
+    await writeFile(
+      join(repoDir, "WORKFLOW.md"),
+      "---\ntracker:\n  kind: github-project\n  priority:\n    source: labels\n    labels:\n      P0: 0\n      P1: 1\ncodex:\n  command: fake-agent\n---\nPrompt body\n",
+      "utf8"
+    );
+
+    const report = await withCwd(repoDir, () =>
+      runDoctorDiagnostics(baseOptions(configDir), [], {
+        ...authDependencies(),
+        inspectManagedProjectSelection: async () => ({
+          kind: "resolved",
+          projectId: "tenant-a",
+          projectConfig: createProjectConfig(workspaceDir),
+        }),
+        getProjectDetail: (async () => createProjectDetail() as never) as never,
+        listRepositoryLabels: (async () => [{ name: "P0" }, { name: "P1" }]) as never,
+        fetchProjectIssues: (async () => [
+          createTrackedIssue({
+            state: "In progress",
+            labels: ["p0"],
+          }),
+        ]) as never,
+        pathEnv,
+      })
+    );
+
+    const priorityChecks = report.checks.filter(
+      (check) => check.id === "priority_mapping"
+    );
+    expect(report.ok).toBe(true);
+    expect(priorityChecks).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          title: "Active issues with unmapped priority labels",
+        }),
+      ])
+    );
+    expect(priorityChecks).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          title: "Active issues with multiple priority labels",
+        }),
       ])
     );
   });

--- a/packages/cli/src/commands/doctor.test.ts
+++ b/packages/cli/src/commands/doctor.test.ts
@@ -1726,4 +1726,247 @@ describe("doctor command handler", () => {
       }),
     });
   });
+
+  it("warns for legacy-only priority_field without failing doctor", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "doctor-config-"));
+    const workspaceDir = join(configDir, "workspaces");
+    await prepareDoctorPaths(configDir, workspaceDir);
+    const { repoDir, pathEnv } = await createWorkflowFixture();
+    await writeFile(
+      join(repoDir, "WORKFLOW.md"),
+      "---\ntracker:\n  kind: github-project\n  priority_field: Priority\ncodex:\n  command: fake-agent\n---\nPrompt body\n",
+      "utf8"
+    );
+
+    const report = await withCwd(repoDir, () =>
+      runDoctorDiagnostics(baseOptions(configDir), [], {
+        ...authDependencies(),
+        inspectManagedProjectSelection: async () => ({
+          kind: "resolved",
+          projectId: "tenant-a",
+          projectConfig: createProjectConfig(workspaceDir),
+        }),
+        getProjectDetail: (async () => createProjectDetail() as never) as never,
+        pathEnv,
+      })
+    );
+
+    expect(report.ok).toBe(true);
+    expect(
+      report.checks.find(
+        (check) =>
+          check.id === "priority_mapping" &&
+          check.title === "Legacy priority mapping"
+      )
+    ).toMatchObject({
+      status: "warn",
+      summary: expect.stringContaining("deprecated"),
+    });
+  });
+
+  it("warns that explicit priority wins over legacy priority_field", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "doctor-config-"));
+    const workspaceDir = join(configDir, "workspaces");
+    await prepareDoctorPaths(configDir, workspaceDir);
+    const { repoDir, pathEnv } = await createWorkflowFixture();
+    await writeFile(
+      join(repoDir, "WORKFLOW.md"),
+      "---\ntracker:\n  kind: github-project\n  priority_field: Priority\n  priority:\n    source: disabled\ncodex:\n  command: fake-agent\n---\nPrompt body\n",
+      "utf8"
+    );
+
+    const report = await withCwd(repoDir, () =>
+      runDoctorDiagnostics(baseOptions(configDir), [], {
+        ...authDependencies(),
+        inspectManagedProjectSelection: async () => ({
+          kind: "resolved",
+          projectId: "tenant-a",
+          projectConfig: createProjectConfig(workspaceDir),
+        }),
+        getProjectDetail: (async () => createProjectDetail() as never) as never,
+        pathEnv,
+      })
+    );
+
+    expect(report.ok).toBe(true);
+    expect(
+      report.checks.find(
+        (check) =>
+          check.id === "priority_mapping" &&
+          check.title === "Priority mapping precedence"
+      )
+    ).toMatchObject({
+      status: "warn",
+      summary: expect.stringContaining("explicit tracker.priority wins"),
+    });
+  });
+
+  it("warns for project-field priority drift without failing doctor", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "doctor-config-"));
+    const workspaceDir = join(configDir, "workspaces");
+    await prepareDoctorPaths(configDir, workspaceDir);
+    const { repoDir, pathEnv } = await createWorkflowFixture();
+    await writeFile(
+      join(repoDir, "WORKFLOW.md"),
+      "---\ntracker:\n  kind: github-project\n  priority:\n    source: project-field\n    field: Priority\n    values:\n      High: 1\n      Missing: 2\ncodex:\n  command: fake-agent\n---\nPrompt body\n",
+      "utf8"
+    );
+
+    const report = await withCwd(repoDir, () =>
+      runDoctorDiagnostics(baseOptions(configDir), [], {
+        ...authDependencies(),
+        inspectManagedProjectSelection: async () => ({
+          kind: "resolved",
+          projectId: "tenant-a",
+          projectConfig: createProjectConfig(workspaceDir),
+        }),
+        getProjectDetail: (async () =>
+          ({
+            ...createProjectDetail(),
+            statusFields: [
+              {
+                id: "priority",
+                name: "Priority",
+                options: [
+                  { id: "p0", name: "High", description: null, color: null },
+                  { id: "p1", name: "Low", description: null, color: null },
+                ],
+              },
+            ],
+          }) as never) as never,
+        fetchProjectIssues: (async () => [
+          createTrackedIssue({
+            state: "In progress",
+            priority: null,
+            metadata: { Priority: "Low" },
+          }),
+        ]) as never,
+        pathEnv,
+      })
+    );
+
+    expect(report.ok).toBe(true);
+    expect(
+      report.checks.filter((check) => check.id === "priority_mapping")
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          status: "warn",
+          title: "Unmapped priority Project options",
+        }),
+        expect.objectContaining({
+          status: "warn",
+          title: "Missing priority Project options",
+        }),
+        expect.objectContaining({
+          status: "warn",
+          title: "Active issues with unmapped priority values",
+        }),
+      ])
+    );
+  });
+
+  it("warns when the configured priority Project field is missing", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "doctor-config-"));
+    const workspaceDir = join(configDir, "workspaces");
+    await prepareDoctorPaths(configDir, workspaceDir);
+    const { repoDir, pathEnv } = await createWorkflowFixture();
+    await writeFile(
+      join(repoDir, "WORKFLOW.md"),
+      "---\ntracker:\n  kind: github-project\n  priority:\n    source: project-field\n    field: Priority\n    values:\n      High: 1\ncodex:\n  command: fake-agent\n---\nPrompt body\n",
+      "utf8"
+    );
+
+    const report = await withCwd(repoDir, () =>
+      runDoctorDiagnostics(baseOptions(configDir), [], {
+        ...authDependencies(),
+        inspectManagedProjectSelection: async () => ({
+          kind: "resolved",
+          projectId: "tenant-a",
+          projectConfig: createProjectConfig(workspaceDir),
+        }),
+        getProjectDetail: (async () =>
+          ({
+            ...createProjectDetail(),
+            statusFields: [
+              {
+                id: "severity",
+                name: "Severity",
+                options: [],
+              },
+            ],
+          }) as never) as never,
+        fetchProjectIssues: (async () => []) as never,
+        pathEnv,
+      })
+    );
+
+    expect(report.ok).toBe(true);
+    expect(
+      report.checks.find(
+        (check) =>
+          check.id === "priority_mapping" &&
+          check.title === "Priority Project field drift"
+      )
+    ).toMatchObject({
+      status: "warn",
+      summary: expect.stringContaining("was not found"),
+    });
+  });
+
+  it("warns for label priority drift and active label conflicts", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "doctor-config-"));
+    const workspaceDir = join(configDir, "workspaces");
+    await prepareDoctorPaths(configDir, workspaceDir);
+    const { repoDir, pathEnv } = await createWorkflowFixture();
+    await writeFile(
+      join(repoDir, "WORKFLOW.md"),
+      "---\ntracker:\n  kind: github-project\n  priority:\n    source: labels\n    labels:\n      P0: 0\n      P1: 1\n      P9: 9\ncodex:\n  command: fake-agent\n---\nPrompt body\n",
+      "utf8"
+    );
+
+    const report = await withCwd(repoDir, () =>
+      runDoctorDiagnostics(baseOptions(configDir), [], {
+        ...authDependencies(),
+        inspectManagedProjectSelection: async () => ({
+          kind: "resolved",
+          projectId: "tenant-a",
+          projectConfig: createProjectConfig(workspaceDir),
+        }),
+        getProjectDetail: (async () => createProjectDetail() as never) as never,
+        listRepositoryLabels: (async () => [{ name: "P0" }, { name: "P1" }]) as never,
+        fetchProjectIssues: (async () => [
+          createTrackedIssue({
+            state: "In progress",
+            labels: ["P0", "P1", "P2"],
+          }),
+        ]) as never,
+        pathEnv,
+      })
+    );
+
+    expect(report.ok).toBe(true);
+    expect(
+      report.checks.filter((check) => check.id === "priority_mapping")
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          status: "warn",
+          title: "Missing configured priority labels",
+        }),
+        expect.objectContaining({
+          status: "warn",
+          title: "Stale priority label mappings",
+        }),
+        expect.objectContaining({
+          status: "warn",
+          title: "Active issues with multiple priority labels",
+        }),
+        expect.objectContaining({
+          status: "warn",
+          title: "Active issues with unmapped priority labels",
+        }),
+      ])
+    );
+  });
 });

--- a/packages/cli/src/commands/doctor.test.ts
+++ b/packages/cli/src/commands/doctor.test.ts
@@ -1969,4 +1969,65 @@ describe("doctor command handler", () => {
       ])
     );
   });
+
+  it("does not report stale label drift when repository labels cannot be read", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "doctor-config-"));
+    const workspaceDir = join(configDir, "workspaces");
+    await prepareDoctorPaths(configDir, workspaceDir);
+    const { repoDir, pathEnv } = await createWorkflowFixture();
+    await writeFile(
+      join(repoDir, "WORKFLOW.md"),
+      "---\ntracker:\n  kind: github-project\n  priority:\n    source: labels\n    labels:\n      P0: 0\n      P1: 1\ncodex:\n  command: fake-agent\n---\nPrompt body\n",
+      "utf8"
+    );
+
+    const report = await withCwd(repoDir, () =>
+      runDoctorDiagnostics(baseOptions(configDir), [], {
+        ...authDependencies(),
+        inspectManagedProjectSelection: async () => ({
+          kind: "resolved",
+          projectId: "tenant-a",
+          projectConfig: createProjectConfig(workspaceDir),
+        }),
+        getProjectDetail: (async () => createProjectDetail() as never) as never,
+        listRepositoryLabels: (async () => {
+          throw new Error("labels unavailable");
+        }) as never,
+        fetchProjectIssues: (async () => [
+          createTrackedIssue({
+            state: "In progress",
+            labels: ["P0", "P1", "P2"],
+          }),
+        ]) as never,
+        pathEnv,
+      })
+    );
+
+    const priorityChecks = report.checks.filter(
+      (check) => check.id === "priority_mapping"
+    );
+    expect(report.ok).toBe(true);
+    expect(priorityChecks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          status: "warn",
+          title: "Priority label drift",
+        }),
+        expect.objectContaining({
+          status: "warn",
+          title: "Active issues with multiple priority labels",
+        }),
+        expect.objectContaining({
+          status: "warn",
+          title: "Active issues with unmapped priority labels",
+        }),
+      ])
+    );
+    expect(priorityChecks).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ title: "Missing configured priority labels" }),
+        expect.objectContaining({ title: "Stale priority label mappings" }),
+      ])
+    );
+  });
 });

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -23,6 +23,7 @@ import {
   findLinkedRepository,
   getProjectDetail,
   GitHubApiError,
+  listRepositoryLabels,
   type ProjectDetail,
 } from "../github/client.js";
 import {
@@ -40,6 +41,10 @@ import {
 } from "../github/gh-auth.js";
 import type { GlobalOptions } from "../index.js";
 import { resolveRuntimeRoot } from "../orchestrator-runtime.js";
+import {
+  buildPriorityConfigDiagnostics,
+  buildPriorityDriftDiagnostics,
+} from "../priority-diagnostics.js";
 import { inspectManagedProjectSelection } from "../project-selection.js";
 import {
   parseIssueReference,
@@ -67,6 +72,7 @@ type DoctorCheckId =
   | "smoke_issue"
   | "workflow_prompt_render"
   | "workflow_hooks"
+  | "priority_mapping"
   | "claude_binary"
   | "anthropic_api_key"
   | "claude_mcp_config";
@@ -160,6 +166,7 @@ export type DoctorDependencies = {
   inspectManagedProjectSelection: typeof inspectManagedProjectSelection;
   createClient: typeof createClient;
   getProjectDetail: typeof getProjectDetail;
+  listRepositoryLabels: typeof listRepositoryLabels;
   fetchProjectIssues: typeof fetchGithubProjectIssues;
   fetchProjectIssue: typeof fetchGithubProjectIssueByRepositoryAndNumber;
   readFile: typeof readFile;
@@ -192,6 +199,7 @@ const DEFAULT_DEPENDENCIES: DoctorDependencies = {
   inspectManagedProjectSelection,
   createClient,
   getProjectDetail,
+  listRepositoryLabels,
   fetchProjectIssues: fetchGithubProjectIssues,
   fetchProjectIssue: fetchGithubProjectIssueByRepositoryAndNumber,
   readFile,
@@ -645,6 +653,7 @@ function buildGithubTrackerConfig(input: {
     apiUrl: input.projectConfig.projectConfig.tracker.apiUrl,
     lifecycle: input.workflow.lifecycle,
     assignedOnly: settings?.assignedOnly === true,
+    priority: input.workflow.tracker.priority,
     priorityFieldName:
       typeof settings?.priorityFieldName === "string"
         ? settings.priorityFieldName
@@ -652,6 +661,168 @@ function buildGithubTrackerConfig(input: {
     timeoutMs:
       typeof settings?.timeoutMs === "number" ? settings.timeoutMs : undefined,
   };
+}
+
+async function buildPriorityMappingChecks(input: {
+  auth: ResolvedGitHubAuth | null;
+  selection: Awaited<ReturnType<typeof inspectManagedProjectSelection>> | null;
+  workflow: WorkflowCheckState;
+  projectDetail: ProjectDetail | null;
+  projectBindingId: string | null;
+  deps: DoctorDependencies;
+}): Promise<DoctorCheckResult[]> {
+  if (input.workflow.status !== "pass") {
+    return [];
+  }
+
+  const configDiagnostics = buildPriorityConfigDiagnostics(
+    input.workflow.workflow
+  );
+  const checks = configDiagnostics.map((diagnostic) =>
+    warnCheck(
+      "priority_mapping",
+      diagnostic.title,
+      diagnostic.summary,
+      diagnostic.remediation,
+      diagnostic.details
+    )
+  );
+
+  const priority = input.workflow.workflow.tracker.priority;
+  const parsedWorkflow = input.workflow.workflow;
+  if (
+    input.workflow.workflow.tracker.kind !== "github-project" ||
+    !priority ||
+    priority.source === "disabled"
+  ) {
+    if (checks.length === 0) {
+      checks.push(
+        passCheck(
+          "priority_mapping",
+          "Priority mapping",
+          priority?.source === "disabled"
+            ? "Explicit priority mapping is disabled; dispatch priority resolves to null."
+            : "No explicit priority mapping drift checks are required.",
+          { source: priority?.source ?? null }
+        )
+      );
+    }
+    return checks;
+  }
+
+  if (
+    !input.auth ||
+    !input.selection ||
+    input.selection.kind !== "resolved" ||
+    !input.projectDetail ||
+    !input.projectBindingId
+  ) {
+    checks.push(
+      warnCheck(
+        "priority_mapping",
+        "Priority mapping drift",
+        "Live priority mapping drift checks could not run because GitHub authentication, managed project selection, or project resolution is unavailable.",
+        "Fix the prerequisite doctor checks, then re-run 'gh-symphony doctor'.",
+        {
+          blockedBy: [
+            ...(!input.auth ? ["gh_authentication"] : []),
+            ...(!input.selection || input.selection.kind !== "resolved"
+              ? ["managed_project"]
+              : []),
+            ...(!input.projectDetail || !input.projectBindingId
+              ? ["github_project_resolution"]
+              : []),
+          ],
+        }
+      )
+    );
+    return checks;
+  }
+
+  const client = input.deps.createClient(input.auth.token, {
+    apiUrl: input.selection.projectConfig.tracker.apiUrl,
+  });
+  let repositoryLabels: Array<{ repository: string; labels: string[] }> = [];
+  if (priority.source === "labels") {
+    try {
+      repositoryLabels = await Promise.all(
+        input.projectDetail.linkedRepositories.map(async (repository) => ({
+          repository: `${repository.owner}/${repository.name}`,
+          labels: (
+            await input.deps.listRepositoryLabels(
+              client,
+              repository.owner,
+              repository.name
+            )
+          ).map((label) => label.name),
+        }))
+      );
+    } catch (error) {
+      checks.push(
+        warnCheck(
+          "priority_mapping",
+          "Priority label drift",
+          "Live repository labels could not be read for priority mapping drift checks.",
+          "Confirm GitHub token repository access and re-run 'gh-symphony doctor'.",
+          { error: formatSmokeError(error) }
+        )
+      );
+    }
+  }
+
+  let activeIssues: TrackedIssue[] = [];
+  try {
+    const trackerConfig = buildGithubTrackerConfig({
+      projectConfig: input.selection,
+      bindingId: input.projectBindingId,
+      token: input.auth.token,
+      workflow: input.workflow.workflow,
+    });
+    activeIssues = (await input.deps.fetchProjectIssues(trackerConfig)).filter(
+      (issue) => isActiveSmokeIssue(issue, parsedWorkflow)
+    );
+  } catch (error) {
+    checks.push(
+      warnCheck(
+        "priority_mapping",
+        "Active priority drift",
+        "Active issues could not be read for priority mapping drift checks.",
+        "Confirm GitHub token scopes, project visibility, and network access, then re-run 'gh-symphony doctor'.",
+        { error: formatSmokeError(error) }
+      )
+    );
+  }
+
+  const driftDiagnostics = buildPriorityDriftDiagnostics({
+    workflow: parsedWorkflow,
+    projectDetail: input.projectDetail,
+    repositoryLabels,
+    activeIssues,
+  });
+  checks.push(
+    ...driftDiagnostics.map((diagnostic) =>
+      warnCheck(
+        "priority_mapping",
+        diagnostic.title,
+        diagnostic.summary,
+        diagnostic.remediation,
+        diagnostic.details
+      )
+    )
+  );
+
+  if (checks.length === 0) {
+    checks.push(
+      passCheck(
+        "priority_mapping",
+        "Priority mapping",
+        "Explicit priority mapping matches the live Project/repository state inspected by doctor.",
+        { source: priority.source }
+      )
+    );
+  }
+
+  return checks;
 }
 
 function isActiveSmokeIssue(
@@ -1564,6 +1735,17 @@ export async function runDoctorDiagnostics(
       )
     );
   }
+
+  checks.push(
+    ...(await buildPriorityMappingChecks({
+      auth,
+      selection: resolvedProjectConfig,
+      workflow,
+      projectDetail: resolvedGithubProjectDetail,
+      projectBindingId: resolvedGithubProjectBindingId,
+      deps,
+    }))
+  );
 
   if (parsedArgs.smoke) {
     checks.push(

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -742,7 +742,8 @@ async function buildPriorityMappingChecks(input: {
   const client = input.deps.createClient(input.auth.token, {
     apiUrl: input.selection.projectConfig.tracker.apiUrl,
   });
-  let repositoryLabels: Array<{ repository: string; labels: string[] }> = [];
+  let repositoryLabels: Array<{ repository: string; labels: string[] }> | null =
+    priority.source === "labels" ? [] : null;
   if (priority.source === "labels") {
     try {
       repositoryLabels = await Promise.all(
@@ -767,6 +768,7 @@ async function buildPriorityMappingChecks(input: {
           { error: formatSmokeError(error) }
         )
       );
+      repositoryLabels = null;
     }
   }
 

--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -97,6 +97,87 @@ describe("workflow command handler", () => {
     expect(stdout.output()).toContain("active_states=Ready, In progress");
   });
 
+  it("prints a validation warning when legacy priority_field is configured", async () => {
+    const root = await mkdtemp(join(tmpdir(), "workflow-validate-priority-"));
+    const workflowPath = join(root, "WORKFLOW.md");
+    const stdout = captureWrites(process.stdout);
+
+    await writeFile(
+      workflowPath,
+      `---
+tracker:
+  kind: github-project
+  project_id: project-123
+  priority_field: Priority
+codex:
+  command: codex app-server
+---
+Prompt {{ issue.identifier }}
+`,
+      "utf8"
+    );
+
+    try {
+      await workflowCommand(["validate", "--file", workflowPath], {
+        configDir: root,
+        verbose: false,
+        json: false,
+        noColor: false,
+      });
+    } finally {
+      stdout.restore();
+    }
+
+    expect(stdout.output()).toContain("Warnings");
+    expect(stdout.output()).toContain("Legacy priority mapping");
+  });
+
+  it("includes priority precedence warnings in JSON validation output", async () => {
+    const root = await mkdtemp(join(tmpdir(), "workflow-validate-json-"));
+    const workflowPath = join(root, "WORKFLOW.md");
+    const stdout = captureWrites(process.stdout);
+
+    await writeFile(
+      workflowPath,
+      `---
+tracker:
+  kind: github-project
+  project_id: project-123
+  priority_field: Priority
+  priority:
+    source: disabled
+codex:
+  command: codex app-server
+---
+Prompt {{ issue.identifier }}
+`,
+      "utf8"
+    );
+
+    try {
+      await workflowCommand(["validate", "--file", workflowPath], {
+        configDir: root,
+        verbose: false,
+        json: true,
+        noColor: false,
+      });
+    } finally {
+      stdout.restore();
+    }
+
+    const report = JSON.parse(stdout.output()) as {
+      warnings: Array<{ title: string; summary: string }>;
+    };
+    expect(report.warnings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          title: "Priority mapping precedence",
+          summary: expect.stringContaining("explicit tracker.priority wins"),
+        }),
+      ])
+    );
+  });
+
   it("previews a workflow with the built-in sample issue", async () => {
     const root = await mkdtemp(join(tmpdir(), "workflow-preview-"));
     const workflowPath = join(root, "WORKFLOW.md");

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -22,6 +22,10 @@ import {
   validateGitHubToken,
 } from "../github/gh-auth.js";
 import type { GlobalOptions } from "../index.js";
+import {
+  buildPriorityConfigDiagnostics,
+  type PriorityDiagnostic,
+} from "../priority-diagnostics.js";
 import { inspectManagedProjectSelection } from "../project-selection.js";
 import initCommand from "./workflow-init.js";
 
@@ -72,6 +76,7 @@ type WorkflowValidationReport = {
     promptRetry: "pass";
     continuationGuidance: "pass" | "skip";
   };
+  warnings: PriorityDiagnostic[];
   summary: {
     trackerKind: string | null;
     githubProjectId: string | null;
@@ -585,6 +590,7 @@ function formatAuthError(error: GhAuthError | Error): string {
 async function loadLiveIssue(
   issueReference: string,
   projectId: string | undefined,
+  workflow: ReturnType<typeof parseWorkflowMarkdown>,
   options: GlobalOptions
 ): Promise<{
   issue: TrackedIssue;
@@ -657,6 +663,7 @@ async function loadLiveIssue(
       apiUrl: selection.projectConfig.tracker.apiUrl,
       assignedOnly:
         selection.projectConfig.tracker.settings?.assignedOnly === true,
+      priority: workflow.tracker.priority,
       priorityFieldName:
         typeof selection.projectConfig.tracker.settings?.priorityFieldName ===
         "string"
@@ -791,6 +798,7 @@ function validateWorkflow(
       promptRetry: "pass",
       continuationGuidance: continuationGuidanceStatus,
     },
+    warnings: buildPriorityConfigDiagnostics(workflow),
     summary: {
       trackerKind: workflow.tracker.kind,
       githubProjectId: workflow.githubProjectId,
@@ -862,6 +870,15 @@ Hooks
   before_remove=${report.summary.hooks.beforeRemove ?? "unset"}
   hooks.timeout_ms=${report.summary.hooks.timeoutMs}
 `);
+  if (report.warnings.length > 0) {
+    process.stdout.write("\nWarnings\n");
+    for (const warning of report.warnings) {
+      process.stdout.write(`  ${warning.title}: ${warning.summary}\n`);
+      if (warning.remediation) {
+        process.stdout.write(`    Fix: ${warning.remediation}\n`);
+      }
+    }
+  }
 }
 
 async function runValidate(
@@ -904,7 +921,7 @@ async function runPreview(
   const { issue, sampleSource } = flags.issue
     ? workflow.tracker.kind === "linear"
       ? await loadLinearIssue(flags.issue, workflow, options)
-      : await loadLiveIssue(flags.issue, flags.projectId, options)
+      : await loadLiveIssue(flags.issue, flags.projectId, workflow, options)
     : await loadSampleIssue(flags.sample);
   const renderedPrompt = renderIssueWorkflowPreview({
     workflow,

--- a/packages/cli/src/github/client.ts
+++ b/packages/cli/src/github/client.ts
@@ -56,6 +56,10 @@ export type RepositoryLookupResult = LinkedRepository & {
   visibility: "public" | "private" | "internal" | null;
 };
 
+export type RepositoryLabel = {
+  name: string;
+};
+
 export type ProjectTextField = {
   id: string;
   name: string;
@@ -241,6 +245,54 @@ export async function getRepositoryMetadata(
     visibility:
       repo.visibility ?? (repo.private === true ? "private" : "public"),
   };
+}
+
+export async function listRepositoryLabels(
+  client: GitHubClient,
+  owner: string,
+  name: string
+): Promise<RepositoryLabel[]> {
+  const restUrl = client.apiUrl.replace("/graphql", "");
+  const baseUrl = restUrl === client.apiUrl ? REST_API_URL : restUrl;
+  const labels: RepositoryLabel[] = [];
+  let page = 1;
+
+  while (true) {
+    const response = await client.fetchImpl(
+      `${baseUrl}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(name)}/labels?per_page=100&page=${page}`,
+      {
+        headers: {
+          authorization: `Bearer ${client.token}`,
+          accept: "application/vnd.github+json",
+        },
+      }
+    );
+
+    if (!response.ok) {
+      const payload = (await response.json().catch(() => null)) as {
+        message?: string;
+      } | null;
+      const message = payload?.message?.trim() || response.statusText;
+      throw new GitHubApiError(
+        `GitHub label lookup failed for ${owner}/${name}: ${response.status} ${message}`.trim(),
+        response.status
+      );
+    }
+
+    const pageLabels = (await response.json()) as Array<{ name?: string }>;
+    labels.push(
+      ...pageLabels.flatMap((label) =>
+        typeof label.name === "string" ? [{ name: label.name }] : []
+      )
+    );
+
+    if (pageLabels.length < 100) {
+      break;
+    }
+    page += 1;
+  }
+
+  return labels;
 }
 
 // ── 2.1: Token validation & scope check ──────────────────────────────────────

--- a/packages/cli/src/priority-diagnostics.ts
+++ b/packages/cli/src/priority-diagnostics.ts
@@ -55,7 +55,7 @@ export function buildPriorityConfigDiagnostics(
 export function buildPriorityDriftDiagnostics(input: {
   workflow: ParsedWorkflow;
   projectDetail: ProjectDetail;
-  repositoryLabels: RepositoryLabelSnapshot[];
+  repositoryLabels: RepositoryLabelSnapshot[] | null;
   activeIssues: TrackedIssue[];
 }): PriorityDiagnostic[] {
   const priority = input.workflow.tracker.priority;
@@ -156,44 +156,46 @@ function buildProjectFieldDriftDiagnostics(input: {
 
 function buildLabelDriftDiagnostics(input: {
   priority: Extract<WorkflowPriorityConfig, { source: "labels" }>;
-  repositoryLabels: RepositoryLabelSnapshot[];
+  repositoryLabels: RepositoryLabelSnapshot[] | null;
   activeIssues: TrackedIssue[];
 }): PriorityDiagnostic[] {
   const diagnostics: PriorityDiagnostic[] = [];
   const configuredLabels = Object.keys(input.priority.labels);
-  const missingByRepository = input.repositoryLabels.flatMap((snapshot) => {
-    const live = new Set(snapshot.labels);
-    const missing = configuredLabels.filter((label) => !live.has(label));
-    return missing.length > 0
-      ? [{ repository: snapshot.repository, missing }]
-      : [];
-  });
-
-  if (missingByRepository.length > 0) {
-    diagnostics.push({
-      title: "Missing configured priority labels",
-      summary:
-        "One or more configured tracker.priority.labels entries are absent from linked repositories.",
-      remediation:
-        "Create the labels in each linked repository, rename the mapping keys to exact live labels, or remove stale mappings.",
-      details: { missingByRepository },
+  if (input.repositoryLabels) {
+    const missingByRepository = input.repositoryLabels.flatMap((snapshot) => {
+      const live = new Set(snapshot.labels);
+      const missing = configuredLabels.filter((label) => !live.has(label));
+      return missing.length > 0
+        ? [{ repository: snapshot.repository, missing }]
+        : [];
     });
-  }
 
-  const liveLabels = new Set(
-    input.repositoryLabels.flatMap((snapshot) => snapshot.labels)
-  );
-  const missingEverywhere = configuredLabels.filter(
-    (label) => !liveLabels.has(label)
-  );
-  if (missingEverywhere.length > 0) {
-    diagnostics.push({
-      title: "Stale priority label mappings",
-      summary: `tracker.priority.labels references label(s) that do not exist in any linked repository: ${missingEverywhere.join(", ")}.`,
-      remediation:
-        "Rename the mapping keys to exact live labels, create those labels, or remove stale mappings.",
-      details: { missingEverywhere },
-    });
+    if (missingByRepository.length > 0) {
+      diagnostics.push({
+        title: "Missing configured priority labels",
+        summary:
+          "One or more configured tracker.priority.labels entries are absent from linked repositories.",
+        remediation:
+          "Create the labels in each linked repository, rename the mapping keys to exact live labels, or remove stale mappings.",
+        details: { missingByRepository },
+      });
+    }
+
+    const liveLabels = new Set(
+      input.repositoryLabels.flatMap((snapshot) => snapshot.labels)
+    );
+    const missingEverywhere = configuredLabels.filter(
+      (label) => !liveLabels.has(label)
+    );
+    if (missingEverywhere.length > 0) {
+      diagnostics.push({
+        title: "Stale priority label mappings",
+        summary: `tracker.priority.labels references label(s) that do not exist in any linked repository: ${missingEverywhere.join(", ")}.`,
+        remediation:
+          "Rename the mapping keys to exact live labels, create those labels, or remove stale mappings.",
+        details: { missingEverywhere },
+      });
+    }
   }
 
   const configuredLabelSet = new Set(configuredLabels);

--- a/packages/cli/src/priority-diagnostics.ts
+++ b/packages/cli/src/priority-diagnostics.ts
@@ -1,0 +1,237 @@
+import type {
+  ParsedWorkflow,
+  TrackedIssue,
+  WorkflowPriorityConfig,
+} from "@gh-symphony/core";
+import type { ProjectDetail } from "./github/client.js";
+
+export type PriorityDiagnostic = {
+  title: string;
+  summary: string;
+  remediation?: string;
+  details?: Record<string, unknown>;
+};
+
+type RepositoryLabelSnapshot = {
+  repository: string;
+  labels: string[];
+};
+
+export function buildPriorityConfigDiagnostics(
+  workflow: ParsedWorkflow
+): PriorityDiagnostic[] {
+  const diagnostics: PriorityDiagnostic[] = [];
+
+  if (workflow.tracker.priorityFieldName) {
+    if (workflow.tracker.priority) {
+      diagnostics.push({
+        title: "Priority mapping precedence",
+        summary:
+          "Both legacy tracker.priority_field and explicit tracker.priority are configured; explicit tracker.priority wins.",
+        remediation:
+          "Remove tracker.priority_field after confirming the explicit tracker.priority mapping is correct.",
+        details: {
+          priorityFieldName: workflow.tracker.priorityFieldName,
+          explicitSource: workflow.tracker.priority.source,
+        },
+      });
+    } else {
+      diagnostics.push({
+        title: "Legacy priority mapping",
+        summary:
+          "tracker.priority_field is deprecated and still supported with legacy Project option-order semantics.",
+        remediation:
+          "Migrate to tracker.priority with an explicit project-field, labels, or disabled source.",
+        details: {
+          priorityFieldName: workflow.tracker.priorityFieldName,
+        },
+      });
+    }
+  }
+
+  return diagnostics;
+}
+
+export function buildPriorityDriftDiagnostics(input: {
+  workflow: ParsedWorkflow;
+  projectDetail: ProjectDetail;
+  repositoryLabels: RepositoryLabelSnapshot[];
+  activeIssues: TrackedIssue[];
+}): PriorityDiagnostic[] {
+  const priority = input.workflow.tracker.priority;
+  if (!priority || priority.source === "disabled") {
+    return [];
+  }
+
+  if (priority.source === "project-field") {
+    return buildProjectFieldDriftDiagnostics({
+      priority,
+      projectDetail: input.projectDetail,
+      activeIssues: input.activeIssues,
+    });
+  }
+
+  return buildLabelDriftDiagnostics({
+    priority,
+    repositoryLabels: input.repositoryLabels,
+    activeIssues: input.activeIssues,
+  });
+}
+
+function buildProjectFieldDriftDiagnostics(input: {
+  priority: Extract<WorkflowPriorityConfig, { source: "project-field" }>;
+  projectDetail: ProjectDetail;
+  activeIssues: TrackedIssue[];
+}): PriorityDiagnostic[] {
+  const diagnostics: PriorityDiagnostic[] = [];
+  const field = input.projectDetail.statusFields.find(
+    (candidate) => candidate.name === input.priority.field
+  );
+
+  if (!field) {
+    diagnostics.push({
+      title: "Priority Project field drift",
+      summary: `Configured priority field "${input.priority.field}" was not found in the GitHub Project schema.`,
+      remediation:
+        "Update tracker.priority.field to the exact live Project V2 single-select field name, or disable priority mapping.",
+      details: {
+        field: input.priority.field,
+        availableFields: input.projectDetail.statusFields.map(
+          (candidate) => candidate.name
+        ),
+      },
+    });
+    return diagnostics;
+  }
+
+  const liveOptions = new Set(field.options.map((option) => option.name));
+  const mappedOptions = new Set(Object.keys(input.priority.values));
+  const unmappedLiveOptions = [...liveOptions].filter(
+    (option) => !mappedOptions.has(option)
+  );
+  const missingConfiguredOptions = [...mappedOptions].filter(
+    (option) => !liveOptions.has(option)
+  );
+
+  if (unmappedLiveOptions.length > 0) {
+    diagnostics.push({
+      title: "Unmapped priority Project options",
+      summary: `Priority field "${field.name}" has live option(s) not mapped in tracker.priority.values: ${unmappedLiveOptions.join(", ")}.`,
+      remediation:
+        "Add explicit numeric mappings for these options or accept that issues holding them resolve to priority = null.",
+      details: { field: field.name, unmappedLiveOptions },
+    });
+  }
+
+  if (missingConfiguredOptions.length > 0) {
+    diagnostics.push({
+      title: "Missing priority Project options",
+      summary: `tracker.priority.values references option(s) that do not exist in priority field "${field.name}": ${missingConfiguredOptions.join(", ")}.`,
+      remediation:
+        "Rename the mapping keys to match live Project option display names or remove stale mappings.",
+      details: { field: field.name, missingConfiguredOptions },
+    });
+  }
+
+  const activeUnmapped = input.activeIssues.flatMap((issue) => {
+    const rawValue = issue.metadata?.[field.name];
+    return typeof rawValue === "string" &&
+      rawValue.length > 0 &&
+      !mappedOptions.has(rawValue)
+      ? [{ issue: issue.identifier, value: rawValue }]
+      : [];
+  });
+  if (activeUnmapped.length > 0) {
+    diagnostics.push({
+      title: "Active issues with unmapped priority values",
+      summary: `Active issue(s) currently hold unmapped "${field.name}" value(s); they resolve to priority = null.`,
+      remediation:
+        "Map the live value in tracker.priority.values, change the issue value, or leave it unmapped intentionally.",
+      details: { field: field.name, activeUnmapped },
+    });
+  }
+
+  return diagnostics;
+}
+
+function buildLabelDriftDiagnostics(input: {
+  priority: Extract<WorkflowPriorityConfig, { source: "labels" }>;
+  repositoryLabels: RepositoryLabelSnapshot[];
+  activeIssues: TrackedIssue[];
+}): PriorityDiagnostic[] {
+  const diagnostics: PriorityDiagnostic[] = [];
+  const configuredLabels = Object.keys(input.priority.labels);
+  const missingByRepository = input.repositoryLabels.flatMap((snapshot) => {
+    const live = new Set(snapshot.labels);
+    const missing = configuredLabels.filter((label) => !live.has(label));
+    return missing.length > 0
+      ? [{ repository: snapshot.repository, missing }]
+      : [];
+  });
+
+  if (missingByRepository.length > 0) {
+    diagnostics.push({
+      title: "Missing configured priority labels",
+      summary:
+        "One or more configured tracker.priority.labels entries are absent from linked repositories.",
+      remediation:
+        "Create the labels in each linked repository, rename the mapping keys to exact live labels, or remove stale mappings.",
+      details: { missingByRepository },
+    });
+  }
+
+  const liveLabels = new Set(
+    input.repositoryLabels.flatMap((snapshot) => snapshot.labels)
+  );
+  const missingEverywhere = configuredLabels.filter(
+    (label) => !liveLabels.has(label)
+  );
+  if (missingEverywhere.length > 0) {
+    diagnostics.push({
+      title: "Stale priority label mappings",
+      summary: `tracker.priority.labels references label(s) that do not exist in any linked repository: ${missingEverywhere.join(", ")}.`,
+      remediation:
+        "Rename the mapping keys to exact live labels, create those labels, or remove stale mappings.",
+      details: { missingEverywhere },
+    });
+  }
+
+  const configuredLabelSet = new Set(configuredLabels);
+  const activeConflicts = input.activeIssues.flatMap((issue) => {
+    const matches = issue.labels.filter((label) => configuredLabelSet.has(label));
+    return matches.length > 1 ? [{ issue: issue.identifier, labels: matches }] : [];
+  });
+  if (activeConflicts.length > 0) {
+    diagnostics.push({
+      title: "Active issues with multiple priority labels",
+      summary:
+        "Active issue(s) have multiple configured priority labels; runtime chooses the lowest numeric value and emits priority.label_conflict_resolved.",
+      remediation:
+        "Remove extra priority labels from the issue if only one priority label should apply.",
+      details: { activeConflicts },
+    });
+  }
+
+  const activeUnmapped = input.activeIssues.flatMap((issue) => {
+    const labels = issue.labels.filter(
+      (label) => isPriorityLikeLabel(label) && !configuredLabelSet.has(label)
+    );
+    return labels.length > 0 ? [{ issue: issue.identifier, labels }] : [];
+  });
+  if (activeUnmapped.length > 0) {
+    diagnostics.push({
+      title: "Active issues with unmapped priority labels",
+      summary:
+        "Active issue(s) have priority-like labels not mapped by tracker.priority.labels; those labels do not affect dispatch priority.",
+      remediation:
+        "Add explicit mappings for these labels, rename the issue labels, or leave them unmapped intentionally.",
+      details: { activeUnmapped },
+    });
+  }
+
+  return diagnostics;
+}
+
+function isPriorityLikeLabel(label: string): boolean {
+  return /^(p\d+|priority[:/\s_-].+|prio[:/\s_-].+)$/i.test(label.trim());
+}

--- a/packages/cli/src/priority-diagnostics.ts
+++ b/packages/cli/src/priority-diagnostics.ts
@@ -198,9 +198,16 @@ function buildLabelDriftDiagnostics(input: {
     }
   }
 
-  const configuredLabelSet = new Set(configuredLabels);
+  const configuredLabelByNormalized = new Map(
+    configuredLabels.map((label) => [normalizeLabelForComparison(label), label])
+  );
   const activeConflicts = input.activeIssues.flatMap((issue) => {
-    const matches = issue.labels.filter((label) => configuredLabelSet.has(label));
+    const matches = issue.labels.flatMap((label) => {
+      const configuredLabel = configuredLabelByNormalized.get(
+        normalizeLabelForComparison(label)
+      );
+      return configuredLabel ? [configuredLabel] : [];
+    });
     return matches.length > 1 ? [{ issue: issue.identifier, labels: matches }] : [];
   });
   if (activeConflicts.length > 0) {
@@ -216,7 +223,9 @@ function buildLabelDriftDiagnostics(input: {
 
   const activeUnmapped = input.activeIssues.flatMap((issue) => {
     const labels = issue.labels.filter(
-      (label) => isPriorityLikeLabel(label) && !configuredLabelSet.has(label)
+      (label) =>
+        isPriorityLikeLabel(label) &&
+        !configuredLabelByNormalized.has(normalizeLabelForComparison(label))
     );
     return labels.length > 0 ? [{ issue: issue.identifier, labels }] : [];
   });
@@ -236,4 +245,8 @@ function buildLabelDriftDiagnostics(input: {
 
 function isPriorityLikeLabel(label: string): boolean {
   return /^(p\d+|priority[:/\s_-].+|prio[:/\s_-].+)$/i.test(label.trim());
+}
+
+function normalizeLabelForComparison(label: string): string {
+  return label.trim().toLowerCase();
 }


### PR DESCRIPTION
## Issues

- Fixes #338

## Summary

- Adds warning-only CLI diagnostics for explicit GitHub priority mapping drift and legacy `tracker.priority_field` migration.
- Documents explicit `project-field`, `labels`, and `disabled` priority mappings with no-fallback semantics.
- Addresses review feedback for label diagnostics when repository label snapshots fail and when active issue labels arrive lowercase-normalized from the GitHub adapter.

## Changes

- Added `priority_mapping` doctor checks for missing Project fields, missing/stale labels, unmapped live Project options, stale configured mappings, active unmapped values, and multiple configured labels.
- Added local `workflow validate` priority warnings for legacy-only config and explicit-over-legacy precedence.
- Passed explicit priority config into live CLI issue fetches so diagnostics/preview reflect C1 runtime resolution.
- Added REST label lookup support for linked repositories and updated README/CLI docs.
- Treat failed repository label enumeration as an unknown snapshot, while preserving active-issue priority conflict/unmapped diagnostics.
- Normalize active-issue priority label comparisons so configured labels such as `P0` match adapter-normalized labels such as `p0`, avoiding false unmapped warnings and preserving conflict diagnostics.
- Merged `origin/main` and resolved the C2 overlap in `packages/cli/src/github/client.ts`.

## Evidence

- `pnpm --filter @gh-symphony/cli test -- doctor workflow`
- `pnpm lint && pnpm test && pnpm typecheck && pnpm build`
- Manual TC: simulated `listRepositoryLabels` failure with label-based priority mapping; doctor reports `Priority label drift` plus active issue observations, and does not report `Missing configured priority labels` or `Stale priority label mappings` from an unknown snapshot.
- Manual TC: active issue labels `p0`/`p1` with configured labels `P0`/`P1` report a multi-label conflict, while a mapped `p0` label alone is not reported as unmapped.
- Docker E2E not run: this changes CLI diagnostics/docs only and does not alter orchestrator dispatch, worker lifecycle, tracker adapter runtime semantics, or status API behavior.

## Human Validation

- [ ] Confirm `gh-symphony doctor` warning text is actionable against a real GitHub Project.
- [ ] Confirm docs match the desired migration guidance for existing `tracker.priority_field` users.
- [ ] Confirm no-fallback semantics are clear for both Project field and label priority sources.

## Risks

- Doctor now reads repository labels and active Project issues when explicit priority mapping is configured, so diagnostics may take slightly longer on large projects. Drift remains warning-only.