### PR TITLE
feat(cli): generate explicit priority mappings

### DIFF
--- a/packages/cli/src/commands/setup.test.ts
+++ b/packages/cli/src/commands/setup.test.ts
@@ -208,6 +208,10 @@ describe("setup command", () => {
     );
 
     expect(workflow).toContain("project_id: PVT_setup_1");
+    expect(workflow).toContain("source: disabled");
+    expect(workflow).toContain("# Optional template: project-field priority source.");
+    expect(workflow).toContain("# Optional template: labels priority source.");
+    expect(workflow).not.toContain("priority_field:");
     expect(contextYaml).toContain("PVT_setup_1");
     expect(project.projectId).toBe("repository");
     expect(project.workspaceDir).toBe(cwd);
@@ -228,7 +232,8 @@ describe("setup command", () => {
       .mockResolvedValueOnce(MOCK_PROJECT_SUMMARY.id as never)
       .mockResolvedValueOnce("wait" as never)
       .mockResolvedValueOnce("active" as never)
-      .mockResolvedValueOnce("terminal" as never);
+      .mockResolvedValueOnce("terminal" as never)
+      .mockResolvedValueOnce("disabled" as never);
     vi.mocked(p.confirm)
       .mockResolvedValueOnce(true as never)
       .mockResolvedValueOnce(true as never)
@@ -260,7 +265,50 @@ describe("setup command", () => {
     );
   });
 
-  it("warns and skips tracker.priority_field in non-interactive mode when priority fields are ambiguous", async () => {
+  it("lets interactive setup map existing repository labels as the priority source", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "setup-interactive-labels-cwd-"));
+    const configDir = await mkdtemp(
+      join(tmpdir(), "setup-interactive-labels-config-")
+    );
+    initializeGitRemote(cwd);
+    process.chdir(cwd);
+
+    vi.spyOn(githubClient, "listRepositoryLabels").mockResolvedValue([
+      { name: "priority: p0", color: "ff0000", description: null },
+      { name: "priority: p1", color: "ffaa00", description: null },
+    ]);
+    vi.mocked(p.select)
+      .mockResolvedValueOnce(MOCK_PROJECT_SUMMARY.id as never)
+      .mockResolvedValueOnce("wait" as never)
+      .mockResolvedValueOnce("active" as never)
+      .mockResolvedValueOnce("terminal" as never)
+      .mockResolvedValueOnce("labels" as never);
+    vi.mocked(p.multiselect).mockResolvedValueOnce([
+      "priority: p0",
+      "priority: p1",
+    ] as never);
+    vi.mocked(p.text)
+      .mockResolvedValueOnce("0" as never)
+      .mockResolvedValueOnce("1" as never);
+    vi.mocked(p.confirm)
+      .mockResolvedValueOnce(false as never)
+      .mockResolvedValueOnce(true as never);
+
+    await setupCommand([], {
+      configDir,
+      verbose: false,
+      json: false,
+      noColor: true,
+    });
+
+    const workflow = await readFile(join(cwd, "WORKFLOW.md"), "utf8");
+    expect(workflow).toContain("source: labels");
+    expect(workflow).toContain('"priority: p0": 0');
+    expect(workflow).toContain('"priority: p1": 1');
+    expect(workflow).not.toContain("priority_field:");
+  });
+
+  it("warns and writes disabled priority scaffold in non-interactive mode when priority fields are ambiguous", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "setup-non-interactive-priority-cwd-"));
     const configDir = await mkdtemp(
       join(tmpdir(), "setup-non-interactive-priority-config-")
@@ -285,9 +333,12 @@ describe("setup command", () => {
     const workflow = await readFile(join(cwd, "WORKFLOW.md"), "utf8");
 
     expect(stderrWrite).toHaveBeenCalledWith(
-      'Warning: Multiple priority-like single-select fields found ("Priority (Team)", "Priority (Severity)"). Skipping tracker.priority_field in non-interactive mode.\n'
+      'Warning: Multiple priority-like single-select fields found ("Priority (Team)", "Priority (Severity)"). Writing disabled priority scaffold in non-interactive mode.\n'
     );
     expect(workflow).not.toContain("priority_field:");
+    expect(workflow).toContain("source: disabled");
+    expect(workflow).toContain("# Optional template: project-field priority source.");
+    expect(workflow).toContain("# Optional template: labels priority source.");
   });
 
   it("uses --assigned-only as the interactive prompt default and preserves the setting", async () => {
@@ -302,7 +353,8 @@ describe("setup command", () => {
       .mockResolvedValueOnce(MOCK_PROJECT_SUMMARY.id as never)
       .mockResolvedValueOnce("wait" as never)
       .mockResolvedValueOnce("active" as never)
-      .mockResolvedValueOnce("terminal" as never);
+      .mockResolvedValueOnce("terminal" as never)
+      .mockResolvedValueOnce("disabled" as never);
     vi.mocked(p.confirm)
       .mockResolvedValueOnce(true as never)
       .mockResolvedValueOnce(true as never);
@@ -324,7 +376,7 @@ describe("setup command", () => {
     expect(project.tracker.settings?.assignedOnly).toBe(true);
     expect(vi.mocked(p.confirm).mock.calls[0]?.[0]).toMatchObject({
       message:
-        "Step 3/3 — Only process issues assigned to the authenticated GitHub user?",
+        "Step 4/4 — Only process issues assigned to the authenticated GitHub user?",
       initialValue: true,
     });
   });

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -18,6 +18,8 @@ import {
   buildAutomaticStateMappings,
   planWorkflowArtifacts,
   resolvePriorityField,
+  promptPriorityConfig,
+  collectPriorityLabelNames,
   renderDryRunPreview,
   resolveStatusField,
   writeEcosystem,
@@ -243,9 +245,18 @@ async function runNonInteractive(
     resolvePriorityField(projectDetail, statusField);
   if (ambiguousPriorityFields.length > 0) {
     process.stderr.write(
-      `Warning: Multiple priority-like single-select fields found (${ambiguousPriorityFields.map((field) => `"${field.name}"`).join(", ")}). Skipping tracker.priority_field in non-interactive mode.\n`
+      `Warning: Multiple priority-like single-select fields found (${ambiguousPriorityFields.map((field) => `"${field.name}"`).join(", ")}). Writing disabled priority scaffold in non-interactive mode.\n`
     );
   }
+  const priority = priorityField
+    ? {
+        source: "project-field" as const,
+        field: priorityField.name,
+        values: Object.fromEntries(
+          priorityField.options.map((option, index) => [option.name, index])
+        ),
+      }
+    : { source: "disabled" as const };
   const workflowValidation = validateStateMapping(mappings);
   if (!workflowValidation.valid) {
     process.stderr.write(
@@ -262,6 +273,8 @@ async function runNonInteractive(
     projectDetail,
     statusField,
     priorityField,
+    priority,
+    includePriorityTemplates: !priorityField,
     mappings,
     runtime: "codex",
     skipSkills: flags.skipSkills,
@@ -274,6 +287,8 @@ async function runNonInteractive(
     projectDetail,
     statusField,
     priorityField,
+    priority,
+    includePriorityTemplates: !priorityField,
     runtime: "codex",
     skipSkills: flags.skipSkills,
     skipContext: flags.skipContext,
@@ -385,8 +400,12 @@ async function runInteractive(
   }
 
   const priorityResolution = resolvePriorityField(projectDetail, statusField);
+  const priorityLabelNames = await collectPriorityLabelNames(
+    client,
+    projectDetail.linkedRepositories
+  );
   const mappings = await promptStateMappings(statusField, {
-    stepLabel: priorityResolution.ambiguous.length > 0 ? "Step 2/4" : "Step 2/3",
+    stepLabel: "Step 2/4",
   });
   const workflowValidation = validateStateMapping(mappings);
   if (!workflowValidation.valid) {
@@ -401,42 +420,17 @@ async function runInteractive(
     p.log.warn(`  ⚠ ${warning}`);
   }
 
-  const priorityField =
-    priorityResolution.ambiguous.length > 0
-      ? await (async () => {
-          const selectedId = await abortIfCancelled(
-            p.select({
-              message:
-                "Step 3/4 — Multiple GitHub Project priority fields look plausible. Select the one Symphony should use:",
-              options: [
-                ...priorityResolution.ambiguous.map((field) => ({
-                  value: field.id,
-                  label: field.name,
-                  hint: `${field.options.length} option${field.options.length === 1 ? "" : "s"}`,
-                })),
-                {
-                  value: "__skip_priority_field__",
-                  label: "Skip priority-aware dispatch",
-                  hint: "Leave tracker.priority_field unset",
-                },
-              ],
-            })
-          );
-          if (selectedId === "__skip_priority_field__") {
-            return null;
-          }
-          return (
-            priorityResolution.ambiguous.find((field) => field.id === selectedId) ??
-            null
-          );
-        })()
-      : priorityResolution.field;
+  const { priority, priorityField } = await promptPriorityConfig({
+    priorityResolution,
+    labelNames: priorityLabelNames,
+    stepLabel: "Step 3/4",
+  });
 
   const promptAssignedOnly = await abortIfCancelled(
     p.confirm({
       message:
         `${
-          priorityResolution.ambiguous.length > 0 ? "Step 4/4" : "Step 3/3"
+          "Step 4/4"
         } — Only process issues assigned to the authenticated GitHub user?`,
       initialValue: flags.assignedOnly ?? false,
     })
@@ -450,6 +444,8 @@ async function runInteractive(
     projectDetail,
     statusField,
     priorityField,
+    priority,
+    includePriorityTemplates: priority.source === "disabled",
     mappings,
     runtime: "codex",
     skipSkills: flags.skipSkills,
@@ -488,6 +484,8 @@ async function runInteractive(
       projectDetail,
       statusField,
       priorityField,
+      priority,
+      includePriorityTemplates: priority.source === "disabled",
       runtime: "codex",
       skipSkills: flags.skipSkills,
       skipContext: flags.skipContext,

--- a/packages/cli/src/commands/workflow-init.test.ts
+++ b/packages/cli/src/commands/workflow-init.test.ts
@@ -45,6 +45,7 @@ import {
   generateProjectId,
   planWorkflowArtifacts,
   planEcosystem,
+  promptPriorityConfig,
   renderDryRunPreview,
   writeConfig,
   writeEcosystem,
@@ -490,6 +491,52 @@ describe("init priority field detection", () => {
         ],
       ])
     );
+  });
+
+  it("validates interactive priority mapping values as non-empty integers", async () => {
+    vi.mocked(p.select).mockResolvedValueOnce("project-field" as never);
+    vi.mocked(p.text).mockResolvedValue("2" as never);
+
+    const projectFieldResult = await promptPriorityConfig({
+      priorityResolution: { field: MOCK_PRIORITY_FIELD, ambiguous: [] },
+      labelNames: [],
+    });
+
+    expect(projectFieldResult.priority).toEqual({
+      source: "project-field",
+      field: "Priority",
+      values: {
+        P0: 2,
+        P1: 2,
+      },
+    });
+    const projectFieldValidate = vi.mocked(p.text).mock.calls[0]?.[0].validate;
+    expect(projectFieldValidate?.("")).toBe("Enter an integer.");
+    expect(projectFieldValidate?.("2.5")).toBe("Enter an integer.");
+    expect(projectFieldValidate?.("-2")).toBeUndefined();
+
+    vi.mocked(p.select).mockReset();
+    vi.mocked(p.multiselect).mockReset();
+    vi.mocked(p.text).mockReset();
+    vi.mocked(p.select).mockResolvedValueOnce("labels" as never);
+    vi.mocked(p.multiselect).mockResolvedValueOnce(["priority: p0"] as never);
+    vi.mocked(p.text).mockResolvedValue("3" as never);
+
+    const labelResult = await promptPriorityConfig({
+      priorityResolution: { field: null, ambiguous: [] },
+      labelNames: ["priority: p0"],
+    });
+
+    expect(labelResult.priority).toEqual({
+      source: "labels",
+      labels: {
+        "priority: p0": 3,
+      },
+    });
+    const labelValidate = vi.mocked(p.text).mock.calls[0]?.[0].validate;
+    expect(labelValidate?.(" ")).toBe("Enter an integer.");
+    expect(labelValidate?.("1.5")).toBe("Enter an integer.");
+    expect(labelValidate?.("0")).toBeUndefined();
   });
 });
 

--- a/packages/cli/src/commands/workflow-init.test.ts
+++ b/packages/cli/src/commands/workflow-init.test.ts
@@ -279,7 +279,7 @@ describe("init priority field detection", () => {
     process.exitCode = undefined;
   });
 
-  it("adds tracker.priority_field during non-interactive dry-run when Priority exists", async () => {
+  it("adds explicit project-field priority mapping during non-interactive dry-run when Priority exists", async () => {
     const configDir = await mkdtemp(join(tmpdir(), "cli-init-priority-nonint-"));
     const stdout = vi
       .spyOn(process.stdout, "write")
@@ -322,8 +322,15 @@ describe("init priority field detection", () => {
 
     const payload = JSON.parse(
       stdout.mock.calls.map(([chunk]) => String(chunk)).join("")
-    ) as { priorityFieldName: string | null };
-    expect(payload.priorityFieldName).toBe("Priority");
+    ) as { priority: { source: string; field?: string; values?: Record<string, number> } };
+    expect(payload.priority).toEqual({
+      source: "project-field",
+      field: "Priority",
+      values: {
+        P0: 0,
+        P1: 1,
+      },
+    });
   });
 
   it("allows Claude preflight for init --runtime claude-code with local auth", async () => {
@@ -444,7 +451,11 @@ describe("init priority field detection", () => {
       .mockResolvedValueOnce("active" as never)
       .mockResolvedValueOnce("active" as never)
       .mockResolvedValueOnce("terminal" as never)
+      .mockResolvedValueOnce("project-field" as never)
       .mockResolvedValueOnce("priority-severity" as never);
+    vi.mocked(p.text)
+      .mockResolvedValueOnce("0" as never)
+      .mockResolvedValueOnce("1" as never);
 
     await initCommand(["--dry-run", "--output", join(configDir, "WORKFLOW.md")], {
       configDir,
@@ -454,13 +465,27 @@ describe("init priority field detection", () => {
     });
 
     const rendered = stdout.mock.calls.map(([chunk]) => String(chunk)).join("");
-    expect(rendered).toContain("Priority field   Priority (Severity)");
+    expect(rendered).toContain("Priority source   project-field");
+    expect(rendered).toContain("Priority mapping  Priority (Severity): P0=0, P1=1");
     expect(vi.mocked(p.select).mock.calls).toEqual(
       expect.arrayContaining([
         [
           expect.objectContaining({
-            message:
-              "Step 4/4 — Multiple GitHub Project priority fields look plausible. Select the one Symphony should use:",
+            message: "Step 4/4 — Choose one priority source:",
+          }),
+        ],
+      ])
+    );
+    expect(vi.mocked(p.text).mock.calls).toEqual(
+      expect.arrayContaining([
+        [
+          expect.objectContaining({
+            message: 'Priority value for option "P0"',
+          }),
+        ],
+        [
+          expect.objectContaining({
+            message: 'Priority value for option "P1"',
           }),
         ],
       ])
@@ -571,7 +596,8 @@ describe("init ecosystem generation", () => {
     expect(preview).toContain("create");
     expect(preview).toContain(DEFAULT_AFTER_CREATE_HOOK_PATH);
     expect(preview).toContain(".gh-symphony/context.yaml");
-    expect(preview).toContain("Priority field   Priority");
+    expect(preview).toContain("Priority source   project-field");
+    expect(preview).toContain("Priority mapping  Priority: P0=0, P1=1");
     expect(preview).toContain("Detected environment inputs");
     expect(preview).toContain("Dry run only. No files were written.");
   });
@@ -603,7 +629,14 @@ describe("init ecosystem generation", () => {
 
     expect(result.dryRun).toBe(true);
     expect(result.output).toBe(join(cwd, "WORKFLOW.md"));
-    expect(result.priorityFieldName).toBe("Priority");
+    expect(result.priority).toEqual({
+      source: "project-field",
+      field: "Priority",
+      values: {
+        P0: 0,
+        P1: 1,
+      },
+    });
     expect(result.files[0]).toMatchObject({
       label: "WORKFLOW.md",
       status: "create",
@@ -741,7 +774,9 @@ describe("init ecosystem generation", () => {
     });
 
     expect(plan.workflowMd).toContain("### Repository Validation Guidance");
-    expect(plan.workflowMd).toContain("priority_field: Priority");
+    expect(plan.workflowMd).toContain("source: project-field");
+    expect(plan.workflowMd).toContain('field: "Priority"');
+    expect(plan.workflowMd).not.toContain("priority_field:");
     expect(plan.workflowMd).toContain("Detected repository validation commands:");
     expect(plan.workflowMd).toContain("`npm test`");
     expect(plan.workflowMd).toContain("`npm run lint`");

--- a/packages/cli/src/commands/workflow-init.ts
+++ b/packages/cli/src/commands/workflow-init.ts
@@ -591,9 +591,7 @@ async function promptProjectFieldPriorityValues(
         message: `Priority value for option "${option.name}"`,
         placeholder: String(index),
         initialValue: String(index),
-        validate(value) {
-          return Number.isFinite(Number(value)) ? undefined : "Enter a number.";
-        },
+        validate: validatePriorityInteger,
       })
     );
     values[option.name] = Number(rawValue);
@@ -666,9 +664,7 @@ export async function promptPriorityConfig(input: {
           message: `Priority value for label "${label}"`,
           placeholder: String(index),
           initialValue: String(index),
-          validate(value) {
-            return Number.isFinite(Number(value)) ? undefined : "Enter a number.";
-          },
+          validate: validatePriorityInteger,
         })
       );
       labels[label] = Number(rawValue);
@@ -695,6 +691,13 @@ export async function promptPriorityConfig(input: {
     },
     priorityField,
   };
+}
+
+function validatePriorityInteger(value: string): string | undefined {
+  const trimmed = value.trim();
+  return trimmed !== "" && Number.isInteger(Number(trimmed))
+    ? undefined
+    : "Enter an integer.";
 }
 
 export async function promptStateMappings(

--- a/packages/cli/src/commands/workflow-init.ts
+++ b/packages/cli/src/commands/workflow-init.ts
@@ -4,6 +4,7 @@ import {
   resolveClaudeCommandBinary,
   runClaudePreflight,
 } from "@gh-symphony/runtime-claude";
+import type { WorkflowPriorityConfig } from "@gh-symphony/core";
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { chmod, mkdir, readFile, rename, writeFile } from "node:fs/promises";
@@ -15,6 +16,7 @@ import {
   checkRequiredScopes,
   discoverUserProjects,
   listUserProjects,
+  listRepositoryLabels,
   getProjectDetail,
   GitHubScopeError,
   type GitHubClient,
@@ -310,6 +312,8 @@ type EcosystemOptions = {
   projectDetail: ProjectDetail;
   statusField: ProjectStatusField;
   priorityField: ProjectStatusField | null;
+  priority?: WorkflowPriorityConfig;
+  includePriorityTemplates?: boolean;
   runtime: string;
   skipSkills: boolean;
   skipContext: boolean;
@@ -320,7 +324,7 @@ export type EcosystemResult = {
   projectId: string;
   githubProjectTitle: string;
   runtime: string;
-  priorityFieldName: string | null;
+  priority: WorkflowPriorityConfig;
   skillsDir: string | null;
   skipSkills: boolean;
   afterCreateHookWritten: boolean;
@@ -346,7 +350,7 @@ export type EcosystemPlan = {
   projectId: string;
   githubProjectTitle: string;
   runtime: string;
-  priorityFieldName: string | null;
+  priority: WorkflowPriorityConfig;
   skillsDir: string | null;
   skipSkills: boolean;
   environment: Awaited<ReturnType<typeof detectEnvironment>>;
@@ -359,7 +363,7 @@ export type DryRunJsonResult = {
   projectId: string;
   githubProjectTitle: string;
   runtime: string;
-  priorityFieldName: string | null;
+  priority: WorkflowPriorityConfig;
   files: Array<{
     path: string;
     label: string;
@@ -375,6 +379,8 @@ export type WorkflowArtifactsOptions = {
   projectDetail: ProjectDetail;
   statusField: ProjectStatusField;
   priorityField: ProjectStatusField | null;
+  priority?: WorkflowPriorityConfig;
+  includePriorityTemplates?: boolean;
   mappings: Record<string, StateMapping>;
   runtime: string;
   skipSkills: boolean;
@@ -499,6 +505,45 @@ export function resolvePriorityField(
   return { field: null, ambiguous: [] };
 }
 
+function buildProjectFieldPriority(
+  field: ProjectStatusField
+): WorkflowPriorityConfig {
+  return {
+    source: "project-field",
+    field: field.name,
+    values: Object.fromEntries(
+      field.options.map((option, index) => [option.name, index])
+    ),
+  };
+}
+
+function buildDisabledPriority(): WorkflowPriorityConfig {
+  return { source: "disabled" };
+}
+
+export async function collectPriorityLabelNames(
+  client: GitHubClient,
+  repositories: LinkedRepository[]
+): Promise<string[]> {
+  const labels = new Set<string>();
+  for (const repository of repositories) {
+    try {
+      const repoLabels = await listRepositoryLabels(
+        client,
+        repository.owner,
+        repository.name
+      );
+      for (const label of repoLabels) {
+        labels.add(label.name);
+      }
+    } catch {
+      // Label priority is optional setup data. If labels cannot be listed,
+      // the operator can still choose project-field or disabled.
+    }
+  }
+  return [...labels].sort((a, b) => a.localeCompare(b));
+}
+
 async function promptPriorityField(
   priorityCandidates: ProjectStatusField[],
   options?: {
@@ -521,7 +566,7 @@ async function promptPriorityField(
         {
           value: "__skip_priority_field__",
           label: "Skip priority-aware dispatch",
-          hint: "Leave tracker.priority_field unset",
+          hint: "Write source: disabled",
         },
       ],
     })
@@ -534,6 +579,122 @@ async function promptPriorityField(
   return (
     priorityCandidates.find((field) => field.id === selectedFieldId) ?? null
   );
+}
+
+async function promptProjectFieldPriorityValues(
+  field: ProjectStatusField
+): Promise<Record<string, number>> {
+  const values: Record<string, number> = {};
+  for (const [index, option] of field.options.entries()) {
+    const rawValue = await abortIfCancelled(
+      p.text({
+        message: `Priority value for option "${option.name}"`,
+        placeholder: String(index),
+        initialValue: String(index),
+        validate(value) {
+          return Number.isFinite(Number(value)) ? undefined : "Enter a number.";
+        },
+      })
+    );
+    values[option.name] = Number(rawValue);
+  }
+  return values;
+}
+
+export async function promptPriorityConfig(input: {
+  priorityResolution: ReturnType<typeof resolvePriorityField>;
+  labelNames: string[];
+  stepLabel?: string;
+}): Promise<{
+  priority: WorkflowPriorityConfig;
+  priorityField: ProjectStatusField | null;
+}> {
+  const hasProjectField =
+    Boolean(input.priorityResolution.field) ||
+    input.priorityResolution.ambiguous.length > 0;
+  const hasLabels = input.labelNames.length > 0;
+  const selectedSource = await abortIfCancelled(
+    p.select({
+      message: `${input.stepLabel ?? "Priority"} — Choose one priority source:`,
+      options: [
+        ...(hasProjectField
+          ? [
+              {
+                value: "project-field",
+                label: "GitHub Project field",
+                hint: "Map single-select options to explicit numbers",
+              },
+            ]
+          : []),
+        ...(hasLabels
+          ? [
+              {
+                value: "labels",
+                label: "GitHub labels",
+                hint: "Map existing repository labels to explicit numbers",
+              },
+            ]
+          : []),
+        {
+          value: "disabled",
+          label: "Disabled",
+          hint: "Write source: disabled",
+        },
+      ],
+    })
+  );
+
+  if (selectedSource === "disabled") {
+    return { priority: buildDisabledPriority(), priorityField: null };
+  }
+
+  if (selectedSource === "labels") {
+    const selectedLabels = await abortIfCancelled(
+      p.multiselect({
+        message: "Select priority labels to map:",
+        options: input.labelNames.map((label) => ({
+          value: label,
+          label,
+        })),
+        required: true,
+      })
+    );
+    const labels: Record<string, number> = {};
+    for (const [index, label] of selectedLabels.entries()) {
+      const rawValue = await abortIfCancelled(
+        p.text({
+          message: `Priority value for label "${label}"`,
+          placeholder: String(index),
+          initialValue: String(index),
+          validate(value) {
+            return Number.isFinite(Number(value)) ? undefined : "Enter a number.";
+          },
+        })
+      );
+      labels[label] = Number(rawValue);
+    }
+    return { priority: { source: "labels", labels }, priorityField: null };
+  }
+
+  const priorityField =
+    input.priorityResolution.ambiguous.length > 0
+      ? await promptPriorityField(input.priorityResolution.ambiguous, {
+          stepLabel: "Priority field",
+        })
+      : input.priorityResolution.field;
+
+  if (!priorityField) {
+    return { priority: buildDisabledPriority(), priorityField: null };
+  }
+
+  return {
+    priority: {
+      source: "project-field",
+      field: priorityField.name,
+      values: await promptProjectFieldPriorityValues(priorityField),
+    },
+    priorityField,
+  };
 }
 
 export async function promptStateMappings(
@@ -579,10 +740,17 @@ export async function planWorkflowArtifacts(
   opts: WorkflowArtifactsOptions
 ): Promise<WorkflowArtifactsPlan> {
   const environment = opts.environment ?? (await detectEnvironment(opts.cwd));
+  const priority =
+    opts.priority ??
+    (opts.priorityField
+      ? buildProjectFieldPriority(opts.priorityField)
+      : buildDisabledPriority());
   const workflowMd = generateWorkflowMarkdown({
     projectId: opts.projectDetail.id,
     stateFieldName: opts.statusField.name,
-    priorityFieldName: opts.priorityField?.name ?? null,
+    priority,
+    includePriorityTemplates:
+      opts.includePriorityTemplates ?? priority.source === "disabled",
     mappings: opts.mappings,
     lifecycle: toWorkflowLifecycleConfig(opts.statusField.name, opts.mappings),
     runtime: opts.runtime,
@@ -600,6 +768,9 @@ export async function planWorkflowArtifacts(
     projectDetail: opts.projectDetail,
     statusField: opts.statusField,
     priorityField: opts.priorityField,
+    priority,
+    includePriorityTemplates:
+      opts.includePriorityTemplates ?? priority.source === "disabled",
     runtime: opts.runtime,
     skipSkills: opts.skipSkills,
     skipContext: opts.skipContext,
@@ -644,6 +815,11 @@ export async function planEcosystem(
     skipSkills,
     skipContext,
   } = opts;
+  const priority =
+    opts.priority ??
+    (priorityField
+      ? buildProjectFieldPriority(priorityField)
+      : buildDisabledPriority());
   const ghSymphonyDir = join(cwd, ".gh-symphony");
   const environment = opts.environment ?? (await detectEnvironment(cwd));
   const files: PlannedFileChange[] = [];
@@ -685,7 +861,7 @@ export async function planEcosystem(
       role: null as "active" | "wait" | "terminal" | null,
     })),
     projectId: projectDetail.id,
-    priorityFieldName: priorityField?.name ?? null,
+    priority,
     detectedEnvironment: environment,
   });
   files.push(
@@ -739,7 +915,7 @@ export async function planEcosystem(
     projectId: projectDetail.id,
     githubProjectTitle: projectDetail.title,
     runtime,
-    priorityFieldName: priorityField?.name ?? null,
+    priority,
     skillsDir,
     skipSkills,
     environment,
@@ -794,7 +970,7 @@ export async function writeEcosystem(
     projectId: plan.projectId,
     githubProjectTitle: plan.githubProjectTitle,
     runtime: plan.runtime,
-    priorityFieldName: plan.priorityFieldName,
+    priority: plan.priority,
     skillsDir: plan.skillsDir,
     skipSkills: plan.skipSkills,
     afterCreateHookWritten,
@@ -806,6 +982,30 @@ export async function writeEcosystem(
 }
 
 // ── Ecosystem summary output ─────────────────────────────────────────────────
+
+function formatPrioritySummaryLines(priority: WorkflowPriorityConfig): string[] {
+  if (priority.source === "disabled") {
+    return ["Priority source   disabled"];
+  }
+
+  if (priority.source === "project-field") {
+    const mapping = Object.entries(priority.values)
+      .map(([name, value]) => `${name}=${value}`)
+      .join(", ");
+    return [
+      "Priority source   project-field",
+      `Priority mapping  ${priority.field}: ${mapping || "none"}`,
+    ];
+  }
+
+  const mapping = Object.entries(priority.labels)
+    .map(([name, value]) => `${name}=${value}`)
+    .join(", ");
+  return [
+    "Priority source   labels",
+    `Priority mapping  ${mapping || "none"}`,
+  ];
+}
 
 function printEcosystemSummary(
   result: EcosystemResult,
@@ -820,9 +1020,7 @@ function printEcosystemSummary(
     `GitHub Project   ${result.githubProjectTitle}  (${result.projectId})`
   );
   lines.push(`Runtime   ${result.runtime}`);
-  if (result.priorityFieldName) {
-    lines.push(`Priority field   ${result.priorityFieldName}`);
-  }
+  lines.push(...formatPrioritySummaryLines(result.priority));
   lines.push("");
   lines.push("Generated files");
   lines.push(`  ✓ WORKFLOW.md                          ${relWorkflow}`);
@@ -884,9 +1082,7 @@ export function renderDryRunPreview(
     `GitHub Project   ${ecosystemPlan.githubProjectTitle}  (${ecosystemPlan.projectId})`
   );
   lines.push(`Runtime   ${ecosystemPlan.runtime}`);
-  if (ecosystemPlan.priorityFieldName) {
-    lines.push(`Priority field   ${ecosystemPlan.priorityFieldName}`);
-  }
+  lines.push(...formatPrioritySummaryLines(ecosystemPlan.priority));
   lines.push("");
   lines.push("Planned file changes");
   lines.push(
@@ -920,7 +1116,7 @@ export function buildDryRunJsonResult(
     projectId: ecosystemPlan.projectId,
     githubProjectTitle: ecosystemPlan.githubProjectTitle,
     runtime: ecosystemPlan.runtime,
-    priorityFieldName: ecosystemPlan.priorityFieldName,
+    priority: ecosystemPlan.priority,
     files: [workflowPlan, ...ecosystemPlan.files].map((file) => ({
       path: file.path,
       label: file.label,
@@ -1028,9 +1224,12 @@ async function runNonInteractive(
     resolvePriorityField(githubProject, statusField);
   if (ambiguousPriorityFields.length > 0) {
     process.stderr.write(
-      `Warning: Multiple priority-like single-select fields found (${ambiguousPriorityFields.map((field) => `"${field.name}"`).join(", ")}). Skipping tracker.priority_field in non-interactive mode.\n`
+      `Warning: Multiple priority-like single-select fields found (${ambiguousPriorityFields.map((field) => `"${field.name}"`).join(", ")}). Writing disabled priority scaffold in non-interactive mode.\n`
     );
   }
+  const priority = autoPriorityField
+    ? buildProjectFieldPriority(autoPriorityField)
+    : buildDisabledPriority();
 
   const validation = validateStateMapping(mappings);
   if (!validation.valid) {
@@ -1048,6 +1247,8 @@ async function runNonInteractive(
     projectDetail: githubProject,
     statusField,
     priorityField: autoPriorityField,
+    priority,
+    includePriorityTemplates: !autoPriorityField,
     mappings,
     runtime,
     skipSkills: flags.skipSkills,
@@ -1074,6 +1275,8 @@ async function runNonInteractive(
     projectDetail: githubProject,
     statusField,
     priorityField: autoPriorityField,
+    priority,
+    includePriorityTemplates: !autoPriorityField,
     runtime,
     skipSkills: flags.skipSkills,
     skipContext: flags.skipContext,
@@ -1206,16 +1409,18 @@ async function runInteractiveStandalone(
   }
 
   const priorityResolution = resolvePriorityField(projectDetail, statusField);
+  const priorityLabelNames = await collectPriorityLabelNames(
+    client,
+    projectDetail.linkedRepositories
+  );
   const mappings = await promptStateMappings(statusField, {
-    stepLabel:
-      priorityResolution.ambiguous.length > 0 ? "Step 3/4" : "Step 3/3",
+    stepLabel: "Step 3/4",
   });
-  let priorityField = priorityResolution.field;
-  if (priorityResolution.ambiguous.length > 0) {
-    priorityField = await promptPriorityField(priorityResolution.ambiguous, {
-      stepLabel: "Step 4/4",
-    });
-  }
+  const { priority, priorityField } = await promptPriorityConfig({
+    priorityResolution,
+    labelNames: priorityLabelNames,
+    stepLabel: "Step 4/4",
+  });
 
   const validation = validateStateMapping(mappings);
   if (!validation.valid) {
@@ -1237,6 +1442,8 @@ async function runInteractiveStandalone(
     projectDetail,
     statusField,
     priorityField,
+    priority,
+    includePriorityTemplates: priority.source === "disabled",
     mappings,
     runtime,
     skipSkills: flags.skipSkills,
@@ -1255,6 +1462,8 @@ async function runInteractiveStandalone(
     projectDetail,
     statusField,
     priorityField,
+    priority,
+    includePriorityTemplates: priority.source === "disabled",
     runtime,
     skipSkills: flags.skipSkills,
     skipContext: flags.skipContext,

--- a/packages/cli/src/github/client.ts
+++ b/packages/cli/src/github/client.ts
@@ -56,6 +56,12 @@ export type RepositoryLookupResult = LinkedRepository & {
   visibility: "public" | "private" | "internal" | null;
 };
 
+export type RepositoryLabel = {
+  name: string;
+  color: string | null;
+  description: string | null;
+};
+
 export type ProjectTextField = {
   id: string;
   name: string;
@@ -241,6 +247,56 @@ export async function getRepositoryMetadata(
     visibility:
       repo.visibility ?? (repo.private === true ? "private" : "public"),
   };
+}
+
+export async function listRepositoryLabels(
+  client: GitHubClient,
+  owner: string,
+  name: string
+): Promise<RepositoryLabel[]> {
+  const restUrl = client.apiUrl.replace("/graphql", "");
+  const baseUrl = restUrl === client.apiUrl ? REST_API_URL : restUrl;
+  const labels: RepositoryLabel[] = [];
+  let page = 1;
+
+  while (true) {
+    const response = await client.fetchImpl(
+      `${baseUrl}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(name)}/labels?per_page=100&page=${page}`,
+      {
+        headers: {
+          authorization: `Bearer ${client.token}`,
+          accept: "application/vnd.github+json",
+        },
+      }
+    );
+
+    if (!response.ok) {
+      throw new GitHubApiError(
+        `GitHub labels request failed: ${response.status} ${response.statusText}`,
+        response.status
+      );
+    }
+
+    const payload = (await response.json()) as Array<{
+      name: string;
+      color?: string | null;
+      description?: string | null;
+    }>;
+    labels.push(
+      ...payload.map((label) => ({
+        name: label.name,
+        color: label.color ?? null,
+        description: label.description ?? null,
+      }))
+    );
+
+    if (payload.length < 100) {
+      break;
+    }
+    page += 1;
+  }
+
+  return labels;
 }
 
 // ── 2.1: Token validation & scope check ──────────────────────────────────────

--- a/packages/cli/src/workflow/generate-reference-workflow.test.ts
+++ b/packages/cli/src/workflow/generate-reference-workflow.test.ts
@@ -17,7 +17,14 @@ const defaultInput: ReferenceWorkflowInput = {
     { name: "Done", role: "terminal" },
   ],
   projectId: "PVT_abc123",
-  priorityFieldName: "Priority",
+  priority: {
+    source: "project-field",
+    field: "Priority",
+    values: {
+      P0: 0,
+      P1: 1,
+    },
+  },
   detectedEnvironment: {
     packageManager: "pnpm",
     testCommand: "pnpm --filter @gh-symphony/cli test",
@@ -159,17 +166,24 @@ describe("generateReferenceWorkflow", () => {
     expect(output).not.toContain("#   teamId:");
   });
 
-  it("includes priority_field in front matter when configured", () => {
+  it("includes explicit project-field priority mapping in front matter when configured", () => {
     const output = generateReferenceWorkflow(defaultInput);
-    expect(output).toContain("priority_field: Priority");
+    expect(output).toContain("priority:");
+    expect(output).toContain("source: project-field");
+    expect(output).toContain('field: "Priority"');
+    expect(output).toContain('"P0": 0');
+    expect(output).not.toContain("priority_field:");
   });
 
-  it("shows priority_field as an optional reference when not configured", () => {
+  it("shows disabled priority and optional explicit templates when not configured", () => {
     const output = generateReferenceWorkflow({
       ...defaultInput,
-      priorityFieldName: null,
+      priority: null,
     });
-    expect(output).toContain("# priority_field: Priority");
+    expect(output).toContain("source: disabled");
+    expect(output).toContain("# Optional template: project-field priority source.");
+    expect(output).toContain("# Optional template: labels priority source.");
+    expect(output).not.toContain("priority_field:");
   });
 
   it("does not include allowed_repositories in front matter", () => {

--- a/packages/cli/src/workflow/generate-reference-workflow.test.ts
+++ b/packages/cli/src/workflow/generate-reference-workflow.test.ts
@@ -181,6 +181,9 @@ describe("generateReferenceWorkflow", () => {
       priority: null,
     });
     expect(output).toContain("source: disabled");
+    expect(output).toContain(
+      "# Priority dispatch is disabled until an operator chooses one explicit source."
+    );
     expect(output).toContain("# Optional template: project-field priority source.");
     expect(output).toContain("# Optional template: labels priority source.");
     expect(output).not.toContain("priority_field:");

--- a/packages/cli/src/workflow/generate-reference-workflow.ts
+++ b/packages/cli/src/workflow/generate-reference-workflow.ts
@@ -388,9 +388,15 @@ function buildReferencePriorityLines(
   priority: WorkflowPriorityConfig | null
 ): string[] {
   const lines: string[] = [];
-  lines.push(
-    "  # Priority is explicit. Numbers below are editable policy (lower = higher priority)."
-  );
+  if (priority?.source === "project-field" || priority?.source === "labels") {
+    lines.push(
+      "  # Priority is explicit. Numbers below are editable policy (lower = higher priority)."
+    );
+  } else {
+    lines.push(
+      "  # Priority dispatch is disabled until an operator chooses one explicit source."
+    );
+  }
   lines.push(
     "  # See docs/adr/2026-05-18_explicit-dispatch-priority-mappings.md"
   );

--- a/packages/cli/src/workflow/generate-reference-workflow.ts
+++ b/packages/cli/src/workflow/generate-reference-workflow.ts
@@ -1,3 +1,4 @@
+import type { WorkflowPriorityConfig } from "@gh-symphony/core";
 import type { DetectedEnvironment } from "../detection/environment-detector.js";
 import {
   DEFAULT_AFTER_CREATE_HOOK_COMMENT,
@@ -13,7 +14,7 @@ export type ReferenceWorkflowInput = {
     role: "active" | "wait" | "terminal" | null;
   }>;
   projectId: string;
-  priorityFieldName: string | null;
+  priority: WorkflowPriorityConfig | null;
   detectedEnvironment: Pick<
     DetectedEnvironment,
     "packageManager" | "testCommand" | "lintCommand" | "buildCommand" | "monorepo"
@@ -45,11 +46,7 @@ export function generateReferenceWorkflow(
   lines.push("  kind: github-project");
   lines.push(`  project_id: ${input.projectId}`);
   lines.push("  state_field: Status");
-  if (input.priorityFieldName) {
-    lines.push(`  priority_field: ${input.priorityFieldName}`);
-  } else {
-    lines.push("  # priority_field: Priority");
-  }
+  lines.push(...buildReferencePriorityLines(input.priority));
   lines.push("");
 
   const activeColumns = input.statusColumns.filter((c) => c.role === "active");
@@ -385,6 +382,57 @@ export function generateReferenceWorkflow(
   lines.push("");
 
   return lines.join("\n");
+}
+
+function buildReferencePriorityLines(
+  priority: WorkflowPriorityConfig | null
+): string[] {
+  const lines: string[] = [];
+  lines.push(
+    "  # Priority is explicit. Numbers below are editable policy (lower = higher priority)."
+  );
+  lines.push(
+    "  # See docs/adr/2026-05-18_explicit-dispatch-priority-mappings.md"
+  );
+  if (priority?.source === "project-field") {
+    lines.push("  priority:");
+    lines.push("    source: project-field");
+    lines.push(`    field: ${JSON.stringify(priority.field)}`);
+    lines.push("    values:");
+    for (const [name, value] of Object.entries(priority.values)) {
+      lines.push(`      ${JSON.stringify(name)}: ${value}`);
+    }
+    return lines;
+  }
+
+  if (priority?.source === "labels") {
+    lines.push("  priority:");
+    lines.push("    source: labels");
+    lines.push("    labels:");
+    for (const [name, value] of Object.entries(priority.labels)) {
+      lines.push(`      ${JSON.stringify(name)}: ${value}`);
+    }
+    return lines;
+  }
+
+  lines.push("  priority:");
+  lines.push("    source: disabled");
+  lines.push("");
+  lines.push("  # Optional template: project-field priority source.");
+  lines.push("  # priority:");
+  lines.push("  #   source: project-field");
+  lines.push("  #   field: Priority");
+  lines.push("  #   values:");
+  lines.push("  #     Urgent: 0");
+  lines.push("  #     High: 1");
+  lines.push("");
+  lines.push("  # Optional template: labels priority source.");
+  lines.push("  # priority:");
+  lines.push("  #   source: labels");
+  lines.push("  #   labels:");
+  lines.push("  #     P0: 0");
+  lines.push("  #     P1: 1");
+  return lines;
 }
 
 

--- a/packages/cli/src/workflow/generate-workflow-md.test.ts
+++ b/packages/cli/src/workflow/generate-workflow-md.test.ts
@@ -84,6 +84,9 @@ describe("generateWorkflowMarkdown", () => {
 
     expect(markdown).not.toContain("priority_field:");
     expect(markdown).toContain("source: disabled");
+    expect(markdown).toContain(
+      "# Priority dispatch is disabled until an operator chooses one explicit source."
+    );
     expect(markdown).toContain("# Optional template: project-field priority source.");
     expect(markdown).toContain("# Optional template: labels priority source.");
     expect(parsed.tracker.priority).toEqual({ source: "disabled" });
@@ -113,6 +116,25 @@ describe("generateWorkflowMarkdown", () => {
         "priority: p1": 1,
       },
     });
+  });
+
+  it("round-trips escaped priority field and label names", () => {
+    const priority = {
+      source: "labels" as const,
+      labels: {
+        'priority "p0"': 0,
+        "path \\ p1": 1,
+      },
+    };
+    const markdown = generateWorkflowMarkdown({
+      ...defaultInput,
+      priority,
+    });
+    const parsed = parseWorkflowMarkdown(markdown, {});
+
+    expect(markdown).toContain('"priority \\"p0\\"": 0');
+    expect(markdown).toContain('"path \\\\ p1": 1');
+    expect(parsed.tracker.priority).toEqual(priority);
   });
 
   it("includes a Status Map section in the prompt body", () => {

--- a/packages/cli/src/workflow/generate-workflow-md.test.ts
+++ b/packages/cli/src/workflow/generate-workflow-md.test.ts
@@ -13,7 +13,14 @@ describe("generateWorkflowMarkdown", () => {
   const defaultInput = {
     projectId: "PVT_abc123",
     stateFieldName: "Stage",
-    priorityFieldName: "Priority",
+    priority: {
+      source: "project-field" as const,
+      field: "Priority",
+      values: {
+        P0: 0,
+        P1: 1,
+      },
+    },
     mappings: {
       Queued: { role: "active" as const, goal: "Triage and plan the issue" },
       Doing: { role: "active" as const, goal: "Implement the solution" },
@@ -54,23 +61,58 @@ describe("generateWorkflowMarkdown", () => {
     expect(parsed.lifecycle.blockerCheckStates).toEqual(["Queued"]);
   });
 
-  it("emits tracker.priority_field when configured", () => {
+  it("emits explicit project-field priority mapping when configured", () => {
     const markdown = generateWorkflowMarkdown(defaultInput);
     const parsed = parseWorkflowMarkdown(markdown, {});
 
-    expect(markdown).toContain("priority_field: Priority");
-    expect(parsed.tracker.priorityFieldName).toBe("Priority");
+    expect(markdown).toContain("priority:");
+    expect(markdown).toContain("source: project-field");
+    expect(markdown).toContain('field: "Priority"');
+    expect(markdown).toContain('"P0": 0');
+    expect(markdown).not.toContain("priority_field:");
+    expect(parsed.tracker.priority).toEqual(defaultInput.priority);
+    expect(parsed.tracker.priorityFieldName).toBeNull();
   });
 
-  it("omits tracker.priority_field when not configured", () => {
+  it("emits disabled priority scaffold with templates when no field is configured", () => {
     const markdown = generateWorkflowMarkdown({
       ...defaultInput,
-      priorityFieldName: null,
+      priority: { source: "disabled" as const },
+      includePriorityTemplates: true,
     });
     const parsed = parseWorkflowMarkdown(markdown, {});
 
     expect(markdown).not.toContain("priority_field:");
+    expect(markdown).toContain("source: disabled");
+    expect(markdown).toContain("# Optional template: project-field priority source.");
+    expect(markdown).toContain("# Optional template: labels priority source.");
+    expect(parsed.tracker.priority).toEqual({ source: "disabled" });
     expect(parsed.tracker.priorityFieldName).toBeNull();
+  });
+
+  it("emits explicit labels priority mapping when configured", () => {
+    const markdown = generateWorkflowMarkdown({
+      ...defaultInput,
+      priority: {
+        source: "labels" as const,
+        labels: {
+          "priority: p0": 0,
+          "priority: p1": 1,
+        },
+      },
+    });
+    const parsed = parseWorkflowMarkdown(markdown, {});
+
+    expect(markdown).toContain("source: labels");
+    expect(markdown).toContain('"priority: p0": 0');
+    expect(markdown).not.toContain("priority_field:");
+    expect(parsed.tracker.priority).toEqual({
+      source: "labels",
+      labels: {
+        "priority: p0": 0,
+        "priority: p1": 1,
+      },
+    });
   });
 
   it("includes a Status Map section in the prompt body", () => {

--- a/packages/cli/src/workflow/generate-workflow-md.ts
+++ b/packages/cli/src/workflow/generate-workflow-md.ts
@@ -95,9 +95,15 @@ function buildPriorityFrontMatter(
     return lines;
   }
 
-  lines.push(
-    "  # Priority is explicit. Numbers below are editable policy (lower = higher priority)."
-  );
+  if (input.priority.source === "disabled") {
+    lines.push(
+      "  # Priority dispatch is disabled until an operator chooses one explicit source."
+    );
+  } else {
+    lines.push(
+      "  # Priority is explicit. Numbers below are editable policy (lower = higher priority)."
+    );
+  }
   lines.push(
     "  # See docs/adr/2026-05-18_explicit-dispatch-priority-mappings.md"
   );

--- a/packages/cli/src/workflow/generate-workflow-md.ts
+++ b/packages/cli/src/workflow/generate-workflow-md.ts
@@ -1,4 +1,7 @@
-import type { WorkflowLifecycleConfig } from "@gh-symphony/core";
+import type {
+  WorkflowLifecycleConfig,
+  WorkflowPriorityConfig,
+} from "@gh-symphony/core";
 import type { StateMapping } from "../config.js";
 import type { DetectedEnvironment } from "../detection/environment-detector.js";
 import { CLAUDE_RUNTIME_PROMPT_PREAMBLE } from "../prompts/runtime-claude-constraints.js";
@@ -12,7 +15,8 @@ import {
 export type GenerateWorkflowInput = {
   projectId: string;
   stateFieldName: string;
-  priorityFieldName: string | null;
+  priority: WorkflowPriorityConfig | null;
+  includePriorityTemplates?: boolean;
   mappings: Record<string, StateMapping>;
   lifecycle: WorkflowLifecycleConfig;
   runtime: string;
@@ -41,9 +45,7 @@ function buildFrontMatter(input: GenerateWorkflowInput): string {
   lines.push("  kind: github-project");
   lines.push(`  project_id: ${input.projectId}`);
   lines.push(`  state_field: ${input.stateFieldName}`);
-  if (input.priorityFieldName) {
-    lines.push(`  priority_field: ${input.priorityFieldName}`);
-  }
+  lines.push(...buildPriorityFrontMatter(input));
 
   if (input.lifecycle.activeStates.length > 0) {
     lines.push("  active_states:");
@@ -83,6 +85,70 @@ function buildFrontMatter(input: GenerateWorkflowInput): string {
   lines.push(...buildRuntimeFrontMatter(input.runtime));
 
   return lines.join("\n") + "\n";
+}
+
+function buildPriorityFrontMatter(
+  input: Pick<GenerateWorkflowInput, "priority" | "includePriorityTemplates">
+): string[] {
+  const lines: string[] = [];
+  if (!input.priority) {
+    return lines;
+  }
+
+  lines.push(
+    "  # Priority is explicit. Numbers below are editable policy (lower = higher priority)."
+  );
+  lines.push(
+    "  # See docs/adr/2026-05-18_explicit-dispatch-priority-mappings.md"
+  );
+  lines.push("  priority:");
+
+  if (input.priority.source === "project-field") {
+    lines.push("    source: project-field");
+    lines.push(`    field: ${formatYamlScalar(input.priority.field)}`);
+    lines.push("    values:");
+    for (const [name, value] of Object.entries(input.priority.values)) {
+      lines.push(`      ${formatYamlKey(name)}: ${value}`);
+    }
+    return lines;
+  }
+
+  if (input.priority.source === "labels") {
+    lines.push("    source: labels");
+    lines.push("    labels:");
+    for (const [name, value] of Object.entries(input.priority.labels)) {
+      lines.push(`      ${formatYamlKey(name)}: ${value}`);
+    }
+    return lines;
+  }
+
+  lines.push("    source: disabled");
+  if (input.includePriorityTemplates) {
+    lines.push("");
+    lines.push("  # Optional template: project-field priority source.");
+    lines.push("  # priority:");
+    lines.push("  #   source: project-field");
+    lines.push("  #   field: Priority");
+    lines.push("  #   values:");
+    lines.push("  #     Urgent: 0");
+    lines.push("  #     High: 1");
+    lines.push("");
+    lines.push("  # Optional template: labels priority source.");
+    lines.push("  # priority:");
+    lines.push("  #   source: labels");
+    lines.push("  #   labels:");
+    lines.push("  #     P0: 0");
+    lines.push("  #     P1: 1");
+  }
+  return lines;
+}
+
+function formatYamlScalar(value: string): string {
+  return JSON.stringify(value);
+}
+
+function formatYamlKey(value: string): string {
+  return JSON.stringify(value);
 }
 
 function buildPromptBody(input: GenerateWorkflowInput): string {

--- a/packages/core/src/workflow-loader.test.ts
+++ b/packages/core/src/workflow-loader.test.ts
@@ -126,6 +126,31 @@ Prompt body.
     });
   });
 
+  it("parses generated priority comments and quoted mapping keys", () => {
+    const workflow = parseWorkflowMarkdown(`---
+tracker:
+  kind: github-project
+  # Priority is explicit. Numbers below are editable policy.
+  priority:
+    source: labels
+    labels:
+      "priority: p0": 0
+      "priority: p1": 1
+codex:
+  command: codex app-server
+---
+Prompt body.
+`);
+
+    expect(workflow.tracker.priority).toEqual({
+      source: "labels",
+      labels: {
+        "priority: p0": 0,
+        "priority: p1": 1,
+      },
+    });
+  });
+
   it("parses disabled priority source without rejecting legacy priority_field", () => {
     const workflow = parseWorkflowMarkdown(`---
 tracker:

--- a/packages/core/src/workflow-loader.test.ts
+++ b/packages/core/src/workflow-loader.test.ts
@@ -151,6 +151,34 @@ Prompt body.
     });
   });
 
+  it("unescapes quoted priority field and mapping names", () => {
+    const workflow = parseWorkflowMarkdown(`---
+tracker:
+  kind: github-project
+  priority:
+    source: project-field
+    field: "Priority \\"dispatch\\" \\\\ team"
+    values:
+      "label \\"p0\\"": 0
+      "path \\\\ p1": 1
+      'single '' quote': 2
+codex:
+  command: codex app-server
+---
+Prompt body.
+`);
+
+    expect(workflow.tracker.priority).toEqual({
+      source: "project-field",
+      field: 'Priority "dispatch" \\ team',
+      values: {
+        'label "p0"': 0,
+        "path \\ p1": 1,
+        "single ' quote": 2,
+      },
+    });
+  });
+
   it("parses disabled priority source without rejecting legacy priority_field", () => {
     const workflow = parseWorkflowMarkdown(`---
 tracker:

--- a/packages/core/src/workflow/parser.ts
+++ b/packages/core/src/workflow/parser.ts
@@ -313,6 +313,10 @@ function parseBlock(
       index += 1;
       continue;
     }
+    if (line.trim().startsWith("#")) {
+      index += 1;
+      continue;
+    }
 
     const lineIndent = countIndent(line);
     if (lineIndent < indent) {
@@ -363,12 +367,17 @@ function parseBlock(
       );
     }
     collectionType = "object";
-    const separatorIndex = trimmed.indexOf(":");
+    const separatorIndex = findMappingSeparator(trimmed);
     if (separatorIndex < 0) {
       throw new Error(`Invalid workflow front matter line "${trimmed}".`);
     }
 
-    const key = trimmed.slice(0, separatorIndex).trim();
+    const rawKey = trimmed.slice(0, separatorIndex).trim();
+    const parsedKey = parseScalar(rawKey);
+    if (typeof parsedKey !== "string") {
+      throw new Error(`Invalid workflow front matter key "${rawKey}".`);
+    }
+    const key = parsedKey;
     const remainder = trimmed.slice(separatorIndex + 1).trim();
     if (remainder === "|" || remainder === "|-") {
       const [multiline, nextIndex] = parseMultilineScalar(
@@ -424,6 +433,31 @@ function parseMultilineScalar(
 
 function countIndent(line: string): number {
   return line.match(/^ */)?.[0].length ?? 0;
+}
+
+function findMappingSeparator(value: string): number {
+  let quote: '"' | "'" | null = null;
+  for (let index = 0; index < value.length; index += 1) {
+    const char = value[index];
+    if (quote) {
+      if (char === "\\") {
+        index += 1;
+        continue;
+      }
+      if (char === quote) {
+        quote = null;
+      }
+      continue;
+    }
+    if (char === '"' || char === "'") {
+      quote = char;
+      continue;
+    }
+    if (char === ":") {
+      return index;
+    }
+  }
+  return -1;
 }
 
 function parseScalar(value: string): WorkflowFrontMatterNode {

--- a/packages/core/src/workflow/parser.ts
+++ b/packages/core/src/workflow/parser.ts
@@ -468,11 +468,18 @@ function parseScalar(value: string): WorkflowFrontMatterNode {
     return parseInlineArray(value);
   }
   if (/^-?\d+$/.test(value)) return Number.parseInt(value, 10);
-  if (
-    (value.startsWith('"') && value.endsWith('"')) ||
-    (value.startsWith("'") && value.endsWith("'"))
-  ) {
-    return value.slice(1, -1);
+  if (value.startsWith('"') && value.endsWith('"')) {
+    try {
+      const parsed = JSON.parse(value);
+      if (typeof parsed === "string") {
+        return parsed;
+      }
+    } catch {
+      throw new Error(`Invalid quoted workflow front matter scalar "${value}".`);
+    }
+  }
+  if (value.startsWith("'") && value.endsWith("'")) {
+    return value.slice(1, -1).replace(/''/g, "'");
   }
   return value;
 }


### PR DESCRIPTION
## Issues

- Fixes #337

## Summary

- New workflow init/setup output emits explicit `tracker.priority` blocks instead of `priority_field`.
- Interactive setup selects exactly one priority source: Project field, labels, or disabled.
- Review hardening now makes generated quoted priority names round-trip exactly and rejects non-integer prompt values before writing `WORKFLOW.md`.

## Changes

- Added explicit priority rendering for generated `WORKFLOW.md` and reference workflow templates, including ADR disabled-source scaffolds.
- Added setup/init priority source prompts, editable numeric mapping prompts, repo label listing, and dry-run/summary priority output.
- Updated front-matter parsing to allow generated comments, quoted mapping keys, and escaped quoted scalar/key round-trips.
- Tightened interactive priority mapping validation to require non-empty integers for project-field options and label mappings.
- Expanded generator, setup/init, and parser tests for project-field, labels, disabled, no-field scaffold, escaped names, and integer validation behavior.

## Evidence

- `pnpm --filter @gh-symphony/cli test -- generate-workflow-md generate-reference-workflow workflow-init setup`
- `pnpm --filter @gh-symphony/core test -- workflow-loader`
- `pnpm lint && pnpm test && pnpm typecheck && pnpm build`

## Human Validation

- [ ] Confirm `workflow init --non-interactive` writes a project-field mapping when a `Priority` single-select field exists.
- [ ] Confirm setup can choose labels and writes exact label-name mappings.
- [ ] Confirm no-field non-interactive output contains active `source: disabled` plus commented templates.
- [ ] Confirm priority names containing quotes or backslashes round-trip from generated front matter.

## Risks

- The parser now accepts comments in front matter and unescapes quoted scalars/keys so generated workflows can round-trip; this is intended parser leniency for generated priority mappings.
