### PR TITLE
fix(worker): avoid false clean convergence

### DIFF
--- a/.changeset/clean-commit-convergence.md
+++ b/.changeset/clean-commit-convergence.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Fix worker convergence detection so clean workspaces after successful commits are treated as productive when Git HEAD advances, preventing false `convergence_detected: workspace unchanged` failures for issue #343.

--- a/packages/worker/src/convergence-detection.test.ts
+++ b/packages/worker/src/convergence-detection.test.ts
@@ -67,7 +67,7 @@ describe("convergence detection helpers", () => {
       stdio: "ignore",
     });
     execSync(
-      'git -c user.name="Test User" -c user.email="test@example.com" commit -m "initial"',
+      'git -c user.name="Test User" -c user.email="test@example.com" -c commit.gpgsign=false commit -m "initial"',
       {
         cwd: repoRoot,
         stdio: "ignore",
@@ -123,6 +123,31 @@ describe("convergence detection helpers", () => {
           fingerprint: "",
           changedFiles: [],
           headSha: "2222222222222222222222222222222222222222",
+          lastError: null,
+        }
+      )
+    ).toEqual({
+      nonProductive: false,
+      repeatedPattern: false,
+      reason: null,
+      headChanged: true,
+      fingerprintUnchanged: true,
+    });
+  });
+
+  it("treats clean snapshots with newly available HEAD as productive", () => {
+    expect(
+      evaluateTurnProgress(
+        {
+          fingerprint: "",
+          changedFiles: [],
+          headSha: null,
+          lastError: null,
+        },
+        {
+          fingerprint: "",
+          changedFiles: [],
+          headSha: "1111111111111111111111111111111111111111",
           lastError: null,
         }
       )

--- a/packages/worker/src/convergence-detection.test.ts
+++ b/packages/worker/src/convergence-detection.test.ts
@@ -50,19 +50,104 @@ describe("convergence detection helpers", () => {
 
     expect(snapshot.fingerprint).toContain("notes.txt");
     expect(snapshot.changedFiles).toEqual(["?? notes.txt"]);
+    expect(snapshot.headSha).toBeNull();
   });
 
-  it("marks unchanged workspace snapshots as non-productive", () => {
+  it("captures the git HEAD SHA when a commit exists", async () => {
+    const repoRoot = await mkdtemp(join(tmpdir(), "worker-convergence-"));
+    tempRoots.push(repoRoot);
+
+    execSync("git init", {
+      cwd: repoRoot,
+      stdio: "ignore",
+    });
+    await writeFile(join(repoRoot, "notes.txt"), "hello\n", "utf8");
+    execSync("git add notes.txt", {
+      cwd: repoRoot,
+      stdio: "ignore",
+    });
+    execSync(
+      'git -c user.name="Test User" -c user.email="test@example.com" commit -m "initial"',
+      {
+        cwd: repoRoot,
+        stdio: "ignore",
+      }
+    );
+
+    const headSha = execSync("git rev-parse HEAD", {
+      cwd: repoRoot,
+      encoding: "utf8",
+    }).trim();
+    const snapshot = captureTurnWorkspaceSnapshot(repoRoot);
+
+    expect(snapshot.fingerprint).toBe("");
+    expect(snapshot.changedFiles).toEqual([]);
+    expect(snapshot.headSha).toBe(headSha);
+  });
+
+  it("marks clean snapshots with unchanged HEAD as non-productive", () => {
+    expect(
+      evaluateTurnProgress(
+        {
+          fingerprint: "",
+          changedFiles: [],
+          headSha: "1111111111111111111111111111111111111111",
+          lastError: null,
+        },
+        {
+          fingerprint: "",
+          changedFiles: [],
+          headSha: "1111111111111111111111111111111111111111",
+          lastError: null,
+        }
+      )
+    ).toEqual({
+      nonProductive: true,
+      repeatedPattern: true,
+      reason: "workspace unchanged",
+      headChanged: false,
+      fingerprintUnchanged: true,
+    });
+  });
+
+  it("treats clean snapshots with changed HEAD as productive", () => {
+    expect(
+      evaluateTurnProgress(
+        {
+          fingerprint: "",
+          changedFiles: [],
+          headSha: "1111111111111111111111111111111111111111",
+          lastError: null,
+        },
+        {
+          fingerprint: "",
+          changedFiles: [],
+          headSha: "2222222222222222222222222222222222222222",
+          lastError: null,
+        }
+      )
+    ).toEqual({
+      nonProductive: false,
+      repeatedPattern: false,
+      reason: null,
+      headChanged: true,
+      fingerprintUnchanged: true,
+    });
+  });
+
+  it("marks unchanged dirty workspace snapshots as non-productive", () => {
     expect(
       evaluateTurnProgress(
         {
           fingerprint: "M src/index.ts",
           changedFiles: ["M src/index.ts"],
+          headSha: "1111111111111111111111111111111111111111",
           lastError: null,
         },
         {
           fingerprint: "M src/index.ts",
           changedFiles: ["M src/index.ts"],
+          headSha: "1111111111111111111111111111111111111111",
           lastError: null,
         }
       )
@@ -70,6 +155,8 @@ describe("convergence detection helpers", () => {
       nonProductive: true,
       repeatedPattern: true,
       reason: "workspace diff unchanged (1 tracked change)",
+      headChanged: false,
+      fingerprintUnchanged: true,
     });
   });
 
@@ -79,11 +166,13 @@ describe("convergence detection helpers", () => {
         {
           fingerprint: null,
           changedFiles: [],
+          headSha: null,
           lastError: "turn_failed: tool execution failed",
         },
         {
           fingerprint: null,
           changedFiles: [],
+          headSha: null,
           lastError: "turn_failed: tool execution failed",
         }
       )
@@ -91,6 +180,33 @@ describe("convergence detection helpers", () => {
       nonProductive: true,
       repeatedPattern: true,
       reason: "repeated error: turn_failed: tool execution failed",
+      headChanged: false,
+      fingerprintUnchanged: false,
+    });
+  });
+
+  it("treats changed HEAD as productive even when the last error repeats", () => {
+    expect(
+      evaluateTurnProgress(
+        {
+          fingerprint: "",
+          changedFiles: [],
+          headSha: "1111111111111111111111111111111111111111",
+          lastError: "turn_failed: transient failure",
+        },
+        {
+          fingerprint: "",
+          changedFiles: [],
+          headSha: "2222222222222222222222222222222222222222",
+          lastError: "turn_failed: transient failure",
+        }
+      )
+    ).toEqual({
+      nonProductive: false,
+      repeatedPattern: false,
+      reason: null,
+      headChanged: true,
+      fingerprintUnchanged: true,
     });
   });
 
@@ -100,11 +216,13 @@ describe("convergence detection helpers", () => {
         {
           fingerprint: "",
           changedFiles: [],
+          headSha: "1111111111111111111111111111111111111111",
           lastError: null,
         },
         {
           fingerprint: "M src/index.ts",
           changedFiles: ["M src/index.ts"],
+          headSha: "1111111111111111111111111111111111111111",
           lastError: null,
         }
       )
@@ -112,6 +230,8 @@ describe("convergence detection helpers", () => {
       nonProductive: false,
       repeatedPattern: false,
       reason: null,
+      headChanged: false,
+      fingerprintUnchanged: false,
     });
   });
 });

--- a/packages/worker/src/convergence-detection.ts
+++ b/packages/worker/src/convergence-detection.ts
@@ -69,8 +69,7 @@ export function evaluateTurnProgress(
   current: TurnProgressSnapshot
 ): TurnProgressEvaluation {
   const headChanged =
-    previous.headSha !== null &&
-    current.headSha !== null &&
+    (previous.headSha !== null || current.headSha !== null) &&
     previous.headSha !== current.headSha;
   const fingerprintUnchanged =
     previous.fingerprint !== null &&

--- a/packages/worker/src/convergence-detection.ts
+++ b/packages/worker/src/convergence-detection.ts
@@ -5,6 +5,7 @@ const DEFAULT_MAX_NONPRODUCTIVE_TURNS = 3;
 export type TurnWorkspaceSnapshot = {
   fingerprint: string | null;
   changedFiles: string[];
+  headSha: string | null;
 };
 
 export type TurnProgressSnapshot = TurnWorkspaceSnapshot & {
@@ -15,6 +16,8 @@ export type TurnProgressEvaluation = {
   nonProductive: boolean;
   repeatedPattern: boolean;
   reason: string | null;
+  headChanged: boolean;
+  fingerprintUnchanged: boolean;
 };
 
 export function resolveMaxNonProductiveTurns(
@@ -30,6 +33,7 @@ export function resolveMaxNonProductiveTurns(
 export function captureTurnWorkspaceSnapshot(
   cwd: string
 ): TurnWorkspaceSnapshot {
+  const headSha = captureGitHeadSha(cwd);
   const result = spawnSync(
     "git",
     ["status", "--porcelain=v1", "--untracked-files=all"],
@@ -43,6 +47,7 @@ export function captureTurnWorkspaceSnapshot(
     return {
       fingerprint: null,
       changedFiles: [],
+      headSha,
     };
   }
 
@@ -55,6 +60,7 @@ export function captureTurnWorkspaceSnapshot(
   return {
     fingerprint: changedFiles.join("\n"),
     changedFiles,
+    headSha,
   };
 }
 
@@ -62,6 +68,14 @@ export function evaluateTurnProgress(
   previous: TurnProgressSnapshot,
   current: TurnProgressSnapshot
 ): TurnProgressEvaluation {
+  const headChanged =
+    previous.headSha !== null &&
+    current.headSha !== null &&
+    previous.headSha !== current.headSha;
+  const fingerprintUnchanged =
+    previous.fingerprint !== null &&
+    current.fingerprint !== null &&
+    previous.fingerprint === current.fingerprint;
   const normalizedPreviousError = normalizeError(previous.lastError);
   const normalizedCurrentError = normalizeError(current.lastError);
   const repeatedError =
@@ -69,20 +83,27 @@ export function evaluateTurnProgress(
     normalizedCurrentError !== null &&
     normalizedPreviousError === normalizedCurrentError;
 
+  if (headChanged) {
+    return {
+      nonProductive: false,
+      repeatedPattern: false,
+      reason: null,
+      headChanged,
+      fingerprintUnchanged,
+    };
+  }
+
   if (repeatedError) {
     return {
       nonProductive: true,
       repeatedPattern: true,
       reason: `repeated error: ${normalizedCurrentError}`,
+      headChanged,
+      fingerprintUnchanged,
     };
   }
 
-  const unchangedWorkspace =
-    previous.fingerprint !== null &&
-    current.fingerprint !== null &&
-    previous.fingerprint === current.fingerprint;
-
-  if (unchangedWorkspace) {
+  if (fingerprintUnchanged) {
     return {
       nonProductive: true,
       repeatedPattern: true,
@@ -90,6 +111,8 @@ export function evaluateTurnProgress(
         current.changedFiles.length > 0
           ? `workspace diff unchanged (${current.changedFiles.length} tracked change${current.changedFiles.length === 1 ? "" : "s"})`
           : "workspace unchanged",
+      headChanged,
+      fingerprintUnchanged,
     };
   }
 
@@ -97,7 +120,23 @@ export function evaluateTurnProgress(
     nonProductive: false,
     repeatedPattern: false,
     reason: null,
+    headChanged,
+    fingerprintUnchanged,
   };
+}
+
+function captureGitHeadSha(cwd: string): string | null {
+  const result = spawnSync("git", ["rev-parse", "HEAD"], {
+    cwd,
+    encoding: "utf8",
+  });
+
+  if (result.status !== 0) {
+    return null;
+  }
+
+  const headSha = result.stdout.trim();
+  return headSha.length > 0 ? headSha : null;
 }
 
 function normalizeError(value: string | null): string | null {

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -1627,6 +1627,36 @@ async function runCodexClientProtocol(
         previousTurnProgressSnapshot,
         currentTurnProgressSnapshot
       );
+      const progressLogContext = {
+        reason: turnProgress.reason,
+        nonProductive: turnProgress.nonProductive,
+        repeatedPattern: turnProgress.repeatedPattern,
+        headChanged: turnProgress.headChanged,
+        fingerprintUnchanged: turnProgress.fingerprintUnchanged,
+        previous: {
+          fingerprint:
+            previousTurnProgressSnapshot.fingerprint === null
+              ? null
+              : previousTurnProgressSnapshot.fingerprint.length > 0
+                ? previousTurnProgressSnapshot.fingerprint
+                : "<clean>",
+          changedFilesCount: previousTurnProgressSnapshot.changedFiles.length,
+          headSha: previousTurnProgressSnapshot.headSha,
+        },
+        current: {
+          fingerprint:
+            currentTurnProgressSnapshot.fingerprint === null
+              ? null
+              : currentTurnProgressSnapshot.fingerprint.length > 0
+                ? currentTurnProgressSnapshot.fingerprint
+                : "<clean>",
+          changedFilesCount: currentTurnProgressSnapshot.changedFiles.length,
+          headSha: currentTurnProgressSnapshot.headSha,
+        },
+      };
+      process.stderr.write(
+        `[worker] turn progress evaluation ${JSON.stringify(progressLogContext)}\n`
+      );
       previousTurnProgressSnapshot = currentTurnProgressSnapshot;
 
       if (turnProgress.nonProductive) {

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -911,6 +911,26 @@ function summarizeRuntimeStderr(stderr: string): string | null {
   return lines.slice(-3).join(" | ").slice(0, 1000);
 }
 
+function formatTurnProgressFingerprint(fingerprint: string | null): {
+  state: "unavailable" | "clean" | "dirty";
+  length: number | null;
+  preview: string | null;
+} {
+  if (fingerprint === null) {
+    return { state: "unavailable", length: null, preview: null };
+  }
+
+  if (fingerprint.length === 0) {
+    return { state: "clean", length: 0, preview: "<clean>" };
+  }
+
+  return {
+    state: "dirty",
+    length: fingerprint.length,
+    preview: fingerprint.slice(0, 500),
+  };
+}
+
 async function exitWorkerStartupFailure(message: string): Promise<void> {
   runtimeState.status = "failed";
   runtimeState.runPhase = "failed";
@@ -1634,22 +1654,16 @@ async function runCodexClientProtocol(
         headChanged: turnProgress.headChanged,
         fingerprintUnchanged: turnProgress.fingerprintUnchanged,
         previous: {
-          fingerprint:
-            previousTurnProgressSnapshot.fingerprint === null
-              ? null
-              : previousTurnProgressSnapshot.fingerprint.length > 0
-                ? previousTurnProgressSnapshot.fingerprint
-                : "<clean>",
+          fingerprint: formatTurnProgressFingerprint(
+            previousTurnProgressSnapshot.fingerprint
+          ),
           changedFilesCount: previousTurnProgressSnapshot.changedFiles.length,
           headSha: previousTurnProgressSnapshot.headSha,
         },
         current: {
-          fingerprint:
-            currentTurnProgressSnapshot.fingerprint === null
-              ? null
-              : currentTurnProgressSnapshot.fingerprint.length > 0
-                ? currentTurnProgressSnapshot.fingerprint
-                : "<clean>",
+          fingerprint: formatTurnProgressFingerprint(
+            currentTurnProgressSnapshot.fingerprint
+          ),
           changedFilesCount: currentTurnProgressSnapshot.changedFiles.length,
           headSha: currentTurnProgressSnapshot.headSha,
         },


### PR DESCRIPTION
## Issues

- Fixes #343

## Summary

- Prevent worker convergence detection from treating clean-after-commit turns as non-productive when Git `HEAD` advanced or first becomes available.
- Add structured turn progress logging so operators can distinguish unchanged fingerprints from `HEAD` changes without emitting unbounded dirty fingerprints.

## Changes

- `TurnWorkspaceSnapshot` records `headSha` from `git rev-parse HEAD` when Git metadata is available.
- `evaluateTurnProgress()` treats HEAD value transitions, including `null -> sha`, as productive before repeated fingerprint/error convergence checks.
- Repeated clean fingerprints still converge only when `HEAD` is unchanged or unavailable; repeated dirty diffs and repeated errors without `HEAD` progress remain non-productive.
- Worker progress logs now include fingerprint state, length, bounded preview, changed file counts, and previous/current `headSha`.
- Added regression coverage for clean/dirty snapshots, changed `HEAD`, newly available `HEAD`, repeated errors, and snapshot `HEAD` capture; made the git commit test disable `commit.gpgsign` for hermeticity.
- Added `.changeset/clean-commit-convergence.md` for `@gh-symphony/cli` patch release notes.

## Evidence

- `pnpm --filter @gh-symphony/worker test -- convergence-detection.test.ts` — passed, 11 tests.
- `pnpm --filter @gh-symphony/worker test` — passed, 127 tests.
- `pnpm --filter @gh-symphony/worker lint` — passed.
- `pnpm --filter @gh-symphony/worker typecheck` — passed.
- `pnpm lint && pnpm test && pnpm typecheck && pnpm build` — passed.
- Docker E2E blackbox per `AGENT_TEST.md`: built/started Docker runtime, injected `happy-path.json`, observed worker run in `running`, removed fixture, refreshed until `health=idle`, `activeRuns=0`, `retryQueue=[]`, `lastError=null` — passed.

## Human Validation

- [ ] Confirm a real clean-after-commit worker turn with advanced `HEAD` does not increment the non-productive turn counter.
- [ ] Confirm convergence still triggers for genuine repeated clean no-op turns where `HEAD` is unchanged.
- [ ] Confirm worker logs show enough context to compare previous/current fingerprint and `HEAD` values without oversized fingerprint output.

## Risks

- `HEAD` capture depends on Git metadata in the workspace; non-Git workspaces continue to fall back to existing fingerprint/error behavior.