### PR TITLE
chore: add explicit priority mappings changeset

### DIFF
--- a/.changeset/explicit-priority-mappings.md
+++ b/.changeset/explicit-priority-mappings.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Add explicit dispatch priority mappings for GitHub Project V2 workflows from issue #236, including `tracker.priority` configuration, generated setup/init mappings, drift diagnostics, and no-fallback runtime behavior while preserving legacy `tracker.priority_field` compatibility.


### PR DESCRIPTION
## Issues

- Fixes #236

## Summary

- Adds the missing patch Changeset for the explicit dispatch priority mapping umbrella.
- Records the user-visible CLI/runtime behavior delivered through #336, #337, and #338 for `@gh-symphony/cli`.

## Changes

- Adds `.changeset/explicit-priority-mappings.md` with a patch bump for `@gh-symphony/cli`.
- References issue #236 in the Changeset summary and preserves the release package scope required by the workflow.

## Evidence

- `pnpm lint && pnpm test && pnpm typecheck && pnpm build`
- Docker E2E smoke: `docker compose -f docker-compose.e2e.yml -f docker-compose.e2e.events.yml up -d --build`, `/healthz`, `/api/v1/refresh`, and `/api/v1/state` with `health: running` and `activeRuns: 1` after injecting `e2e/fixtures/happy-path.json`.
- Manual check: #336, #337, and #338 are closed and in Done; PRs #339, #342, and #341 are merged with passing CI.

## Human Validation

- [ ] Confirm the release note accurately describes the explicit priority mapping behavior.
- [ ] Confirm only `@gh-symphony/cli` receives the patch Changeset.
- [ ] Confirm the umbrella issue can close after this release-note PR merges.

## Risks

- Low: this PR is release metadata only and does not change runtime code.