### PR TITLE
feat(cli): preflight repo start tracker auth

### DIFF
--- a/.changeset/fast-repo-start-auth.md
+++ b/.changeset/fast-repo-start-auth.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": minor
+---
+
+Fail fast during `gh-symphony repo start` when GitHub tracker authentication is missing, invalid, or lacks required scopes, with guided `gh auth` remediation for issue #350. Linear tracker starts now also require `LINEAR_API_KEY` to be present before orchestration begins.

--- a/.changeset/fast-repo-start-auth.md
+++ b/.changeset/fast-repo-start-auth.md
@@ -1,5 +1,5 @@
 ---
-"@gh-symphony/cli": minor
+"@gh-symphony/cli": patch
 ---
 
 Fail fast during `gh-symphony repo start` when GitHub tracker authentication is missing, invalid, or lacks required scopes, with guided `gh auth` remediation for issue #350. Linear tracker starts now also require `LINEAR_API_KEY` to be present before orchestration begins.

--- a/packages/cli/src/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/src/commands/__snapshots__/help.test.ts.snap
@@ -15,7 +15,7 @@ exports[`help output > renders the colored grouped help snapshot 1`] = `
 
 [33m[1mOrchestration (current repository):[0m[0m
   [36mrepo init[0m                   Initialize gh-symphony for the current repository
-  [36mrepo start[0m                  Start the orchestrator (foreground)
+  [36mrepo start[0m                  Start the orchestrator after validating tracker authentication
   [36mrepo start --daemon[0m         Start the orchestrator in the background
   [36mrepo start --assigned-only[0m  Process only issues assigned to the authenticated user
   [36mrepo stop[0m                   Stop the background orchestrator
@@ -57,7 +57,7 @@ Setup:
 
 Orchestration (current repository):
   repo init                   Initialize gh-symphony for the current repository
-  repo start                  Start the orchestrator (foreground)
+  repo start                  Start the orchestrator after validating tracker authentication
   repo start --daemon         Start the orchestrator in the background
   repo start --assigned-only  Process only issues assigned to the authenticated user
   repo stop                   Stop the background orchestrator

--- a/packages/cli/src/commands/help.ts
+++ b/packages/cli/src/commands/help.ts
@@ -61,7 +61,8 @@ export const HELP_SECTIONS: HelpSection[] = [
       },
       {
         name: "repo start",
-        description: "Start the orchestrator (foreground)",
+        description:
+          "Start the orchestrator after validating tracker authentication",
       },
       {
         name: "repo start --daemon",

--- a/packages/cli/src/commands/lifecycle.test.ts
+++ b/packages/cli/src/commands/lifecycle.test.ts
@@ -1,13 +1,16 @@
 import { mkdtemp, mkdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { CliProjectConfig } from "../config.js";
 
 const orchestratorRunCli = vi.fn();
 const spawnMock = vi.fn();
 const selectMock = vi.fn();
 const cancelMock = vi.fn();
+const ghAuthMocks = vi.hoisted(() => ({
+  resolveGitHubAuth: vi.fn(),
+}));
 
 vi.mock("@gh-symphony/orchestrator", () => ({
   runCli: orchestratorRunCli,
@@ -37,16 +40,35 @@ vi.mock("node:child_process", async () => {
   };
 });
 
+vi.mock("../github/gh-auth.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../github/gh-auth.js")>();
+  return {
+    ...actual,
+    resolveGitHubAuth: ghAuthMocks.resolveGitHubAuth,
+  };
+});
+
 const runModule = await import("./run.js");
 const startModule = await import("./start.js");
 const recoverModule = await import("./recover.js");
 const stopModule = await import("./stop.js");
+
+beforeEach(() => {
+  ghAuthMocks.resolveGitHubAuth.mockReset();
+  ghAuthMocks.resolveGitHubAuth.mockResolvedValue({
+    source: "gh",
+    token: "validated-token",
+    login: "octocat",
+    scopes: ["repo", "read:org", "project"],
+  });
+});
 
 afterEach(() => {
   orchestratorRunCli.mockReset();
   spawnMock.mockReset();
   selectMock.mockReset();
   cancelMock.mockReset();
+  ghAuthMocks.resolveGitHubAuth.mockReset();
   vi.restoreAllMocks();
   process.exitCode = undefined;
 });
@@ -211,7 +233,9 @@ describe("lifecycle command integration", () => {
 
     expect(orchestratorRunCli).not.toHaveBeenCalled();
     expect(cancelMock).toHaveBeenCalledWith("Cancelled.");
-    expect(stderr.mock.calls.map((call) => String(call[0])).join("")).not.toContain(
+    expect(
+      stderr.mock.calls.map((call) => String(call[0])).join("")
+    ).not.toContain(
       "No repository runtime config found. Run 'gh-symphony repo init' first."
     );
     expect(process.exitCode).toBe(130);
@@ -270,20 +294,24 @@ describe("lifecycle command integration", () => {
       activeProject: "tenant-a",
       projects: [createTenant("tenant-a", "acme", "platform")],
     });
-    await writeFile(join(configDir, "projects", "tenant-a", "daemon.pid"), "111\n");
+    await writeFile(
+      join(configDir, "projects", "tenant-a", "daemon.pid"),
+      "111\n"
+    );
     await writeFile(join(configDir, "projects", "tenant-a", "port"), "41001\n");
 
-    const killSpy = vi
-      .spyOn(process, "kill")
-      .mockImplementation(((pid: number, signal?: NodeJS.Signals | 0) => {
-        if (signal === 0) {
-          return true;
-        }
-        if (pid !== 111 || signal !== "SIGTERM") {
-          throw new Error(`unexpected kill ${pid} ${String(signal)}`);
-        }
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(((
+      pid: number,
+      signal?: NodeJS.Signals | 0
+    ) => {
+      if (signal === 0) {
         return true;
-      }) as typeof process.kill);
+      }
+      if (pid !== 111 || signal !== "SIGTERM") {
+        throw new Error(`unexpected kill ${pid} ${String(signal)}`);
+      }
+      return true;
+    }) as typeof process.kill);
 
     await stopModule.default([], baseOptions(configDir));
 
@@ -302,20 +330,24 @@ describe("lifecycle command integration", () => {
         createTenant("tenant-b", "beta", "api"),
       ],
     });
-    await writeFile(join(configDir, "projects", "tenant-a", "daemon.pid"), "111\n");
+    await writeFile(
+      join(configDir, "projects", "tenant-a", "daemon.pid"),
+      "111\n"
+    );
 
     const killSpy = vi.spyOn(process, "kill");
     const stderr = vi
       .spyOn(process.stderr, "write")
       .mockImplementation(() => true);
 
-    await stopModule.default(["--proejct-id", "tenant-a"], baseOptions(configDir));
+    await stopModule.default(
+      ["--proejct-id", "tenant-a"],
+      baseOptions(configDir)
+    );
 
     const output = stderr.mock.calls.map((call) => String(call[0])).join("");
     expect(output).toContain("Unknown option '--proejct-id'");
-    expect(output).toContain(
-      "Usage: gh-symphony repo stop [--force]"
-    );
+    expect(output).toContain("Usage: gh-symphony repo stop [--force]");
     expect(killSpy).not.toHaveBeenCalled();
     await expect(
       readFile(join(configDir, "projects", "tenant-a", "daemon.pid"), "utf8")

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -16,7 +16,7 @@ import {
   ensureGhAuth,
   getGhToken,
   GhAuthError,
-  KNOWN_REQUIRED_SCOPES,
+  REQUIRED_GH_SCOPES,
 } from "../github/gh-auth.js";
 import {
   abortIfCancelled,
@@ -87,7 +87,7 @@ function displayScopeError(
     `Token is missing required scope${plural}: ${error.requiredScopes.join(", ")}`
   );
   const currentSet = new Set(error.currentScopes.map((s) => s.toLowerCase()));
-  const scopesToAdd = KNOWN_REQUIRED_SCOPES.filter((s) => !currentSet.has(s));
+  const scopesToAdd = REQUIRED_GH_SCOPES.filter((s) => !currentSet.has(s));
   const scopeArg =
     scopesToAdd.length > 0
       ? scopesToAdd.join(",")
@@ -98,7 +98,9 @@ function displayScopeError(
   );
 }
 
-async function resolveProjectDetail(client: GitHubClient): Promise<ProjectDetail> {
+async function resolveProjectDetail(
+  client: GitHubClient
+): Promise<ProjectDetail> {
   const projects = await listUserProjects(client);
 
   if (projects.length === 0) {
@@ -341,11 +343,17 @@ async function runInteractive(
     authSpinner.stop("Authentication failed.");
     if (error instanceof GhAuthError) {
       if (error.code === "not_installed") {
-        p.log.error("gh CLI가 설치되어 있지 않습니다. https://cli.github.com 에서 설치하세요.");
+        p.log.error(
+          "gh CLI가 설치되어 있지 않습니다. https://cli.github.com 에서 설치하세요."
+        );
       } else if (error.code === "not_authenticated") {
-        p.log.error("gh auth login --scopes repo,read:org,project 를 실행하세요.");
+        p.log.error(
+          "gh auth login --scopes repo,read:org,project 를 실행하세요."
+        );
       } else if (error.code === "missing_scopes") {
-        p.log.error("gh auth refresh --scopes repo,read:org,project 를 실행하세요.");
+        p.log.error(
+          "gh auth refresh --scopes repo,read:org,project 를 실행하세요."
+        );
       } else {
         p.log.error(error.message);
       }
@@ -480,7 +488,9 @@ async function runInteractive(
       repoDir: process.cwd(),
       workflowFile: workflowPath,
     });
-    writeSpinner.stop(`Setup saved for ${runtime.repository.owner}/${runtime.repository.name}.`);
+    writeSpinner.stop(
+      `Setup saved for ${runtime.repository.owner}/${runtime.repository.name}.`
+    );
   } catch (error) {
     writeSpinner.stop("Setup failed.");
     p.log.error(error instanceof Error ? error.message : "Unknown error");

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -12,7 +12,12 @@ import {
   type ProjectDetail,
   type ProjectSummary,
 } from "../github/client.js";
-import { ensureGhAuth, getGhToken, GhAuthError } from "../github/gh-auth.js";
+import {
+  ensureGhAuth,
+  getGhToken,
+  GhAuthError,
+  KNOWN_REQUIRED_SCOPES,
+} from "../github/gh-auth.js";
 import {
   abortIfCancelled,
   buildAutomaticStateMappings,
@@ -28,8 +33,6 @@ import {
 } from "./workflow-init.js";
 import { validateStateMapping } from "../mapping/smart-defaults.js";
 import { initRepoRuntime } from "../repo-runtime.js";
-
-const KNOWN_REQUIRED_SCOPES = ["repo", "read:org", "project"] as const;
 
 type SetupFlags = {
   nonInteractive: boolean;

--- a/packages/cli/src/commands/start.test.ts
+++ b/packages/cli/src/commands/start.test.ts
@@ -57,8 +57,7 @@ vi.mock("@gh-symphony/control-plane", () => ({
 }));
 
 vi.mock("../github/gh-auth.js", async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import("../github/gh-auth.js")>();
+  const actual = await importOriginal<typeof import("../github/gh-auth.js")>();
   return {
     ...actual,
     resolveGitHubAuth: ghAuthMocks.resolveGitHubAuth,
@@ -235,6 +234,46 @@ describe("start command foreground locking", () => {
     await startModule.default([], baseOptions(configDir));
 
     expect(process.env.GITHUB_GRAPHQL_TOKEN).toBe("validated-token");
+    expect(exitSpy).toHaveBeenCalledWith(0);
+  });
+
+  it("reports the env token source when GitHub auth resolves from GITHUB_GRAPHQL_TOKEN", async () => {
+    const configDir = await createConfigFixture({
+      activeProject: "tenant-a",
+      projects: [createProject("tenant-a", "acme", "platform")],
+    });
+    ghAuthMocks.resolveGitHubAuth.mockResolvedValue({
+      source: "env",
+      token: "env-token",
+      login: "env-user",
+      scopes: ["repo", "read:org", "project"],
+    });
+    const lock = {
+      lockPath: join(configDir, ".lock"),
+      ownerToken: "owner",
+      pid: 1234,
+      startedAt: "2026-03-17T00:00:00.000Z",
+    };
+    acquireProjectLock.mockResolvedValue(lock);
+    run.mockImplementation(async () => {
+      process.emit("SIGINT");
+    });
+    const exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation(
+        ((_code?: number) => undefined) as (code?: number) => never
+      );
+    const stdout = captureWrites(process.stdout);
+
+    try {
+      await startModule.default([], baseOptions(configDir));
+    } finally {
+      stdout.restore();
+    }
+
+    expect(stdout.output()).toContain(
+      "Authenticated via GITHUB_GRAPHQL_TOKEN as env-user"
+    );
     expect(exitSpy).toHaveBeenCalledWith(0);
   });
 
@@ -525,7 +564,17 @@ describe("start command foreground locking", () => {
         summary: { dispatched: 0, suppressed: 0, recovered: 0, activeRuns: 0 },
         activeRuns: [],
         retryQueue: [],
-        lastError: "GitHub GraphQL request failed with status 401",
+        lastError: "Token is missing required GitHub scopes.",
+      });
+      await onTick?.({
+        repository: { owner: "acme", name: "platform" },
+        tracker: { adapter: "github-project", bindingId: "project-1" },
+        health: "degraded",
+        lastTickAt: "2026-03-17T00:02:00.000Z",
+        summary: { dispatched: 0, suppressed: 0, recovered: 0, activeRuns: 0 },
+        activeRuns: [],
+        retryQueue: [],
+        lastError: "Token is missing required GitHub scopes.",
       });
     });
     const exitSpy = vi
@@ -545,11 +594,64 @@ describe("start command foreground locking", () => {
       "Stopping repo start because GitHub authentication can no longer be validated."
     );
     expect(stderr.output()).toContain(
-      "Run 'gh auth login --scopes repo,read:org,project' to re-authenticate"
+      "Run 'gh auth refresh --scopes repo,read:org,project', then re-run 'gh-symphony repo start'."
     );
     expect(shutdown).toHaveBeenCalledTimes(1);
     expect(releaseProjectLock).toHaveBeenCalledWith(lock);
     expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it("does not classify non-GitHub tracker 401 snapshots as GitHub auth failures", async () => {
+    const linearProject = createProject("tenant-a", "acme", "platform");
+    linearProject.tracker = {
+      adapter: "linear",
+      bindingId: "linear-workspace",
+      settings: {},
+    };
+    process.env.LINEAR_API_KEY = "linear-key";
+    const configDir = await createConfigFixture({
+      activeProject: "tenant-a",
+      projects: [linearProject],
+    });
+    const lock = {
+      lockPath: join(configDir, ".lock"),
+      ownerToken: "owner",
+      pid: 1234,
+      startedAt: "2026-03-17T00:00:00.000Z",
+    };
+    acquireProjectLock.mockResolvedValue(lock);
+    run.mockImplementation(async () => {
+      const onTick = serviceDependencies.at(-1)?.onTick as
+        | ((snapshot: Record<string, unknown>) => Promise<void>)
+        | undefined;
+      await onTick?.({
+        repository: { owner: "acme", name: "platform" },
+        tracker: { adapter: "linear", bindingId: "linear-workspace" },
+        health: "degraded",
+        lastTickAt: "2026-03-17T00:01:00.000Z",
+        summary: { dispatched: 0, suppressed: 0, recovered: 0, activeRuns: 0 },
+        activeRuns: [],
+        retryQueue: [],
+        lastError: "Linear API request failed with status 401",
+      });
+      process.emit("SIGINT");
+    });
+    const exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation(
+        ((_code?: number) => undefined) as (code?: number) => never
+      );
+    const stderr = captureWrites(process.stderr);
+
+    try {
+      await startModule.default([], baseOptions(configDir));
+    } finally {
+      stderr.restore();
+    }
+
+    expect(stderr.output()).not.toContain("gh auth");
+    expect(shutdown).toHaveBeenCalledTimes(1);
+    expect(exitSpy).toHaveBeenCalledWith(0);
   });
 
   it("shuts down cleanly when service.run throws a GitHub scope error", async () => {

--- a/packages/cli/src/commands/start.test.ts
+++ b/packages/cli/src/commands/start.test.ts
@@ -349,6 +349,73 @@ describe("start command foreground locking", () => {
     expect(process.exitCode).toBe(1);
   });
 
+  it("runs interactive gh scope remediation and starts with the refreshed token", async () => {
+    const restoreTty = forceTty(true);
+    const configDir = await createConfigFixture({
+      activeProject: "tenant-a",
+      projects: [createProject("tenant-a", "acme", "platform")],
+    });
+    const lock = {
+      lockPath: join(configDir, ".lock"),
+      ownerToken: "owner",
+      pid: 1234,
+      startedAt: "2026-03-17T00:00:00.000Z",
+    };
+    ghAuthMocks.resolveGitHubAuth
+      .mockRejectedValueOnce(
+        new ghAuth.GhAuthError(
+          "missing_scopes",
+          "Run 'gh auth refresh --scopes repo,read:org,project'. Missing scopes: project",
+          {
+            missingScopes: ["project"],
+            currentScopes: ["repo", "read:org"],
+            source: "gh",
+          }
+        )
+      )
+      .mockResolvedValueOnce({
+        source: "gh",
+        token: "refreshed-token",
+        login: "octocat",
+        scopes: ["repo", "read:org", "project"],
+      });
+    ghAuthMocks.runGhAuthRefresh.mockReturnValue({
+      status: "applied",
+      summary: "GitHub auth scopes refreshed.",
+    });
+    acquireProjectLock.mockResolvedValue(lock);
+    run.mockImplementation(async () => {
+      process.emit("SIGINT");
+    });
+    const exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation(
+        ((_code?: number) => undefined) as (code?: number) => never
+      );
+    const stderr = captureWrites(process.stderr);
+
+    try {
+      await startModule.default([], baseOptions(configDir));
+    } finally {
+      stderr.restore();
+      restoreTty();
+    }
+
+    expect(promptMocks.confirm).toHaveBeenCalledWith({
+      message: "Run 'gh auth refresh --scopes project' now?",
+      initialValue: true,
+    });
+    expect(ghAuthMocks.runGhAuthRefresh).toHaveBeenCalledWith({
+      interactive: true,
+    });
+    expect(ghAuthMocks.runGhAuthLogin).not.toHaveBeenCalled();
+    expect(stderr.output()).toContain("GitHub auth scopes refreshed.");
+    expect(process.env.GITHUB_GRAPHQL_TOKEN).toBe("refreshed-token");
+    expect(acquireProjectLock).toHaveBeenCalled();
+    expect(run).toHaveBeenCalled();
+    expect(exitSpy).toHaveBeenCalledWith(0);
+  });
+
   it("fails fast for Linear projects when LINEAR_API_KEY is missing", async () => {
     const linearProject = createProject("tenant-a", "acme", "platform");
     linearProject.tracker = {

--- a/packages/cli/src/commands/start.test.ts
+++ b/packages/cli/src/commands/start.test.ts
@@ -20,6 +20,9 @@ const ghAuthMocks = vi.hoisted(() => ({
   runGhAuthLogin: vi.fn(),
   runGhAuthRefresh: vi.fn(),
 }));
+const promptMocks = vi.hoisted(() => ({
+  confirm: vi.fn(),
+}));
 
 vi.mock("@gh-symphony/orchestrator", () => ({
   acquireProjectLock,
@@ -55,6 +58,14 @@ vi.mock("@gh-symphony/dashboard", () => ({
 vi.mock("@gh-symphony/control-plane", () => ({
   startControlPlaneServer,
 }));
+
+vi.mock("@clack/prompts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@clack/prompts")>();
+  return {
+    ...actual,
+    confirm: promptMocks.confirm,
+  };
+});
 
 vi.mock("../github/gh-auth.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../github/gh-auth.js")>();
@@ -101,6 +112,8 @@ beforeEach(() => {
   });
   ghAuthMocks.runGhAuthLogin.mockReset();
   ghAuthMocks.runGhAuthRefresh.mockReset();
+  promptMocks.confirm.mockReset();
+  promptMocks.confirm.mockResolvedValue(true);
   process.env.GITHUB_GRAPHQL_TOKEN = originalGithubToken;
   process.env.LINEAR_API_KEY = originalLinearApiKey;
   serviceDependencies.length = 0;
@@ -112,6 +125,29 @@ afterEach(() => {
   process.env.GITHUB_GRAPHQL_TOKEN = originalGithubToken;
   process.env.LINEAR_API_KEY = originalLinearApiKey;
 });
+
+function forceTty(value: boolean): () => void {
+  const originalStdinTty = process.stdin.isTTY;
+  const originalStdoutTty = process.stdout.isTTY;
+  Object.defineProperty(process.stdin, "isTTY", {
+    configurable: true,
+    value,
+  });
+  Object.defineProperty(process.stdout, "isTTY", {
+    configurable: true,
+    value,
+  });
+  return () => {
+    Object.defineProperty(process.stdin, "isTTY", {
+      configurable: true,
+      value: originalStdinTty,
+    });
+    Object.defineProperty(process.stdout, "isTTY", {
+      configurable: true,
+      value: originalStdoutTty,
+    });
+  };
+}
 
 describe("shutdownForegroundOrchestrator", () => {
   it("exits after releasing the foreground lock", async () => {
@@ -275,6 +311,42 @@ describe("start command foreground locking", () => {
       "Authenticated via GITHUB_GRAPHQL_TOKEN as env-user"
     );
     expect(exitSpy).toHaveBeenCalledWith(0);
+  });
+
+  it("does not offer interactive gh remediation for env-token auth failures", async () => {
+    const restoreTty = forceTty(true);
+    const configDir = await createConfigFixture({
+      activeProject: "tenant-a",
+      projects: [createProject("tenant-a", "acme", "platform")],
+    });
+    ghAuthMocks.resolveGitHubAuth.mockRejectedValue(
+      new ghAuth.GhAuthError(
+        "missing_scopes",
+        "GITHUB_GRAPHQL_TOKEN is missing required scopes: project",
+        {
+          missingScopes: ["project"],
+          currentScopes: ["repo", "read:org"],
+          source: "env",
+        }
+      )
+    );
+    const stderr = captureWrites(process.stderr);
+
+    try {
+      await startModule.default([], baseOptions(configDir));
+    } finally {
+      stderr.restore();
+      restoreTty();
+    }
+
+    expect(stderr.output()).toContain("Update GITHUB_GRAPHQL_TOKEN");
+    expect(stderr.output()).not.toContain("Run 'undefined' now?");
+    expect(promptMocks.confirm).not.toHaveBeenCalled();
+    expect(ghAuthMocks.runGhAuthRefresh).not.toHaveBeenCalled();
+    expect(ghAuthMocks.runGhAuthLogin).not.toHaveBeenCalled();
+    expect(acquireProjectLock).not.toHaveBeenCalled();
+    expect(run).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
   });
 
   it("fails fast for Linear projects when LINEAR_API_KEY is missing", async () => {
@@ -602,16 +674,19 @@ describe("start command foreground locking", () => {
   });
 
   it("does not classify non-GitHub tracker 401 snapshots as GitHub auth failures", async () => {
-    const linearProject = createProject("tenant-a", "acme", "platform");
-    linearProject.tracker = {
-      adapter: "linear",
-      bindingId: "linear-workspace",
-      settings: {},
+    const fileProject = createProject("tenant-a", "acme", "platform");
+    fileProject.tracker = {
+      adapter: "file",
+      bindingId: "file-tracker",
+      settings: {
+        projectId: "file-tracker",
+        repository: "acme/platform",
+        issuesPath: "/tmp/issues.json",
+      },
     };
-    process.env.LINEAR_API_KEY = "linear-key";
     const configDir = await createConfigFixture({
       activeProject: "tenant-a",
-      projects: [linearProject],
+      projects: [fileProject],
     });
     const lock = {
       lockPath: join(configDir, ".lock"),
@@ -626,13 +701,13 @@ describe("start command foreground locking", () => {
         | undefined;
       await onTick?.({
         repository: { owner: "acme", name: "platform" },
-        tracker: { adapter: "linear", bindingId: "linear-workspace" },
+        tracker: { adapter: "file", bindingId: "file-tracker" },
         health: "degraded",
         lastTickAt: "2026-03-17T00:01:00.000Z",
         summary: { dispatched: 0, suppressed: 0, recovered: 0, activeRuns: 0 },
         activeRuns: [],
         retryQueue: [],
-        lastError: "Linear API request failed with status 401",
+        lastError: "Tracker request failed with status 401",
       });
       process.emit("SIGINT");
     });
@@ -644,14 +719,17 @@ describe("start command foreground locking", () => {
     const stderr = captureWrites(process.stderr);
 
     try {
-      await startModule.default([], baseOptions(configDir));
+      await startModule.default(["--once"], baseOptions(configDir));
     } finally {
       stderr.restore();
     }
 
     expect(stderr.output()).not.toContain("gh auth");
-    expect(shutdown).toHaveBeenCalledTimes(1);
-    expect(exitSpy).toHaveBeenCalledWith(0);
+    expect(stderr.output()).not.toContain(
+      "Stopping repo start because GitHub authentication can no longer be validated."
+    );
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(exitSpy).not.toHaveBeenCalledWith(1);
   });
 
   it("shuts down cleanly when service.run throws a GitHub scope error", async () => {
@@ -689,6 +767,45 @@ describe("start command foreground locking", () => {
     expect(stderr.output()).toContain(
       "Run 'gh auth refresh --scopes project', then re-run 'gh-symphony repo start'."
     );
+    expect(shutdown).toHaveBeenCalledTimes(1);
+    expect(releaseProjectLock).toHaveBeenCalledWith(lock);
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it("keeps env-token remediation when runtime GitHub auth fails after env preflight", async () => {
+    const configDir = await createConfigFixture({
+      activeProject: "tenant-a",
+      projects: [createProject("tenant-a", "acme", "platform")],
+    });
+    ghAuthMocks.resolveGitHubAuth.mockResolvedValue({
+      source: "env",
+      token: "env-token",
+      login: "env-user",
+      scopes: ["repo", "read:org", "project"],
+    });
+    const lock = {
+      lockPath: join(configDir, ".lock"),
+      ownerToken: "owner",
+      pid: 1234,
+      startedAt: "2026-03-17T00:00:00.000Z",
+    };
+    acquireProjectLock.mockResolvedValue(lock);
+    run.mockRejectedValue(new githubClient.GitHubApiError("Bad credentials", 401));
+    const exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation(
+        ((_code?: number) => undefined) as (code?: number) => never
+      );
+    const stderr = captureWrites(process.stderr);
+
+    try {
+      await startModule.default([], baseOptions(configDir));
+    } finally {
+      stderr.restore();
+    }
+
+    expect(stderr.output()).toContain("Update or unset GITHUB_GRAPHQL_TOKEN");
+    expect(stderr.output()).not.toContain("gh auth login");
     expect(shutdown).toHaveBeenCalledTimes(1);
     expect(releaseProjectLock).toHaveBeenCalledWith(lock);
     expect(exitSpy).toHaveBeenCalledWith(1);

--- a/packages/cli/src/commands/start.test.ts
+++ b/packages/cli/src/commands/start.test.ts
@@ -15,6 +15,11 @@ const requestReconcile = vi.fn();
 const resolveDashboardResponse = vi.fn();
 const startControlPlaneServer = vi.fn();
 const serviceDependencies: Array<Record<string, unknown>> = [];
+const ghAuthMocks = vi.hoisted(() => ({
+  resolveGitHubAuth: vi.fn(),
+  runGhAuthLogin: vi.fn(),
+  runGhAuthRefresh: vi.fn(),
+}));
 
 vi.mock("@gh-symphony/orchestrator", () => ({
   acquireProjectLock,
@@ -51,7 +56,22 @@ vi.mock("@gh-symphony/control-plane", () => ({
   startControlPlaneServer,
 }));
 
+vi.mock("../github/gh-auth.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../github/gh-auth.js")>();
+  return {
+    ...actual,
+    resolveGitHubAuth: ghAuthMocks.resolveGitHubAuth,
+    runGhAuthLogin: ghAuthMocks.runGhAuthLogin,
+    runGhAuthRefresh: ghAuthMocks.runGhAuthRefresh,
+  };
+});
+
 const startModule = await import("./start.js");
+const ghAuth = await import("../github/gh-auth.js");
+const githubClient = await import("../github/client.js");
+const originalGithubToken = process.env.GITHUB_GRAPHQL_TOKEN;
+const originalLinearApiKey = process.env.LINEAR_API_KEY;
 
 beforeEach(() => {
   acquireProjectLock.mockReset();
@@ -73,12 +93,25 @@ beforeEach(() => {
     async ({ port }: { port: number }) =>
       createMockControlPlaneStartResult(port)
   );
+  ghAuthMocks.resolveGitHubAuth.mockReset();
+  ghAuthMocks.resolveGitHubAuth.mockResolvedValue({
+    source: "gh",
+    token: "validated-token",
+    login: "octocat",
+    scopes: ["repo", "read:org", "project"],
+  });
+  ghAuthMocks.runGhAuthLogin.mockReset();
+  ghAuthMocks.runGhAuthRefresh.mockReset();
+  process.env.GITHUB_GRAPHQL_TOKEN = originalGithubToken;
+  process.env.LINEAR_API_KEY = originalLinearApiKey;
   serviceDependencies.length = 0;
 });
 
 afterEach(() => {
   vi.restoreAllMocks();
   process.exitCode = undefined;
+  process.env.GITHUB_GRAPHQL_TOKEN = originalGithubToken;
+  process.env.LINEAR_API_KEY = originalLinearApiKey;
 });
 
 describe("shutdownForegroundOrchestrator", () => {
@@ -122,6 +155,118 @@ describe("shutdownForegroundOrchestrator", () => {
 });
 
 describe("start command foreground locking", () => {
+  it.each([
+    [
+      "not_installed",
+      "gh CLI is not installed.",
+      "Install gh CLI from https://cli.github.com or set GITHUB_GRAPHQL_TOKEN.",
+    ],
+    [
+      "not_authenticated",
+      "gh CLI is not authenticated.",
+      "Run 'gh auth login --scopes repo,read:org,project', then re-run 'gh-symphony repo start'.",
+    ],
+    [
+      "missing_scopes",
+      "Run 'gh auth refresh --scopes repo,read:org,project'. Missing scopes: project",
+      "Run 'gh auth refresh --scopes project', then re-run 'gh-symphony repo start'.",
+    ],
+    [
+      "invalid_token",
+      "GITHUB_GRAPHQL_TOKEN is invalid or expired.",
+      "Run 'gh auth login --scopes repo,read:org,project' to re-authenticate, then re-run 'gh-symphony repo start'.",
+    ],
+    [
+      "token_failed",
+      "gh CLI token could not be validated.",
+      "Run 'gh auth login --scopes repo,read:org,project' to re-authenticate, then re-run 'gh-symphony repo start'.",
+    ],
+  ] as const)(
+    "fails fast before constructing the orchestrator when GitHub auth returns %s",
+    async (code, message, expectedHint) => {
+      const configDir = await createConfigFixture({
+        activeProject: "tenant-a",
+        projects: [createProject("tenant-a", "acme", "platform")],
+      });
+      ghAuthMocks.resolveGitHubAuth.mockRejectedValue(
+        new ghAuth.GhAuthError(code, message, {
+          missingScopes: code === "missing_scopes" ? ["project"] : undefined,
+          currentScopes:
+            code === "missing_scopes" ? ["repo", "read:org"] : undefined,
+        })
+      );
+      const stderr = captureWrites(process.stderr);
+
+      try {
+        await startModule.default([], baseOptions(configDir));
+      } finally {
+        stderr.restore();
+      }
+
+      expect(stderr.output()).toContain(expectedHint);
+      expect(acquireProjectLock).not.toHaveBeenCalled();
+      expect(run).not.toHaveBeenCalled();
+      expect(serviceDependencies).toHaveLength(0);
+      expect(process.exitCode).toBe(1);
+    }
+  );
+
+  it("stores the validated GitHub token before starting orchestration", async () => {
+    const configDir = await createConfigFixture({
+      activeProject: "tenant-a",
+      projects: [createProject("tenant-a", "acme", "platform")],
+    });
+    const lock = {
+      lockPath: join(configDir, ".lock"),
+      ownerToken: "owner",
+      pid: 1234,
+      startedAt: "2026-03-17T00:00:00.000Z",
+    };
+    acquireProjectLock.mockResolvedValue(lock);
+    run.mockImplementation(async () => {
+      process.emit("SIGINT");
+    });
+    const exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation(
+        ((_code?: number) => undefined) as (code?: number) => never
+      );
+
+    await startModule.default([], baseOptions(configDir));
+
+    expect(process.env.GITHUB_GRAPHQL_TOKEN).toBe("validated-token");
+    expect(exitSpy).toHaveBeenCalledWith(0);
+  });
+
+  it("fails fast for Linear projects when LINEAR_API_KEY is missing", async () => {
+    const linearProject = createProject("tenant-a", "acme", "platform");
+    linearProject.tracker = {
+      adapter: "linear",
+      bindingId: "linear-workspace",
+      settings: {},
+    };
+    delete process.env.LINEAR_API_KEY;
+    const configDir = await createConfigFixture({
+      activeProject: "tenant-a",
+      projects: [linearProject],
+    });
+    const stderr = captureWrites(process.stderr);
+
+    try {
+      await startModule.default([], baseOptions(configDir));
+    } finally {
+      stderr.restore();
+    }
+
+    expect(stderr.output()).toContain(
+      "Set LINEAR_API_KEY in the environment before running 'gh-symphony repo start'."
+    );
+    expect(ghAuthMocks.resolveGitHubAuth).not.toHaveBeenCalled();
+    expect(acquireProjectLock).not.toHaveBeenCalled();
+    expect(run).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+  });
+
   it("runs a single orchestration tick and exits naturally with --once", async () => {
     const configDir = await createConfigFixture({
       activeProject: "tenant-a",
@@ -354,6 +499,97 @@ describe("start command foreground locking", () => {
     expect(stdout.output()).toContain("Worker stderr (acme/platform#1):");
     expect(stdout.output()).toContain("last failure");
     expect(exitSpy).toHaveBeenCalledWith(0);
+  });
+
+  it("shuts down cleanly when a tick reports a GitHub auth failure", async () => {
+    const configDir = await createConfigFixture({
+      activeProject: "tenant-a",
+      projects: [createProject("tenant-a", "acme", "platform")],
+    });
+    const lock = {
+      lockPath: join(configDir, ".lock"),
+      ownerToken: "owner",
+      pid: 1234,
+      startedAt: "2026-03-17T00:00:00.000Z",
+    };
+    acquireProjectLock.mockResolvedValue(lock);
+    run.mockImplementation(async () => {
+      const onTick = serviceDependencies.at(-1)?.onTick as
+        | ((snapshot: Record<string, unknown>) => Promise<void>)
+        | undefined;
+      await onTick?.({
+        repository: { owner: "acme", name: "platform" },
+        tracker: { adapter: "github-project", bindingId: "project-1" },
+        health: "degraded",
+        lastTickAt: "2026-03-17T00:01:00.000Z",
+        summary: { dispatched: 0, suppressed: 0, recovered: 0, activeRuns: 0 },
+        activeRuns: [],
+        retryQueue: [],
+        lastError: "GitHub GraphQL request failed with status 401",
+      });
+    });
+    const exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation(
+        ((_code?: number) => undefined) as (code?: number) => never
+      );
+    const stderr = captureWrites(process.stderr);
+
+    try {
+      await startModule.default([], baseOptions(configDir));
+    } finally {
+      stderr.restore();
+    }
+
+    expect(stderr.output()).toContain(
+      "Stopping repo start because GitHub authentication can no longer be validated."
+    );
+    expect(stderr.output()).toContain(
+      "Run 'gh auth login --scopes repo,read:org,project' to re-authenticate"
+    );
+    expect(shutdown).toHaveBeenCalledTimes(1);
+    expect(releaseProjectLock).toHaveBeenCalledWith(lock);
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it("shuts down cleanly when service.run throws a GitHub scope error", async () => {
+    const configDir = await createConfigFixture({
+      activeProject: "tenant-a",
+      projects: [createProject("tenant-a", "acme", "platform")],
+    });
+    const lock = {
+      lockPath: join(configDir, ".lock"),
+      ownerToken: "owner",
+      pid: 1234,
+      startedAt: "2026-03-17T00:00:00.000Z",
+    };
+    acquireProjectLock.mockResolvedValue(lock);
+    run.mockRejectedValue(
+      new githubClient.GitHubScopeError(
+        "Token is missing required scopes: project",
+        ["project"],
+        ["repo", "read:org"]
+      )
+    );
+    const exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation(
+        ((_code?: number) => undefined) as (code?: number) => never
+      );
+    const stderr = captureWrites(process.stderr);
+
+    try {
+      await startModule.default([], baseOptions(configDir));
+    } finally {
+      stderr.restore();
+    }
+
+    expect(stderr.output()).toContain(
+      "Run 'gh auth refresh --scopes project', then re-run 'gh-symphony repo start'."
+    );
+    expect(shutdown).toHaveBeenCalledTimes(1);
+    expect(releaseProjectLock).toHaveBeenCalledWith(lock);
+    expect(exitSpy).toHaveBeenCalledWith(1);
   });
 
   it("retries the foreground run loop after a service.run error", async () => {

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -38,6 +38,7 @@ import { bold, dim, green, red, yellow, cyan, setNoColor } from "../ansi.js";
 import {
   formatGhAuthRemediation,
   GhAuthError,
+  type GitHubAuthSource,
   resolveGitHubAuth,
   runGhAuthLogin,
   runGhAuthRefresh,
@@ -58,6 +59,10 @@ function logLine(icon: string, msg: string): void {
 }
 
 const REPO_START_COMMAND = "gh-symphony repo start";
+
+type RepoStartAuthPreflightResult =
+  | { ok: true; githubAuthSource?: GitHubAuthSource }
+  | { ok: false };
 
 function isInteractiveTerminal(): boolean {
   return process.stdin.isTTY === true && process.stdout.isTTY === true;
@@ -86,38 +91,40 @@ function displayGitHubAuthSuccess(auth: {
 
 async function resolveRepoStartGitHubAuth(input: {
   allowInteractiveRemediation: boolean;
-}): Promise<boolean> {
+}): Promise<RepoStartAuthPreflightResult> {
   try {
     const auth = await resolveGitHubAuth();
     process.env.GITHUB_GRAPHQL_TOKEN = auth.token;
     displayGitHubAuthSuccess(auth);
-    return true;
+    return { ok: true, githubAuthSource: auth.source };
   } catch (error) {
     if (!(error instanceof GhAuthError)) {
       throw error;
     }
 
-    displayGhAuthError(error);
+    const remediation = formatGhAuthRemediation(error, {
+      retryCommand: REPO_START_COMMAND,
+    });
+    process.stderr.write(`${remediation.title}: ${remediation.message}\n`);
+    process.stderr.write(`${remediation.hint}\n`);
 
     const canRemediate =
       input.allowInteractiveRemediation &&
       isInteractiveTerminal() &&
-      error.code !== "not_installed";
+      remediation.command !== undefined &&
+      error.details.source !== "env";
     if (!canRemediate) {
       process.exitCode = 1;
-      return false;
+      return { ok: false };
     }
 
-    const remediation = formatGhAuthRemediation(error, {
-      retryCommand: REPO_START_COMMAND,
-    });
     const shouldRun = await p.confirm({
       message: `Run '${remediation.command}' now?`,
       initialValue: true,
     });
     if (p.isCancel(shouldRun) || shouldRun !== true) {
       process.exitCode = 1;
-      return false;
+      return { ok: false };
     }
 
     const result =
@@ -127,19 +134,19 @@ async function resolveRepoStartGitHubAuth(input: {
     process.stderr.write(`${result.summary}\n`);
     if (result.status !== "applied") {
       process.exitCode = 1;
-      return false;
+      return { ok: false };
     }
 
     try {
       const auth = await resolveGitHubAuth();
       process.env.GITHUB_GRAPHQL_TOKEN = auth.token;
       displayGitHubAuthSuccess(auth);
-      return true;
+      return { ok: true, githubAuthSource: auth.source };
     } catch (retryError) {
       if (retryError instanceof GhAuthError) {
         displayGhAuthError(retryError);
         process.exitCode = 1;
-        return false;
+        return { ok: false };
       }
       throw retryError;
     }
@@ -149,7 +156,7 @@ async function resolveRepoStartGitHubAuth(input: {
 async function preflightRepoStartAuth(
   projectConfig: OrchestratorProjectConfig,
   input: { daemon: boolean }
-): Promise<boolean> {
+): Promise<RepoStartAuthPreflightResult> {
   if (projectConfig.tracker.adapter === "github-project") {
     return resolveRepoStartGitHubAuth({
       allowInteractiveRemediation: !input.daemon,
@@ -158,16 +165,16 @@ async function preflightRepoStartAuth(
 
   if (projectConfig.tracker.adapter === "linear") {
     if (process.env.LINEAR_API_KEY?.trim()) {
-      return true;
+      return { ok: true };
     }
     process.stderr.write(
       "Linear authentication is required. Set LINEAR_API_KEY in the environment before running 'gh-symphony repo start'.\n"
     );
     process.exitCode = 1;
-    return false;
+    return { ok: false };
   }
 
-  return true;
+  return { ok: true };
 }
 
 function isGitHubAuthRuntimeError(error: unknown): error is Error {
@@ -201,7 +208,10 @@ function isGitHubAuthRuntimeError(error: unknown): error is Error {
   return false;
 }
 
-function ghRuntimeErrorToAuthError(error: Error): GhAuthError {
+function ghRuntimeErrorToAuthError(
+  error: Error,
+  source?: GitHubAuthSource
+): GhAuthError {
   if (error instanceof GhAuthError) {
     return error;
   }
@@ -212,6 +222,7 @@ function ghRuntimeErrorToAuthError(error: Error): GhAuthError {
       {
         missingScopes: [...error.requiredScopes],
         currentScopes: [...error.currentScopes],
+        source,
       }
     );
   }
@@ -220,16 +231,20 @@ function ghRuntimeErrorToAuthError(error: Error): GhAuthError {
     error.message.toLowerCase().includes("missing required scopes") ||
     error.message.toLowerCase().includes("missing_scopes")
   ) {
-    return new GhAuthError("missing_scopes", error.message);
+    return new GhAuthError("missing_scopes", error.message, { source });
   }
   return new GhAuthError(
     "invalid_token",
-    error.message || "GitHub token validation failed."
+    error.message || "GitHub token validation failed.",
+    { source }
   );
 }
 
-function displayRuntimeAuthShutdown(error: Error): void {
-  const authError = ghRuntimeErrorToAuthError(error);
+function displayRuntimeAuthShutdown(
+  error: Error,
+  source?: GitHubAuthSource
+): void {
+  const authError = ghRuntimeErrorToAuthError(error, source);
   displayGhAuthError(authError);
   process.stderr.write(
     "Stopping repo start because GitHub authentication can no longer be validated.\n"
@@ -684,9 +699,10 @@ const handler = async (
     return;
   }
 
-  if (
-    !(await preflightRepoStartAuth(projectConfig, { daemon: parsed.daemon }))
-  ) {
+  const authPreflight = await preflightRepoStartAuth(projectConfig, {
+    daemon: parsed.daemon,
+  });
+  if (!authPreflight.ok) {
     return;
   }
 
@@ -732,7 +748,10 @@ const handler = async (
             const runtimeError = new Error(snapshot.lastError);
             if (isGitHubAuthRuntimeError(runtimeError)) {
               authShutdownRequested = true;
-              displayRuntimeAuthShutdown(runtimeError);
+              displayRuntimeAuthShutdown(
+                runtimeError,
+                authPreflight.githubAuthSource
+              );
               process.exitCode = 1;
               requestShutdown?.();
               return;
@@ -762,7 +781,7 @@ const handler = async (
         } catch (error) {
           if (shouldElevateGitHubAuthRuntimeError(projectConfig, error)) {
             authShutdownRequested = true;
-            displayRuntimeAuthShutdown(error);
+            displayRuntimeAuthShutdown(error, authPreflight.githubAuthSource);
             process.exitCode = 1;
             requestShutdown?.();
             return;
@@ -902,7 +921,7 @@ const handler = async (
 
           if (shouldElevateGitHubAuthRuntimeError(projectConfig, error)) {
             authShutdownRequested = true;
-            displayRuntimeAuthShutdown(error);
+            displayRuntimeAuthShutdown(error, authPreflight.githubAuthSource);
             process.exitCode = 1;
             await shutdown();
             return;

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -71,13 +71,26 @@ function displayGhAuthError(error: GhAuthError): void {
   process.stderr.write(`${remediation.hint}\n`);
 }
 
+function formatAuthSource(source: "env" | "gh"): string {
+  return source === "env" ? "GITHUB_GRAPHQL_TOKEN" : "gh CLI";
+}
+
+function displayGitHubAuthSuccess(auth: {
+  source: "env" | "gh";
+  login: string;
+}): void {
+  process.stdout.write(
+    `Authenticated via ${formatAuthSource(auth.source)} as ${auth.login}\n`
+  );
+}
+
 async function resolveRepoStartGitHubAuth(input: {
   allowInteractiveRemediation: boolean;
 }): Promise<boolean> {
   try {
     const auth = await resolveGitHubAuth();
     process.env.GITHUB_GRAPHQL_TOKEN = auth.token;
-    process.stdout.write(`Authenticated via gh CLI as ${auth.login}\n`);
+    displayGitHubAuthSuccess(auth);
     return true;
   } catch (error) {
     if (!(error instanceof GhAuthError)) {
@@ -120,7 +133,7 @@ async function resolveRepoStartGitHubAuth(input: {
     try {
       const auth = await resolveGitHubAuth();
       process.env.GITHUB_GRAPHQL_TOKEN = auth.token;
-      process.stdout.write(`Authenticated via gh CLI as ${auth.login}\n`);
+      displayGitHubAuthSuccess(auth);
       return true;
     } catch (retryError) {
       if (retryError instanceof GhAuthError) {
@@ -174,6 +187,8 @@ function isGitHubAuthRuntimeError(error: unknown): error is Error {
     }
     const message = error.message.toLowerCase();
     return (
+      message.includes("missing required github scopes") ||
+      message.includes("missing required scopes") ||
       message.includes("missing required scope") ||
       message.includes("missing_scopes") ||
       message.includes("bad credentials") ||
@@ -200,6 +215,13 @@ function ghRuntimeErrorToAuthError(error: Error): GhAuthError {
       }
     );
   }
+  if (
+    error.message.toLowerCase().includes("missing required github scopes") ||
+    error.message.toLowerCase().includes("missing required scopes") ||
+    error.message.toLowerCase().includes("missing_scopes")
+  ) {
+    return new GhAuthError("missing_scopes", error.message);
+  }
   return new GhAuthError(
     "invalid_token",
     error.message || "GitHub token validation failed."
@@ -209,7 +231,19 @@ function ghRuntimeErrorToAuthError(error: Error): GhAuthError {
 function displayRuntimeAuthShutdown(error: Error): void {
   const authError = ghRuntimeErrorToAuthError(error);
   displayGhAuthError(authError);
-  process.stderr.write("Stopping repo start because GitHub authentication can no longer be validated.\n");
+  process.stderr.write(
+    "Stopping repo start because GitHub authentication can no longer be validated.\n"
+  );
+}
+
+function shouldElevateGitHubAuthRuntimeError(
+  projectConfig: OrchestratorProjectConfig,
+  error: unknown
+): error is Error {
+  return (
+    projectConfig.tracker.adapter === "github-project" &&
+    isGitHubAuthRuntimeError(error)
+  );
 }
 
 type ForegroundShutdownOptions = {
@@ -650,7 +684,9 @@ const handler = async (
     return;
   }
 
-  if (!(await preflightRepoStartAuth(projectConfig, { daemon: parsed.daemon }))) {
+  if (
+    !(await preflightRepoStartAuth(projectConfig, { daemon: parsed.daemon }))
+  ) {
     return;
   }
 
@@ -679,14 +715,23 @@ const handler = async (
     let prevSnapshot: ProjectStatusSnapshot | null = null;
     let isFirst = true;
     let requestShutdown: (() => void) | null = null;
+    let authShutdownRequested = false;
     const service = new OrchestratorService(store, projectConfig, {
       logLevel,
       assignedOnly: parsed.assignedOnly,
       onTick: async (snapshot) => {
         try {
-          if (snapshot.lastError) {
+          if (authShutdownRequested) {
+            return;
+          }
+
+          if (
+            projectConfig.tracker.adapter === "github-project" &&
+            snapshot.lastError
+          ) {
             const runtimeError = new Error(snapshot.lastError);
             if (isGitHubAuthRuntimeError(runtimeError)) {
+              authShutdownRequested = true;
               displayRuntimeAuthShutdown(runtimeError);
               process.exitCode = 1;
               requestShutdown?.();
@@ -715,7 +760,8 @@ const handler = async (
           prevSnapshot = snapshot;
           isFirst = false;
         } catch (error) {
-          if (isGitHubAuthRuntimeError(error)) {
+          if (shouldElevateGitHubAuthRuntimeError(projectConfig, error)) {
+            authShutdownRequested = true;
             displayRuntimeAuthShutdown(error);
             process.exitCode = 1;
             requestShutdown?.();
@@ -854,7 +900,8 @@ const handler = async (
             break;
           }
 
-          if (isGitHubAuthRuntimeError(error)) {
+          if (shouldElevateGitHubAuthRuntimeError(projectConfig, error)) {
+            authShutdownRequested = true;
             displayRuntimeAuthShutdown(error);
             process.exitCode = 1;
             await shutdown();

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -102,12 +102,11 @@ async function resolveRepoStartGitHubAuth(input: {
       throw error;
     }
 
+    displayGhAuthError(error);
+
     const remediation = formatGhAuthRemediation(error, {
       retryCommand: REPO_START_COMMAND,
     });
-    process.stderr.write(`${remediation.title}: ${remediation.message}\n`);
-    process.stderr.write(`${remediation.hint}\n`);
-
     const canRemediate =
       input.allowInteractiveRemediation &&
       isInteractiveTerminal() &&

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -2,6 +2,7 @@ import { writeFile, mkdir, readFile, rm } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { spawn } from "node:child_process";
 import { createServer, type Server, type ServerResponse } from "node:http";
+import * as p from "@clack/prompts";
 import type { GlobalOptions } from "../index.js";
 import {
   daemonPidPath,
@@ -34,7 +35,14 @@ import {
 } from "../project-selection.js";
 import { rejectRemovedProjectId } from "../removed-project-id.js";
 import { bold, dim, green, red, yellow, cyan, setNoColor } from "../ansi.js";
-import { getGhToken } from "../github/gh-auth.js";
+import {
+  formatGhAuthRemediation,
+  GhAuthError,
+  resolveGitHubAuth,
+  runGhAuthLogin,
+  runGhAuthRefresh,
+} from "../github/gh-auth.js";
+import { GitHubApiError, GitHubScopeError } from "../github/client.js";
 import { formatRepositoryDisplay } from "../format/repository.js";
 
 function timestamp(): string {
@@ -47,6 +55,161 @@ function timestamp(): string {
 
 function logLine(icon: string, msg: string): void {
   process.stdout.write(`${timestamp()} ${icon} ${msg}\n`);
+}
+
+const REPO_START_COMMAND = "gh-symphony repo start";
+
+function isInteractiveTerminal(): boolean {
+  return process.stdin.isTTY === true && process.stdout.isTTY === true;
+}
+
+function displayGhAuthError(error: GhAuthError): void {
+  const remediation = formatGhAuthRemediation(error, {
+    retryCommand: REPO_START_COMMAND,
+  });
+  process.stderr.write(`${remediation.title}: ${remediation.message}\n`);
+  process.stderr.write(`${remediation.hint}\n`);
+}
+
+async function resolveRepoStartGitHubAuth(input: {
+  allowInteractiveRemediation: boolean;
+}): Promise<boolean> {
+  try {
+    const auth = await resolveGitHubAuth();
+    process.env.GITHUB_GRAPHQL_TOKEN = auth.token;
+    process.stdout.write(`Authenticated via gh CLI as ${auth.login}\n`);
+    return true;
+  } catch (error) {
+    if (!(error instanceof GhAuthError)) {
+      throw error;
+    }
+
+    displayGhAuthError(error);
+
+    const canRemediate =
+      input.allowInteractiveRemediation &&
+      isInteractiveTerminal() &&
+      error.code !== "not_installed";
+    if (!canRemediate) {
+      process.exitCode = 1;
+      return false;
+    }
+
+    const remediation = formatGhAuthRemediation(error, {
+      retryCommand: REPO_START_COMMAND,
+    });
+    const shouldRun = await p.confirm({
+      message: `Run '${remediation.command}' now?`,
+      initialValue: true,
+    });
+    if (p.isCancel(shouldRun) || shouldRun !== true) {
+      process.exitCode = 1;
+      return false;
+    }
+
+    const result =
+      error.code === "missing_scopes"
+        ? runGhAuthRefresh({ interactive: true })
+        : runGhAuthLogin({ interactive: true });
+    process.stderr.write(`${result.summary}\n`);
+    if (result.status !== "applied") {
+      process.exitCode = 1;
+      return false;
+    }
+
+    try {
+      const auth = await resolveGitHubAuth();
+      process.env.GITHUB_GRAPHQL_TOKEN = auth.token;
+      process.stdout.write(`Authenticated via gh CLI as ${auth.login}\n`);
+      return true;
+    } catch (retryError) {
+      if (retryError instanceof GhAuthError) {
+        displayGhAuthError(retryError);
+        process.exitCode = 1;
+        return false;
+      }
+      throw retryError;
+    }
+  }
+}
+
+async function preflightRepoStartAuth(
+  projectConfig: OrchestratorProjectConfig,
+  input: { daemon: boolean }
+): Promise<boolean> {
+  if (projectConfig.tracker.adapter === "github-project") {
+    return resolveRepoStartGitHubAuth({
+      allowInteractiveRemediation: !input.daemon,
+    });
+  }
+
+  if (projectConfig.tracker.adapter === "linear") {
+    if (process.env.LINEAR_API_KEY?.trim()) {
+      return true;
+    }
+    process.stderr.write(
+      "Linear authentication is required. Set LINEAR_API_KEY in the environment before running 'gh-symphony repo start'.\n"
+    );
+    process.exitCode = 1;
+    return false;
+  }
+
+  return true;
+}
+
+function isGitHubAuthRuntimeError(error: unknown): error is Error {
+  if (error instanceof GitHubScopeError) {
+    return true;
+  }
+  if (error instanceof GhAuthError) {
+    return error.code === "missing_scopes" || error.code === "invalid_token";
+  }
+  if (error instanceof GitHubApiError) {
+    return error.status === 401;
+  }
+  if (error instanceof Error) {
+    const maybeStatus = (error as { status?: unknown }).status;
+    if (maybeStatus === 401) {
+      return true;
+    }
+    const message = error.message.toLowerCase();
+    return (
+      message.includes("missing required scope") ||
+      message.includes("missing_scopes") ||
+      message.includes("bad credentials") ||
+      message.includes("invalid token") ||
+      message.includes("authentication failed") ||
+      message.includes("status 401") ||
+      message.includes("401 unauthorized")
+    );
+  }
+  return false;
+}
+
+function ghRuntimeErrorToAuthError(error: Error): GhAuthError {
+  if (error instanceof GhAuthError) {
+    return error;
+  }
+  if (error instanceof GitHubScopeError) {
+    return new GhAuthError(
+      "missing_scopes",
+      `GitHub token is missing required scopes: ${error.requiredScopes.join(", ")}`,
+      {
+        missingScopes: [...error.requiredScopes],
+        currentScopes: [...error.currentScopes],
+      }
+    );
+  }
+  return new GhAuthError(
+    "invalid_token",
+    error.message || "GitHub token validation failed."
+  );
+}
+
+function displayRuntimeAuthShutdown(error: Error): void {
+  const authError = ghRuntimeErrorToAuthError(error);
+  displayGhAuthError(authError);
+  process.stderr.write("Stopping repo start because GitHub authentication can no longer be validated.\n");
 }
 
 type ForegroundShutdownOptions = {
@@ -486,6 +649,11 @@ const handler = async (
     process.exitCode = 2;
     return;
   }
+
+  if (!(await preflightRepoStartAuth(projectConfig, { daemon: parsed.daemon }))) {
+    return;
+  }
+
   if (parsed.daemon) {
     await startDaemon(
       options,
@@ -499,15 +667,6 @@ const handler = async (
   }
 
   // ── 5.1: Foreground mode with live logging ────────────────────────────────
-  if (!process.env.GITHUB_GRAPHQL_TOKEN) {
-    try {
-      process.env.GITHUB_GRAPHQL_TOKEN = getGhToken();
-    } catch {
-      // gh CLI not installed/authenticated — GITHUB_GRAPHQL_TOKEN stays unset
-      // Workers will fail if token is needed but not available
-    }
-  }
-
   let projectLock: ProjectLockHandle | null = null;
   try {
     projectLock = await acquireProjectLock({
@@ -519,11 +678,22 @@ const handler = async (
     const store = createStore(runtimeRoot);
     let prevSnapshot: ProjectStatusSnapshot | null = null;
     let isFirst = true;
+    let requestShutdown: (() => void) | null = null;
     const service = new OrchestratorService(store, projectConfig, {
       logLevel,
       assignedOnly: parsed.assignedOnly,
       onTick: async (snapshot) => {
         try {
+          if (snapshot.lastError) {
+            const runtimeError = new Error(snapshot.lastError);
+            if (isGitHubAuthRuntimeError(runtimeError)) {
+              displayRuntimeAuthShutdown(runtimeError);
+              process.exitCode = 1;
+              requestShutdown?.();
+              return;
+            }
+          }
+
           logTickResult(snapshot, prevSnapshot, isFirst);
 
           if (!isFirst) {
@@ -545,6 +715,12 @@ const handler = async (
           prevSnapshot = snapshot;
           isFirst = false;
         } catch (error) {
+          if (isGitHubAuthRuntimeError(error)) {
+            displayRuntimeAuthShutdown(error);
+            process.exitCode = 1;
+            requestShutdown?.();
+            return;
+          }
           logLine(
             red("\u2717"),
             red(
@@ -583,6 +759,9 @@ const handler = async (
       void shutdown();
     };
     const handleSigterm = () => {
+      void shutdown();
+    };
+    requestShutdown = () => {
       void shutdown();
     };
     process.on("SIGINT", handleSigint);
@@ -673,6 +852,13 @@ const handler = async (
         } catch (error) {
           if (shuttingDown) {
             break;
+          }
+
+          if (isGitHubAuthRuntimeError(error)) {
+            displayRuntimeAuthShutdown(error);
+            process.exitCode = 1;
+            await shutdown();
+            return;
           }
 
           logLine(
@@ -770,7 +956,7 @@ export async function shutdownForegroundOrchestrator(
     );
   }
 
-  return (input.exit ?? process.exit)(0);
+  return (input.exit ?? process.exit)(process.exitCode ?? 0);
 }
 
 function hasConfiguredRepository(config: {

--- a/packages/cli/src/github/gh-auth.test.ts
+++ b/packages/cli/src/github/gh-auth.test.ts
@@ -1,8 +1,6 @@
 import type { execFileSync, spawnSync } from "node:child_process";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import {
-  GitHubApiError,
-} from "./client.js";
+import { GitHubApiError } from "./client.js";
 import {
   GhAuthError,
   checkGhAuthenticated,
@@ -10,6 +8,7 @@ import {
   checkGhScopes,
   detectGitHubAuthSource,
   ensureGhAuth,
+  formatGhAuthRemediation,
   getEnvGitHubToken,
   getGhToken,
   getGhTokenWithSource,
@@ -139,9 +138,7 @@ describe("getGhTokenWithSource", () => {
   it("returns env token metadata before subprocess lookup", () => {
     const execImpl = vi.fn(() => "should-not-be-used") as ExecMock;
 
-    expect(
-      getGhTokenWithSource({ execImpl, envToken: "env-token" })
-    ).toEqual({
+    expect(getGhTokenWithSource({ execImpl, envToken: "env-token" })).toEqual({
       token: "env-token",
       source: "env",
     });
@@ -152,9 +149,7 @@ describe("getGhTokenWithSource", () => {
     process.env.GITHUB_GRAPHQL_TOKEN = "env-token";
     const execImpl = vi.fn(() => "ghp_test123\n") as ExecMock;
 
-    expect(
-      getGhTokenWithSource({ execImpl, envToken: undefined })
-    ).toEqual({
+    expect(getGhTokenWithSource({ execImpl, envToken: undefined })).toEqual({
       token: "ghp_test123",
       source: "gh",
     });
@@ -206,9 +201,7 @@ describe("validateGitHubToken", () => {
           scopes: ["repo", "read:org"],
         })) as never,
       })
-    ).rejects.toThrowError(
-      expect.objectContaining({ code: "missing_scopes" })
-    );
+    ).rejects.toThrowError(expect.objectContaining({ code: "missing_scopes" }));
   });
 
   it("preserves non-auth GitHub API failures for env-token validation", async () => {
@@ -466,6 +459,38 @@ describe("resolveGitHubAuth", () => {
   });
 });
 
+describe("formatGhAuthRemediation", () => {
+  it("points env-token scope failures at GITHUB_GRAPHQL_TOKEN instead of gh auth refresh", () => {
+    const remediation = formatGhAuthRemediation(
+      new GhAuthError(
+        "missing_scopes",
+        "GITHUB_GRAPHQL_TOKEN is missing required scopes: project",
+        {
+          missingScopes: ["project"],
+          currentScopes: ["repo", "read:org"],
+          source: "env",
+        }
+      )
+    );
+
+    expect(remediation.command).toBeUndefined();
+    expect(remediation.hint).toContain("Update GITHUB_GRAPHQL_TOKEN");
+    expect(remediation.hint).not.toContain("gh auth refresh");
+  });
+
+  it("points env-token validation failures at updating or unsetting the env var", () => {
+    const remediation = formatGhAuthRemediation(
+      new GhAuthError("invalid_token", "GITHUB_GRAPHQL_TOKEN is invalid.", {
+        source: "env",
+      })
+    );
+
+    expect(remediation.command).toBeUndefined();
+    expect(remediation.hint).toContain("Update or unset GITHUB_GRAPHQL_TOKEN");
+    expect(remediation.hint).not.toContain("gh auth login");
+  });
+});
+
 describe("runGhAuthLogin", () => {
   it("returns manual when no interactive terminal is available", () => {
     expect(runGhAuthLogin({ interactive: false })).toEqual({
@@ -482,9 +507,7 @@ describe("runGhAuthRefresh", () => {
   it("runs gh auth refresh in interactive terminals", () => {
     const spawnImpl = vi.fn(() => buildSpawnResult(0)) as SpawnMock;
 
-    expect(
-      runGhAuthRefresh({ spawnImpl, interactive: true })
-    ).toMatchObject({
+    expect(runGhAuthRefresh({ spawnImpl, interactive: true })).toMatchObject({
       mode: "refresh",
       status: "applied",
       command: "gh auth refresh --scopes repo,read:org,project",

--- a/packages/cli/src/github/gh-auth.ts
+++ b/packages/cli/src/github/gh-auth.ts
@@ -149,6 +149,10 @@ export function formatGhAuthRemediation(
         hint: `Run '${command}' to re-authenticate, then re-run '${retryCommand}'.`,
       };
     }
+    default: {
+      const exhaustive: never = error.code;
+      throw new Error(`Unhandled GhAuthError code: ${exhaustive}`);
+    }
   }
 }
 

--- a/packages/cli/src/github/gh-auth.ts
+++ b/packages/cli/src/github/gh-auth.ts
@@ -66,7 +66,7 @@ function ghTokenReadErrorMessage(): string {
 }
 
 function missingGhScopesMessage(missing: string[]): string {
-  return `Run 'gh auth refresh --scopes repo,read:org,project'. Missing scopes: ${missing.join(", ")}`;
+  return `Run 'gh auth refresh --scopes ${REQUIRED_GH_SCOPES.join(",")}'. Missing scopes: ${missing.join(", ")}`;
 }
 
 function parseMissingScopes(message: string): string[] {

--- a/packages/cli/src/github/gh-auth.ts
+++ b/packages/cli/src/github/gh-auth.ts
@@ -18,7 +18,6 @@ type ExecError = Error & {
 };
 
 export const REQUIRED_GH_SCOPES = ["repo", "read:org", "project"] as const;
-export const KNOWN_REQUIRED_SCOPES = REQUIRED_GH_SCOPES;
 export type GitHubAuthSource = "env" | "gh";
 
 export type GhAuthRemediationResult = {
@@ -40,6 +39,7 @@ export class GhAuthError extends Error {
     public readonly details: {
       missingScopes?: string[];
       currentScopes?: string[];
+      source?: GitHubAuthSource;
     } = {}
   ) {
     super(message);
@@ -94,7 +94,7 @@ export function formatGhAuthRemediation(
         hint: "Install gh CLI from https://cli.github.com or set GITHUB_GRAPHQL_TOKEN.",
       };
     case "not_authenticated": {
-      const command = `gh auth login --scopes ${KNOWN_REQUIRED_SCOPES.join(",")}`;
+      const command = `gh auth login --scopes ${REQUIRED_GH_SCOPES.join(",")}`;
       return {
         title: "GitHub authentication is required",
         message: error.message,
@@ -103,21 +103,27 @@ export function formatGhAuthRemediation(
       };
     }
     case "missing_scopes": {
+      if (error.details.source === "env") {
+        return {
+          title: "GitHub token is missing required scopes",
+          message: error.message,
+          hint: `Update GITHUB_GRAPHQL_TOKEN with a token that has ${REQUIRED_GH_SCOPES.join(",")} scopes, or unset it to use gh CLI auth, then re-run '${retryCommand}'.`,
+        };
+      }
       const currentSet = new Set(
         (error.details.currentScopes ?? []).map((scope) => scope.toLowerCase())
       );
       const inferredMissing =
         currentSet.size > 0
-          ? KNOWN_REQUIRED_SCOPES.filter((scope) => !currentSet.has(scope))
+          ? REQUIRED_GH_SCOPES.filter((scope) => !currentSet.has(scope))
           : [];
-      const missing =
-        error.details.missingScopes?.length
-          ? error.details.missingScopes
-          : inferredMissing.length > 0
-            ? inferredMissing
-            : parseMissingScopes(error.message);
+      const missing = error.details.missingScopes?.length
+        ? error.details.missingScopes
+        : inferredMissing.length > 0
+          ? inferredMissing
+          : parseMissingScopes(error.message);
       const scopeArg =
-        missing.length > 0 ? missing.join(",") : KNOWN_REQUIRED_SCOPES.join(",");
+        missing.length > 0 ? missing.join(",") : REQUIRED_GH_SCOPES.join(",");
       const command = `gh auth refresh --scopes ${scopeArg}`;
       return {
         title: "GitHub token is missing required scopes",
@@ -128,7 +134,14 @@ export function formatGhAuthRemediation(
     }
     case "invalid_token":
     case "token_failed": {
-      const command = `gh auth login --scopes ${KNOWN_REQUIRED_SCOPES.join(",")}`;
+      if (error.details.source === "env") {
+        return {
+          title: "GitHub token validation failed",
+          message: error.message,
+          hint: `Update or unset GITHUB_GRAPHQL_TOKEN, then re-run '${retryCommand}'.`,
+        };
+      }
+      const command = `gh auth login --scopes ${REQUIRED_GH_SCOPES.join(",")}`;
       return {
         title: "GitHub token validation failed",
         message: error.message,
@@ -153,7 +166,8 @@ function classifyTokenValidationError(
         source === "env" ? "invalid_token" : "token_failed",
         source === "env"
           ? "GITHUB_GRAPHQL_TOKEN is invalid or expired."
-          : ghTokenReadErrorMessage()
+          : ghTokenReadErrorMessage(),
+        { source }
       );
     }
 
@@ -161,7 +175,9 @@ function classifyTokenValidationError(
       source === "env"
         ? "GITHUB_GRAPHQL_TOKEN could not be validated"
         : "gh CLI token could not be validated";
-    return new GhAuthError("token_failed", `${prefix}: ${error.message}`);
+    return new GhAuthError("token_failed", `${prefix}: ${error.message}`, {
+      source,
+    });
   }
 
   if (error instanceof Error) {
@@ -169,14 +185,17 @@ function classifyTokenValidationError(
       source === "env"
         ? "GITHUB_GRAPHQL_TOKEN could not be validated"
         : "gh CLI token could not be validated";
-    return new GhAuthError("token_failed", `${prefix}: ${error.message}`);
+    return new GhAuthError("token_failed", `${prefix}: ${error.message}`, {
+      source,
+    });
   }
 
   return new GhAuthError(
     "token_failed",
     source === "env"
       ? "GITHUB_GRAPHQL_TOKEN could not be validated."
-      : "gh CLI token could not be validated."
+      : "gh CLI token could not be validated.",
+    { source }
   );
 }
 
@@ -279,7 +298,7 @@ export function getGhTokenWithSource(opts?: {
     opts !== undefined &&
     Object.prototype.hasOwnProperty.call(opts, "envToken");
   const envToken = hasExplicitEnvToken
-    ? opts.envToken?.trim() ?? null
+    ? (opts.envToken?.trim() ?? null)
     : getEnvGitHubToken();
   if (envToken) {
     return { token: envToken, source: "env" };
@@ -337,14 +356,22 @@ export async function validateGitHubToken(
       throw new GhAuthError(
         "missing_scopes",
         `GITHUB_GRAPHQL_TOKEN is missing required scopes: ${scopeCheck.missing.join(", ")}`,
-        { missingScopes: [...scopeCheck.missing], currentScopes: viewer.scopes }
+        {
+          missingScopes: [...scopeCheck.missing],
+          currentScopes: viewer.scopes,
+          source,
+        }
       );
     }
 
     throw new GhAuthError(
       "missing_scopes",
       missingGhScopesMessage(scopeCheck.missing),
-      { missingScopes: [...scopeCheck.missing], currentScopes: viewer.scopes }
+      {
+        missingScopes: [...scopeCheck.missing],
+        currentScopes: viewer.scopes,
+        source,
+      }
     );
   }
 
@@ -403,7 +430,8 @@ export function ensureGhAuth(opts?: {
   if (!checkGhInstalled({ execImpl })) {
     throw new GhAuthError(
       "not_installed",
-      "gh CLI is not installed. Install it from https://cli.github.com or set GITHUB_GRAPHQL_TOKEN."
+      "gh CLI is not installed. Install it from https://cli.github.com or set GITHUB_GRAPHQL_TOKEN.",
+      { source: "gh" }
     );
   }
 
@@ -411,7 +439,8 @@ export function ensureGhAuth(opts?: {
   if (!auth.authenticated) {
     throw new GhAuthError(
       "not_authenticated",
-      "Run 'gh auth login --scopes repo,read:org,project' or set GITHUB_GRAPHQL_TOKEN."
+      "Run 'gh auth login --scopes repo,read:org,project' or set GITHUB_GRAPHQL_TOKEN.",
+      { source: "gh" }
     );
   }
 
@@ -423,6 +452,7 @@ export function ensureGhAuth(opts?: {
       {
         missingScopes: [...scopeCheck.missing],
         currentScopes: scopeCheck.scopes,
+        source: "gh",
       }
     );
   }

--- a/packages/cli/src/github/gh-auth.ts
+++ b/packages/cli/src/github/gh-auth.ts
@@ -18,6 +18,7 @@ type ExecError = Error & {
 };
 
 export const REQUIRED_GH_SCOPES = ["repo", "read:org", "project"] as const;
+export const KNOWN_REQUIRED_SCOPES = REQUIRED_GH_SCOPES;
 export type GitHubAuthSource = "env" | "gh";
 
 export type GhAuthRemediationResult = {
@@ -35,12 +36,23 @@ export class GhAuthError extends Error {
       | "missing_scopes"
       | "token_failed"
       | "invalid_token",
-    message: string
+    message: string,
+    public readonly details: {
+      missingScopes?: string[];
+      currentScopes?: string[];
+    } = {}
   ) {
     super(message);
     this.name = "GhAuthError";
   }
 }
+
+export type GhAuthRemediation = {
+  title: string;
+  message: string;
+  command?: string;
+  hint: string;
+};
 
 export type ResolvedGitHubAuth = {
   source: GitHubAuthSource;
@@ -55,6 +67,76 @@ function ghTokenReadErrorMessage(): string {
 
 function missingGhScopesMessage(missing: string[]): string {
   return `Run 'gh auth refresh --scopes repo,read:org,project'. Missing scopes: ${missing.join(", ")}`;
+}
+
+function parseMissingScopes(message: string): string[] {
+  const matched = message.match(/Missing scopes:\s*([^.\n]+)/i);
+  if (!matched) {
+    return [];
+  }
+  return matched[1]
+    .split(",")
+    .map((scope) => scope.trim())
+    .filter((scope) => scope.length > 0);
+}
+
+export function formatGhAuthRemediation(
+  error: GhAuthError,
+  opts?: { retryCommand?: string }
+): GhAuthRemediation {
+  const retryCommand = opts?.retryCommand ?? "gh-symphony repo start";
+
+  switch (error.code) {
+    case "not_installed":
+      return {
+        title: "GitHub authentication is not available",
+        message: error.message,
+        hint: "Install gh CLI from https://cli.github.com or set GITHUB_GRAPHQL_TOKEN.",
+      };
+    case "not_authenticated": {
+      const command = `gh auth login --scopes ${KNOWN_REQUIRED_SCOPES.join(",")}`;
+      return {
+        title: "GitHub authentication is required",
+        message: error.message,
+        command,
+        hint: `Run '${command}', then re-run '${retryCommand}'.`,
+      };
+    }
+    case "missing_scopes": {
+      const currentSet = new Set(
+        (error.details.currentScopes ?? []).map((scope) => scope.toLowerCase())
+      );
+      const inferredMissing =
+        currentSet.size > 0
+          ? KNOWN_REQUIRED_SCOPES.filter((scope) => !currentSet.has(scope))
+          : [];
+      const missing =
+        error.details.missingScopes?.length
+          ? error.details.missingScopes
+          : inferredMissing.length > 0
+            ? inferredMissing
+            : parseMissingScopes(error.message);
+      const scopeArg =
+        missing.length > 0 ? missing.join(",") : KNOWN_REQUIRED_SCOPES.join(",");
+      const command = `gh auth refresh --scopes ${scopeArg}`;
+      return {
+        title: "GitHub token is missing required scopes",
+        message: error.message,
+        command,
+        hint: `Run '${command}', then re-run '${retryCommand}'.`,
+      };
+    }
+    case "invalid_token":
+    case "token_failed": {
+      const command = `gh auth login --scopes ${KNOWN_REQUIRED_SCOPES.join(",")}`;
+      return {
+        title: "GitHub token validation failed",
+        message: error.message,
+        command,
+        hint: `Run '${command}' to re-authenticate, then re-run '${retryCommand}'.`,
+      };
+    }
+  }
 }
 
 function classifyTokenValidationError(
@@ -254,13 +336,15 @@ export async function validateGitHubToken(
     if (source === "env") {
       throw new GhAuthError(
         "missing_scopes",
-        `GITHUB_GRAPHQL_TOKEN is missing required scopes: ${scopeCheck.missing.join(", ")}`
+        `GITHUB_GRAPHQL_TOKEN is missing required scopes: ${scopeCheck.missing.join(", ")}`,
+        { missingScopes: [...scopeCheck.missing], currentScopes: viewer.scopes }
       );
     }
 
     throw new GhAuthError(
       "missing_scopes",
-      missingGhScopesMessage(scopeCheck.missing)
+      missingGhScopesMessage(scopeCheck.missing),
+      { missingScopes: [...scopeCheck.missing], currentScopes: viewer.scopes }
     );
   }
 
@@ -335,7 +419,11 @@ export function ensureGhAuth(opts?: {
   if (!scopeCheck.valid) {
     throw new GhAuthError(
       "missing_scopes",
-      missingGhScopesMessage(scopeCheck.missing)
+      missingGhScopesMessage(scopeCheck.missing),
+      {
+        missingScopes: [...scopeCheck.missing],
+        currentScopes: scopeCheck.scopes,
+      }
     );
   }
 


### PR DESCRIPTION
## Issues

- Fixes #350

## Summary

- `gh-symphony repo start` now fails fast for GitHub Project auth problems before orchestration starts, with guided remediation for missing gh auth, missing scopes, invalid tokens, and token validation failures.
- Runtime GitHub auth/scope failures are elevated into clean shutdown instead of repeated tick-loop failures, while Linear projects fail fast when `LINEAR_API_KEY` is missing.
- Latest review follow-up dedupes auth error printing, adds interactive gh auto-remediation happy-path coverage, and makes `formatGhAuthRemediation()` exhaustive for future auth error codes.

## Changes

- Add repo-start auth preflight for GitHub Project and Linear trackers before lock acquisition/orchestrator construction.
- Add shared GitHub auth remediation formatting with source-aware env-token vs gh CLI guidance.
- Preserve GitHub auth source for runtime auth shutdown remediation and gate runtime shutdown to GitHub tracker projects.
- Update `repo start` help text, snapshots, tests, and patch changeset for `@gh-symphony/cli`.

## Evidence

- `pnpm --filter @gh-symphony/cli test -- start.test.ts gh-auth.test.ts lifecycle.test.ts` -> passed, 66 tests.
- `pnpm --filter @gh-symphony/cli typecheck` -> passed.
- `pnpm lint && pnpm test && pnpm typecheck && pnpm build` -> passed.
- Prior Docker E2E blackbox TC for this PR: `docker compose -f docker-compose.e2e.yml -f docker-compose.e2e.events.yml up -d --build`; health check; happy-path fixture refresh; state check observed `health: running`, `activeRuns: 1`, `lastError: null`; stack shut down.

## Human Validation

- [ ] Confirm `repo start` foreground and `--daemon` fail fast with expected GitHub auth remediation.
- [ ] Confirm interactive gh remediation succeeds after user confirmation and starts orchestration with the refreshed token.
- [ ] Confirm Linear projects still fail fast with clear `LINEAR_API_KEY` guidance when the key is absent.

## Risks

- This intentionally changes stale or under-scoped auth from repeated runtime failures into immediate non-zero startup/runtime shutdown with remediation text.