### PR TITLE
feat(tracker-linear): add assigned-only filter

### DIFF
--- a/.changeset/linear-assigned-only.md
+++ b/.changeset/linear-assigned-only.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Add Linear tracker support for the runtime `--assigned-only` filter so issue polling can be scoped to Linear issues assigned to the API key identity. References #349.

--- a/README.md
+++ b/README.md
@@ -447,6 +447,8 @@ tracker:
 
 `gh-symphony repo init` validates that `tracker.project_slug` is present and that the `tracker.api_key` reference resolves, for example through `LINEAR_API_KEY`. Linear config aliases such as `tracker.project_id`, `projectId`, `project_id`, and `teamId` are rejected. The legacy `.gh-symphony/config.json` file is not used as the Linear source of truth.
 
+`gh-symphony repo start --assigned-only` also applies to Linear trackers. Linear pushes the filter into GraphQL as `assignee.isMe = true`, so the result set is scoped to the user represented by the configured API key. With a personal API key this means issues assigned to that person; with a service-account key it means issues assigned to the service account, and Symphony does not fail fast because Linear does not expose enough token metadata in the issue query path to distinguish those cases reliably.
+
 Linear orchestration is polling-only. There is intentionally no Linear webhook setup command; state transitions, workpad comments, and PR handoff policy belong in `WORKFLOW.md`. See `docs/examples/linear-WORKFLOW.md` for a complete example.
 
 ### Configuration

--- a/docs/adr/2026-04-29_linear-tracker-integration.md
+++ b/docs/adr/2026-04-29_linear-tracker-integration.md
@@ -174,9 +174,10 @@ Implement the tracker adapter read contract and keep write operations out of orc
 
 ### `listIssues(project, deps)` / candidate polling
 
-- Linear GraphQL query filters by `project: { slugId: { eq: $projectSlug } }` and `state: { name: { in: $stateNames } }`.
+- Linear GraphQL query filters by an `IssueFilter` containing `project: { slugId: { eq: <projectSlug> } }` and `state: { name: { in: <stateNames> } }`.
 - Page size defaults to 50 and cursor pagination is required.
-- Optional `assignedOnly` may query viewer and add `assignee` filtering, matching the Elixir reference behavior.
+- Optional `assignedOnly` adds Linear GraphQL `assignee: { isMe: { eq: true } }` filtering at query time, matching the runtime input shape used by the GitHub tracker.
+- Linear `isMe` resolves to the identity represented by the configured API key. Personal API keys therefore scope polling to issues assigned to that person; service-account keys scope polling to issues assigned to the service account. The adapter should not fail fast for service-account usage unless Linear exposes reliable token identity metadata in the read path.
 - `repository` is injected from the orchestrator instance repo, not from Linear response.
 - Normalize Linear response to `TrackedIssue`.
 

--- a/packages/tracker-linear/src/orchestrator-adapter.ts
+++ b/packages/tracker-linear/src/orchestrator-adapter.ts
@@ -72,6 +72,14 @@ type LinearIssuesResponse = {
   issues?: LinearConnection<LinearIssueNode> | null;
 };
 
+type LinearIssueFilter = {
+  project: { slugId: { eq: string } };
+  state?: { name: { in: string[] } };
+  id?: { in: string[] };
+  identifier?: { in: string[] };
+  assignee?: { isMe: { eq: true } };
+};
+
 const LINEAR_ISSUE_FIELDS = /* GraphQL */ `
   nodes {
     id
@@ -112,18 +120,14 @@ const LINEAR_ISSUE_FIELDS = /* GraphQL */ `
 
 const LINEAR_ISSUES_BY_STATES_QUERY = /* GraphQL */ `
   query SymphonyLinearIssues(
-    $projectSlug: String!
-    $stateNames: [String!]!
+    $filter: IssueFilter!
     $first: Int!
     $after: String
   ) {
     issues(
       first: $first
       after: $after
-      filter: {
-        project: { slugId: { eq: $projectSlug } }
-        state: { name: { in: $stateNames } }
-      }
+      filter: $filter
     ) {
       ${LINEAR_ISSUE_FIELDS}
     }
@@ -132,18 +136,14 @@ const LINEAR_ISSUES_BY_STATES_QUERY = /* GraphQL */ `
 
 const LINEAR_ISSUES_BY_IDS_QUERY = /* GraphQL */ `
   query SymphonyLinearIssueStates(
-    $projectSlug: String!
-    $issueIds: [ID!]!
+    $filter: IssueFilter!
     $first: Int!
     $after: String
   ) {
     issues(
       first: $first
       after: $after
-      filter: {
-        project: { slugId: { eq: $projectSlug } }
-        id: { in: $issueIds }
-      }
+      filter: $filter
     ) {
       ${LINEAR_ISSUE_FIELDS}
     }
@@ -152,18 +152,14 @@ const LINEAR_ISSUES_BY_IDS_QUERY = /* GraphQL */ `
 
 const LINEAR_ISSUES_BY_IDENTIFIERS_QUERY = /* GraphQL */ `
   query SymphonyLinearIssueStatesByIdentifier(
-    $projectSlug: String!
-    $issueIdentifiers: [String!]!
+    $filter: IssueFilter!
     $first: Int!
     $after: String
   ) {
     issues(
       first: $first
       after: $after
-      filter: {
-        project: { slugId: { eq: $projectSlug } }
-        identifier: { in: $issueIdentifiers }
-      }
+      filter: $filter
     ) {
       ${LINEAR_ISSUE_FIELDS}
     }
@@ -257,6 +253,7 @@ async function listLinearIssues(
       issueIds && issueIds.every(isLinearIdentifier)
         ? issueIds.map((identifier) => identifier.trim().toUpperCase())
         : undefined,
+    assignedOnly: config.assignedOnly,
     pageSize: config.pageSize,
   });
 
@@ -269,6 +266,14 @@ async function listLinearIssues(
     value: result.rateLimits,
     writable: true,
   });
+
+  if (config.assignedOnly) {
+    emitAssignedOnlyFilterEvent({
+      projectSlug: config.projectSlug,
+      includedCount: issues.length,
+    });
+  }
+
   return issues;
 }
 
@@ -279,6 +284,7 @@ async function fetchPaginatedLinearIssues(
     stateNames?: string[];
     issueIds?: string[];
     issueIdentifiers?: string[];
+    assignedOnly: boolean;
     pageSize: number;
   }
 ): Promise<{
@@ -299,12 +305,7 @@ async function fetchPaginatedLinearIssues(
       data: LinearIssuesResponse;
       rateLimits: LinearRateLimitPayload | null;
     } = await client<LinearIssuesResponse>(query, {
-      projectSlug: input.projectSlug,
-      ...(input.issueIdentifiers
-        ? { issueIdentifiers: input.issueIdentifiers }
-        : input.issueIds
-          ? { issueIds: input.issueIds }
-          : { stateNames: input.stateNames ?? [] }),
+      filter: buildLinearIssueFilter(input),
       first: input.pageSize,
       after,
     });
@@ -320,6 +321,24 @@ async function fetchPaginatedLinearIssues(
   return {
     nodes: issues,
     rateLimits: latestRateLimits,
+  };
+}
+
+function buildLinearIssueFilter(input: {
+  projectSlug: string;
+  stateNames?: string[];
+  issueIds?: string[];
+  issueIdentifiers?: string[];
+  assignedOnly: boolean;
+}): LinearIssueFilter {
+  return {
+    project: { slugId: { eq: input.projectSlug } },
+    ...(input.issueIdentifiers
+      ? { identifier: { in: input.issueIdentifiers } }
+      : input.issueIds
+        ? { id: { in: input.issueIds } }
+        : { state: { name: { in: input.stateNames ?? [] } } }),
+    ...(input.assignedOnly ? { assignee: { isMe: { eq: true } } } : {}),
   };
 }
 
@@ -521,12 +540,37 @@ function resolveLinearTrackerConfig(
 
   return {
     endpoint: resolveLinearEndpoint(project.tracker),
+    assignedOnly: resolveAssignedOnly(project.tracker, dependencies),
     pageSize:
       readPositiveIntegerSetting(project.tracker, "pageSize") ??
       DEFAULT_PAGE_SIZE,
     projectSlug,
     token,
   };
+}
+
+const warnedLegacyAssignedOnlyProjectIds = new Set<string>();
+
+function resolveAssignedOnly(
+  tracker: OrchestratorTrackerConfig,
+  dependencies: OrchestratorTrackerDependencies
+): boolean {
+  if (dependencies.assignedOnly !== undefined) {
+    return dependencies.assignedOnly;
+  }
+
+  const legacyAssignedOnly = readBooleanSetting(tracker, "assignedOnly");
+  if (legacyAssignedOnly) {
+    const warningKey = `${tracker.adapter}:${tracker.bindingId}`;
+    if (!warnedLegacyAssignedOnlyProjectIds.has(warningKey)) {
+      warnedLegacyAssignedOnlyProjectIds.add(warningKey);
+      console.warn(
+        "[gh-symphony] Deprecated tracker.settings.assignedOnly detected. Use 'gh-symphony repo start --assigned-only' instead; persisted assignedOnly support will be removed in the next major release."
+      );
+    }
+  }
+
+  return legacyAssignedOnly;
 }
 
 function resolveLinearEndpoint(tracker: OrchestratorTrackerConfig): string {
@@ -568,6 +612,14 @@ function readPositiveIntegerSetting(
   );
 }
 
+function readBooleanSetting(
+  tracker: OrchestratorTrackerConfig,
+  key: string
+): boolean {
+  const value = tracker.settings?.[key];
+  return value === true;
+}
+
 function readStringArray(value: unknown): string[] | undefined {
   if (value === undefined) {
     return undefined;
@@ -582,6 +634,22 @@ function readStringArray(value: unknown): string[] | undefined {
     return undefined;
   }
   return value.filter((entry): entry is string => typeof entry === "string");
+}
+
+function emitAssignedOnlyFilterEvent(input: {
+  projectSlug: string;
+  includedCount: number;
+}): void {
+  console.info(
+    JSON.stringify({
+      event: "tracker-assigned-only-filtered",
+      tracker: "linear",
+      projectSlug: input.projectSlug,
+      assigneeFilter: "isMe",
+      includedCount: input.includedCount,
+      excludedCount: null,
+    })
+  );
 }
 
 function requireString(value: unknown, label: string): string {

--- a/packages/tracker-linear/src/orchestrator-adapter.ts
+++ b/packages/tracker-linear/src/orchestrator-adapter.ts
@@ -617,7 +617,7 @@ function readBooleanSetting(
   key: string
 ): boolean {
   const value = tracker.settings?.[key];
-  return value === true;
+  return value === true || value === "true";
 }
 
 function readStringArray(value: unknown): string[] | undefined {

--- a/packages/tracker-linear/src/tracker-linear.test.ts
+++ b/packages/tracker-linear/src/tracker-linear.test.ts
@@ -262,6 +262,58 @@ describe("linearTrackerAdapter", () => {
     expect(request.variables.filter).not.toHaveProperty("assignee");
   });
 
+  it('falls back to legacy string assignedOnly tracker setting with a deprecation warning', async () => {
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const fetchImpl = vi.fn().mockResolvedValue(
+        jsonResponse({
+          data: {
+            issues: {
+              nodes: [],
+              pageInfo: { hasNextPage: false, endCursor: null },
+            },
+          },
+        })
+      );
+
+      await linearTrackerAdapter.listIssues(
+        makeProject({
+          bindingId: "symphony-legacy-string",
+          settings: {
+            projectSlug: "symphony-0c79b11b75ea",
+            activeStates: "Todo",
+            assignedOnly: "true",
+          },
+        }),
+        {
+          fetchImpl,
+          token: "linear-token",
+        }
+      );
+
+      const request = JSON.parse(
+        String(fetchImpl.mock.calls[0]?.[1]?.body)
+      ) as {
+        variables: Record<string, unknown>;
+      };
+      expect(request.variables.filter).toMatchObject({
+        project: { slugId: { eq: "symphony-0c79b11b75ea" } },
+        state: { name: { in: ["Todo"] } },
+        assignee: { isMe: { eq: true } },
+      });
+      expect(infoSpy).toHaveBeenCalledWith(
+        expect.stringContaining('"event":"tracker-assigned-only-filtered"')
+      );
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Deprecated tracker.settings.assignedOnly")
+      );
+    } finally {
+      infoSpy.mockRestore();
+      warnSpy.mockRestore();
+    }
+  });
+
   it("emits assignedOnly observability when the Linear filter is active", async () => {
     const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
     try {

--- a/packages/tracker-linear/src/tracker-linear.test.ts
+++ b/packages/tracker-linear/src/tracker-linear.test.ts
@@ -123,18 +123,17 @@ describe("linearTrackerAdapter", () => {
       String(fetchImpl.mock.calls[1]?.[1]?.body)
     ) as { variables: Record<string, unknown> };
 
-    expect(firstRequest.query).toContain(
-      "project: { slugId: { eq: $projectSlug } }"
-    );
-    expect(firstRequest.query).toContain(
-      "state: { name: { in: $stateNames } }"
-    );
+    expect(firstRequest.query).toContain("$filter: IssueFilter!");
+    expect(firstRequest.query).toContain("filter: $filter");
     expect(firstRequest.variables).toMatchObject({
-      projectSlug: "symphony-0c79b11b75ea",
-      stateNames: ["Todo", "In Progress"],
+      filter: {
+        project: { slugId: { eq: "symphony-0c79b11b75ea" } },
+        state: { name: { in: ["Todo", "In Progress"] } },
+      },
       first: 50,
       after: null,
     });
+    expect(firstRequest.variables.filter).not.toHaveProperty("assignee");
     expect(secondRequest.variables.after).toBe("cursor-1");
     expect(issues).toMatchObject([
       {
@@ -189,7 +188,123 @@ describe("linearTrackerAdapter", () => {
       variables: Record<string, unknown>;
     };
     expect(projectItemsCache.getOrLoad).not.toHaveBeenCalled();
-    expect(request.variables.stateNames).toEqual(["Rework"]);
+    expect(request.variables.filter).toMatchObject({
+      project: { slugId: { eq: "symphony-0c79b11b75ea" } },
+      state: { name: { in: ["Rework"] } },
+    });
+  });
+
+  it("adds an assignee isMe filter when runtime assignedOnly is enabled", async () => {
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+    try {
+      const fetchImpl = vi.fn().mockResolvedValue(
+        jsonResponse({
+          data: {
+            issues: {
+              nodes: [],
+              pageInfo: { hasNextPage: false, endCursor: null },
+            },
+          },
+        })
+      );
+
+      await linearTrackerAdapter.listIssues(makeProject(), {
+        assignedOnly: true,
+        fetchImpl,
+        token: "linear-token",
+      });
+
+      const request = JSON.parse(
+        String(fetchImpl.mock.calls[0]?.[1]?.body)
+      ) as {
+        variables: Record<string, unknown>;
+      };
+      expect(request.variables.filter).toMatchObject({
+        project: { slugId: { eq: "symphony-0c79b11b75ea" } },
+        state: { name: { in: ["Todo", "In Progress"] } },
+        assignee: { isMe: { eq: true } },
+      });
+    } finally {
+      infoSpy.mockRestore();
+    }
+  });
+
+  it("uses runtime assignedOnly before legacy tracker settings", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonResponse({
+        data: {
+          issues: {
+            nodes: [],
+            pageInfo: { hasNextPage: false, endCursor: null },
+          },
+        },
+      })
+    );
+
+    await linearTrackerAdapter.listIssues(
+      makeProject({
+        settings: {
+          projectSlug: "symphony-0c79b11b75ea",
+          activeStates: "Todo",
+          assignedOnly: true,
+        },
+      }),
+      {
+        assignedOnly: false,
+        fetchImpl,
+        token: "linear-token",
+      }
+    );
+
+    const request = JSON.parse(String(fetchImpl.mock.calls[0]?.[1]?.body)) as {
+      variables: Record<string, unknown>;
+    };
+    expect(request.variables.filter).not.toHaveProperty("assignee");
+  });
+
+  it("emits assignedOnly observability when the Linear filter is active", async () => {
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+    try {
+      const fetchImpl = vi.fn().mockResolvedValue(
+        jsonResponse({
+          data: {
+            issues: {
+              nodes: [
+                {
+                  id: "issue-1",
+                  identifier: "ENG-1",
+                  number: 1,
+                  title: "Assigned issue",
+                  state: { name: "Todo" },
+                  labels: { nodes: [] },
+                  relations: { nodes: [] },
+                },
+              ],
+              pageInfo: { hasNextPage: false, endCursor: null },
+            },
+          },
+        })
+      );
+
+      const issues = await linearTrackerAdapter.listIssues(makeProject(), {
+        assignedOnly: true,
+        fetchImpl,
+        token: "linear-token",
+      });
+
+      expect(issues).toHaveLength(1);
+      expect(infoSpy).toHaveBeenCalledWith(
+        expect.stringContaining('"event":"tracker-assigned-only-filtered"')
+      );
+      expect(infoSpy).toHaveBeenCalledWith(
+        expect.stringContaining('"tracker":"linear"')
+      );
+      expect(infoSpy).toHaveBeenCalledWith(
+        expect.stringContaining('"includedCount":1')
+      );
+    } finally {
+      infoSpy.mockRestore();
+    }
   });
 
   it("normalizes Linear rate-limit headers onto listed issues", async () => {
@@ -341,7 +456,10 @@ describe("linearTrackerAdapter", () => {
     const request = JSON.parse(String(fetchImpl.mock.calls[0]?.[1]?.body)) as {
       variables: Record<string, unknown>;
     };
-    expect(request.variables.issueIds).toEqual(["issue-1", "issue-2"]);
+    expect(request.variables.filter).toMatchObject({
+      project: { slugId: { eq: "symphony-0c79b11b75ea" } },
+      id: { in: ["issue-1", "issue-2"] },
+    });
   });
 
   it("fetchIssueStatesByIds routes Linear identifiers through an identifier filter", async () => {
@@ -366,10 +484,12 @@ describe("linearTrackerAdapter", () => {
       variables: Record<string, unknown>;
     };
     expect(request.query).toContain(
-      "identifier: { in: $issueIdentifiers }"
+      "query SymphonyLinearIssueStatesByIdentifier"
     );
-    expect(request.variables.issueIdentifiers).toEqual(["ENG-123"]);
-    expect(request.variables).not.toHaveProperty("issueIds");
+    expect(request.variables.filter).toMatchObject({
+      project: { slugId: { eq: "symphony-0c79b11b75ea" } },
+      identifier: { in: ["ENG-123"] },
+    });
   });
 
   it("injects worker environment without requiring team id", () => {


### PR DESCRIPTION
## Issues

- Fixes #349

## Summary

- Adds Linear `assignedOnly` support so `gh-symphony repo start --assigned-only` scopes Linear polling to issues assigned to the API key identity.
- Emits the same `tracker-assigned-only-filtered` observability event name used by the GitHub tracker.
- Matches GitHub legacy setting parsing by accepting both `assignedOnly: true` and `assignedOnly: "true"` when runtime input is absent.

## Changes

- Builds Linear GraphQL `IssueFilter` variables for state/id/identifier queries and adds `assignee: { isMe: { eq: true } }` when assigned-only is active.
- Mirrors GitHub precedence for runtime `dependencies.assignedOnly` over legacy `tracker.settings.assignedOnly`, including the existing deprecation warning for legacy config.
- Documents Linear personal API key vs service-account API key behavior in `README.md` and the Linear ADR.
- Adds Linear adapter tests for filter-off, filter-on, runtime precedence, legacy string parsing, and event emission.
- Adds a patch changeset for `@gh-symphony/cli`.

## Evidence

- `pnpm --filter @gh-symphony/tracker-linear test`
- `pnpm lint && pnpm test && pnpm typecheck && pnpm build`
- Docker E2E TC per `AGENT_TEST.md`: started `docker-compose.e2e.yml` with events override, verified `/healthz`, injected `e2e/fixtures/happy-path.json`, observed `test-owner/test-repo#1` dispatched/running through `/api/v1/state`, confirmed Docker logs reached stub-worker `completed`, then reset fixture and shut the stack down.

## Human Validation

- [ ] Confirm Linear polling with `gh-symphony repo start --assigned-only` returns only issues assigned to the Linear API key identity.
- [ ] Confirm dashboards ingest `tracker-assigned-only-filtered` from Linear as expected.
- [ ] Confirm service-account API key behavior matches deployment expectations.

## Risks

- Linear `isMe` is evaluated by Linear against the token identity. Service-account keys therefore filter to issues assigned to that service account; the adapter does not fail fast because the read path does not reliably expose token type metadata.