### PR TITLE
feat(cli): prompt for blocker check states

### DIFF
--- a/.changeset/explicit-blocker-check-states.md
+++ b/.changeset/explicit-blocker-check-states.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": minor
+---
+
+Make `blocker_check_states` an explicit setup/workflow init choice for #357, always serialize empty blocker selections, add independent `planning_states` for worker phase classification, and default missing blocker config to disabled instead of implicit `Todo`.

--- a/README.md
+++ b/README.md
@@ -548,7 +548,7 @@ export GITHUB_GRAPHQL_TOKEN=ghp_your_classic_token
 
 The generated file includes:
 
-- **Lifecycle**: `active_states`, `terminal_states`, `blocker_check_states` derived from the status column mapping
+- **Lifecycle**: `active_states`, `terminal_states`, explicit `blocker_check_states`, and `planning_states` derived from the status column mapping
 - **Runtime**: `agent_command` derived from `gh-symphony workflow init`
 - **Hooks**: `after_create` hook path
 - **Scheduler**: `poll_interval_ms`
@@ -607,7 +607,7 @@ The orchestrator resolves the workflow policy using this fallback chain:
 
 1. **Repository WORKFLOW.md** — if the target repository has a `WORKFLOW.md` at its root, use it.
 2. **Project WORKFLOW.md** — if the repository has no `WORKFLOW.md`, fall back to the project-level `WORKFLOW.md`.
-3. **Hardcoded defaults** — if neither file exists, use built-in defaults (`Todo`, `In Progress` as active; `Done` as terminal).
+3. **Hardcoded defaults** — if neither file exists, use built-in defaults (`Todo`, `In Progress` as active; `Done` as terminal; blocker check and planning states disabled).
 
 This means you can:
 

--- a/e2e/seed/WORKFLOW.md
+++ b/e2e/seed/WORKFLOW.md
@@ -11,6 +11,8 @@ tracker:
     - Cancelled
   blocker_check_states:
     - Ready
+  planning_states:
+    - Ready
 polling:
   interval_ms: 5000
 agent:

--- a/e2e/seed/init-local.sh
+++ b/e2e/seed/init-local.sh
@@ -51,6 +51,8 @@ tracker:
     - Cancelled
   blocker_check_states:
     - Ready
+  planning_states:
+    - Ready
 polling:
   interval_ms: 5000
 agent:

--- a/packages/cli/src/commands/setup.test.ts
+++ b/packages/cli/src/commands/setup.test.ts
@@ -100,20 +100,33 @@ const MOCK_PROJECT_DETAIL_WITH_AMBIGUOUS_PRIORITY = {
       id: "priority-team",
       name: "Priority (Team)",
       options: [
-        { id: "p1", name: "P1", description: null, color: "RED" as string | null },
+        {
+          id: "p1",
+          name: "P1",
+          description: null,
+          color: "RED" as string | null,
+        },
       ],
     },
     {
       id: "priority-severity",
       name: "Priority (Severity)",
       options: [
-        { id: "high", name: "High", description: null, color: "ORANGE" as string | null },
+        {
+          id: "high",
+          name: "High",
+          description: null,
+          color: "ORANGE" as string | null,
+        },
       ],
     },
   ],
 };
 
-function initializeGitRemote(cwd: string, remote = "https://github.com/acme/repo-a.git"): void {
+function initializeGitRemote(
+  cwd: string,
+  remote = "https://github.com/acme/repo-a.git"
+): void {
   execFileSync("git", ["init"], { cwd, stdio: "ignore" });
   execFileSync("git", ["remote", "add", "origin", remote], {
     cwd,
@@ -187,7 +200,9 @@ describe("setup command", () => {
 
   it("writes workflow files and managed-project config in non-interactive mode", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "setup-non-interactive-cwd-"));
-    const configDir = await mkdtemp(join(tmpdir(), "setup-non-interactive-config-"));
+    const configDir = await mkdtemp(
+      join(tmpdir(), "setup-non-interactive-config-")
+    );
     initializeGitRemote(cwd);
     process.chdir(cwd);
 
@@ -204,12 +219,17 @@ describe("setup command", () => {
       "utf8"
     );
     const project = JSON.parse(
-      await readFile(join(cwd, ".runtime", "orchestrator", "project.json"), "utf8")
+      await readFile(
+        join(cwd, ".runtime", "orchestrator", "project.json"),
+        "utf8"
+      )
     );
 
     expect(workflow).toContain("project_id: PVT_setup_1");
     expect(workflow).toContain("source: disabled");
-    expect(workflow).toContain("# Optional template: project-field priority source.");
+    expect(workflow).toContain(
+      "# Optional template: project-field priority source."
+    );
     expect(workflow).toContain("# Optional template: labels priority source.");
     expect(workflow).not.toContain("priority_field:");
     expect(contextYaml).toContain("PVT_setup_1");
@@ -224,7 +244,9 @@ describe("setup command", () => {
 
   it("shows a final summary and writes the selected repositories in interactive mode", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "setup-interactive-cwd-"));
-    const configDir = await mkdtemp(join(tmpdir(), "setup-interactive-config-"));
+    const configDir = await mkdtemp(
+      join(tmpdir(), "setup-interactive-config-")
+    );
     initializeGitRemote(cwd, "https://github.com/acme/repo-b.git");
     process.chdir(cwd);
 
@@ -290,7 +312,9 @@ describe("setup command", () => {
     vi.mocked(p.text)
       .mockResolvedValueOnce("0" as never)
       .mockResolvedValueOnce("1" as never);
-    vi.mocked(p.confirm).mockResolvedValueOnce(true as never);
+    vi.mocked(p.confirm)
+      .mockResolvedValueOnce(true as never)
+      .mockResolvedValueOnce(true as never);
 
     await setupCommand([], {
       configDir,
@@ -307,7 +331,9 @@ describe("setup command", () => {
   });
 
   it("warns and writes disabled priority scaffold in non-interactive mode when priority fields are ambiguous", async () => {
-    const cwd = await mkdtemp(join(tmpdir(), "setup-non-interactive-priority-cwd-"));
+    const cwd = await mkdtemp(
+      join(tmpdir(), "setup-non-interactive-priority-cwd-")
+    );
     const configDir = await mkdtemp(
       join(tmpdir(), "setup-non-interactive-priority-config-")
     );
@@ -335,7 +361,9 @@ describe("setup command", () => {
     );
     expect(workflow).not.toContain("priority_field:");
     expect(workflow).toContain("source: disabled");
-    expect(workflow).toContain("# Optional template: project-field priority source.");
+    expect(workflow).toContain(
+      "# Optional template: project-field priority source."
+    );
     expect(workflow).toContain("# Optional template: labels priority source.");
   });
 
@@ -358,7 +386,9 @@ describe("setup command", () => {
   });
 
   it("does not prompt for or persist assigned-only during interactive setup", async () => {
-    const cwd = await mkdtemp(join(tmpdir(), "setup-interactive-assigned-cwd-"));
+    const cwd = await mkdtemp(
+      join(tmpdir(), "setup-interactive-assigned-cwd-")
+    );
     const configDir = await mkdtemp(
       join(tmpdir(), "setup-interactive-assigned-config-")
     );
@@ -371,7 +401,9 @@ describe("setup command", () => {
       .mockResolvedValueOnce("active" as never)
       .mockResolvedValueOnce("terminal" as never)
       .mockResolvedValueOnce("disabled" as never);
-    vi.mocked(p.confirm).mockResolvedValueOnce(true as never);
+    vi.mocked(p.confirm)
+      .mockResolvedValueOnce(true as never)
+      .mockResolvedValueOnce(true as never);
 
     await setupCommand([], {
       configDir,
@@ -388,8 +420,8 @@ describe("setup command", () => {
     );
 
     expect(project.tracker.settings?.assignedOnly).toBeUndefined();
-    expect(vi.mocked(p.confirm)).toHaveBeenCalledTimes(1);
-    expect(vi.mocked(p.confirm).mock.calls[0]?.[0]).toMatchObject({
+    expect(vi.mocked(p.confirm)).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(p.confirm).mock.calls[1]?.[0]).toMatchObject({
       message: "Write files and register this managed project?",
     });
   });

--- a/packages/cli/src/commands/setup.test.ts
+++ b/packages/cli/src/commands/setup.test.ts
@@ -287,6 +287,33 @@ describe("setup command", () => {
     );
   });
 
+  it("validates state mappings before prompting for blocker checks", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "setup-invalid-mapping-cwd-"));
+    const configDir = await mkdtemp(
+      join(tmpdir(), "setup-invalid-mapping-config-")
+    );
+    initializeGitRemote(cwd);
+    process.chdir(cwd);
+
+    vi.mocked(p.select)
+      .mockResolvedValueOnce(MOCK_PROJECT_SUMMARY.id as never)
+      .mockResolvedValueOnce("wait" as never)
+      .mockResolvedValueOnce("wait" as never)
+      .mockResolvedValueOnce("wait" as never);
+
+    await setupCommand([], {
+      configDir,
+      verbose: false,
+      json: false,
+      noColor: true,
+    });
+
+    expect(process.exitCode).toBe(1);
+    expect(p.log.error).toHaveBeenCalledWith("Mapping validation failed:");
+    expect(p.confirm).not.toHaveBeenCalled();
+    expect(p.multiselect).not.toHaveBeenCalled();
+  });
+
   it("lets interactive setup map existing repository labels as the priority source", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "setup-interactive-labels-cwd-"));
     const configDir = await mkdtemp(

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -30,8 +30,12 @@ import {
   writeEcosystem,
   writeWorkflowPlan,
   promptStateMappings,
+  promptBlockerCheck,
 } from "./workflow-init.js";
-import { validateStateMapping } from "../mapping/smart-defaults.js";
+import {
+  toWorkflowLifecycleConfig,
+  validateStateMapping,
+} from "../mapping/smart-defaults.js";
 import { initRepoRuntime } from "../repo-runtime.js";
 
 type SetupFlags = {
@@ -130,7 +134,7 @@ async function selectProjectSummary(
 
   const selectedProjectId = await abortIfCancelled(
     p.select({
-      message: "Step 1/3 — Select a GitHub Project board:",
+      message: "Step 1/5 — Select a GitHub Project board:",
       options: projects.map((project) => ({
         value: project.id,
         label: `${project.owner.login}/${project.title}`,
@@ -411,7 +415,15 @@ async function runInteractive(
     projectDetail.linkedRepositories
   );
   const mappings = await promptStateMappings(statusField, {
-    stepLabel: "Step 2/3",
+    stepLabel: "Step 2/5",
+  });
+  const lifecycleBase = toWorkflowLifecycleConfig(statusField.name, mappings);
+  const blockerCheckStates = await promptBlockerCheck(lifecycleBase, {
+    stepLabel: "Step 3/5",
+  });
+  const lifecycle = toWorkflowLifecycleConfig(statusField.name, mappings, {
+    blockerCheckStates,
+    planningStates: blockerCheckStates,
   });
   const workflowValidation = validateStateMapping(mappings);
   if (!workflowValidation.valid) {
@@ -429,7 +441,7 @@ async function runInteractive(
   const { priority, priorityField } = await promptPriorityConfig({
     priorityResolution,
     labelNames: priorityLabelNames,
-    stepLabel: "Step 3/3",
+    stepLabel: "Step 4/5",
   });
 
   const workflowPath = resolve(flags.output ?? "WORKFLOW.md");
@@ -442,6 +454,7 @@ async function runInteractive(
     priority,
     includePriorityTemplates: priority.source === "disabled",
     mappings,
+    lifecycle,
     runtime: "codex",
     skipSkills: flags.skipSkills,
     skipContext: flags.skipContext,
@@ -479,6 +492,7 @@ async function runInteractive(
       statusField,
       priorityField,
       priority,
+      lifecycle,
       includePriorityTemplates: priority.source === "disabled",
       runtime: "codex",
       skipSkills: flags.skipSkills,

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -134,7 +134,7 @@ async function selectProjectSummary(
 
   const selectedProjectId = await abortIfCancelled(
     p.select({
-      message: "Step 1/5 — Select a GitHub Project board:",
+      message: "Step 1/4 — Select a GitHub Project board:",
       options: projects.map((project) => ({
         value: project.id,
         label: `${project.owner.login}/${project.title}`,
@@ -415,15 +415,7 @@ async function runInteractive(
     projectDetail.linkedRepositories
   );
   const mappings = await promptStateMappings(statusField, {
-    stepLabel: "Step 2/5",
-  });
-  const lifecycleBase = toWorkflowLifecycleConfig(statusField.name, mappings);
-  const blockerCheckStates = await promptBlockerCheck(lifecycleBase, {
-    stepLabel: "Step 3/5",
-  });
-  const lifecycle = toWorkflowLifecycleConfig(statusField.name, mappings, {
-    blockerCheckStates,
-    planningStates: blockerCheckStates,
+    stepLabel: "Step 2/4",
   });
   const workflowValidation = validateStateMapping(mappings);
   if (!workflowValidation.valid) {
@@ -438,10 +430,19 @@ async function runInteractive(
     p.log.warn(`  ⚠ ${warning}`);
   }
 
+  const lifecycleBase = toWorkflowLifecycleConfig(statusField.name, mappings);
+  const blockerCheckStates = await promptBlockerCheck(lifecycleBase, {
+    stepLabel: "Step 3/4",
+  });
+  const lifecycle = toWorkflowLifecycleConfig(statusField.name, mappings, {
+    blockerCheckStates,
+    planningStates: blockerCheckStates,
+  });
+
   const { priority, priorityField } = await promptPriorityConfig({
     priorityResolution,
     labelNames: priorityLabelNames,
-    stepLabel: "Step 4/5",
+    stepLabel: "Step 4/4",
   });
 
   const workflowPath = resolve(flags.output ?? "WORKFLOW.md");

--- a/packages/cli/src/commands/workflow-init.test.ts
+++ b/packages/cli/src/commands/workflow-init.test.ts
@@ -571,6 +571,58 @@ describe("init priority field detection", () => {
     );
   });
 
+  it("validates state mappings before prompting for blocker checks", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "cli-init-invalid-map-"));
+    vi.spyOn(ghAuth, "resolveGitHubAuth").mockResolvedValue({
+      source: "env",
+      login: "env-user",
+      token: "env-token",
+      scopes: ["repo", "read:org", "project"],
+    });
+    vi.spyOn(githubClient, "createClient").mockReturnValue({} as never);
+    vi.spyOn(githubClient, "discoverUserProjects").mockResolvedValue({
+      projects: [
+        {
+          id: "project-1",
+          title: "Roadmap",
+          shortDescription: "",
+          url: "https://github.com/users/tester/projects/1",
+          openItemCount: 3,
+          owner: { login: "tester", type: "User" },
+        },
+      ],
+      partial: false,
+      reason: null,
+      requests: 1,
+    });
+    vi.spyOn(githubClient, "getProjectDetail").mockResolvedValue({
+      ...MOCK_PROJECT_DETAIL,
+      id: "project-1",
+      statusFields: [MOCK_STATUS_FIELD],
+    });
+    vi.mocked(p.select)
+      .mockResolvedValueOnce("codex-app-server" as never)
+      .mockResolvedValueOnce("project-1" as never)
+      .mockResolvedValueOnce("wait" as never)
+      .mockResolvedValueOnce("wait" as never)
+      .mockResolvedValueOnce("wait" as never);
+
+    await initCommand(
+      ["--dry-run", "--output", join(configDir, "WORKFLOW.md")],
+      {
+        configDir,
+        verbose: false,
+        json: false,
+        noColor: true,
+      }
+    );
+
+    expect(process.exitCode).toBe(1);
+    expect(p.log.error).toHaveBeenCalledWith("Mapping validation failed:");
+    expect(p.confirm).not.toHaveBeenCalled();
+    expect(p.multiselect).not.toHaveBeenCalled();
+  });
+
   it("validates interactive priority mapping values as non-empty integers", async () => {
     vi.mocked(p.select).mockResolvedValueOnce("project-field" as never);
     vi.mocked(p.text).mockResolvedValue("2" as never);

--- a/packages/cli/src/commands/workflow-init.test.ts
+++ b/packages/cli/src/commands/workflow-init.test.ts
@@ -1,4 +1,11 @@
-import { chmod, mkdir, mkdtemp, readFile, stat, writeFile } from "node:fs/promises";
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  readFile,
+  stat,
+  writeFile,
+} from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -45,6 +52,7 @@ import {
   generateProjectId,
   planWorkflowArtifacts,
   planEcosystem,
+  promptBlockerCheck,
   promptPriorityConfig,
   renderDryRunPreview,
   writeConfig,
@@ -121,7 +129,9 @@ describe("init interactive auth", () => {
   });
 
   it("warns when project discovery hits a safety limit", async () => {
-    const configDir = await mkdtemp(join(tmpdir(), "cli-init-partial-projects-"));
+    const configDir = await mkdtemp(
+      join(tmpdir(), "cli-init-partial-projects-")
+    );
     vi.spyOn(ghAuth, "resolveGitHubAuth").mockResolvedValue({
       source: "env",
       login: "env-user",
@@ -145,6 +155,55 @@ describe("init interactive auth", () => {
 
     expect(p.log.warn).toHaveBeenCalledWith(
       "Project discovery may be incomplete: the GitHub API request budget reached the safety cap. Showing 0 discovered projects after 40 requests."
+    );
+  });
+});
+
+describe("promptBlockerCheck", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.mocked(p.confirm).mockReset();
+    vi.mocked(p.multiselect).mockReset();
+    vi.mocked(p.log.info).mockImplementation(() => undefined);
+    vi.mocked(p.log.warn).mockImplementation(() => undefined);
+  });
+
+  it("returns the single active state when enabled", async () => {
+    vi.mocked(p.confirm).mockResolvedValueOnce(true as never);
+
+    await expect(
+      promptBlockerCheck({ activeStates: ["In Progress"] })
+    ).resolves.toEqual(["In Progress"]);
+    expect(p.multiselect).not.toHaveBeenCalled();
+  });
+
+  it("defaults a multi-select to the first active state", async () => {
+    vi.mocked(p.confirm).mockResolvedValueOnce(true as never);
+    vi.mocked(p.multiselect).mockResolvedValueOnce(["Todo"] as never);
+
+    await expect(
+      promptBlockerCheck({ activeStates: ["Todo", "진행 중"] })
+    ).resolves.toEqual(["Todo"]);
+    expect(p.multiselect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        initialValues: ["Todo"],
+        options: expect.arrayContaining([
+          expect.objectContaining({ value: "Todo" }),
+          expect.objectContaining({ value: "진행 중" }),
+        ]),
+      })
+    );
+  });
+
+  it("returns an empty list when disabled or no active states exist", async () => {
+    vi.mocked(p.confirm).mockResolvedValueOnce(false as never);
+
+    await expect(
+      promptBlockerCheck({ activeStates: ["Todo"] })
+    ).resolves.toEqual([]);
+    await expect(promptBlockerCheck({ activeStates: [] })).resolves.toEqual([]);
+    expect(p.log.warn).toHaveBeenCalledWith(
+      "No active states; blocker check cannot be enabled."
     );
   });
 });
@@ -280,7 +339,9 @@ describe("init priority field detection", () => {
   });
 
   it("adds explicit project-field priority mapping during non-interactive dry-run when Priority exists", async () => {
-    const configDir = await mkdtemp(join(tmpdir(), "cli-init-priority-nonint-"));
+    const configDir = await mkdtemp(
+      join(tmpdir(), "cli-init-priority-nonint-")
+    );
     const stdout = vi
       .spyOn(process.stdout, "write")
       .mockReturnValue(true as never);
@@ -311,7 +372,12 @@ describe("init priority field detection", () => {
     });
 
     await initCommand(
-      ["--non-interactive", "--dry-run", "--output", join(configDir, "WORKFLOW.md")],
+      [
+        "--non-interactive",
+        "--dry-run",
+        "--output",
+        join(configDir, "WORKFLOW.md"),
+      ],
       {
         configDir,
         verbose: false,
@@ -322,7 +388,13 @@ describe("init priority field detection", () => {
 
     const payload = JSON.parse(
       stdout.mock.calls.map(([chunk]) => String(chunk)).join("")
-    ) as { priority: { source: string; field?: string; values?: Record<string, number> } };
+    ) as {
+      priority: {
+        source: string;
+        field?: string;
+        values?: Record<string, number>;
+      };
+    };
     expect(payload.priority).toEqual({
       source: "project-field",
       field: "Priority",
@@ -334,13 +406,15 @@ describe("init priority field detection", () => {
   });
 
   it("allows Claude preflight for init --runtime claude-code with local auth", async () => {
-    const configDir = await mkdtemp(join(tmpdir(), "cli-init-claude-preflight-"));
+    const configDir = await mkdtemp(
+      join(tmpdir(), "cli-init-claude-preflight-")
+    );
     const binDir = join(configDir, "bin");
     await mkdir(binDir, { recursive: true });
     const claude = join(binDir, "claude");
     await writeFile(
       claude,
-      "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then echo 'claude 1.0.0'; fi\n",
+      '#!/bin/sh\nif [ "$1" = "--version" ]; then echo \'claude 1.0.0\'; fi\n',
       "utf8"
     );
     await chmod(claude, 0o755);
@@ -457,21 +531,26 @@ describe("init priority field detection", () => {
       .mockResolvedValueOnce("0" as never)
       .mockResolvedValueOnce("1" as never);
 
-    await initCommand(["--dry-run", "--output", join(configDir, "WORKFLOW.md")], {
-      configDir,
-      verbose: false,
-      json: false,
-      noColor: true,
-    });
+    await initCommand(
+      ["--dry-run", "--output", join(configDir, "WORKFLOW.md")],
+      {
+        configDir,
+        verbose: false,
+        json: false,
+        noColor: true,
+      }
+    );
 
     const rendered = stdout.mock.calls.map(([chunk]) => String(chunk)).join("");
     expect(rendered).toContain("Priority source   project-field");
-    expect(rendered).toContain("Priority mapping  Priority (Severity): P0=0, P1=1");
+    expect(rendered).toContain(
+      "Priority mapping  Priority (Severity): P0=0, P1=1"
+    );
     expect(vi.mocked(p.select).mock.calls).toEqual(
       expect.arrayContaining([
         [
           expect.objectContaining({
-            message: "Step 4/4 — Choose one priority source:",
+            message: "Step 5/5 — Choose one priority source:",
           }),
         ],
       ])
@@ -689,10 +768,14 @@ describe("init ecosystem generation", () => {
       mode: "overwrite",
     });
     expect(
-      result.files.some((file) => file.path.endsWith(DEFAULT_AFTER_CREATE_HOOK_PATH))
+      result.files.some((file) =>
+        file.path.endsWith(DEFAULT_AFTER_CREATE_HOOK_PATH)
+      )
     ).toBe(true);
     expect(
-      result.files.some((file) => file.path.endsWith(".gh-symphony/context.yaml"))
+      result.files.some((file) =>
+        file.path.endsWith(".gh-symphony/context.yaml")
+      )
     ).toBe(true);
     expect(result.environment.packageManager).toBeDefined();
   });
@@ -772,12 +855,16 @@ describe("init ecosystem generation", () => {
       "utf8"
     );
 
-    expect(referenceWorkflow).toContain("Detected repository validation commands:");
+    expect(referenceWorkflow).toContain(
+      "Detected repository validation commands:"
+    );
     expect(referenceWorkflow).toContain("`pnpm test`");
     expect(referenceWorkflow).toContain(
       "(script: `pnpm --filter fixture test`)"
     );
-    expect(referenceWorkflow).toContain("This repository appears to be a monorepo");
+    expect(referenceWorkflow).toContain(
+      "This repository appears to be a monorepo"
+    );
     expect(skill).toContain("Detected repository validation commands:");
     expect(skill).toContain("`pnpm lint`");
     expect(skill).toContain("(script: `pnpm --filter fixture lint`)");
@@ -823,7 +910,9 @@ describe("init ecosystem generation", () => {
     expect(plan.workflowMd).toContain("source: project-field");
     expect(plan.workflowMd).toContain('field: "Priority"');
     expect(plan.workflowMd).not.toContain("priority_field:");
-    expect(plan.workflowMd).toContain("Detected repository validation commands:");
+    expect(plan.workflowMd).toContain(
+      "Detected repository validation commands:"
+    );
     expect(plan.workflowMd).toContain("`npm test`");
     expect(plan.workflowMd).toContain("`npm run lint`");
     expect(plan.workflowMd).toContain("Use `npm` conventions");
@@ -831,7 +920,10 @@ describe("init ecosystem generation", () => {
 
   it("threads non-Node repository commands into generated workflow artifacts", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "cli-non-node-guidance-"));
-    await writeFile(join(cwd, "pyproject.toml"), "[project]\nname = 'fixture'\n");
+    await writeFile(
+      join(cwd, "pyproject.toml"),
+      "[project]\nname = 'fixture'\n"
+    );
     await writeFile(join(cwd, "uv.lock"), "version = 1\n");
     await writeFile(join(cwd, "pytest.ini"), "[pytest]\n");
     await writeFile(
@@ -855,13 +947,17 @@ describe("init ecosystem generation", () => {
       skipContext: false,
     });
 
-    expect(plan.workflowMd).toContain("Detected repository validation commands:");
+    expect(plan.workflowMd).toContain(
+      "Detected repository validation commands:"
+    );
     expect(plan.workflowMd).toContain("`make test`");
     expect(plan.workflowMd).toContain("`make lint`");
     expect(plan.workflowMd).toContain("Use `uv` conventions");
-    expect(plan.ecosystemPlan.files.some((file) => file.path.endsWith("reference-workflow.md"))).toBe(
-      true
-    );
+    expect(
+      plan.ecosystemPlan.files.some((file) =>
+        file.path.endsWith("reference-workflow.md")
+      )
+    ).toBe(true);
   });
 
   it("scaffolds codex-app-server runtime defaults into WORKFLOW.md", async () => {
@@ -933,7 +1029,7 @@ describe("init ecosystem generation", () => {
     const claude = join(binDir, "claude");
     await writeFile(
       claude,
-      "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then echo 'claude 1.0.0'; fi\n",
+      '#!/bin/sh\nif [ "$1" = "--version" ]; then echo \'claude 1.0.0\'; fi\n',
       "utf8"
     );
     await chmod(claude, 0o755);
@@ -980,18 +1076,21 @@ describe("init ecosystem generation", () => {
       .mockResolvedValueOnce("active" as never)
       .mockResolvedValueOnce("terminal" as never);
 
-    await initCommand(["--dry-run", "--output", join(configDir, "WORKFLOW.md")], {
-      configDir,
-      verbose: false,
-      json: false,
-      noColor: true,
-    });
+    await initCommand(
+      ["--dry-run", "--output", join(configDir, "WORKFLOW.md")],
+      {
+        configDir,
+        verbose: false,
+        json: false,
+        noColor: true,
+      }
+    );
 
     const rendered = stdout.mock.calls.map(([chunk]) => String(chunk)).join("");
     expect(rendered).toContain("Runtime   claude-print");
     expect(p.select).toHaveBeenCalledWith(
       expect.objectContaining({
-        message: "Step 1/3 — Select the agent runtime:",
+        message: "Step 1/5 — Select the agent runtime:",
       })
     );
     expect(p.log.info).toHaveBeenCalledWith(

--- a/packages/cli/src/commands/workflow-init.ts
+++ b/packages/cli/src/commands/workflow-init.ts
@@ -4,7 +4,10 @@ import {
   resolveClaudeCommandBinary,
   runClaudePreflight,
 } from "@gh-symphony/runtime-claude";
-import type { WorkflowPriorityConfig } from "@gh-symphony/core";
+import type {
+  WorkflowLifecycleConfig,
+  WorkflowPriorityConfig,
+} from "@gh-symphony/core";
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { chmod, mkdir, readFile, rename, writeFile } from "node:fs/promises";
@@ -241,7 +244,7 @@ function validateInitRuntime(runtime: string): string | null {
 async function promptRuntimeSelection(): Promise<InitRuntimeKind> {
   return abortIfCancelled(
     p.select({
-      message: "Step 1/3 — Select the agent runtime:",
+      message: "Step 1/5 — Select the agent runtime:",
       options: [
         {
           value: "codex-app-server",
@@ -318,6 +321,7 @@ type EcosystemOptions = {
   skipSkills: boolean;
   skipContext: boolean;
   environment?: DetectedEnvironment;
+  lifecycle?: WorkflowLifecycleConfig;
 };
 
 export type EcosystemResult = {
@@ -325,6 +329,8 @@ export type EcosystemResult = {
   githubProjectTitle: string;
   runtime: string;
   priority: WorkflowPriorityConfig;
+  lifecycle: WorkflowLifecycleConfig;
+  waitStates: string[];
   skillsDir: string | null;
   skipSkills: boolean;
   afterCreateHookWritten: boolean;
@@ -351,6 +357,8 @@ export type EcosystemPlan = {
   githubProjectTitle: string;
   runtime: string;
   priority: WorkflowPriorityConfig;
+  lifecycle: WorkflowLifecycleConfig;
+  waitStates: string[];
   skillsDir: string | null;
   skipSkills: boolean;
   environment: Awaited<ReturnType<typeof detectEnvironment>>;
@@ -382,6 +390,7 @@ export type WorkflowArtifactsOptions = {
   priority?: WorkflowPriorityConfig;
   includePriorityTemplates?: boolean;
   mappings: Record<string, StateMapping>;
+  lifecycle?: WorkflowLifecycleConfig;
   runtime: string;
   skipSkills: boolean;
   skipContext: boolean;
@@ -739,6 +748,68 @@ export async function promptStateMappings(
   return mappings;
 }
 
+export function getDefaultBlockerCheckStates(
+  lifecycle: Pick<WorkflowLifecycleConfig, "activeStates">
+): string[] {
+  const firstActive = lifecycle.activeStates[0];
+  return firstActive ? [firstActive] : [];
+}
+
+export async function promptBlockerCheck(
+  lifecycle: Pick<WorkflowLifecycleConfig, "activeStates">,
+  options?: {
+    stepLabel?: string;
+  }
+): Promise<string[]> {
+  const stepLabel = options?.stepLabel ?? "Step 3/5";
+  const activeStates = lifecycle.activeStates;
+  const defaultStates = getDefaultBlockerCheckStates(lifecycle);
+
+  if (activeStates.length === 0) {
+    p.log.warn("No active states; blocker check cannot be enabled.");
+    p.log.info("Blocker check: disabled");
+    return [];
+  }
+
+  const activeStateSummary =
+    activeStates.length === 1
+      ? `"${activeStates[0]}"`
+      : "selected active states";
+
+  const enabled = await abortIfCancelled(
+    p.confirm({
+      message: `${stepLabel} — Enable blocker check? Issues with unresolved "blocked by" dependencies will be held back from dispatch on ${activeStateSummary}.`,
+      initialValue: true,
+    })
+  );
+
+  if (!enabled) {
+    p.log.info("Blocker check: disabled");
+    return [];
+  }
+
+  if (activeStates.length === 1) {
+    p.log.info(`Blocker check applies to: ${activeStates[0]}`);
+    return [activeStates[0]!];
+  }
+
+  const selectedStates = await abortIfCancelled(
+    p.multiselect({
+      message: `${stepLabel} — Which active states should be blocker-checked?`,
+      options: activeStates.map((state) => ({
+        value: state,
+        label: state,
+        hint: defaultStates.includes(state) ? "default" : undefined,
+      })),
+      initialValues: defaultStates,
+      required: true,
+    })
+  );
+
+  p.log.info(`Blocker check applies to: ${selectedStates.join(", ")}`);
+  return [...selectedStates];
+}
+
 export async function planWorkflowArtifacts(
   opts: WorkflowArtifactsOptions
 ): Promise<WorkflowArtifactsPlan> {
@@ -748,6 +819,18 @@ export async function planWorkflowArtifacts(
     (opts.priorityField
       ? buildProjectFieldPriority(opts.priorityField)
       : buildDisabledPriority());
+  const defaultLifecycle = toWorkflowLifecycleConfig(
+    opts.statusField.name,
+    opts.mappings
+  );
+  const defaultBlockerCheckStates =
+    getDefaultBlockerCheckStates(defaultLifecycle);
+  const lifecycle =
+    opts.lifecycle ??
+    toWorkflowLifecycleConfig(opts.statusField.name, opts.mappings, {
+      blockerCheckStates: defaultBlockerCheckStates,
+      planningStates: defaultBlockerCheckStates,
+    });
   const workflowMd = generateWorkflowMarkdown({
     projectId: opts.projectDetail.id,
     stateFieldName: opts.statusField.name,
@@ -755,7 +838,7 @@ export async function planWorkflowArtifacts(
     includePriorityTemplates:
       opts.includePriorityTemplates ?? priority.source === "disabled",
     mappings: opts.mappings,
-    lifecycle: toWorkflowLifecycleConfig(opts.statusField.name, opts.mappings),
+    lifecycle,
     runtime: opts.runtime,
     detectedEnvironment: environment,
   });
@@ -772,6 +855,7 @@ export async function planWorkflowArtifacts(
     statusField: opts.statusField,
     priorityField: opts.priorityField,
     priority,
+    lifecycle,
     includePriorityTemplates:
       opts.includePriorityTemplates ?? priority.source === "disabled",
     runtime: opts.runtime,
@@ -806,6 +890,17 @@ function summarizeEnvironment(
   ];
 }
 
+function deriveWaitStates(
+  statusField: ProjectStatusField,
+  lifecycle: WorkflowLifecycleConfig
+): string[] {
+  const active = new Set(lifecycle.activeStates);
+  const terminal = new Set(lifecycle.terminalStates);
+  return statusField.options
+    .map((option) => option.name)
+    .filter((state) => !active.has(state) && !terminal.has(state));
+}
+
 export async function planEcosystem(
   opts: EcosystemOptions
 ): Promise<EcosystemPlan> {
@@ -823,6 +918,22 @@ export async function planEcosystem(
     (priorityField
       ? buildProjectFieldPriority(priorityField)
       : buildDisabledPriority());
+  const automaticLifecycle = toWorkflowLifecycleConfig(
+    statusField.name,
+    buildAutomaticStateMappings(statusField)
+  );
+  const defaultBlockerCheckStates =
+    getDefaultBlockerCheckStates(automaticLifecycle);
+  const lifecycle =
+    opts.lifecycle ??
+    toWorkflowLifecycleConfig(
+      statusField.name,
+      buildAutomaticStateMappings(statusField),
+      {
+        blockerCheckStates: defaultBlockerCheckStates,
+        planningStates: defaultBlockerCheckStates,
+      }
+    );
   const ghSymphonyDir = join(cwd, ".gh-symphony");
   const environment = opts.environment ?? (await detectEnvironment(cwd));
   const files: PlannedFileChange[] = [];
@@ -865,6 +976,7 @@ export async function planEcosystem(
     })),
     projectId: projectDetail.id,
     priority,
+    lifecycle,
     detectedEnvironment: environment,
   });
   files.push(
@@ -919,6 +1031,8 @@ export async function planEcosystem(
     githubProjectTitle: projectDetail.title,
     runtime,
     priority,
+    lifecycle,
+    waitStates: deriveWaitStates(statusField, lifecycle),
     skillsDir,
     skipSkills,
     environment,
@@ -974,6 +1088,8 @@ export async function writeEcosystem(
     githubProjectTitle: plan.githubProjectTitle,
     runtime: plan.runtime,
     priority: plan.priority,
+    lifecycle: plan.lifecycle,
+    waitStates: plan.waitStates,
     skillsDir: plan.skillsDir,
     skipSkills: plan.skipSkills,
     afterCreateHookWritten,
@@ -986,7 +1102,9 @@ export async function writeEcosystem(
 
 // ── Ecosystem summary output ─────────────────────────────────────────────────
 
-function formatPrioritySummaryLines(priority: WorkflowPriorityConfig): string[] {
+function formatPrioritySummaryLines(
+  priority: WorkflowPriorityConfig
+): string[] {
   if (priority.source === "disabled") {
     return ["Priority source   disabled"];
   }
@@ -1004,9 +1122,25 @@ function formatPrioritySummaryLines(priority: WorkflowPriorityConfig): string[] 
   const mapping = Object.entries(priority.labels)
     .map(([name, value]) => `${name}=${value}`)
     .join(", ");
+  return ["Priority source   labels", `Priority mapping  ${mapping || "none"}`];
+}
+
+function formatLifecycleValue(states: string[]): string {
+  return states.length > 0 ? states.join(", ") : "disabled";
+}
+
+function formatLifecycleSummaryLines(
+  lifecycle: WorkflowLifecycleConfig,
+  waitStates: string[]
+): string[] {
   return [
-    "Priority source   labels",
-    `Priority mapping  ${mapping || "none"}`,
+    "Lifecycle",
+    `  Status field   ${lifecycle.stateFieldName}`,
+    `  Active         ${lifecycle.activeStates.join(", ") || "(none)"}`,
+    `  Wait           ${waitStates.join(", ") || "(none)"}`,
+    `  Terminal       ${lifecycle.terminalStates.join(", ") || "(none)"}`,
+    `  Blocker check  ${formatLifecycleValue(lifecycle.blockerCheckStates)}`,
+    `  Planning       ${formatLifecycleValue(lifecycle.planningStates)}`,
   ];
 }
 
@@ -1024,6 +1158,10 @@ function printEcosystemSummary(
   );
   lines.push(`Runtime   ${result.runtime}`);
   lines.push(...formatPrioritySummaryLines(result.priority));
+  lines.push("");
+  lines.push(
+    ...formatLifecycleSummaryLines(result.lifecycle, result.waitStates)
+  );
   lines.push("");
   lines.push("Generated files");
   lines.push(`  ✓ WORKFLOW.md                          ${relWorkflow}`);
@@ -1086,6 +1224,13 @@ export function renderDryRunPreview(
   );
   lines.push(`Runtime   ${ecosystemPlan.runtime}`);
   lines.push(...formatPrioritySummaryLines(ecosystemPlan.priority));
+  lines.push("");
+  lines.push(
+    ...formatLifecycleSummaryLines(
+      ecosystemPlan.lifecycle,
+      ecosystemPlan.waitStates
+    )
+  );
   lines.push("");
   lines.push("Planned file changes");
   lines.push(
@@ -1242,6 +1387,13 @@ async function runNonInteractive(
     process.exitCode = 1;
     return;
   }
+  const defaultBlockerCheckStates = getDefaultBlockerCheckStates(
+    toWorkflowLifecycleConfig(statusField.name, mappings)
+  );
+  const lifecycle = toWorkflowLifecycleConfig(statusField.name, mappings, {
+    blockerCheckStates: defaultBlockerCheckStates,
+    planningStates: defaultBlockerCheckStates,
+  });
 
   const outputPath = resolve(flags.output ?? "WORKFLOW.md");
   const { workflowPlan, ecosystemPlan } = await planWorkflowArtifacts({
@@ -1253,6 +1405,7 @@ async function runNonInteractive(
     priority,
     includePriorityTemplates: !autoPriorityField,
     mappings,
+    lifecycle,
     runtime,
     skipSkills: flags.skipSkills,
     skipContext: flags.skipContext,
@@ -1280,6 +1433,7 @@ async function runNonInteractive(
     priorityField: autoPriorityField,
     priority,
     includePriorityTemplates: !autoPriorityField,
+    lifecycle,
     runtime,
     skipSkills: flags.skipSkills,
     skipContext: flags.skipContext,
@@ -1377,7 +1531,7 @@ async function runInteractiveStandalone(
 
   const selectedGithubProjectId = await abortIfCancelled(
     p.select({
-      message: "Step 2/3 — Select a GitHub Project board:",
+      message: "Step 2/5 — Select a GitHub Project board:",
       options: projects.map((proj) => ({
         value: proj.id,
         label: `${proj.owner.login}/${proj.title}`,
@@ -1417,12 +1571,15 @@ async function runInteractiveStandalone(
     projectDetail.linkedRepositories
   );
   const mappings = await promptStateMappings(statusField, {
-    stepLabel: "Step 3/4",
+    stepLabel: "Step 3/5",
   });
-  const { priority, priorityField } = await promptPriorityConfig({
-    priorityResolution,
-    labelNames: priorityLabelNames,
-    stepLabel: "Step 4/4",
+  const lifecycleBase = toWorkflowLifecycleConfig(statusField.name, mappings);
+  const blockerCheckStates = await promptBlockerCheck(lifecycleBase, {
+    stepLabel: "Step 4/5",
+  });
+  const lifecycle = toWorkflowLifecycleConfig(statusField.name, mappings, {
+    blockerCheckStates,
+    planningStates: blockerCheckStates,
   });
 
   const validation = validateStateMapping(mappings);
@@ -1437,6 +1594,11 @@ async function runInteractiveStandalone(
   for (const warn of validation.warnings) {
     p.log.warn(`  ⚠ ${warn}`);
   }
+  const { priority, priorityField } = await promptPriorityConfig({
+    priorityResolution,
+    labelNames: priorityLabelNames,
+    stepLabel: "Step 5/5",
+  });
 
   const outputPath = resolve(flags.output ?? "WORKFLOW.md");
   const { workflowPlan, ecosystemPlan } = await planWorkflowArtifacts({
@@ -1448,6 +1610,7 @@ async function runInteractiveStandalone(
     priority,
     includePriorityTemplates: priority.source === "disabled",
     mappings,
+    lifecycle,
     runtime,
     skipSkills: flags.skipSkills,
     skipContext: flags.skipContext,
@@ -1467,6 +1630,7 @@ async function runInteractiveStandalone(
     priorityField,
     priority,
     includePriorityTemplates: priority.source === "disabled",
+    lifecycle,
     runtime,
     skipSkills: flags.skipSkills,
     skipContext: flags.skipContext,

--- a/packages/cli/src/commands/workflow-init.ts
+++ b/packages/cli/src/commands/workflow-init.ts
@@ -1573,14 +1573,6 @@ async function runInteractiveStandalone(
   const mappings = await promptStateMappings(statusField, {
     stepLabel: "Step 3/5",
   });
-  const lifecycleBase = toWorkflowLifecycleConfig(statusField.name, mappings);
-  const blockerCheckStates = await promptBlockerCheck(lifecycleBase, {
-    stepLabel: "Step 4/5",
-  });
-  const lifecycle = toWorkflowLifecycleConfig(statusField.name, mappings, {
-    blockerCheckStates,
-    planningStates: blockerCheckStates,
-  });
 
   const validation = validateStateMapping(mappings);
   if (!validation.valid) {
@@ -1594,6 +1586,15 @@ async function runInteractiveStandalone(
   for (const warn of validation.warnings) {
     p.log.warn(`  ⚠ ${warn}`);
   }
+
+  const lifecycleBase = toWorkflowLifecycleConfig(statusField.name, mappings);
+  const blockerCheckStates = await promptBlockerCheck(lifecycleBase, {
+    stepLabel: "Step 4/5",
+  });
+  const lifecycle = toWorkflowLifecycleConfig(statusField.name, mappings, {
+    blockerCheckStates,
+    planningStates: blockerCheckStates,
+  });
   const { priority, priorityField } = await promptPriorityConfig({
     priorityResolution,
     labelNames: priorityLabelNames,

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -84,6 +84,7 @@ type WorkflowValidationReport = {
     activeStates: string[];
     terminalStates: string[];
     blockerCheckStates: string[];
+    planningStates: string[];
     pollingIntervalMs: number;
     workspaceRoot: string | null;
     agentCommand: string;
@@ -747,8 +748,9 @@ async function loadLinearIssue(
     repository: projectConfig.repository,
     tracker: projectConfig.tracker,
   };
-  const trackerAdapter =
-    workflowCommandDependencies.resolveTrackerAdapter(projectConfig.tracker);
+  const trackerAdapter = workflowCommandDependencies.resolveTrackerAdapter(
+    projectConfig.tracker
+  );
   const [issue] = await trackerAdapter.fetchIssueStatesByIds(
     orchestratorProject,
     [issueIdentifier.trim().toUpperCase()],
@@ -806,6 +808,7 @@ function validateWorkflow(
       activeStates: workflow.lifecycle.activeStates,
       terminalStates: workflow.lifecycle.terminalStates,
       blockerCheckStates: workflow.lifecycle.blockerCheckStates,
+      planningStates: workflow.lifecycle.planningStates,
       pollingIntervalMs: workflow.polling.intervalMs,
       workspaceRoot: workflow.workspace.root,
       agentCommand: workflow.agentCommand,
@@ -846,6 +849,7 @@ Lifecycle
   active_states=${report.summary.activeStates.join(", ") || "(none)"}
   terminal_states=${report.summary.terminalStates.join(", ") || "(none)"}
   blocker_check_states=${report.summary.blockerCheckStates.join(", ") || "(none)"}
+  planning_states=${report.summary.planningStates.join(", ") || "(none)"}
 
 Runtime
   polling.interval_ms=${report.summary.pollingIntervalMs}
@@ -912,7 +916,9 @@ async function runPreview(
   if (
     flags.issue &&
     workflow.tracker.kind !== "github-project" &&
-    !(workflow.tracker.kind === "linear" && isLinearIssueIdentifier(flags.issue))
+    !(
+      workflow.tracker.kind === "linear" && isLinearIssueIdentifier(flags.issue)
+    )
   ) {
     throw new Error(
       "Live issue preview requires 'tracker.kind: github-project' with owner/repo#number or 'tracker.kind: linear' with a Linear identifier such as ENG-123."

--- a/packages/cli/src/mapping/smart-defaults.test.ts
+++ b/packages/cli/src/mapping/smart-defaults.test.ts
@@ -133,20 +133,37 @@ describe("toWorkflowLifecycleConfig", () => {
     expect(config.stateFieldName).toBe("Status");
     expect(config.activeStates).toEqual(["Todo", "In Progress"]);
     expect(config.terminalStates).toEqual(["Done"]);
-    expect(config.blockerCheckStates).toEqual(["Todo"]);
+    expect(config.blockerCheckStates).toEqual([]);
+    expect(config.planningStates).toEqual([]);
   });
 
-  it("produces correct config with only active and terminal states", () => {
+  it("uses explicit blocker and planning states when provided", () => {
     const mappings: Record<string, StateMapping> = {
       Todo: { role: "active" },
       "In Progress": { role: "active" },
       Done: { role: "terminal" },
     };
 
-    const config = toWorkflowLifecycleConfig("Status", mappings);
+    const config = toWorkflowLifecycleConfig("Status", mappings, {
+      blockerCheckStates: ["Todo"],
+      planningStates: ["In Progress"],
+    });
     expect(config.activeStates).toEqual(["Todo", "In Progress"]);
     expect(config.terminalStates).toEqual(["Done"]);
     expect(config.blockerCheckStates).toEqual(["Todo"]);
+    expect(config.planningStates).toEqual(["In Progress"]);
+  });
+
+  it("defaults planning states to explicit blocker check states", () => {
+    const mappings: Record<string, StateMapping> = {
+      Todo: { role: "active" },
+      Done: { role: "terminal" },
+    };
+
+    const config = toWorkflowLifecycleConfig("Status", mappings, {
+      blockerCheckStates: ["Todo"],
+    });
+    expect(config.planningStates).toEqual(["Todo"]);
   });
 });
 

--- a/packages/cli/src/mapping/smart-defaults.ts
+++ b/packages/cli/src/mapping/smart-defaults.ts
@@ -47,11 +47,14 @@ export function inferAllStateRoles(columnNames: string[]): StateRoleMapping[] {
 
 export function toWorkflowLifecycleConfig(
   stateFieldName: string,
-  mappings: Record<string, StateMapping>
+  mappings: Record<string, StateMapping>,
+  options: {
+    blockerCheckStates?: string[];
+    planningStates?: string[];
+  } = {}
 ): WorkflowLifecycleConfig {
   const activeStates: string[] = [];
   const terminalStates: string[] = [];
-  const blockerCheckStates: string[] = [];
 
   for (const [columnName, mapping] of Object.entries(mappings)) {
     switch (mapping.role) {
@@ -67,16 +70,14 @@ export function toWorkflowLifecycleConfig(
     }
   }
 
-  // Default blocker check: first active state (typically "Todo"-like)
-  if (activeStates.length > 0) {
-    blockerCheckStates.push(activeStates[0]!);
-  }
+  const blockerCheckStates = options.blockerCheckStates ?? [];
 
   return {
     stateFieldName,
     activeStates,
     terminalStates,
     blockerCheckStates,
+    planningStates: options.planningStates ?? blockerCheckStates,
   };
 }
 

--- a/packages/cli/src/workflow/generate-reference-workflow.test.ts
+++ b/packages/cli/src/workflow/generate-reference-workflow.test.ts
@@ -207,10 +207,27 @@ describe("generateReferenceWorkflow", () => {
     expect(output).toContain("    - Done");
   });
 
-  it("includes blocker_check_states set to first active column", () => {
+  it("defaults blocker_check_states to an explicit empty list without lifecycle input", () => {
     const output = generateReferenceWorkflow(defaultInput);
-    expect(output).toContain("blocker_check_states:");
-    expect(output).toContain("    - Todo");
+    expect(output).toContain("blocker_check_states: []");
+    expect(output).toContain("planning_states: []");
+  });
+
+  it("includes configured blocker and planning states from lifecycle input", () => {
+    const output = generateReferenceWorkflow({
+      ...defaultInput,
+      lifecycle: {
+        stateField: "Status",
+        activeStates: ["Todo", "In Progress"],
+        waitStates: ["In Review"],
+        terminalStates: ["Done"],
+        blockerCheckStates: ["Todo"],
+        planningStates: ["In Progress"],
+      },
+    });
+
+    expect(output).toContain("blocker_check_states:\n    - Todo");
+    expect(output).toContain("planning_states:\n    - In Progress");
   });
 
   it("handles null role columns in Status Map", () => {

--- a/packages/cli/src/workflow/generate-reference-workflow.ts
+++ b/packages/cli/src/workflow/generate-reference-workflow.ts
@@ -1,4 +1,7 @@
-import type { WorkflowPriorityConfig } from "@gh-symphony/core";
+import type {
+  WorkflowLifecycleConfig,
+  WorkflowPriorityConfig,
+} from "@gh-symphony/core";
 import type { DetectedEnvironment } from "../detection/environment-detector.js";
 import {
   DEFAULT_AFTER_CREATE_HOOK_COMMENT,
@@ -15,9 +18,14 @@ export type ReferenceWorkflowInput = {
   }>;
   projectId: string;
   priority: WorkflowPriorityConfig | null;
+  lifecycle?: WorkflowLifecycleConfig;
   detectedEnvironment: Pick<
     DetectedEnvironment,
-    "packageManager" | "testCommand" | "lintCommand" | "buildCommand" | "monorepo"
+    | "packageManager"
+    | "testCommand"
+    | "lintCommand"
+    | "buildCommand"
+    | "monorepo"
   >;
 };
 
@@ -54,7 +62,10 @@ export function generateReferenceWorkflow(
   const terminalColumns = input.statusColumns.filter(
     (c) => c.role === "terminal"
   );
-  const firstActive = activeColumns[0];
+  const blockerCheckStates =
+    input.lifecycle?.blockerCheckStates ??
+    (activeColumns[0] ? [activeColumns[0].name] : []);
+  const planningStates = input.lifecycle?.planningStates ?? blockerCheckStates;
 
   if (activeColumns.length > 0) {
     lines.push("  active_states:");
@@ -74,12 +85,10 @@ export function generateReferenceWorkflow(
     lines.push("  terminal_states: [{terminal column names}]");
   }
 
-  if (firstActive) {
-    lines.push("  blocker_check_states:");
-    lines.push(`    - ${firstActive.name}`);
-  } else {
-    lines.push("  blocker_check_states: [{first active state}]");
-  }
+  lines.push(
+    ...buildReferenceStringList("blocker_check_states", blockerCheckStates)
+  );
+  lines.push(...buildReferenceStringList("planning_states", planningStates));
 
   lines.push("");
   lines.push("# Linear tracker example:");
@@ -95,7 +104,9 @@ export function generateReferenceWorkflow(
   lines.push("#     - Done");
   lines.push("#     - Canceled");
   lines.push("#     - Duplicate");
-  lines.push("# Linear uses repository-local polling; gh-symphony does not provide");
+  lines.push(
+    "# Linear uses repository-local polling; gh-symphony does not provide"
+  );
   lines.push("# a Linear webhook setup command.");
   lines.push("");
 
@@ -384,6 +395,14 @@ export function generateReferenceWorkflow(
   return lines.join("\n");
 }
 
+function buildReferenceStringList(key: string, values: string[]): string[] {
+  if (values.length === 0) {
+    return [`  ${key}: []`];
+  }
+
+  return [`  ${key}:`, ...values.map((value) => `    - ${value}`)];
+}
+
 function buildReferencePriorityLines(
   priority: WorkflowPriorityConfig | null
 ): string[] {
@@ -440,7 +459,6 @@ function buildReferencePriorityLines(
   lines.push("  #     P1: 1");
   return lines;
 }
-
 
 function resolveRoleAction(
   role: "active" | "wait" | "terminal" | null

--- a/packages/cli/src/workflow/generate-reference-workflow.ts
+++ b/packages/cli/src/workflow/generate-reference-workflow.ts
@@ -62,9 +62,7 @@ export function generateReferenceWorkflow(
   const terminalColumns = input.statusColumns.filter(
     (c) => c.role === "terminal"
   );
-  const blockerCheckStates =
-    input.lifecycle?.blockerCheckStates ??
-    (activeColumns[0] ? [activeColumns[0].name] : []);
+  const blockerCheckStates = input.lifecycle?.blockerCheckStates ?? [];
   const planningStates = input.lifecycle?.planningStates ?? blockerCheckStates;
 
   if (activeColumns.length > 0) {

--- a/packages/cli/src/workflow/generate-workflow-md.test.ts
+++ b/packages/cli/src/workflow/generate-workflow-md.test.ts
@@ -32,6 +32,7 @@ describe("generateWorkflowMarkdown", () => {
       activeStates: ["Queued", "Doing"],
       terminalStates: ["Done"],
       blockerCheckStates: ["Queued"],
+      planningStates: ["Queued"],
     },
     runtime: "codex-app-server",
     detectedEnvironment: {
@@ -59,6 +60,24 @@ describe("generateWorkflowMarkdown", () => {
     expect(parsed.lifecycle.activeStates).toEqual(["Queued", "Doing"]);
     expect(parsed.lifecycle.terminalStates).toEqual(["Done"]);
     expect(parsed.lifecycle.blockerCheckStates).toEqual(["Queued"]);
+    expect(parsed.lifecycle.planningStates).toEqual(["Queued"]);
+  });
+
+  it("emits empty blocker and planning state lists explicitly", () => {
+    const markdown = generateWorkflowMarkdown({
+      ...defaultInput,
+      lifecycle: {
+        ...defaultInput.lifecycle,
+        blockerCheckStates: [],
+        planningStates: [],
+      },
+    });
+    const parsed = parseWorkflowMarkdown(markdown, {});
+
+    expect(markdown).toContain("blocker_check_states: []");
+    expect(markdown).toContain("planning_states: []");
+    expect(parsed.lifecycle.blockerCheckStates).toEqual([]);
+    expect(parsed.lifecycle.planningStates).toEqual([]);
   });
 
   it("emits explicit project-field priority mapping when configured", () => {
@@ -87,7 +106,9 @@ describe("generateWorkflowMarkdown", () => {
     expect(markdown).toContain(
       "# Priority dispatch is disabled until an operator chooses one explicit source."
     );
-    expect(markdown).toContain("# Optional template: project-field priority source.");
+    expect(markdown).toContain(
+      "# Optional template: project-field priority source."
+    );
     expect(markdown).toContain("# Optional template: labels priority source.");
     expect(parsed.tracker.priority).toEqual({ source: "disabled" });
     expect(parsed.tracker.priorityFieldName).toBeNull();
@@ -279,9 +300,7 @@ describe("generateWorkflowMarkdown", () => {
       expect(markdown).toContain(`command: ${runtime}`);
       expect(parsed.promptTemplate.startsWith("## Status Map")).toBe(true);
       expect(parsed.promptTemplate).not.toContain("## Runtime Constraints");
-      expect(parsed.promptTemplate).not.toContain(
-        "Runtime trade-off note:"
-      );
+      expect(parsed.promptTemplate).not.toContain("Runtime trade-off note:");
     }
   });
 

--- a/packages/cli/src/workflow/generate-workflow-md.ts
+++ b/packages/cli/src/workflow/generate-workflow-md.ts
@@ -61,12 +61,18 @@ function buildFrontMatter(input: GenerateWorkflowInput): string {
     }
   }
 
-  if (input.lifecycle.blockerCheckStates.length > 0) {
-    lines.push("  blocker_check_states:");
-    for (const state of input.lifecycle.blockerCheckStates) {
-      lines.push(`    - ${state}`);
-    }
-  }
+  lines.push(
+    ...buildStringListFrontMatter(
+      "blocker_check_states",
+      input.lifecycle.blockerCheckStates
+    )
+  );
+  lines.push(
+    ...buildStringListFrontMatter(
+      "planning_states",
+      input.lifecycle.planningStates
+    )
+  );
 
   lines.push("polling:");
   lines.push(`  interval_ms: ${input.pollIntervalMs ?? 30000}`);
@@ -85,6 +91,14 @@ function buildFrontMatter(input: GenerateWorkflowInput): string {
   lines.push(...buildRuntimeFrontMatter(input.runtime));
 
   return lines.join("\n") + "\n";
+}
+
+function buildStringListFrontMatter(key: string, values: string[]): string[] {
+  if (values.length === 0) {
+    return [`  ${key}: []`];
+  }
+
+  return [`  ${key}:`, ...values.map((value) => `    - ${value}`)];
 }
 
 function buildPriorityFrontMatter(

--- a/packages/core/src/workflow-loader.test.ts
+++ b/packages/core/src/workflow-loader.test.ts
@@ -69,9 +69,54 @@ describe("parseWorkflowMarkdown", () => {
     expect(workflow.tracker.kind).toBe("github-project");
     expect(workflow.tracker.priority).toBeNull();
     expect(workflow.tracker.priorityFieldName).toBe("Priority");
+    expect(workflow.lifecycle.blockerCheckStates).toEqual([]);
+    expect(workflow.lifecycle.planningStates).toEqual([]);
     expect(workflow.polling.intervalMs).toBe(30000);
     expect(workflow.agent.maxFailureRetries).toBe(6);
     expect(workflow.agent.maxConcurrentAgentsByState).toEqual({ Todo: 1 });
+  });
+
+  it("falls planning states back to explicit blocker check states", () => {
+    const workflow = parseWorkflowMarkdown(`---
+tracker:
+  kind: github-project
+  active_states:
+    - Todo
+    - In Progress
+  terminal_states:
+    - Done
+  blocker_check_states:
+    - Todo
+codex:
+  command: codex app-server
+---
+Prompt body.
+`);
+
+    expect(workflow.lifecycle.blockerCheckStates).toEqual(["Todo"]);
+    expect(workflow.lifecycle.planningStates).toEqual(["Todo"]);
+  });
+
+  it("parses independent planning states", () => {
+    const workflow = parseWorkflowMarkdown(`---
+tracker:
+  kind: github-project
+  active_states:
+    - Todo
+    - In Progress
+  terminal_states:
+    - Done
+  blocker_check_states: []
+  planning_states:
+    - Todo
+codex:
+  command: codex app-server
+---
+Prompt body.
+`);
+
+    expect(workflow.lifecycle.blockerCheckStates).toEqual([]);
+    expect(workflow.lifecycle.planningStates).toEqual(["Todo"]);
   });
 
   it("parses explicit project-field priority mapping", () => {

--- a/packages/core/src/workflow/config.ts
+++ b/packages/core/src/workflow/config.ts
@@ -23,6 +23,7 @@ export type WorkflowTrackerConfig = {
   priority: WorkflowPriorityConfig | null;
   priorityFieldName: string | null;
   blockerCheckStates: string[];
+  planningStates: string[];
 };
 
 export type WorkflowPriorityConfig =
@@ -160,6 +161,7 @@ export const DEFAULT_WORKFLOW_TRACKER: WorkflowTrackerConfig = {
   priority: null,
   priorityFieldName: null,
   blockerCheckStates: DEFAULT_WORKFLOW_LIFECYCLE.blockerCheckStates,
+  planningStates: DEFAULT_WORKFLOW_LIFECYCLE.planningStates,
 };
 
 export const DEFAULT_WORKFLOW_WORKSPACE: WorkflowWorkspaceConfig = {

--- a/packages/core/src/workflow/lifecycle.ts
+++ b/packages/core/src/workflow/lifecycle.ts
@@ -3,13 +3,15 @@ export type WorkflowLifecycleConfig = {
   activeStates: string[];
   terminalStates: string[];
   blockerCheckStates: string[];
+  planningStates: string[];
 };
 
 export const DEFAULT_WORKFLOW_LIFECYCLE: WorkflowLifecycleConfig = {
   stateFieldName: "Status",
   activeStates: ["Todo", "In Progress"],
   terminalStates: ["Done"],
-  blockerCheckStates: ["Todo"],
+  blockerCheckStates: [],
+  planningStates: [],
 };
 
 export function isStateActive(
@@ -31,7 +33,9 @@ export function matchesWorkflowState(
   candidates: readonly string[]
 ): boolean {
   const normalizedState = normalizeWorkflowState(state);
-  return candidates.some((candidate) => normalizeWorkflowState(candidate) === normalizedState);
+  return candidates.some(
+    (candidate) => normalizeWorkflowState(candidate) === normalizedState
+  );
 }
 
 export function normalizeWorkflowState(state: string): string {

--- a/packages/core/src/workflow/parser.ts
+++ b/packages/core/src/workflow/parser.ts
@@ -74,6 +74,8 @@ export function parseWorkflowMarkdown(
   const blockerCheckStates =
     readStringList(tracker, "blocker_check_states") ??
     DEFAULT_WORKFLOW_TRACKER.blockerCheckStates;
+  const planningStates =
+    readStringList(tracker, "planning_states") ?? blockerCheckStates;
 
   const maxConcurrentAgentsByState = readNumberMap(
     agent,
@@ -125,6 +127,7 @@ export function parseWorkflowMarkdown(
       priority: readPriorityConfig(tracker, env),
       priorityFieldName: readOptionalString(tracker, "priority_field", env),
       blockerCheckStates,
+      planningStates,
     },
     polling: {
       intervalMs:
@@ -168,6 +171,7 @@ export function parseWorkflowMarkdown(
       activeStates,
       terminalStates,
       blockerCheckStates,
+      planningStates,
     },
     format: "front-matter",
     githubProjectId: readOptionalString(tracker, "project_id", env),
@@ -475,7 +479,9 @@ function parseScalar(value: string): WorkflowFrontMatterNode {
         return parsed;
       }
     } catch {
-      throw new Error(`Invalid quoted workflow front matter scalar "${value}".`);
+      throw new Error(
+        `Invalid quoted workflow front matter scalar "${value}".`
+      );
     }
   }
   if (value.startsWith("'") && value.endsWith("'")) {

--- a/packages/orchestrator/src/dispatch.test.ts
+++ b/packages/orchestrator/src/dispatch.test.ts
@@ -230,6 +230,7 @@ describe("explainIssueDispatch", () => {
     activeStates: ["Todo", "In Progress"],
     terminalStates: ["Done"],
     blockerCheckStates: ["Todo"],
+    planningStates: ["Todo"],
   };
   const projectRepository = {
     owner: "acme",
@@ -1123,11 +1124,7 @@ describe("targeted canonical subject dispatch", () => {
       metadata: {
         contentType: "Issue",
         linkedPullRequests: [
-          makePullRequestContext(
-            alternateRepository,
-            111,
-            "feature/pr-111"
-          ),
+          makePullRequestContext(alternateRepository, 111, "feature/pr-111"),
         ],
       },
     });
@@ -1158,9 +1155,7 @@ describe("targeted canonical subject dispatch", () => {
     ]);
     const upsertIssueComment = vi.fn().mockResolvedValue("created");
     adapter.upsertIssueComment = upsertIssueComment;
-    vi.spyOn(trackerAdapters, "resolveTrackerAdapter").mockReturnValue(
-      adapter
-    );
+    vi.spyOn(trackerAdapters, "resolveTrackerAdapter").mockReturnValue(adapter);
 
     const spawnImpl = vi.fn().mockReturnValue({ pid: 5410, unref: vi.fn() });
     const service = new OrchestratorService(store, projectConfig, {

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -1221,6 +1221,7 @@ export class OrchestratorService {
         activeStates: ["Todo", "In Progress"],
         terminalStates: ["Done"],
         blockerCheckStates: ["Todo"],
+        planningStates: ["Todo"],
       },
     };
   }

--- a/packages/worker/src/conformance.test.ts
+++ b/packages/worker/src/conformance.test.ts
@@ -45,7 +45,11 @@ describe("Symphony core conformance", () => {
       continuationGuidance: "Resume using {{lastTurnSummary}}",
       agentCommand: "codex app-server",
       hookPath: "hooks/after_create.sh",
-      lifecycle: DEFAULT_WORKFLOW_LIFECYCLE,
+      lifecycle: {
+        ...DEFAULT_WORKFLOW_LIFECYCLE,
+        blockerCheckStates: ["Todo"],
+        planningStates: ["Todo"],
+      },
     });
   });
 

--- a/packages/worker/src/execution-phase.test.ts
+++ b/packages/worker/src/execution-phase.test.ts
@@ -6,11 +6,11 @@ import {
 } from "./execution-phase.js";
 
 describe("execution phase helpers", () => {
-  it("maps blocker-check states to planning", () => {
+  it("maps planning states to planning", () => {
     expect(
       resolveInitialExecutionPhase({
         issueState: "Todo",
-        blockerCheckStates: ["Todo"],
+        planningStates: ["Todo"],
         activeStates: ["Todo", "In Progress"],
       })
     ).toBe("planning");
@@ -20,7 +20,7 @@ describe("execution phase helpers", () => {
     expect(
       resolveInitialExecutionPhase({
         issueState: "In Progress",
-        blockerCheckStates: ["Todo"],
+        planningStates: ["Todo"],
         activeStates: ["Todo", "In Progress"],
       })
     ).toBe("implementation");

--- a/packages/worker/src/execution-phase.ts
+++ b/packages/worker/src/execution-phase.ts
@@ -4,14 +4,14 @@ export type WorkerTrackerState = "active" | "non-actionable" | "unknown";
 
 export function resolveInitialExecutionPhase(input: {
   issueState: string | null | undefined;
-  blockerCheckStates: string[];
+  planningStates: string[];
   activeStates: string[];
 }): WorkflowExecutionPhase | null {
-  const { issueState, blockerCheckStates, activeStates } = input;
+  const { issueState, planningStates, activeStates } = input;
   if (!issueState) {
     return null;
   }
-  if (blockerCheckStates.includes(issueState)) {
+  if (planningStates.includes(issueState)) {
     return "planning";
   }
   if (activeStates.includes(issueState)) {
@@ -40,7 +40,5 @@ export function resolveFinalExecutionPhase(input: {
   if (input.userInputRequired || input.trackerState !== "non-actionable") {
     return input.currentPhase;
   }
-  return (
-    resolvePausedExecutionPhase(input.currentPhase) ?? input.currentPhase
-  );
+  return resolvePausedExecutionPhase(input.currentPhase) ?? input.currentPhase;
 }

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -522,7 +522,7 @@ async function startAssignedRun() {
     }
     runtimeState.executionPhase = resolveInitialExecutionPhase({
       issueState: runtimeState.run?.state,
-      blockerCheckStates: workflow.lifecycle.blockerCheckStates,
+      planningStates: workflow.lifecycle.planningStates,
       activeStates: workflow.lifecycle.activeStates,
     });
     runtimeState.runPhase = "launching_agent";


### PR DESCRIPTION
## Issues

- Fixes #357

## Summary

- Adds an explicit setup/workflow init blocker-check prompt between lifecycle mapping and priority setup.
- Separates worker planning phase classification into `planning_states` while preserving old workflow compatibility.
- Addresses review feedback by validating mappings before blocker prompts, removing the remaining first-active reference fallback, and making setup step labels consistent.

## Changes

- `gh-symphony setup` and `gh-symphony workflow init` now ask whether blocker checks are enabled and which active states are checked, defaulting to the first active state.
- Generated workflows always serialize `blocker_check_states`, including `[]`, and emit `planning_states` initialized from the blocker selection.
- Parser fallback for missing `blocker_check_states` is now disabled (`[]`); missing `planning_states` falls back to explicit `blocker_check_states` for existing workflows.
- Final setup/init summaries and dry-run previews include lifecycle rows for active, wait, terminal, blocker check, and planning states.
- Worker initial execution phase reads `planning_states`; orchestrator blocker gating continues to read `blocker_check_states`.
- Review rework validates lifecycle mappings before blocker-check prompts and makes reference workflow generation use explicit empty lifecycle defaults when lifecycle input is absent.

## Evidence

- `pnpm --filter @gh-symphony/cli test -- setup.test.ts workflow-init.test.ts generate-reference-workflow.test.ts`
- `pnpm --filter @gh-symphony/cli test`
- `pnpm --filter @gh-symphony/core test`
- `pnpm --filter @gh-symphony/worker test`
- `pnpm lint && pnpm test && pnpm typecheck && pnpm build`
- Docker E2E TC from initial implementation: started `docker-compose.e2e.yml` with events override, injected `e2e/fixtures/happy-path.json`, triggered `/api/v1/refresh`, verified `test-owner/test-repo#1` appeared in `/api/v1/state`, then cleaned up. Review rework only changed CLI prompt ordering/reference generation, so Docker E2E was not rerun.

## Human Validation

- [ ] Confirm interactive `gh-symphony setup` shows the new blocker-check step and lifecycle summary with consistent `Step 1/4` through `Step 4/4` labels.
- [ ] Confirm interactive `gh-symphony workflow init` mirrors setup behavior and validates mappings before blocker-check prompts.
- [ ] Confirm generated opt-out workflows contain `blocker_check_states: []` and do not re-enable Todo via parser or reference-workflow fallback.

## Risks

- Hand-written workflows that omitted `blocker_check_states` now default to no blocker check instead of implicit `Todo`; the changeset calls this out.