### PR TITLE
fix(orchestrator): recover incomplete dirty issue workspaces

### DIFF
--- a/.changeset/recover-incomplete-dirty-workspaces.md
+++ b/.changeset/recover-incomplete-dirty-workspaces.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Recover incomplete Codex turns that leave dirty issue workspaces by surfacing recovery diagnostics and redispatching with explicit dirty-workspace recovery context for #365.

--- a/packages/cli/src/commands/doctor.test.ts
+++ b/packages/cli/src/commands/doctor.test.ts
@@ -413,7 +413,6 @@ describe("runDoctorDiagnostics", () => {
         pathEnv,
       })
     );
-
     expect(report.ok).toBe(true);
     expect(report.projectId).toBe("tenant-a");
     expect(report.authSource).toBe("gh");
@@ -481,7 +480,6 @@ describe("runDoctorDiagnostics", () => {
         pathEnv,
       })
     );
-
     expect(report.ok).toBe(true);
     expect(
       report.checks.find((check) => check.id === "claude_binary")
@@ -616,7 +614,7 @@ describe("runDoctorDiagnostics", () => {
   it("reports an actionable failure for unsupported Node.js versions", async () => {
     const configDir = await mkdtemp(join(tmpdir(), "doctor-config-"));
     const workspaceDir = join(configDir, "workspaces");
-    await mkdir(workspaceDir, { recursive: true });
+    await prepareDoctorPaths(configDir, workspaceDir);
     const { repoDir, pathEnv } = await createWorkflowFixture();
 
     const report = await withCwd(repoDir, () =>
@@ -658,7 +656,7 @@ describe("runDoctorDiagnostics", () => {
   it("reports an actionable failure when Git is missing from PATH", async () => {
     const configDir = await mkdtemp(join(tmpdir(), "doctor-config-"));
     const workspaceDir = join(configDir, "workspaces");
-    await mkdir(workspaceDir, { recursive: true });
+    await prepareDoctorPaths(configDir, workspaceDir);
     const { repoDir, pathEnv } = await createWorkflowFixture("fake-agent", {
       includeGit: false,
     });
@@ -778,12 +776,13 @@ describe("runDoctorDiagnostics", () => {
   it("accepts env-token auth when gh CLI is unavailable", async () => {
     const configDir = await mkdtemp(join(tmpdir(), "doctor-config-"));
     const workspaceDir = join(configDir, "workspaces");
-    await mkdir(workspaceDir, { recursive: true });
+    await prepareDoctorPaths(configDir, workspaceDir);
     const { repoDir, pathEnv } = await createWorkflowFixture();
 
     const report = await withCwd(repoDir, () =>
       runDoctorDiagnostics(baseOptions(configDir), [], {
         checkGhInstalled: () => false,
+        processVersion: DOCTOR_TEST_NODE_VERSION,
         getEnvGitHubToken: () => "env-token",
         validateGitHubToken: (async () =>
           ({
@@ -810,7 +809,6 @@ describe("runDoctorDiagnostics", () => {
         pathEnv,
       })
     );
-
     expect(report.ok).toBe(true);
     expect(
       report.checks.find((check) => check.id === "gh_installation")
@@ -829,7 +827,7 @@ describe("runDoctorDiagnostics", () => {
   it("falls back to gh auth without reusing an invalid env token", async () => {
     const configDir = await mkdtemp(join(tmpdir(), "doctor-config-"));
     const workspaceDir = join(configDir, "workspaces");
-    await mkdir(workspaceDir, { recursive: true });
+    await prepareDoctorPaths(configDir, workspaceDir);
     const { repoDir, pathEnv } = await createWorkflowFixture();
     const getGhToken = vi.fn(() => "gh-token");
     const validateGitHubToken = vi
@@ -847,6 +845,7 @@ describe("runDoctorDiagnostics", () => {
     const report = await withCwd(repoDir, () =>
       runDoctorDiagnostics(baseOptions(configDir), [], {
         checkGhInstalled: () => true,
+        processVersion: DOCTOR_TEST_NODE_VERSION,
         checkGhAuthenticated: () => ({ authenticated: true, login: "gh-user" }),
         checkGhScopes: () => ({
           valid: true,
@@ -874,7 +873,6 @@ describe("runDoctorDiagnostics", () => {
         pathEnv,
       })
     );
-
     expect(report.ok).toBe(true);
     expect(getGhToken).toHaveBeenCalledWith({ allowEnv: false });
     expect(validateGitHubToken).toHaveBeenNthCalledWith(
@@ -991,7 +989,6 @@ describe("runDoctorDiagnostics", () => {
         pathEnv,
       })
     );
-
     expect(report.ok).toBe(true);
     expect(report.authSource).toBe("env");
     expect(report.authLogin).toBe("env-user");
@@ -2133,7 +2130,6 @@ describe("doctor command handler", () => {
         }
       )
     );
-
     expect(report.ok).toBe(true);
     expect(
       report.checks.find((check) => check.id === "smoke_issue")
@@ -2228,7 +2224,6 @@ describe("doctor command handler", () => {
         pathEnv,
       })
     );
-
     expect(report.ok).toBe(true);
     expect(
       report.checks.find(
@@ -2265,7 +2260,6 @@ describe("doctor command handler", () => {
         pathEnv,
       })
     );
-
     expect(report.ok).toBe(true);
     expect(
       report.checks.find(
@@ -2322,7 +2316,6 @@ describe("doctor command handler", () => {
         pathEnv,
       })
     );
-
     expect(report.ok).toBe(true);
     expect(
       report.checks.filter((check) => check.id === "priority_mapping")
@@ -2378,7 +2371,6 @@ describe("doctor command handler", () => {
         pathEnv,
       })
     );
-
     expect(report.ok).toBe(true);
     expect(
       report.checks.find(
@@ -2412,7 +2404,10 @@ describe("doctor command handler", () => {
           projectConfig: createProjectConfig(workspaceDir),
         }),
         getProjectDetail: (async () => createProjectDetail() as never) as never,
-        listRepositoryLabels: (async () => [{ name: "P0" }, { name: "P1" }]) as never,
+        listRepositoryLabels: (async () => [
+          { name: "P0" },
+          { name: "P1" },
+        ]) as never,
         fetchProjectIssues: (async () => [
           createTrackedIssue({
             state: "In progress",
@@ -2422,7 +2417,6 @@ describe("doctor command handler", () => {
         pathEnv,
       })
     );
-
     expect(report.ok).toBe(true);
     expect(
       report.checks.filter((check) => check.id === "priority_mapping")
@@ -2509,7 +2503,9 @@ describe("doctor command handler", () => {
     );
     expect(priorityChecks).not.toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ title: "Missing configured priority labels" }),
+        expect.objectContaining({
+          title: "Missing configured priority labels",
+        }),
         expect.objectContaining({ title: "Stale priority label mappings" }),
       ])
     );
@@ -2535,7 +2531,10 @@ describe("doctor command handler", () => {
           projectConfig: createProjectConfig(workspaceDir),
         }),
         getProjectDetail: (async () => createProjectDetail() as never) as never,
-        listRepositoryLabels: (async () => [{ name: "P0" }, { name: "P1" }]) as never,
+        listRepositoryLabels: (async () => [
+          { name: "P0" },
+          { name: "P1" },
+        ]) as never,
         fetchProjectIssues: (async () => [
           createTrackedIssue({
             state: "In progress",

--- a/packages/cli/src/commands/setup.test.ts
+++ b/packages/cli/src/commands/setup.test.ts
@@ -234,7 +234,7 @@ describe("setup command", () => {
     expect(workflow).not.toContain("priority_field:");
     expect(contextYaml).toContain("PVT_setup_1");
     expect(project.projectId).toBe("repository");
-    expect(project.workspaceDir).toBe(cwd);
+    expect(project.workspaceDir).toBe(process.cwd());
     expect(project.repository).toMatchObject({
       owner: "acme",
       name: "repo-a",
@@ -275,7 +275,7 @@ describe("setup command", () => {
       )
     );
 
-    expect(project.workspaceDir).toBe(cwd);
+    expect(project.workspaceDir).toBe(process.cwd());
     expect(project.repository?.name).toBe("repo-b");
     expect(p.note).toHaveBeenCalledWith(
       expect.stringContaining("Init dry-run preview"),

--- a/packages/cli/src/commands/status.test.ts
+++ b/packages/cli/src/commands/status.test.ts
@@ -144,6 +144,83 @@ describe("status command", () => {
     expect(stdout.output()).toContain("Tokens: 600 / 1,700 total");
   });
 
+  it("renders incomplete-turn recovery details in text status output", async () => {
+    const configDir = await createConfigFixture();
+    const projectId = "tenant-a";
+    await writeFile(
+      join(configDir, "status.json"),
+      JSON.stringify(
+        {
+          projectId,
+          slug: projectId,
+          tracker: { adapter: "github-project", bindingId: "project-1" },
+          lastTickAt: "2026-03-30T11:00:00.000Z",
+          health: "degraded",
+          summary: {
+            dispatched: 2,
+            suppressed: 1,
+            recovered: 0,
+            activeRuns: 0,
+          },
+          activeRuns: [],
+          retryQueue: [],
+          codexTotals: {
+            inputTokens: 1400,
+            outputTokens: 300,
+            totalTokens: 1700,
+            secondsRunning: 60,
+          },
+          lastError: null,
+          recovery: {
+            kind: "incomplete-turn-dirty-workspace",
+            runId: "repository-acme-repo-78-mpmc5cl9",
+            issueId: "issue-78",
+            workspacePath: "/tmp/work/repository",
+            dirtyFiles: [
+              "apps/admin-v1/src/app/router.tsx",
+              "apps/admin-v1/src/widgets/sidebar/Sidebar.tsx",
+            ],
+            lastEvent: "heartbeat",
+            lastEventAt: "2026-05-26T08:20:42.912Z",
+            sessionId: "session-123",
+            threadId: "thread-456",
+            suggestedCommand:
+              "cd /tmp/work/repository && git status --short && git diff",
+          },
+        },
+        null,
+        2
+      ) + "\n",
+      "utf8"
+    );
+    const stdout = captureWrites(process.stdout);
+
+    try {
+      await statusCommand([], {
+        configDir,
+        verbose: false,
+        json: false,
+        noColor: true,
+      });
+    } finally {
+      stdout.restore();
+    }
+
+    const output = stdout.output();
+    expect(output).toContain("Recoverable incomplete turn:");
+    expect(output).toContain("Run        repository-acme-repo-78-mpmc5cl9");
+    expect(output).toContain("Issue      issue-78");
+    expect(output).toContain("Workspace  /tmp/work/repository");
+    expect(output).toContain("apps/admin-v1/src/app/router.tsx");
+    expect(output).toContain("Last       heartbeat");
+    expect(output).toContain("At         2026-05-26T08:20:42.912Z");
+    expect(output).toContain("Session    session-123");
+    expect(output).toContain("Thread     thread-456");
+    expect(output).toContain(
+      "Command    cd /tmp/work/repository && git status --short && git diff"
+    );
+  });
+
   it("falls back to the legacy per-project status snapshot path", async () => {
     const configDir = await createConfigFixture("legacy");
     const stdout = captureWrites(process.stdout);

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -138,6 +138,23 @@ function renderLegacyStatus(
     lines.push("");
   }
 
+  if (snapshot.recovery) {
+    const recovery = snapshot.recovery;
+    lines.push(apply(yellow("  Recoverable incomplete turn:")));
+    lines.push(`    Run        ${recovery.runId}`);
+    lines.push(`    Issue      ${recovery.issueId}`);
+    lines.push(`    Workspace  ${recovery.workspacePath}`);
+    lines.push(
+      `    Dirty      ${recovery.dirtyFiles.length > 0 ? recovery.dirtyFiles.join(", ") : "none"}`
+    );
+    lines.push(`    Last       ${recovery.lastEvent ?? "unknown"}`);
+    lines.push(`    At         ${recovery.lastEventAt ?? "unknown"}`);
+    lines.push(`    Session    ${recovery.sessionId ?? "unknown"}`);
+    lines.push(`    Thread     ${recovery.threadId ?? "unknown"}`);
+    lines.push(`    Command    ${recovery.suggestedCommand}`);
+    lines.push("");
+  }
+
   // Last error
   if (snapshot.lastError) {
     lines.push(apply(red(`  ✗ ${snapshot.lastError}`)));

--- a/packages/cli/src/config.test.ts
+++ b/packages/cli/src/config.test.ts
@@ -51,7 +51,7 @@ describe("resolveConfigDir", () => {
     process.chdir(cwd);
     delete process.env.GH_SYMPHONY_CONFIG_DIR;
 
-    expect(resolveConfigDir()).toBe(runtimeDir);
+    expect(resolveConfigDir()).toBe(join(process.cwd(), REPO_RUNTIME_DIR));
   });
 
   it("falls back to the home config when cwd runtime is not initialized", async () => {

--- a/packages/control-plane/client/src/issueDetail.test.tsx
+++ b/packages/control-plane/client/src/issueDetail.test.tsx
@@ -43,6 +43,7 @@ function createDetail(
       },
     },
     retry: null,
+    recovery: null,
     logs: {
       codex_session_logs: [],
     },
@@ -67,11 +68,14 @@ function createDetail(
   };
 }
 
-function renderIssueDetailView(
-  props: Parameters<typeof IssueDetailView>[0]
-) {
+function renderIssueDetailView(props: Parameters<typeof IssueDetailView>[0]) {
   return renderToStaticMarkup(
-    <Theme appearance="dark" accentColor="blue" grayColor="gray" radius="medium">
+    <Theme
+      appearance="dark"
+      accentColor="blue"
+      grayColor="gray"
+      radius="medium"
+    >
       <IssueDetailView {...props} />
     </Theme>
   );

--- a/packages/core/src/contracts/status-surface.ts
+++ b/packages/core/src/contracts/status-surface.ts
@@ -62,6 +62,7 @@ export const SESSION_EXIT_CLASSIFICATIONS = [
   "user-input-required",
   "timeout",
   "error",
+  "incomplete-turn-dirty-workspace",
 ] as const;
 
 export type SessionExitClassification =
@@ -132,6 +133,23 @@ export type OrchestratorRunRecord = {
   runPhase?: RunAttemptPhase | null;
   /** Latest rate-limit payload observed from the worker runtime */
   rateLimits?: Record<string, unknown> | null;
+  /** Recoverable dirty workspace left by an incomplete runtime session. */
+  recovery?: IncompleteTurnRecoveryInfo | null;
+};
+
+export type IncompleteTurnRecoveryInfo = {
+  kind: "incomplete-turn-dirty-workspace";
+  runId: string;
+  issueId: string;
+  issueIdentifier: string;
+  workspacePath: string;
+  dirtyFiles: string[];
+  lastEvent: string | null;
+  lastEventAt: string | null;
+  sessionId: string | null;
+  threadId: string | null;
+  suggestedCommand: string;
+  detectedAt: string;
 };
 
 export type RuntimeSessionRow = {
@@ -200,6 +218,7 @@ export type ProjectStatusSnapshot = {
     };
   }>;
   runtimeSession?: RuntimeSessionRow | null;
+  recovery?: IncompleteTurnRecoveryInfo | null;
   retryQueue: Array<{
     runId: string;
     issueIdentifier: string;
@@ -255,6 +274,7 @@ export type IssueStatusSnapshot = {
     kind: RetryKind | null;
     error: string | null;
   } | null;
+  recovery: IncompleteTurnRecoveryInfo | null;
   logs: {
     codex_session_logs: Array<{
       label: string;

--- a/packages/core/src/observability/snapshot-builder.test.ts
+++ b/packages/core/src/observability/snapshot-builder.test.ts
@@ -330,6 +330,58 @@ describe("buildProjectSnapshot", () => {
     expect(snapshot.summary.recovered).toBe(1);
   });
 
+  it("surfaces the latest incomplete-turn dirty-workspace recovery", () => {
+    const olderRun = mockRun({
+      runId: "run-old",
+      status: "suppressed",
+      updatedAt: "2024-01-01T00:05:00Z",
+      recovery: {
+        kind: "incomplete-turn-dirty-workspace",
+        runId: "run-old",
+        issueId: "issue-001",
+        issueIdentifier: "acme/platform#42",
+        workspacePath: "/tmp/work/old",
+        dirtyFiles: ["old.txt"],
+        lastEvent: "heartbeat",
+        lastEventAt: "2024-01-01T00:04:00Z",
+        sessionId: "session-old",
+        threadId: "thread-old",
+        suggestedCommand: "cd /tmp/work/old && git status --short && git diff",
+        detectedAt: "2024-01-01T00:05:00Z",
+      },
+    });
+    const latestRun = mockRun({
+      runId: "run-new",
+      status: "suppressed",
+      updatedAt: "2024-01-01T00:07:00Z",
+      recovery: {
+        kind: "incomplete-turn-dirty-workspace",
+        runId: "run-new",
+        issueId: "issue-002",
+        issueIdentifier: "acme/platform#43",
+        workspacePath: "/tmp/work/new",
+        dirtyFiles: ["new.txt"],
+        lastEvent: "heartbeat",
+        lastEventAt: "2024-01-01T00:06:30Z",
+        sessionId: "session-new",
+        threadId: "thread-new",
+        suggestedCommand: "cd /tmp/work/new && git status --short && git diff",
+        detectedAt: "2024-01-01T00:07:00Z",
+      },
+    });
+
+    const snapshot = buildProjectSnapshot({
+      project: mockProject(),
+      activeRuns: [],
+      allRuns: [olderRun, latestRun],
+      summary: { dispatched: 0, suppressed: 1, recovered: 0 },
+      lastTickAt: "2024-01-01T00:10:00Z",
+      lastError: null,
+    });
+
+    expect(snapshot.recovery).toEqual(latestRun.recovery);
+  });
+
   it("uses allRuns for token aggregation when provided, falls back to activeRuns", () => {
     const activeRun = mockRun({
       runId: "run-001",

--- a/packages/core/src/observability/snapshot-builder.test.ts
+++ b/packages/core/src/observability/snapshot-builder.test.ts
@@ -382,6 +382,101 @@ describe("buildProjectSnapshot", () => {
     expect(snapshot.recovery).toEqual(latestRun.recovery);
   });
 
+  it("does not surface stale recovery after the recovery run completes", () => {
+    const suppressedRun = mockRun({
+      runId: "run-suppressed",
+      status: "suppressed",
+      updatedAt: "2024-01-01T00:05:00Z",
+      recovery: {
+        kind: "incomplete-turn-dirty-workspace",
+        runId: "run-suppressed",
+        issueId: "issue-001",
+        issueIdentifier: "acme/platform#42",
+        workspacePath: "/tmp/work/recovered",
+        dirtyFiles: ["partial.txt"],
+        lastEvent: "heartbeat",
+        lastEventAt: "2024-01-01T00:04:00Z",
+        sessionId: "session-old",
+        threadId: "thread-old",
+        suggestedCommand:
+          "cd /tmp/work/recovered && git status --short && git diff",
+        detectedAt: "2024-01-01T00:05:00Z",
+      },
+    });
+    const completedRecoveryRun = mockRun({
+      runId: "run-recovery",
+      status: "succeeded",
+      retryKind: "recovery",
+      updatedAt: "2024-01-01T00:07:00Z",
+      recovery: suppressedRun.recovery,
+    });
+
+    const snapshot = buildProjectSnapshot({
+      project: mockProject(),
+      activeRuns: [],
+      allRuns: [suppressedRun, completedRecoveryRun],
+      summary: { dispatched: 1, suppressed: 1, recovered: 1 },
+      lastTickAt: "2024-01-01T00:10:00Z",
+      lastError: null,
+    });
+
+    expect(snapshot.recovery).toBeNull();
+  });
+
+  it("chooses the newest unresolved recovery deterministically", () => {
+    const olderRunningRun = mockRun({
+      runId: "run-old",
+      status: "running",
+      retryKind: "recovery",
+      updatedAt: "2024-01-01T00:05:00Z",
+      recovery: {
+        kind: "incomplete-turn-dirty-workspace",
+        runId: "run-old",
+        issueId: "issue-001",
+        issueIdentifier: "acme/platform#42",
+        workspacePath: "/tmp/work/old",
+        dirtyFiles: ["old.txt"],
+        lastEvent: "heartbeat",
+        lastEventAt: "2024-01-01T00:04:00Z",
+        sessionId: "session-old",
+        threadId: "thread-old",
+        suggestedCommand: "cd /tmp/work/old && git status --short && git diff",
+        detectedAt: "2024-01-01T00:05:00Z",
+      },
+    });
+    const latestRetryingRun = mockRun({
+      runId: "run-new",
+      status: "retrying",
+      retryKind: "recovery",
+      updatedAt: "2024-01-01T00:07:00Z",
+      recovery: {
+        kind: "incomplete-turn-dirty-workspace",
+        runId: "run-new",
+        issueId: "issue-002",
+        issueIdentifier: "acme/platform#43",
+        workspacePath: "/tmp/work/new",
+        dirtyFiles: ["new.txt"],
+        lastEvent: "heartbeat",
+        lastEventAt: "2024-01-01T00:06:30Z",
+        sessionId: "session-new",
+        threadId: "thread-new",
+        suggestedCommand: "cd /tmp/work/new && git status --short && git diff",
+        detectedAt: "2024-01-01T00:07:00Z",
+      },
+    });
+
+    const snapshot = buildProjectSnapshot({
+      project: mockProject(),
+      activeRuns: [olderRunningRun, latestRetryingRun],
+      allRuns: [],
+      summary: { dispatched: 2, suppressed: 0, recovered: 0 },
+      lastTickAt: "2024-01-01T00:10:00Z",
+      lastError: null,
+    });
+
+    expect(snapshot.recovery).toEqual(latestRetryingRun.recovery);
+  });
+
   it("uses allRuns for token aggregation when provided, falls back to activeRuns", () => {
     const activeRun = mockRun({
       runId: "run-001",

--- a/packages/core/src/observability/snapshot-builder.ts
+++ b/packages/core/src/observability/snapshot-builder.ts
@@ -91,10 +91,8 @@ export function buildProjectSnapshot(
         issueIdentifier: run.issueIdentifier,
         retryKind: run.retryKind ?? "failure",
         nextRetryAt: run.nextRetryAt,
-    })),
-    recovery:
-      activeRuns.find((run) => run.recovery)?.recovery ??
-      findLatestRecovery(allRuns ?? []),
+      })),
+    recovery: findLatestRecovery([...(allRuns ?? []), ...activeRuns]),
     lastError,
     codexTotals: aggregateTokenUsage(allRuns ?? activeRuns, lastTickAt),
     rateLimits: rateLimits ?? null,
@@ -104,13 +102,47 @@ export function buildProjectSnapshot(
 function findLatestRecovery(
   runs: OrchestratorRunRecord[]
 ): ProjectStatusSnapshot["recovery"] {
-  return [...runs]
-    .sort((left, right) => {
-      const leftTime = new Date(left.updatedAt).getTime();
-      const rightTime = new Date(right.updatedAt).getTime();
-      return rightTime - leftTime;
-    })
-    .find((run) => run.recovery)?.recovery ?? null;
+  return (
+    [...runs]
+      .filter((run) => isUnresolvedRecoveryRun(run, runs))
+      .sort((left, right) => {
+        const leftTime = new Date(left.updatedAt).getTime();
+        const rightTime = new Date(right.updatedAt).getTime();
+        return rightTime - leftTime;
+      })
+      .find((run) => run.recovery)?.recovery ?? null
+  );
+}
+
+function isUnresolvedRecoveryRun(
+  run: OrchestratorRunRecord,
+  runs: OrchestratorRunRecord[]
+): boolean {
+  if (!run.recovery) {
+    return false;
+  }
+
+  if (
+    run.status === "suppressed" &&
+    runs.some(
+      (candidate) =>
+        candidate.runId !== run.runId &&
+        candidate.retryKind === "recovery" &&
+        candidate.recovery?.runId === run.recovery?.runId &&
+        new Date(candidate.updatedAt).getTime() >
+          new Date(run.updatedAt).getTime() &&
+        candidate.status !== "running" &&
+        candidate.status !== "retrying"
+    )
+  ) {
+    return false;
+  }
+
+  return (
+    run.status === "suppressed" ||
+    (run.retryKind === "recovery" &&
+      (run.status === "running" || run.status === "retrying"))
+  );
 }
 
 function aggregateTokenUsageByIssue(

--- a/packages/core/src/observability/snapshot-builder.ts
+++ b/packages/core/src/observability/snapshot-builder.ts
@@ -91,11 +91,26 @@ export function buildProjectSnapshot(
         issueIdentifier: run.issueIdentifier,
         retryKind: run.retryKind ?? "failure",
         nextRetryAt: run.nextRetryAt,
-      })),
+    })),
+    recovery:
+      activeRuns.find((run) => run.recovery)?.recovery ??
+      findLatestRecovery(allRuns ?? []),
     lastError,
     codexTotals: aggregateTokenUsage(allRuns ?? activeRuns, lastTickAt),
     rateLimits: rateLimits ?? null,
   };
+}
+
+function findLatestRecovery(
+  runs: OrchestratorRunRecord[]
+): ProjectStatusSnapshot["recovery"] {
+  return [...runs]
+    .sort((left, right) => {
+      const leftTime = new Date(left.updatedAt).getTime();
+      const rightTime = new Date(right.updatedAt).getTime();
+      return rightTime - leftTime;
+    })
+    .find((run) => run.recovery)?.recovery ?? null;
 }
 
 function aggregateTokenUsageByIssue(

--- a/packages/dashboard/src/store.test.ts
+++ b/packages/dashboard/src/store.test.ts
@@ -243,6 +243,7 @@ describe("DashboardFsReader", () => {
         kind: "failure",
         error: "worker failed",
       },
+      recovery: null,
       logs: {
         codex_session_logs: [
           {

--- a/packages/dashboard/src/store.ts
+++ b/packages/dashboard/src/store.ts
@@ -321,6 +321,7 @@ export async function statusForIssue(
               resolvedRun?.lastError ?? issueRecord.retryEntry?.error ?? null,
           }
         : null,
+    recovery: resolvedRun?.recovery ?? null,
     logs: {
       codex_session_logs:
         resolvedRun === null

--- a/packages/orchestrator/src/explain.ts
+++ b/packages/orchestrator/src/explain.ts
@@ -437,6 +437,30 @@ function explainRuntimeOwnership(
     }
   }
 
+  if (
+    latestRun?.status === "suppressed" &&
+    latestRun.recovery?.kind === "incomplete-turn-dirty-workspace"
+  ) {
+    return {
+      id: "runtime_ownership",
+      status: "warn",
+      message:
+        "Latest run has a recoverable incomplete-turn dirty workspace; dispatch will start a recovery turn.",
+      details: {
+        runId: latestRun.recovery.runId,
+        issueId: latestRun.recovery.issueId,
+        workspacePath: latestRun.recovery.workspacePath,
+        dirtyFiles: latestRun.recovery.dirtyFiles,
+        lastEvent: latestRun.recovery.lastEvent,
+        lastEventAt: latestRun.recovery.lastEventAt,
+        sessionId: latestRun.recovery.sessionId,
+        threadId: latestRun.recovery.threadId,
+        suggestedCommand: latestRun.recovery.suggestedCommand,
+      },
+      hint: latestRun.recovery.suggestedCommand,
+    };
+  }
+
   return {
     id: "runtime_ownership",
     status: "pass",

--- a/packages/orchestrator/src/git.test.ts
+++ b/packages/orchestrator/src/git.test.ts
@@ -316,7 +316,9 @@ describe("cloneRepositoryForRun", () => {
     );
     execSync(`git -C "${repository.path}" add WORKFLOW.md`);
     execSync(`git -C "${repository.path}" commit -m "Update PR workflow v2"`);
-    execSync(`git -C "${repository.path}" push --force origin feature/pr-branch`);
+    execSync(
+      `git -C "${repository.path}" push --force origin feature/pr-branch`
+    );
 
     await ensureIssueWorkspaceRepository({
       repository,
@@ -330,6 +332,67 @@ describe("cloneRepositoryForRun", () => {
     expect(
       await readFile(join(repositoryDirectory, "WORKFLOW.md"), "utf8")
     ).toBe("# pull request workflow v2\n");
+  });
+
+  it("skips pull request checkout when dirty recovery preserves an existing workspace", async () => {
+    const tempRoot = await mkdtemp(join(tmpdir(), "orchestrator-git-pr-"));
+    const repository = await createRepositoryFixture(tempRoot);
+    const issueWorkspacePath = join(tempRoot, "workspaces", "acme_platform_2");
+
+    execSync(`git -C "${repository.path}" checkout -b feature/pr-branch`);
+    await writeFile(
+      join(repository.path, "WORKFLOW.md"),
+      "# pull request workflow v1\n",
+      "utf8"
+    );
+    execSync(`git -C "${repository.path}" add WORKFLOW.md`);
+    execSync(`git -C "${repository.path}" commit -m "Update PR workflow v1"`);
+    execSync(`git -C "${repository.path}" push origin feature/pr-branch`);
+
+    const repositoryDirectory = await ensureIssueWorkspaceRepository({
+      repository,
+      issueWorkspacePath,
+      existingWorkspace: false,
+      pullRequestBranch: {
+        headRefName: "feature/pr-branch",
+      },
+    });
+    await writeFile(
+      join(repositoryDirectory, "WORKFLOW.md"),
+      "# partial recovery work\n",
+      "utf8"
+    );
+
+    execSync(`git -C "${repository.path}" checkout feature/pr-branch`);
+    await writeFile(
+      join(repository.path, "WORKFLOW.md"),
+      "# pull request workflow v2\n",
+      "utf8"
+    );
+    execSync(`git -C "${repository.path}" add WORKFLOW.md`);
+    execSync(`git -C "${repository.path}" commit -m "Update PR workflow v2"`);
+    execSync(`git -C "${repository.path}" push origin feature/pr-branch`);
+
+    await expect(
+      ensureIssueWorkspaceRepository({
+        repository,
+        issueWorkspacePath,
+        existingWorkspace: true,
+        pullRequestBranch: {
+          headRefName: "feature/pr-branch",
+        },
+        allowDirtyExistingWorkspace: true,
+      })
+    ).resolves.toBe(repositoryDirectory);
+
+    expect(
+      await readFile(join(repositoryDirectory, "WORKFLOW.md"), "utf8")
+    ).toBe("# partial recovery work\n");
+    expect(
+      execSync(`git -C "${repositoryDirectory}" status --porcelain`, {
+        encoding: "utf8",
+      })
+    ).toContain("M WORKFLOW.md");
   });
 
   it("keeps checkout failures actionable when the pull request branch is missing", async () => {

--- a/packages/orchestrator/src/git.ts
+++ b/packages/orchestrator/src/git.ts
@@ -114,18 +114,24 @@ export async function ensureIssueWorkspaceRepository(input: {
   pullRequestBranch?: PullRequestBranchCheckoutTarget | null;
   allowDirtyExistingWorkspace?: boolean;
 }): Promise<string> {
+  let dirtyExistingWorkspaceAllowed = false;
   const repositoryDirectory = input.existingWorkspace
-    ? await syncExistingIssueWorkspaceRepository({
-        ...input,
-        skipPull: Boolean(input.pullRequestBranch),
-        allowDirty: input.allowDirtyExistingWorkspace,
-      })
+    ? await syncExistingIssueWorkspaceRepository(
+        {
+          ...input,
+          skipPull: Boolean(input.pullRequestBranch),
+          allowDirty: input.allowDirtyExistingWorkspace,
+        },
+        (dirtyAllowed) => {
+          dirtyExistingWorkspaceAllowed = dirtyAllowed;
+        }
+      )
     : await cloneRepositoryForRun({
         repository: input.repository,
         targetDirectory: input.issueWorkspacePath,
       });
 
-  if (input.pullRequestBranch) {
+  if (input.pullRequestBranch && !dirtyExistingWorkspaceAllowed) {
     await checkoutPullRequestBranch(
       repositoryDirectory,
       input.pullRequestBranch
@@ -220,12 +226,15 @@ async function readGitHead(
   }
 }
 
-async function syncExistingIssueWorkspaceRepository(input: {
-  repository: RepositoryRef;
-  issueWorkspacePath: string;
-  skipPull?: boolean;
-  allowDirty?: boolean;
-}): Promise<string> {
+async function syncExistingIssueWorkspaceRepository(
+  input: {
+    repository: RepositoryRef;
+    issueWorkspacePath: string;
+    skipPull?: boolean;
+    allowDirty?: boolean;
+  },
+  onDirtyAllowed?: (dirtyAllowed: boolean) => void
+): Promise<string> {
   await mkdir(input.issueWorkspacePath, { recursive: true });
   const repositoryDirectory = join(input.issueWorkspacePath, "repository");
   const lockDirectory = join(input.issueWorkspacePath, "repository.lock");
@@ -246,6 +255,7 @@ async function syncExistingIssueWorkspaceRepository(input: {
       }
 
       if (dirtyStatus.trim() && input.allowDirty) {
+        onDirtyAllowed?.(true);
         return repositoryDirectory;
       }
 

--- a/packages/orchestrator/src/git.ts
+++ b/packages/orchestrator/src/git.ts
@@ -112,11 +112,13 @@ export async function ensureIssueWorkspaceRepository(input: {
   issueWorkspacePath: string;
   existingWorkspace: boolean;
   pullRequestBranch?: PullRequestBranchCheckoutTarget | null;
+  allowDirtyExistingWorkspace?: boolean;
 }): Promise<string> {
   const repositoryDirectory = input.existingWorkspace
     ? await syncExistingIssueWorkspaceRepository({
         ...input,
         skipPull: Boolean(input.pullRequestBranch),
+        allowDirty: input.allowDirtyExistingWorkspace,
       })
     : await cloneRepositoryForRun({
         repository: input.repository,
@@ -131,6 +133,31 @@ export async function ensureIssueWorkspaceRepository(input: {
   }
 
   return repositoryDirectory;
+}
+
+export type IssueWorkspaceDirtyStatus = {
+  repositoryDirectory: string;
+  dirty: boolean;
+  dirtyFiles: string[];
+  summary: string | null;
+};
+
+export async function inspectIssueWorkspaceDirtyStatus(input: {
+  issueWorkspacePath: string;
+}): Promise<IssueWorkspaceDirtyStatus | null> {
+  const repositoryDirectory = join(input.issueWorkspacePath, "repository");
+  const hasGit = await pathExists(join(repositoryDirectory, ".git"));
+  if (!hasGit) {
+    return null;
+  }
+
+  const status = await readGitStatusPorcelain(repositoryDirectory);
+  return {
+    repositoryDirectory,
+    dirty: status.trim().length > 0,
+    dirtyFiles: parseGitStatusFiles(status),
+    summary: status.trim() ? summarizeGitStatus(status) : null,
+  };
 }
 
 export async function loadRepositoryWorkflow(
@@ -197,6 +224,7 @@ async function syncExistingIssueWorkspaceRepository(input: {
   repository: RepositoryRef;
   issueWorkspacePath: string;
   skipPull?: boolean;
+  allowDirty?: boolean;
 }): Promise<string> {
   await mkdir(input.issueWorkspacePath, { recursive: true });
   const repositoryDirectory = join(input.issueWorkspacePath, "repository");
@@ -215,6 +243,10 @@ async function syncExistingIssueWorkspaceRepository(input: {
           repositoryDirectory,
           `could not be inspected: ${formatCommandError(error, "git status --porcelain failed")}`
         );
+      }
+
+      if (dirtyStatus.trim() && input.allowDirty) {
+        return repositoryDirectory;
       }
 
       if (dirtyStatus.trim()) {
@@ -384,6 +416,14 @@ function summarizeGitStatus(status: string): string {
     .filter(Boolean);
   const summary = lines.slice(0, 5).join("; ");
   return lines.length > 5 ? `${summary}; ...` : summary;
+}
+
+function parseGitStatusFiles(status: string): string[] {
+  return status
+    .trim()
+    .split(/\r?\n/)
+    .map((line) => line.slice(3).trim())
+    .filter(Boolean);
 }
 
 function normalizeWhitespace(value: string): string {

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -260,6 +260,14 @@ describe("OrchestratorService", () => {
       "partial turn output\n",
       "utf8"
     );
+    const overflowDirtyFiles = Array.from(
+      { length: 55 },
+      (_, index) => `zz-overflow-${String(index).padStart(2, "0")}.txt`
+    );
+    for (const file of overflowDirtyFiles) {
+      await writeFile(join(repositoryDirectory, file), "overflow\n", "utf8");
+    }
+    const expectedDirtyFiles = ["partial.txt", ...overflowDirtyFiles];
     await store.saveProjectIssueOrchestrations("tenant-1", [
       {
         issueId: "issue-1",
@@ -343,13 +351,14 @@ describe("OrchestratorService", () => {
     expect(suppressedRun?.runtimeSession?.exitClassification).toBe(
       "incomplete-turn-dirty-workspace"
     );
+    expect(suppressedRun?.runtimeSession?.status).toBe("completed");
     expect(suppressedRun?.recovery).toMatchObject({
       kind: "incomplete-turn-dirty-workspace",
       runId: "run-incomplete",
       issueId: "issue-1",
       issueIdentifier: "acme/platform#1",
       workspacePath: repositoryDirectory,
-      dirtyFiles: ["partial.txt"],
+      dirtyFiles: expectedDirtyFiles,
       lastEvent: "heartbeat",
       lastEventAt: "2026-03-08T00:04:30.000Z",
       sessionId: "thread-1-turn-7",
@@ -369,13 +378,17 @@ describe("OrchestratorService", () => {
       retryKind: "recovery",
       recovery: expect.objectContaining({
         kind: "incomplete-turn-dirty-workspace",
-        dirtyFiles: ["partial.txt"],
+        dirtyFiles: expectedDirtyFiles,
       }),
     });
     expect(spawnEnv?.SYMPHONY_RECOVERY_KIND).toBe(
       "incomplete-turn-dirty-workspace"
     );
-    expect(spawnEnv?.SYMPHONY_RECOVERY_DIRTY_FILES).toBe("partial.txt");
+    expect(spawnEnv?.SYMPHONY_RECOVERY_DIRTY_FILES).toContain("partial.txt");
+    expect(spawnEnv?.SYMPHONY_RECOVERY_DIRTY_FILES).toContain("... and 6 more");
+    expect(spawnEnv?.SYMPHONY_RECOVERY_DIRTY_FILES).not.toContain(
+      "zz-overflow-54.txt"
+    );
     expect(spawnEnv?.SYMPHONY_RECOVERY_SUGGESTED_COMMAND).toBe(
       `cd '${repositoryDirectory}' && git status --short && git diff`
     );
@@ -385,6 +398,7 @@ describe("OrchestratorService", () => {
     expect(spawnEnv?.SYMPHONY_RENDERED_PROMPT).toContain(
       "Last event: heartbeat"
     );
+    expect(spawnEnv?.SYMPHONY_RENDERED_PROMPT).toContain("- ... and 6 more");
     await expect(
       service.statusForIssue("acme/platform#1")
     ).resolves.toMatchObject({
@@ -396,7 +410,7 @@ describe("OrchestratorService", () => {
         runId: "run-incomplete",
         issueId: "issue-1",
         workspacePath: repositoryDirectory,
-        dirtyFiles: ["partial.txt"],
+        dirtyFiles: expectedDirtyFiles,
         lastEvent: "heartbeat",
         lastEventAt: "2026-03-08T00:04:30.000Z",
         sessionId: "thread-1-turn-7",

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -212,6 +212,205 @@ describe("OrchestratorService", () => {
     ).toContain("M WORKFLOW.md");
   });
 
+  it("classifies incomplete dirty turns and redispatches with recovery context", async () => {
+    process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
+    const tempRoot = await mkdtemp(
+      join(tmpdir(), "orchestrator-incomplete-dirty-recovery-")
+    );
+    const repository = await createRepositoryFixture(
+      tempRoot,
+      "acme",
+      "platform"
+    );
+    const store = new OrchestratorFsStore(tempRoot);
+    const projectConfig = createProjectConfig(tempRoot, repository);
+    await store.saveProjectConfig(projectConfig);
+
+    const workspaceKey = deriveIssueWorkspaceKey(
+      {
+        adapter: "github-project",
+        issueSubjectId: "issue-1",
+      },
+      "acme/platform#1"
+    );
+    const issueWorkspacePath = resolveIssueWorkspaceDirectory(
+      store.projectDir(projectConfig.projectId),
+      workspaceKey
+    );
+    const repositoryDirectory = await gitModule.ensureIssueWorkspaceRepository({
+      repository,
+      issueWorkspacePath,
+      existingWorkspace: false,
+    });
+    await store.saveIssueWorkspace({
+      workspaceKey,
+      projectId: projectConfig.projectId,
+      adapter: "github-project",
+      issueSubjectId: "issue-1",
+      issueIdentifier: "acme/platform#1",
+      workspacePath: issueWorkspacePath,
+      repositoryPath: repositoryDirectory,
+      status: "active",
+      createdAt: "2026-03-08T00:00:00.000Z",
+      updatedAt: "2026-03-08T00:00:00.000Z",
+      lastError: null,
+    });
+    await writeFile(
+      join(repositoryDirectory, "partial.txt"),
+      "partial turn output\n",
+      "utf8"
+    );
+    await store.saveProjectIssueOrchestrations("tenant-1", [
+      {
+        issueId: "issue-1",
+        identifier: "acme/platform#1",
+        workspaceKey,
+        completedOnce: false,
+        failureRetryCount: 0,
+        state: "running",
+        currentRunId: "run-incomplete",
+        retryEntry: null,
+        updatedAt: "2026-03-08T00:04:00.000Z",
+      },
+    ]);
+    await store.saveRun({
+      runId: "run-incomplete",
+      projectId: "tenant-1",
+      projectSlug: "tenant-1",
+      issueId: "issue-1",
+      issueSubjectId: "issue-1",
+      issueIdentifier: "acme/platform#1",
+      issueState: "In Review",
+      repository,
+      status: "running",
+      attempt: 1,
+      processId: 4410,
+      port: 4601,
+      workingDirectory: repositoryDirectory,
+      issueWorkspaceKey: workspaceKey,
+      workspaceRuntimeDir: join(tempRoot, "run-incomplete", "workspace"),
+      workflowPath: null,
+      retryKind: null,
+      createdAt: "2026-03-08T00:00:00.000Z",
+      updatedAt: "2026-03-08T00:04:30.000Z",
+      startedAt: "2026-03-08T00:00:00.000Z",
+      completedAt: null,
+      lastError: null,
+      nextRetryAt: null,
+      threadId: "thread-1",
+      cumulativeTurnCount: 7,
+      turnCount: 7,
+      lastEvent: "heartbeat",
+      lastEventAt: "2026-03-08T00:04:30.000Z",
+      runtimeSession: {
+        sessionId: "thread-1-turn-7",
+        threadId: "thread-1",
+        status: "active",
+        startedAt: "2026-03-08T00:00:00.000Z",
+        updatedAt: "2026-03-08T00:04:30.000Z",
+        exitClassification: null,
+      },
+    });
+
+    const spawnImpl = vi.fn().mockReturnValue({
+      pid: 4411,
+      unref: vi.fn(),
+    });
+    let currentTime = new Date("2026-03-08T00:05:00.000Z");
+    const service = new OrchestratorService(store, projectConfig, {
+      fetchImpl: vi
+        .fn()
+        .mockResolvedValueOnce(
+          createTrackerResponseWithState(repository, "In Review")
+        )
+        .mockResolvedValueOnce(
+          createTrackerResponseWithState(repository, "In Review")
+        )
+        .mockResolvedValue(createTrackerResponseWithState(repository, "Todo")),
+      spawnImpl: spawnImpl as never,
+      isProcessRunning: (pid) => pid === 4410,
+      sendSignal: vi.fn(),
+      now: () => currentTime,
+    });
+
+    const suppressed = await service.runOnce();
+    const suppressedRun = await store.loadRun("run-incomplete", "tenant-1");
+    expect(suppressed.summary.suppressed).toBe(1);
+    expect(suppressedRun?.status).toBe("suppressed");
+    expect(suppressedRun?.lastError).toBe(
+      "Run suppressed with recoverable incomplete-turn dirty workspace."
+    );
+    expect(suppressedRun?.runtimeSession?.exitClassification).toBe(
+      "incomplete-turn-dirty-workspace"
+    );
+    expect(suppressedRun?.recovery).toMatchObject({
+      kind: "incomplete-turn-dirty-workspace",
+      runId: "run-incomplete",
+      issueId: "issue-1",
+      issueIdentifier: "acme/platform#1",
+      workspacePath: repositoryDirectory,
+      dirtyFiles: ["partial.txt"],
+      lastEvent: "heartbeat",
+      lastEventAt: "2026-03-08T00:04:30.000Z",
+      sessionId: "thread-1-turn-7",
+      threadId: "thread-1",
+      suggestedCommand: `cd '${repositoryDirectory}' && git status --short && git diff`,
+    });
+
+    currentTime = new Date("2026-03-08T00:06:00.000Z");
+    const redispatched = await service.runOnce();
+    const runs = await store.loadAllRuns();
+    const recoveryRun = runs.find((run) => run.runId !== "run-incomplete");
+    const spawnEnv = spawnImpl.mock.calls[0]?.[2]?.env;
+
+    expect(redispatched.summary.dispatched).toBe(1);
+    expect(recoveryRun).toMatchObject({
+      status: "running",
+      retryKind: "recovery",
+      recovery: expect.objectContaining({
+        kind: "incomplete-turn-dirty-workspace",
+        dirtyFiles: ["partial.txt"],
+      }),
+    });
+    expect(spawnEnv?.SYMPHONY_RECOVERY_KIND).toBe(
+      "incomplete-turn-dirty-workspace"
+    );
+    expect(spawnEnv?.SYMPHONY_RECOVERY_DIRTY_FILES).toBe("partial.txt");
+    expect(spawnEnv?.SYMPHONY_RECOVERY_SUGGESTED_COMMAND).toBe(
+      `cd '${repositoryDirectory}' && git status --short && git diff`
+    );
+    expect(spawnEnv?.SYMPHONY_RENDERED_PROMPT).toContain(
+      "## Recovery Context — Incomplete Turn Dirty Workspace"
+    );
+    expect(spawnEnv?.SYMPHONY_RENDERED_PROMPT).toContain(
+      "Last event: heartbeat"
+    );
+    await expect(
+      service.statusForIssue("acme/platform#1")
+    ).resolves.toMatchObject({
+      issue_identifier: "acme/platform#1",
+      issue_id: "issue-1",
+      status: "running",
+      recovery: {
+        kind: "incomplete-turn-dirty-workspace",
+        runId: "run-incomplete",
+        issueId: "issue-1",
+        workspacePath: repositoryDirectory,
+        dirtyFiles: ["partial.txt"],
+        lastEvent: "heartbeat",
+        lastEventAt: "2026-03-08T00:04:30.000Z",
+        sessionId: "thread-1-turn-7",
+        threadId: "thread-1",
+        suggestedCommand: `cd '${repositoryDirectory}' && git status --short && git diff`,
+      },
+    });
+    expect(
+      execSync(`git -C ${shell(repositoryDirectory)} status --porcelain`, {
+        encoding: "utf8",
+      })
+    ).toContain("?? partial.txt");
+  });
+
   it("clears legacy issue-budget and cross-session resume env before spawning a worker", async () => {
     process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
     process.env.SYMPHONY_GLOBAL_MAX_TURNS = "12";
@@ -2609,6 +2808,7 @@ Prefer focused changes.
         kind: "failure",
         error: "worker failed",
       },
+      recovery: null,
       logs: {
         codex_session_logs: [
           {
@@ -7718,7 +7918,9 @@ Prefer focused changes.
   });
 
   it("records Linear tracker and issue metadata on structured tracker events", async () => {
-    const tempRoot = await mkdtemp(join(tmpdir(), "orchestrator-linear-events-"));
+    const tempRoot = await mkdtemp(
+      join(tmpdir(), "orchestrator-linear-events-")
+    );
     const repository = await createRepositoryFixture(
       tempRoot,
       "acme",
@@ -7742,7 +7944,10 @@ codex:
 ---
 Handle Linear issue.`,
     });
-    await writeFile(join(tempRoot, "worker.js"), "setTimeout(() => {}, 1000);\n");
+    await writeFile(
+      join(tempRoot, "worker.js"),
+      "setTimeout(() => {}, 1000);\n"
+    );
     await chmod(join(tempRoot, "worker.js"), 0o755);
 
     const store = new OrchestratorFsStore(tempRoot);
@@ -7809,11 +8014,16 @@ Handle Linear issue.`,
     await service.runOnce();
 
     const runs = await store.loadAllRuns();
-    const run = runs.find((candidate) => candidate.issueId === "linear-issue-1");
+    const run = runs.find(
+      (candidate) => candidate.issueId === "linear-issue-1"
+    );
     expect(run).toBeDefined();
     const rawEvents = (
       await readFile(
-        join(store.runDir(run?.runId ?? "", projectConfig.projectId), "events.ndjson"),
+        join(
+          store.runDir(run?.runId ?? "", projectConfig.projectId),
+          "events.ndjson"
+        ),
         "utf8"
       )
     )

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -49,6 +49,7 @@ import {
 } from "@gh-symphony/core";
 import {
   ensureIssueWorkspaceRepository,
+  inspectIssueWorkspaceDirtyStatus,
   loadRepositoryWorkflow,
 } from "./git.js";
 import { OrchestratorFsStore } from "./fs-store.js";
@@ -87,6 +88,10 @@ type SpawnLike = (
 type WorkerLogStreamLike = Pick<
   ReturnType<typeof createWriteStream>,
   "write" | "end" | "on"
+>;
+
+type IncompleteTurnRecoveryContext = NonNullable<
+  OrchestratorRunRecord["recovery"]
 >;
 
 export type OrchestratorLogLevel = "normal" | "verbose";
@@ -476,6 +481,7 @@ export class OrchestratorService {
                 currentRun?.lastError ?? issueRecord.retryEntry?.error ?? null,
             }
           : null,
+      recovery: currentRun?.recovery ?? null,
       logs: {
         codex_session_logs:
           currentRun === null
@@ -756,6 +762,12 @@ export class OrchestratorService {
           },
           issue.identifier
         );
+        const recoveryContext = await this.resolveIncompleteTurnRecoveryContext(
+          tenant,
+          issue,
+          latestRunsByIssueId.get(issue.id) ?? null,
+          preferredWorkspaceKey
+        );
         issueRecords = upsertIssueOrchestration(issueRecords, {
           issueId: issue.id,
           identifier: issue.identifier,
@@ -768,7 +780,9 @@ export class OrchestratorService {
         });
         let run: OrchestratorRunRecord;
         try {
-          run = await this.startRun(tenant, issue);
+          run = await this.startRun(tenant, issue, {
+            recovery: recoveryContext,
+          });
         } catch (error) {
           issueRecords = releaseIssueOrchestration(issueRecords, issue.id, now);
           throw error;
@@ -834,6 +848,11 @@ export class OrchestratorService {
           const activeWorkerPid = activeRun.processId;
           this.sendSignal(activeWorkerPid, "SIGTERM");
           this.retireWorkerPid(activeWorkerPid);
+          const recovery = await this.classifyIncompleteTurnDirtyWorkspace(
+            tenant,
+            activeRun,
+            now
+          );
           const suppressedRun: OrchestratorRunRecord = {
             ...activeRun,
             status: "suppressed",
@@ -841,8 +860,24 @@ export class OrchestratorService {
             completedAt: now.toISOString(),
             updatedAt: now.toISOString(),
             runPhase: "canceled_by_reconciliation",
+            runtimeSession: recovery
+              ? buildRuntimeSession(
+                  activeRun.runtimeSession,
+                  recovery.sessionId,
+                  recovery.threadId,
+                  activeRun.runtimeSession?.status ?? null,
+                  activeRun.runtimeSession?.startedAt ??
+                    activeRun.startedAt ??
+                    now.toISOString(),
+                  now.toISOString(),
+                  "incomplete-turn-dirty-workspace"
+                )
+              : activeRun.runtimeSession,
+            recovery,
             lastError:
-              "Run suppressed because the tracker issue is no longer tracked.",
+              recovery
+                ? "Run suppressed with recoverable incomplete-turn dirty workspace."
+                : "Run suppressed because the tracker issue is no longer tracked.",
           };
           await this.store.saveRun(suppressedRun);
           this.logVerbose(
@@ -869,6 +904,13 @@ export class OrchestratorService {
         }
         if (activeRun) {
           const terminalState = isStateTerminal(issue.state, lifecycle);
+          const recovery = terminalState
+            ? null
+            : await this.classifyIncompleteTurnDirtyWorkspace(
+                tenant,
+                activeRun,
+                now
+              );
           const suppressedRun: OrchestratorRunRecord = {
             ...activeRun,
             status: "suppressed",
@@ -876,9 +918,25 @@ export class OrchestratorService {
             completedAt: now.toISOString(),
             updatedAt: now.toISOString(),
             runPhase: "canceled_by_reconciliation",
-            lastError: terminalState
-              ? "Run suppressed because the tracker issue moved to a terminal state."
-              : "Run suppressed because the tracker state is no longer actionable.",
+            runtimeSession: recovery
+              ? buildRuntimeSession(
+                  activeRun.runtimeSession,
+                  recovery.sessionId,
+                  recovery.threadId,
+                  activeRun.runtimeSession?.status ?? null,
+                  activeRun.runtimeSession?.startedAt ??
+                    activeRun.startedAt ??
+                    now.toISOString(),
+                  now.toISOString(),
+                  "incomplete-turn-dirty-workspace"
+                )
+              : activeRun.runtimeSession,
+            recovery,
+            lastError: recovery
+              ? "Run suppressed with recoverable incomplete-turn dirty workspace."
+              : terminalState
+                ? "Run suppressed because the tracker issue moved to a terminal state."
+                : "Run suppressed because the tracker state is no longer actionable.",
           };
           await this.store.saveRun(suppressedRun);
           this.logVerbose(
@@ -1343,7 +1401,10 @@ export class OrchestratorService {
 
   private async startRun(
     tenant: OrchestratorProjectConfig,
-    issue: TrackedIssue
+    issue: TrackedIssue,
+    options: {
+      recovery?: IncompleteTurnRecoveryContext | null;
+    } = {}
   ): Promise<OrchestratorRunRecord> {
     if (this.shuttingDown || !this.running) {
       throw new Error(
@@ -1395,6 +1456,8 @@ export class OrchestratorService {
       issueWorkspacePath,
       existingWorkspace: Boolean(existingWorkspaceRecord),
       pullRequestBranch,
+      allowDirtyExistingWorkspace:
+        options.recovery?.kind === "incomplete-turn-dirty-workspace",
     });
 
     if (!existingWorkspaceRecord) {
@@ -1453,9 +1516,10 @@ export class OrchestratorService {
     const promptVariables = buildPromptVariables(issue, {
       attempt: null, // first execution
     });
-    const renderedPrompt = renderPrompt(
+    const renderedPrompt = appendIncompleteTurnRecoveryPrompt(
       workflow.promptTemplate,
-      promptVariables
+      promptVariables,
+      options.recovery ?? null
     );
 
     // Run before_run hook before spawning the worker
@@ -1557,6 +1621,11 @@ export class OrchestratorService {
           SYMPHONY_CUMULATIVE_OUTPUT_TOKENS: "0",
           SYMPHONY_CUMULATIVE_TOTAL_TOKENS: "0",
           SYMPHONY_LAST_TURN_SUMMARY: "",
+          SYMPHONY_RECOVERY_KIND: options.recovery?.kind ?? "",
+          SYMPHONY_RECOVERY_DIRTY_FILES:
+            options.recovery?.dirtyFiles.join("\n") ?? "",
+          SYMPHONY_RECOVERY_SUGGESTED_COMMAND:
+            options.recovery?.suggestedCommand ?? "",
           SYMPHONY_SESSION_STARTED_AT: "",
           SYMPHONY_READ_TIMEOUT_MS: String(runtimeTimeouts.readTimeoutMs),
           SYMPHONY_TURN_TIMEOUT_MS: String(runtimeTimeouts.turnTimeoutMs),
@@ -1689,7 +1758,7 @@ export class OrchestratorService {
       issueWorkspaceKey: workspaceKey,
       workspaceRuntimeDir,
       workflowPath: workflow.workflowPath,
-      retryKind: null,
+      retryKind: options.recovery ? "recovery" : null,
       threadId: null,
       cumulativeTurnCount: 0,
       lastTurnSummary: null,
@@ -1701,6 +1770,7 @@ export class OrchestratorService {
       nextRetryAt: null,
       runPhase: "preparing_workspace",
       rateLimits: issue.rateLimits ?? null,
+      recovery: options.recovery ?? null,
     };
   }
 
@@ -2473,6 +2543,94 @@ export class OrchestratorService {
       (candidate) => candidate.identifier === issueIdentifier
     );
     return issue ? { issue, issues } : null;
+  }
+
+  private async classifyIncompleteTurnDirtyWorkspace(
+    tenant: OrchestratorProjectConfig,
+    run: OrchestratorRunRecord,
+    now: Date
+  ): Promise<IncompleteTurnRecoveryContext | null> {
+    if (
+      run.runtimeSession?.status !== "active" ||
+      run.runtimeSession.exitClassification !== null ||
+      run.lastEvent === "turn_completed"
+    ) {
+      return null;
+    }
+
+    const workspaceKey =
+      run.issueWorkspaceKey ??
+      deriveIssueWorkspaceKey(
+        {
+          adapter: tenant.tracker.adapter,
+          issueSubjectId: run.issueSubjectId,
+        },
+        run.issueIdentifier
+      );
+    const issueWorkspacePath = resolveIssueWorkspaceDirectory(
+      this.store.projectDir(tenant.projectId),
+      workspaceKey
+    );
+    const dirtyStatus = await inspectIssueWorkspaceDirtyStatus({
+      issueWorkspacePath,
+    });
+
+    if (!dirtyStatus?.dirty) {
+      return null;
+    }
+
+    return {
+      kind: "incomplete-turn-dirty-workspace",
+      runId: run.runId,
+      issueId: run.issueId,
+      issueIdentifier: run.issueIdentifier,
+      workspacePath: dirtyStatus.repositoryDirectory,
+      dirtyFiles: dirtyStatus.dirtyFiles,
+      lastEvent: run.lastEvent ?? null,
+      lastEventAt: run.lastEventAt ?? null,
+      sessionId: run.runtimeSession.sessionId ?? null,
+      threadId: run.threadId ?? run.runtimeSession.threadId ?? null,
+      suggestedCommand: `cd ${shellQuote(dirtyStatus.repositoryDirectory)} && git status --short && git diff`,
+      detectedAt: now.toISOString(),
+    };
+  }
+
+  private async resolveIncompleteTurnRecoveryContext(
+    tenant: OrchestratorProjectConfig,
+    issue: TrackedIssue,
+    latestRun: OrchestratorRunRecord | null,
+    preferredWorkspaceKey: string
+  ): Promise<IncompleteTurnRecoveryContext | null> {
+    const recovery = latestRun?.recovery;
+    if (
+      latestRun?.status !== "suppressed" ||
+      recovery?.kind !== "incomplete-turn-dirty-workspace" ||
+      latestRun.runtimeSession?.exitClassification !==
+        "incomplete-turn-dirty-workspace"
+    ) {
+      return null;
+    }
+
+    const workspaceKey = latestRun.issueWorkspaceKey ?? preferredWorkspaceKey;
+    const dirtyStatus = await inspectIssueWorkspaceDirtyStatus({
+      issueWorkspacePath: resolveIssueWorkspaceDirectory(
+        this.store.projectDir(tenant.projectId),
+        workspaceKey
+      ),
+    });
+
+    if (!dirtyStatus?.dirty) {
+      return null;
+    }
+
+    return {
+      ...recovery,
+      issueId: issue.id,
+      issueIdentifier: issue.identifier,
+      workspacePath: dirtyStatus.repositoryDirectory,
+      dirtyFiles: dirtyStatus.dirtyFiles,
+      suggestedCommand: `cd ${shellQuote(dirtyStatus.repositoryDirectory)} && git status --short && git diff`,
+    };
   }
 
   private async fetchWorkerRunInfo(run: OrchestratorRunRecord): Promise<{
@@ -3347,10 +3505,44 @@ function buildRuntimeSession(
   };
 }
 
+function appendIncompleteTurnRecoveryPrompt(
+  promptTemplate: string,
+  promptVariables: ReturnType<typeof buildPromptVariables>,
+  recovery: IncompleteTurnRecoveryContext | null
+): string {
+  const renderedPrompt = renderPrompt(promptTemplate, promptVariables);
+  if (!recovery) {
+    return renderedPrompt;
+  }
+
+  return [
+    renderedPrompt,
+    "",
+    "## Recovery Context — Incomplete Turn Dirty Workspace",
+    "",
+    `Previous run: ${recovery.runId}`,
+    `Workspace: ${recovery.workspacePath}`,
+    `Last event: ${recovery.lastEvent ?? "unknown"}`,
+    `Last event time: ${recovery.lastEventAt ?? "unknown"}`,
+    `Session id: ${recovery.sessionId ?? "unknown"}`,
+    `Thread id: ${recovery.threadId ?? "unknown"}`,
+    "",
+    "Dirty files:",
+    ...recovery.dirtyFiles.map((file) => `- ${file}`),
+    "",
+    "Inspect the dirty diff before editing. If the partial work is correct, validate it, commit it, and push it. If it is invalid, revert it explicitly and record a blocker/comment with the reason. Do not discard uncommitted work without making an intentional recovery decision.",
+    `Suggested operator command: ${recovery.suggestedCommand}`,
+  ].join("\n");
+}
+
 function resolvePersistedCumulativeTurnCount(
   run: OrchestratorRunRecord
 ): number {
   return run.cumulativeTurnCount ?? run.turnCount ?? 0;
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`;
 }
 
 function resolveCumulativeTurnCount(

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -69,6 +69,7 @@ const CONTINUATION_RETRY_DELAY_MS = 1_000;
 const DEFAULT_WORKER_COMMAND = "node packages/worker/dist/index.js";
 const DEFAULT_MAX_NONPRODUCTIVE_TURNS = 3;
 const LOW_RATE_LIMIT_WARNING_THRESHOLD = 0.05;
+const MAX_RECOVERY_DIRTY_FILES_IN_CONTEXT = 50;
 const MAX_FAILURE_RETRIES_EXCEEDED_REASON = "max_failure_retries_exceeded";
 const LINKED_PR_ACTIVE_ISSUE_INACTIVE_MARKER_PREFIX =
   "gh-symphony:linked-pr-active-while-issue-inactive";
@@ -865,7 +866,7 @@ export class OrchestratorService {
                   activeRun.runtimeSession,
                   recovery.sessionId,
                   recovery.threadId,
-                  activeRun.runtimeSession?.status ?? null,
+                  "completed",
                   activeRun.runtimeSession?.startedAt ??
                     activeRun.startedAt ??
                     now.toISOString(),
@@ -874,10 +875,9 @@ export class OrchestratorService {
                 )
               : activeRun.runtimeSession,
             recovery,
-            lastError:
-              recovery
-                ? "Run suppressed with recoverable incomplete-turn dirty workspace."
-                : "Run suppressed because the tracker issue is no longer tracked.",
+            lastError: recovery
+              ? "Run suppressed with recoverable incomplete-turn dirty workspace."
+              : "Run suppressed because the tracker issue is no longer tracked.",
           };
           await this.store.saveRun(suppressedRun);
           this.logVerbose(
@@ -923,7 +923,7 @@ export class OrchestratorService {
                   activeRun.runtimeSession,
                   recovery.sessionId,
                   recovery.threadId,
-                  activeRun.runtimeSession?.status ?? null,
+                  "completed",
                   activeRun.runtimeSession?.startedAt ??
                     activeRun.startedAt ??
                     now.toISOString(),
@@ -1622,8 +1622,9 @@ export class OrchestratorService {
           SYMPHONY_CUMULATIVE_TOTAL_TOKENS: "0",
           SYMPHONY_LAST_TURN_SUMMARY: "",
           SYMPHONY_RECOVERY_KIND: options.recovery?.kind ?? "",
-          SYMPHONY_RECOVERY_DIRTY_FILES:
-            options.recovery?.dirtyFiles.join("\n") ?? "",
+          SYMPHONY_RECOVERY_DIRTY_FILES: options.recovery
+            ? formatRecoveryDirtyFilesForContext(options.recovery.dirtyFiles)
+            : "",
           SYMPHONY_RECOVERY_SUGGESTED_COMMAND:
             options.recovery?.suggestedCommand ?? "",
           SYMPHONY_SESSION_STARTED_AT: "",
@@ -3528,11 +3529,29 @@ function appendIncompleteTurnRecoveryPrompt(
     `Thread id: ${recovery.threadId ?? "unknown"}`,
     "",
     "Dirty files:",
-    ...recovery.dirtyFiles.map((file) => `- ${file}`),
+    ...formatRecoveryDirtyFileLinesForPrompt(recovery.dirtyFiles),
     "",
     "Inspect the dirty diff before editing. If the partial work is correct, validate it, commit it, and push it. If it is invalid, revert it explicitly and record a blocker/comment with the reason. Do not discard uncommitted work without making an intentional recovery decision.",
     `Suggested operator command: ${recovery.suggestedCommand}`,
   ].join("\n");
+}
+
+function formatRecoveryDirtyFilesForContext(dirtyFiles: string[]): string {
+  return formatRecoveryDirtyFiles(dirtyFiles).join("\n");
+}
+
+function formatRecoveryDirtyFileLinesForPrompt(dirtyFiles: string[]): string[] {
+  return formatRecoveryDirtyFiles(dirtyFiles).map((file) => `- ${file}`);
+}
+
+function formatRecoveryDirtyFiles(dirtyFiles: string[]): string[] {
+  const visibleFiles = dirtyFiles.slice(0, MAX_RECOVERY_DIRTY_FILES_IN_CONTEXT);
+  const remaining = dirtyFiles.length - visibleFiles.length;
+  if (remaining <= 0) {
+    return visibleFiles;
+  }
+
+  return [...visibleFiles, `... and ${remaining} more`];
 }
 
 function resolvePersistedCumulativeTurnCount(


### PR DESCRIPTION
## Issues — Closed #365

## TL;DR

- Detects suppressed incomplete Codex turns that left a dirty issue workspace.
- Persists recovery diagnostics and redispatches the next actionable run with explicit recovery prompt/env context instead of tripping the generic dirty-workspace guard.
- Rework closes the PR-linked checkout dead-end, stale recovery status, active-session suppression status, and oversized dirty-file context risks.

## 변경 지점 다이어그램

```text
active runtime session
  └─ no turn_completed + active session + dirty issue workspace
      ├─ suppress as incomplete-turn-dirty-workspace
      ├─ mark runtime session completed with recovery exit classification
      ├─ retain dirty checkout unchanged
      └─ next actionable tick starts recovery run with bounded dirty-file context
```

## 여기부터 보세요

- `packages/orchestrator/src/service.ts` — classification, suppression persistence, completed runtime-session marking, bounded recovery prompt/env.
- `packages/orchestrator/src/git.ts` — dirty workspace inspection and explicit allow-dirty recovery path that skips PR checkout when preserving partial dirty work.
- `packages/core/src/observability/snapshot-builder.ts` — unresolved-only, deterministic recovery status surfacing.
- `packages/cli/src/commands/status.ts` — operator-visible recovery details in `repo status`.
- `packages/orchestrator/src/service.test.ts`, `packages/orchestrator/src/git.test.ts`, `packages/core/src/observability/snapshot-builder.test.ts` — regression coverage for the dirty recovery and rework cases.

## 위험 & 롤백

- Risk: recovery dispatch intentionally allows an existing dirty checkout only when the latest suppressed run has the matching recovery classification; PR branch checkout is skipped only for that allowed dirty recovery state.
- Rollback: revert the recovery classification/prompt changes and the status contract additions; dirty workspace preservation falls back to the previous generic guard.

## 변경 파일

- `.changeset/recover-incomplete-dirty-workspaces.md`
- `packages/core/src/contracts/status-surface.ts`
- `packages/core/src/observability/snapshot-builder.ts`
- `packages/orchestrator/src/git.ts`
- `packages/orchestrator/src/service.ts`
- `packages/orchestrator/src/explain.ts`
- `packages/cli/src/commands/status.ts`
- related tests/fixtures in core, dashboard, control-plane, orchestrator, and CLI

## Evidence

- `pnpm --filter @gh-symphony/orchestrator test -- src/git.test.ts` — pass
- `pnpm --filter @gh-symphony/orchestrator test -- src/service.test.ts` — pass
- `pnpm --filter @gh-symphony/core test -- src/observability/snapshot-builder.test.ts` — pass
- `pnpm lint && pnpm test && pnpm typecheck && pnpm build` — pass
- Docker E2E blackbox: `docker compose -f docker-compose.e2e.yml -f docker-compose.e2e.events.yml up -d --build`, `/healthz`, fixture copy, `POST /api/v1/refresh`, `/api/v1/state` polling — pass; observed `summary.dispatched: 1`, `summary.activeRuns: 1`, `health: "running"`.

## 머지 후/사람 확인

- [ ] No additional manual validation required beyond review approval.
