### PR TITLE
chore(cli): remove repo-local gh-symphony ecosystem files

### DIFF
--- a/.changeset/legacy-gh-symphony-cleanup.md
+++ b/.changeset/legacy-gh-symphony-cleanup.md
@@ -1,0 +1,7 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Stop generating repo-local `.gh-symphony/` ecosystem files for #360, keep
+`--skip-context` as a deprecated no-op, and offer interactive cleanup for legacy
+context/reference files.

--- a/README.md
+++ b/README.md
@@ -175,8 +175,6 @@ The one-command setup flow will:
 | File                                    | Description                                                       |
 | --------------------------------------- | ----------------------------------------------------------------- |
 | `WORKFLOW.md`                           | Workflow policy — the agent prompt template with lifecycle config |
-| `.gh-symphony/context.yaml`             | Project metadata and environment context                          |
-| `.gh-symphony/reference-workflow.md`    | Reference workflow documentation                                  |
 | `.codex/skills/` (or `.claude/skills/`) | Agent skill definitions, including `/gh-symphony` references      |
 
 Before writing anything, the interactive wizard shows a final summary that combines the workflow file preview and the repository runtime that will be saved under `.runtime/orchestrator/`.
@@ -215,15 +213,13 @@ The interactive wizard will:
 | File                                    | Description                                                       |
 | --------------------------------------- | ----------------------------------------------------------------- |
 | `WORKFLOW.md`                           | Workflow policy — the agent prompt template with lifecycle config |
-| `.gh-symphony/context.yaml`             | Project metadata and environment context                          |
-| `.gh-symphony/reference-workflow.md`    | Reference workflow documentation                                  |
 | `.codex/skills/` (or `.claude/skills/`) | Agent skill definitions, including `/gh-symphony` references      |
 
 Project discovery is pagination-aware for larger GitHub accounts, so personal projects, organization pages, and organization-owned projects are fetched across multiple API pages before selection. If the CLI hits a discovery safety cap, it keeps the partial list and prints a warning before you choose a board.
 
 `gh-symphony workflow init --dry-run` resolves the same generated outputs, shows whether each path would be created, updated, or left unchanged, and prints the detected environment inputs that shaped the preview.
 
-Those detected inputs are also threaded into the generated artifacts themselves: `WORKFLOW.md`, `.gh-symphony/reference-workflow.md`, and the runtime skill templates all include repository-aware validation guidance based on the detected package manager, monorepo shape, and explicit validation entry points when present.
+Those detected inputs are also threaded into the generated artifacts themselves: `WORKFLOW.md` and the runtime skill templates include repository-aware validation guidance based on the detected package manager, monorepo shape, and explicit validation entry points when present.
 
 `workflow init` is not limited to Node repositories. The detector now recognizes conservative validation signals for:
 
@@ -586,9 +582,9 @@ gh-symphony workflow validate
 gh-symphony workflow preview --issue owner/repo#123
 ```
 
-`--dry-run` resolves the same generated `WORKFLOW.md`, `.gh-symphony/context.yaml`,
-`.gh-symphony/reference-workflow.md`, and runtime skill files, then prints whether
-each path would be created, updated, or left unchanged without writing anything.
+`--dry-run` resolves the same generated `WORKFLOW.md` and runtime skill files,
+then prints whether each path would be created, updated, or left unchanged
+without writing anything.
 
 When `gh-symphony workflow init` detects repository validation entry points, it bakes that information back into the generated policy files so the out-of-the-box workflow already tells agents which test/lint/build commands to prefer and whether workspace-aware validation is expected. That includes non-Node repositories when the detector can prove a conservative command from `Makefile`, `justfile`, Python tooling, `go.mod`, or `Cargo.toml`.
 

--- a/docs/adr/2026-05-27_skill-local-gh-symphony-resources.md
+++ b/docs/adr/2026-05-27_skill-local-gh-symphony-resources.md
@@ -1,0 +1,36 @@
+# Skill-Local gh-symphony Resources
+
+Date: 2026-05-27
+
+## Status
+
+Accepted
+
+## Context
+
+The repository workflow policy and orchestration configuration live in
+`WORKFLOW.md`. The `/gh-symphony` skill now ships its design-time references in
+the skill directory itself under `references/`.
+
+Historically, `workflow init` and `setup` also wrote repo-local ecosystem files
+for agent context and schema reference material. Those files duplicated data
+that is already available from `WORKFLOW.md`, generated skill content, or live
+repository detection.
+
+## Decision
+
+`gh-symphony setup` and `gh-symphony workflow init` no longer generate
+repo-local ecosystem files. `WORKFLOW.md` remains the single repository source
+of truth for workflow policy and config, while skill design resources stay
+self-contained with the skill.
+
+Existing legacy files are not read by the orchestrator. Interactive setup/init
+runs detect the old files and offer to remove them. The default is to keep them.
+
+## Consequences
+
+- New repositories have less generated file noise.
+- Skill references can evolve with the skill package instead of being copied
+  into every repository.
+- Existing repositories keep working if legacy files remain present.
+- The deprecated `--skip-context` flag is accepted as a no-op for compatibility.

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @gh-symphony/cli
 
+## Unreleased
+
+- The `.gh-symphony/` directory is no longer generated. Existing files are safe
+  to delete; the legacy-directory prompt during `setup` / `workflow init` will
+  offer to clean up for you.
+
 ## 0.4.0
 
 ### Minor Changes

--- a/packages/cli/src/commands/doctor.test.ts
+++ b/packages/cli/src/commands/doctor.test.ts
@@ -806,6 +806,8 @@ describe("runDoctorDiagnostics", () => {
             textFields: [],
             linkedRepositories: [],
           }) as never) as never,
+        execFileSync: (() => "git version 2.44.0") as never,
+        processVersion: DOCTOR_TEST_NODE_VERSION,
         pathEnv,
       })
     );
@@ -870,6 +872,8 @@ describe("runDoctorDiagnostics", () => {
             textFields: [],
             linkedRepositories: [],
           }) as never) as never,
+        execFileSync: (() => "git version 2.44.0") as never,
+        processVersion: DOCTOR_TEST_NODE_VERSION,
         pathEnv,
       })
     );

--- a/packages/cli/src/commands/setup.test.ts
+++ b/packages/cli/src/commands/setup.test.ts
@@ -193,7 +193,7 @@ describe("setup command", () => {
     );
     expect(stderrWrite).toHaveBeenCalledWith(
       expect.stringContaining(
-        "Supported flags: --non-interactive, --output, --skip-skills, --skip-context."
+        "Supported flags: --non-interactive, --output, --skip-skills. Deprecated no-op: --skip-context."
       )
     );
   });
@@ -214,10 +214,6 @@ describe("setup command", () => {
     });
 
     const workflow = await readFile(join(cwd, "WORKFLOW.md"), "utf8");
-    const contextYaml = await readFile(
-      join(cwd, ".gh-symphony", "context.yaml"),
-      "utf8"
-    );
     const project = JSON.parse(
       await readFile(
         join(cwd, ".runtime", "orchestrator", "project.json"),
@@ -232,7 +228,9 @@ describe("setup command", () => {
     );
     expect(workflow).toContain("# Optional template: labels priority source.");
     expect(workflow).not.toContain("priority_field:");
-    expect(contextYaml).toContain("PVT_setup_1");
+    await expect(
+      readFile(join(cwd, ".gh-symphony", "context.yaml"), "utf8")
+    ).rejects.toThrow();
     expect(project.projectId).toBe("repository");
     expect(project.workspaceDir).toBe(process.cwd());
     expect(project.repository).toMatchObject({

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -31,6 +31,8 @@ import {
   writeWorkflowPlan,
   promptStateMappings,
   promptBlockerCheck,
+  promptLegacyGhSymphonyCleanup,
+  warnDeprecatedSkipContext,
 } from "./workflow-init.js";
 import {
   toWorkflowLifecycleConfig,
@@ -73,7 +75,7 @@ function parseSetupFlags(args: string[]): SetupFlags {
       default:
         if (arg?.startsWith("-")) {
           throw new Error(
-            `Unknown option '${arg}'. Removed project/workspace flags are no longer supported; run 'gh-symphony setup' from inside the target repository. Supported flags: --non-interactive, --output, --skip-skills, --skip-context.`
+            `Unknown option '${arg}'. Removed project/workspace flags are no longer supported; run 'gh-symphony setup' from inside the target repository. Supported flags: --non-interactive, --output, --skip-skills. Deprecated no-op: --skip-context.`
           );
         }
     }
@@ -180,6 +182,9 @@ const handler = async (
     );
     process.exitCode = 2;
     return;
+  }
+  if (flags.skipContext) {
+    warnDeprecatedSkipContext();
   }
 
   if (flags.nonInteractive) {
@@ -481,6 +486,8 @@ async function runInteractive(
     process.exitCode = 130;
     return;
   }
+
+  await promptLegacyGhSymphonyCleanup(process.cwd());
 
   const writeSpinner = p.spinner();
   writeSpinner.start("Writing setup files...");

--- a/packages/cli/src/commands/workflow-init.test.ts
+++ b/packages/cli/src/commands/workflow-init.test.ts
@@ -3,6 +3,7 @@ import {
   mkdir,
   mkdtemp,
   readFile,
+  readdir,
   stat,
   writeFile,
 } from "node:fs/promises";
@@ -52,6 +53,7 @@ import {
   generateProjectId,
   planWorkflowArtifacts,
   planEcosystem,
+  promptLegacyGhSymphonyCleanup,
   promptBlockerCheck,
   promptPriorityConfig,
   renderDryRunPreview,
@@ -772,7 +774,8 @@ describe("init ecosystem generation", () => {
     expect(preview).toContain("Init dry-run preview");
     expect(preview).toContain("create");
     expect(preview).toContain(DEFAULT_AFTER_CREATE_HOOK_PATH);
-    expect(preview).toContain(".gh-symphony/context.yaml");
+    expect(preview).not.toContain(".gh-symphony/context.yaml");
+    expect(preview).not.toContain(".gh-symphony/reference-workflow.md");
     expect(preview).toContain("Priority source   project-field");
     expect(preview).toContain("Priority mapping  Priority: P0=0, P1=1");
     expect(preview).toContain("Detected environment inputs");
@@ -825,14 +828,12 @@ describe("init ecosystem generation", () => {
       )
     ).toBe(true);
     expect(
-      result.files.some((file) =>
-        file.path.endsWith(".gh-symphony/context.yaml")
-      )
-    ).toBe(true);
+      result.files.some((file) => file.path.includes(".gh-symphony"))
+    ).toBe(false);
     expect(result.environment.packageManager).toBeDefined();
   });
 
-  it("generates context.yaml and reference-workflow.md", async () => {
+  it("generates hooks and skill-local references without .gh-symphony files", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "cli-eco-"));
 
     const result = await writeEcosystem({
@@ -846,19 +847,14 @@ describe("init ecosystem generation", () => {
     });
 
     expect(result.afterCreateHookWritten).toBe(true);
-
-    const contextYaml = await readFile(
-      join(cwd, ".gh-symphony", "context.yaml"),
-      "utf8"
-    );
-    expect(contextYaml).toContain("schema_version: 1");
-    expect(contextYaml).toContain("PVT_eco1");
-
-    const refWorkflow = await readFile(
-      join(cwd, ".gh-symphony", "reference-workflow.md"),
-      "utf8"
-    );
-    expect(refWorkflow).toContain("# Reference WORKFLOW.md");
+    expect(result.contextYamlWritten).toBe(false);
+    expect(result.referenceWorkflowWritten).toBe(false);
+    await expect(
+      readFile(join(cwd, ".gh-symphony", "context.yaml"), "utf8")
+    ).rejects.toThrow();
+    await expect(
+      readFile(join(cwd, ".gh-symphony", "reference-workflow.md"), "utf8")
+    ).rejects.toThrow();
 
     const hookPath = join(cwd, DEFAULT_AFTER_CREATE_HOOK_PATH);
     const hook = await readFile(hookPath, "utf8");
@@ -899,7 +895,14 @@ describe("init ecosystem generation", () => {
     });
 
     const referenceWorkflow = await readFile(
-      join(cwd, ".gh-symphony", "reference-workflow.md"),
+      join(
+        cwd,
+        ".codex",
+        "skills",
+        "gh-symphony",
+        "references",
+        "workflow-schema.md"
+      ),
       "utf8"
     );
     const skill = await readFile(
@@ -1022,7 +1025,7 @@ describe("init ecosystem generation", () => {
     expect(plan.workflowMd).toContain("Use `uv` conventions");
     expect(
       plan.ecosystemPlan.files.some((file) =>
-        file.path.endsWith("reference-workflow.md")
+        file.path.endsWith("references/workflow-schema.md")
       )
     ).toBe(true);
   });
@@ -1195,7 +1198,7 @@ describe("init ecosystem generation", () => {
     ).resolves.toContain("# /gh-symphony references");
   });
 
-  it("does not double-wrap shell commands in context.yaml", async () => {
+  it("does not generate context.yaml for shell command runtimes", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "cli-eco-shell-command-"));
 
     await writeEcosystem({
@@ -1208,12 +1211,9 @@ describe("init ecosystem generation", () => {
       skipContext: false,
     });
 
-    const contextYaml = await readFile(
-      join(cwd, ".gh-symphony", "context.yaml"),
-      "utf8"
-    );
-    expect(contextYaml).toContain("agent_command: bash -lc codex app-server");
-    expect(contextYaml).not.toContain("agent_command: bash -lc bash -lc");
+    await expect(
+      readFile(join(cwd, ".gh-symphony", "context.yaml"), "utf8")
+    ).rejects.toThrow();
   });
 
   it("generates frontmatter for all scaffolded codex skills", async () => {
@@ -1291,15 +1291,13 @@ describe("init ecosystem generation", () => {
       readFile(join(cwd, ".codex", "skills", "gh-symphony", "SKILL.md"), "utf8")
     ).rejects.toThrow();
 
-    const contextYaml = await readFile(
-      join(cwd, ".gh-symphony", "context.yaml"),
-      "utf8"
-    );
-    expect(contextYaml).toContain("schema_version: 1");
     expect(result.skillsDir).toBeNull();
+    await expect(
+      readFile(join(cwd, ".gh-symphony", "context.yaml"), "utf8")
+    ).rejects.toThrow();
   });
 
-  it("--skip-context skips context.yaml", async () => {
+  it("--skip-context is a no-op after context generation removal", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "cli-eco-skip-ctx-"));
 
     await writeEcosystem({
@@ -1316,40 +1314,31 @@ describe("init ecosystem generation", () => {
       readFile(join(cwd, ".gh-symphony", "context.yaml"), "utf8")
     ).rejects.toThrow();
 
-    const refWorkflow = await readFile(
-      join(cwd, ".gh-symphony", "reference-workflow.md"),
-      "utf8"
-    );
-    expect(refWorkflow).toContain("# Reference WORKFLOW.md");
+    await expect(
+      readFile(join(cwd, ".gh-symphony", "reference-workflow.md"), "utf8")
+    ).rejects.toThrow();
   });
 
-  it("context.yaml contains statusField.id and option IDs", async () => {
+  it("legacy cleanup removes known .gh-symphony files and empty directory", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "cli-eco-ids-"));
-
-    await writeEcosystem({
-      cwd,
-      projectDetail: MOCK_PROJECT_DETAIL,
-      statusField: {
-        id: "PVTSSF_myfield",
-        name: "Status",
-        options: [
-          { id: "opt_abc", name: "Todo", description: null, color: null },
-          { id: "opt_def", name: "Done", description: null, color: null },
-        ],
-      },
-      priorityField: null,
-      runtime: "codex",
-      skipSkills: true,
-      skipContext: false,
-    });
-
-    const contextYaml = await readFile(
-      join(cwd, ".gh-symphony", "context.yaml"),
-      "utf8"
+    await mkdir(join(cwd, ".gh-symphony"), { recursive: true });
+    await writeFile(join(cwd, ".gh-symphony", "context.yaml"), "old\n");
+    await writeFile(
+      join(cwd, ".gh-symphony", "reference-workflow.md"),
+      "old\n"
     );
-    expect(contextYaml).toContain("PVTSSF_myfield");
-    expect(contextYaml).toContain("opt_abc");
-    expect(contextYaml).toContain("opt_def");
+    vi.mocked(p.confirm).mockResolvedValueOnce(true as never);
+
+    const removed = await promptLegacyGhSymphonyCleanup(cwd);
+
+    expect(removed).toEqual([
+      ".gh-symphony/context.yaml",
+      ".gh-symphony/reference-workflow.md",
+    ]);
+    await expect(
+      readFile(join(cwd, ".gh-symphony", "context.yaml"), "utf8")
+    ).rejects.toThrow();
+    await expect(readdir(join(cwd, ".gh-symphony"))).rejects.toThrow();
   });
 
   it("marks existing skill files as unchanged in dry-run plans", async () => {
@@ -1375,20 +1364,14 @@ describe("init ecosystem generation", () => {
       skipContext: false,
     });
 
-    const referenceWorkflow = plan.files.find((file) =>
-      file.path.endsWith(".gh-symphony/reference-workflow.md")
-    );
-    expect(referenceWorkflow?.status).toBe("unchanged");
-
     const hookScaffold = plan.files.find(
       (file) => file.label === DEFAULT_AFTER_CREATE_HOOK_LABEL
     );
     expect(hookScaffold?.status).toBe("unchanged");
 
-    const contextYaml = plan.files.find((file) =>
-      file.path.endsWith(".gh-symphony/context.yaml")
+    expect(plan.files.some((file) => file.path.includes(".gh-symphony"))).toBe(
+      false
     );
-    expect(contextYaml?.status).toBe("update");
 
     const skillStatuses = plan.files
       .filter((file) => file.label.startsWith("Skill "))

--- a/packages/cli/src/commands/workflow-init.ts
+++ b/packages/cli/src/commands/workflow-init.ts
@@ -10,7 +10,16 @@ import type {
 } from "@gh-symphony/core";
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { chmod, mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import {
+  chmod,
+  mkdir,
+  readFile,
+  readdir,
+  rename,
+  rm,
+  rmdir,
+  writeFile,
+} from "node:fs/promises";
 import { dirname, join, relative, resolve } from "node:path";
 import type { GlobalOptions } from "../index.js";
 import {
@@ -48,15 +57,10 @@ import { resolveGitHubAuth } from "../github/gh-auth.js";
 import { detectEnvironment } from "../detection/environment-detector.js";
 import type { DetectedEnvironment } from "../detection/environment-detector.js";
 import {
-  buildContextYaml,
-  generateContextYamlString,
-} from "../context/generate-context-yaml.js";
-import {
   DEFAULT_AFTER_CREATE_HOOK_CONTENT,
   DEFAULT_AFTER_CREATE_HOOK_LABEL,
   DEFAULT_AFTER_CREATE_HOOK_PATH,
 } from "../workflow/default-hooks.js";
-import { generateReferenceWorkflow } from "../workflow/generate-reference-workflow.js";
 import {
   buildSkillFilePlans,
   resolveSkillsDir,
@@ -66,7 +70,6 @@ import {
   isClaudeRuntime,
   normalizeInitRuntime,
   resolveRuntimeCommand,
-  resolveShellAgentCommand,
   isSupportedInitRuntime,
   type InitRuntimeKind,
 } from "../workflow/workflow-runtime.js";
@@ -140,6 +143,20 @@ type InitFlags = {
   skipContext: boolean;
 };
 
+const SKIP_CONTEXT_DEPRECATION =
+  "--skip-context is deprecated and is now a no-op. Repo-local .gh-symphony/context.yaml is no longer generated.";
+
+const LEGACY_GH_SYMPHONY_FILES = [
+  {
+    relativePath: ".gh-symphony/context.yaml",
+    reason: "replaced by skill-local references/",
+  },
+  {
+    relativePath: ".gh-symphony/reference-workflow.md",
+    reason: null,
+  },
+] as const;
+
 function parseInitFlags(args: string[]): InitFlags {
   const flags: InitFlags = {
     dryRun: false,
@@ -183,6 +200,10 @@ function parseInitFlags(args: string[]): InitFlags {
   return flags;
 }
 
+export function warnDeprecatedSkipContext(): void {
+  p.log.warn(SKIP_CONTEXT_DEPRECATION);
+}
+
 async function runInitRuntimePreflight(runtime: string): Promise<boolean> {
   if (!isClaudeRuntime(runtime)) {
     return true;
@@ -217,6 +238,9 @@ const handler = async (
   options: GlobalOptions
 ): Promise<void> => {
   const flags = parseInitFlags(args);
+  if (flags.skipContext) {
+    warnDeprecatedSkipContext();
+  }
 
   if (flags.nonInteractive) {
     await runNonInteractive(flags, options);
@@ -338,6 +362,7 @@ export type EcosystemResult = {
   referenceWorkflowWritten: boolean;
   skillsWritten: string[];
   skillsSkipped: string[];
+  legacyFilesRemoved: string[];
 };
 
 type PlannedWriteMode = "overwrite" | "create-only";
@@ -403,6 +428,81 @@ export type WorkflowArtifactsPlan = {
   workflowPlan: PlannedFileChange;
   ecosystemPlan: EcosystemPlan;
 };
+
+export async function findLegacyGhSymphonyFiles(
+  cwd: string
+): Promise<string[]> {
+  const found: string[] = [];
+  for (const legacyFile of LEGACY_GH_SYMPHONY_FILES) {
+    try {
+      await readFile(join(cwd, legacyFile.relativePath), "utf8");
+      found.push(legacyFile.relativePath);
+    } catch {
+      // Missing or unreadable legacy files are ignored; generation no longer
+      // depends on them.
+    }
+  }
+  return found;
+}
+
+export async function removeLegacyGhSymphonyFiles(
+  cwd: string,
+  legacyFiles: string[]
+): Promise<string[]> {
+  const removed: string[] = [];
+
+  for (const relativePath of legacyFiles) {
+    await rm(join(cwd, relativePath), { force: true });
+    removed.push(relativePath);
+  }
+
+  const legacyDir = join(cwd, ".gh-symphony");
+  try {
+    const remaining = await readdir(legacyDir);
+    if (remaining.length === 0) {
+      await rmdir(legacyDir);
+    }
+  } catch {
+    // Directory already absent or not readable; cleanup is best-effort.
+  }
+
+  return removed;
+}
+
+export async function promptLegacyGhSymphonyCleanup(
+  cwd: string
+): Promise<string[]> {
+  const legacyFiles = await findLegacyGhSymphonyFiles(cwd);
+  if (legacyFiles.length === 0) {
+    return [];
+  }
+
+  const lines = [
+    "Found legacy .gh-symphony/ directory.",
+    "These files are no longer used:",
+  ];
+  for (const legacyFile of LEGACY_GH_SYMPHONY_FILES) {
+    if (!legacyFiles.includes(legacyFile.relativePath)) {
+      continue;
+    }
+    const suffix = legacyFile.reason ? ` (${legacyFile.reason})` : "";
+    lines.push(`  • ${legacyFile.relativePath}${suffix}`);
+  }
+  lines.push("Safe to delete.");
+  p.log.info(lines.join("\n"));
+
+  const removeFiles = await abortIfCancelled(
+    p.confirm({
+      message: "Remove legacy .gh-symphony/ files?",
+      initialValue: false,
+    })
+  );
+  if (!removeFiles) {
+    return [];
+  }
+
+  return removeLegacyGhSymphonyFiles(cwd, legacyFiles);
+}
 
 async function resolveChangeStatus(
   path: string,
@@ -915,7 +1015,6 @@ export async function planEcosystem(
     priorityField,
     runtime,
     skipSkills,
-    skipContext,
   } = opts;
   const priority =
     opts.priority ??
@@ -938,7 +1037,6 @@ export async function planEcosystem(
         planningStates: defaultBlockerCheckStates,
       }
     );
-  const ghSymphonyDir = join(cwd, ".gh-symphony");
   const environment = opts.environment ?? (await detectEnvironment(cwd));
   const files: PlannedFileChange[] = [];
 
@@ -949,46 +1047,6 @@ export async function planEcosystem(
       content: DEFAULT_AFTER_CREATE_HOOK_CONTENT,
       mode: "create-only",
       executable: true,
-    })
-  );
-
-  if (!skipContext) {
-    const contextYaml = buildContextYaml({
-      projectDetail,
-      statusField,
-      detectedEnvironment: environment,
-      runtime: {
-        agent: runtime,
-        agent_command: resolveShellAgentCommand(runtime),
-      },
-    });
-    files.push(
-      await planFileChange({
-        path: join(ghSymphonyDir, "context.yaml"),
-        label: "Context metadata",
-        content: generateContextYamlString(contextYaml),
-        mode: "overwrite",
-      })
-    );
-  }
-
-  const referenceWorkflow = generateReferenceWorkflow({
-    runtime,
-    statusColumns: statusField.options.map((o) => ({
-      name: o.name,
-      role: null as "active" | "wait" | "terminal" | null,
-    })),
-    projectId: projectDetail.id,
-    priority,
-    lifecycle,
-    detectedEnvironment: environment,
-  });
-  files.push(
-    await planFileChange({
-      path: join(ghSymphonyDir, "reference-workflow.md"),
-      label: "Reference workflow",
-      content: referenceWorkflow,
-      mode: "overwrite",
     })
   );
 
@@ -1012,8 +1070,6 @@ export async function planEcosystem(
           role: null as "active" | "wait" | "terminal" | null,
         })),
         statusFieldId: statusField.id,
-        contextYamlPath: ".gh-symphony/context.yaml",
-        referenceWorkflowPath: ".gh-symphony/reference-workflow.md",
         detectedEnvironment: environment,
       }
     );
@@ -1049,18 +1105,9 @@ export async function writeEcosystem(
   opts: EcosystemOptions
 ): Promise<EcosystemResult> {
   const plan = await planEcosystem(opts);
-  await mkdir(join(opts.cwd, ".gh-symphony"), { recursive: true });
   const afterCreateHookPath = join(opts.cwd, DEFAULT_AFTER_CREATE_HOOK_PATH);
-  const contextYamlPath = join(opts.cwd, ".gh-symphony", "context.yaml");
-  const referenceWorkflowPath = join(
-    opts.cwd,
-    ".gh-symphony",
-    "reference-workflow.md"
-  );
 
   let afterCreateHookWritten = false;
-  let contextYamlWritten = false;
-  let referenceWorkflowWritten = false;
   const skillsWritten: string[] = [];
   const skillsSkipped: string[] = [];
 
@@ -1068,14 +1115,6 @@ export async function writeEcosystem(
     const written = await writePlannedFile(file);
     if (file.path === afterCreateHookPath) {
       afterCreateHookWritten = written;
-      continue;
-    }
-    if (file.path === contextYamlPath) {
-      contextYamlWritten = written;
-      continue;
-    }
-    if (file.path === referenceWorkflowPath) {
-      referenceWorkflowWritten = written;
       continue;
     }
     if (file.label.startsWith("Skill ")) {
@@ -1098,10 +1137,11 @@ export async function writeEcosystem(
     skillsDir: plan.skillsDir,
     skipSkills: plan.skipSkills,
     afterCreateHookWritten,
-    contextYamlWritten,
-    referenceWorkflowWritten,
+    contextYamlWritten: false,
+    referenceWorkflowWritten: false,
     skillsWritten: [...new Set(skillsWritten)].sort(),
     skillsSkipped: [...new Set(skillsSkipped)].sort(),
+    legacyFilesRemoved: [],
   };
 }
 
@@ -1173,16 +1213,6 @@ function printEcosystemSummary(
   if (result.afterCreateHookWritten) {
     lines.push(
       `  ✓ ${DEFAULT_AFTER_CREATE_HOOK_LABEL.padEnd(36)} ${DEFAULT_AFTER_CREATE_HOOK_PATH}`
-    );
-  }
-  if (result.contextYamlWritten) {
-    lines.push(
-      "  ✓ Context metadata                     .gh-symphony/context.yaml"
-    );
-  }
-  if (result.referenceWorkflowWritten) {
-    lines.push(
-      "  ✓ Reference workflow                   .gh-symphony/reference-workflow.md"
     );
   }
 
@@ -1627,6 +1657,7 @@ async function runInteractiveStandalone(
     return;
   }
 
+  await promptLegacyGhSymphonyCleanup(process.cwd());
   await writeWorkflowPlan(workflowPlan);
 
   const ecosystemResult = await writeEcosystem({

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -313,7 +313,7 @@ Commands:
   preview    Render the final worker prompt from a sample or live issue
 
 Options:
-  workflow init [--non-interactive] [--project <id>] [--output <path>] [--skip-skills] [--skip-context] [--dry-run]
+  workflow init [--non-interactive] [--project <id>] [--output <path>] [--skip-skills] [--skip-context (deprecated no-op)] [--dry-run]
   workflow validate [--file <path>]
   workflow preview [issue] [--file <path>] [--issue <owner/repo#number|ENG-123>] [--project-id <projectId>] [--sample <json>] [--attempt <n>]
 

--- a/packages/cli/src/context/generate-context-yaml.ts
+++ b/packages/cli/src/context/generate-context-yaml.ts
@@ -5,6 +5,10 @@ import type { DetectedEnvironment } from "../detection/environment-detector.js";
 import { inferStateRole } from "../mapping/smart-defaults.js";
 import type { ContextYaml } from "./context-types.js";
 
+/**
+ * @deprecated Repo-local `.gh-symphony/context.yaml` is no longer generated.
+ * This module remains for one compatibility release for any direct importers.
+ */
 export type BuildContextYamlParams = {
   projectDetail: ProjectDetail;
   statusField: ProjectStatusField;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -248,7 +248,7 @@ function createProgram(): { program: Command; wasInvoked: () => boolean } {
         "Runtime preset: codex-app-server or claude-print"
       )
       .option("--skip-skills", "Skip runtime skill generation")
-      .option("--skip-context", "Skip .gh-symphony/context.yaml generation")
+      .option("--skip-context", "Deprecated no-op")
       .option("--dry-run", "Preview generated files without writing them")
       .allowExcessArguments(false)
   ).action(async function (this: Command) {
@@ -309,7 +309,7 @@ function createProgram(): { program: Command; wasInvoked: () => boolean } {
       .option("--non-interactive", "Run without prompts")
       .option("--output <path>", "Write WORKFLOW.md to a custom path")
       .option("--skip-skills", "Skip runtime skill generation")
-      .option("--skip-context", "Skip .gh-symphony/context.yaml generation")
+      .option("--skip-context", "Deprecated no-op")
       .allowExcessArguments(false)
   ).action(async function (this: Command) {
     markInvoked();

--- a/packages/cli/src/skills/skill-writer.test.ts
+++ b/packages/cli/src/skills/skill-writer.test.ts
@@ -93,8 +93,6 @@ describe("skill-writer", () => {
           { id: "col-2", name: "Done", role: "terminal" },
         ],
         statusFieldId: "field-123",
-        contextYamlPath: "context.yaml",
-        referenceWorkflowPath: "WORKFLOW.md",
         detectedEnvironment,
       };
 
@@ -123,8 +121,6 @@ describe("skill-writer", () => {
         repositories: [],
         statusColumns: [],
         statusFieldId: "field-123",
-        contextYamlPath: "context.yaml",
-        referenceWorkflowPath: "WORKFLOW.md",
         detectedEnvironment,
       };
 
@@ -164,8 +160,6 @@ describe("skill-writer", () => {
         repositories: [],
         statusColumns: [],
         statusFieldId: "field-123",
-        contextYamlPath: "context.yaml",
-        referenceWorkflowPath: "WORKFLOW.md",
         detectedEnvironment,
       };
 
@@ -208,8 +202,6 @@ describe("skill-writer", () => {
         repositories: [],
         statusColumns: [],
         statusFieldId: "field-123",
-        contextYamlPath: "context.yaml",
-        referenceWorkflowPath: "WORKFLOW.md",
         detectedEnvironment,
       };
 
@@ -244,8 +236,6 @@ describe("skill-writer", () => {
         repositories: [],
         statusColumns: [],
         statusFieldId: "field-123",
-        contextYamlPath: "context.yaml",
-        referenceWorkflowPath: "WORKFLOW.md",
         detectedEnvironment,
       };
 
@@ -276,8 +266,6 @@ describe("skill-writer", () => {
         repositories: [],
         statusColumns: [],
         statusFieldId: "field-123",
-        contextYamlPath: "context.yaml",
-        referenceWorkflowPath: "WORKFLOW.md",
         detectedEnvironment,
       };
 
@@ -301,8 +289,6 @@ describe("skill-writer", () => {
         repositories: [],
         statusColumns: [],
         statusFieldId: "field-123",
-        contextYamlPath: "context.yaml",
-        referenceWorkflowPath: "WORKFLOW.md",
         detectedEnvironment,
       };
 
@@ -332,8 +318,6 @@ describe("skill-writer", () => {
         repositories: [],
         statusColumns: [],
         statusFieldId: "field-123",
-        contextYamlPath: "context.yaml",
-        referenceWorkflowPath: "WORKFLOW.md",
         detectedEnvironment,
       };
 
@@ -377,8 +361,6 @@ describe("skill-writer", () => {
           repositories: [],
           statusColumns: [],
           statusFieldId: "field-123",
-          contextYamlPath: "context.yaml",
-          referenceWorkflowPath: "WORKFLOW.md",
           detectedEnvironment,
         }
       );

--- a/packages/cli/src/skills/templates/commit.test.ts
+++ b/packages/cli/src/skills/templates/commit.test.ts
@@ -9,8 +9,6 @@ const mockCtx: SkillTemplateContext = {
   repositories: [{ owner: "acme", name: "platform" }],
   statusColumns: [{ id: "opt_todo", name: "Todo", role: "active" }],
   statusFieldId: "PVTF_field",
-  contextYamlPath: ".gh-symphony/context.yaml",
-  referenceWorkflowPath: ".gh-symphony/reference-workflow.md",
   detectedEnvironment: {
     packageManager: "pnpm",
     testCommand: "pnpm test",

--- a/packages/cli/src/skills/templates/gh-project.test.ts
+++ b/packages/cli/src/skills/templates/gh-project.test.ts
@@ -13,8 +13,6 @@ const mockCtx: SkillTemplateContext = {
     { id: "opt_done", name: "Done", role: "terminal" },
   ],
   statusFieldId: "PVTF_field123",
-  contextYamlPath: ".gh-symphony/context.yaml",
-  referenceWorkflowPath: ".gh-symphony/reference-workflow.md",
   detectedEnvironment: {
     packageManager: "pnpm",
     testCommand: "pnpm test",

--- a/packages/cli/src/skills/templates/gh-project.ts
+++ b/packages/cli/src/skills/templates/gh-project.ts
@@ -17,7 +17,7 @@ export function generateGhProjectSkill(ctx: SkillTemplateContext): string {
   lines.push("");
   lines.push("- `gh` CLI is authenticated (`gh auth status`)");
   lines.push(
-    `- \`${ctx.contextYamlPath}\` exists with field IDs and option IDs`
+    "- This generated skill contains the status field and option IDs below"
   );
   lines.push("");
   lines.push("## Column ID Quick Reference");

--- a/packages/cli/src/skills/templates/gh-symphony.test.ts
+++ b/packages/cli/src/skills/templates/gh-symphony.test.ts
@@ -14,8 +14,6 @@ const mockCtx: SkillTemplateContext = {
     { id: "opt_done", name: "Done", role: "terminal" },
   ],
   statusFieldId: "PVTF_field123",
-  contextYamlPath: ".gh-symphony/context.yaml",
-  referenceWorkflowPath: ".gh-symphony/reference-workflow.md",
   detectedEnvironment: {
     packageManager: "pnpm",
     testCommand: "pnpm test",
@@ -46,14 +44,11 @@ describe("generateGhSymphonySkill", () => {
     expect(result).toContain("Refine Mode");
   });
 
-  it("references context.yaml path from ctx", () => {
+  it("uses WORKFLOW.md as the policy and config source", () => {
     const result = generateGhSymphonySkill(mockCtx);
-    expect(result).toContain(".gh-symphony/context.yaml");
-  });
-
-  it("references reference-workflow.md path from ctx", () => {
-    const result = generateGhSymphonySkill(mockCtx);
-    expect(result).toContain(".gh-symphony/reference-workflow.md");
+    expect(result).toContain("WORKFLOW.md");
+    expect(result).not.toContain(".gh-symphony/context.yaml");
+    expect(result).not.toContain(".gh-symphony/reference-workflow.md");
   });
 
   it("references composable workflow reference files", () => {

--- a/packages/cli/src/skills/templates/gh-symphony.ts
+++ b/packages/cli/src/skills/templates/gh-symphony.ts
@@ -16,12 +16,7 @@ export function generateGhSymphonySkill(ctx: SkillTemplateContext): string {
   lines.push("");
   lines.push("## Prerequisites");
   lines.push("");
-  lines.push(
-    `- \`${ctx.contextYamlPath}\` must exist (contains GitHub Project metadata)`
-  );
-  lines.push(
-    `- \`${ctx.referenceWorkflowPath}\` may exist for compatibility with older generated ecosystems`
-  );
+  lines.push("- `WORKFLOW.md` is the repository policy and config source");
   lines.push("- `references/README.md` must exist beside this skill");
   lines.push("- `gh` CLI must be authenticated");
   lines.push("");

--- a/packages/cli/src/skills/templates/land.test.ts
+++ b/packages/cli/src/skills/templates/land.test.ts
@@ -9,8 +9,6 @@ const mockCtx: SkillTemplateContext = {
   repositories: [{ owner: "acme", name: "platform" }],
   statusColumns: [{ id: "opt_todo", name: "Todo", role: "active" }],
   statusFieldId: "PVTF_field",
-  contextYamlPath: ".gh-symphony/context.yaml",
-  referenceWorkflowPath: ".gh-symphony/reference-workflow.md",
   detectedEnvironment: {
     packageManager: "pnpm",
     testCommand: "pnpm test",

--- a/packages/cli/src/skills/templates/pull.test.ts
+++ b/packages/cli/src/skills/templates/pull.test.ts
@@ -9,8 +9,6 @@ const mockCtx: SkillTemplateContext = {
   repositories: [{ owner: "acme", name: "platform" }],
   statusColumns: [{ id: "opt_todo", name: "Todo", role: "active" }],
   statusFieldId: "PVTF_field",
-  contextYamlPath: ".gh-symphony/context.yaml",
-  referenceWorkflowPath: ".gh-symphony/reference-workflow.md",
   detectedEnvironment: {
     packageManager: "pnpm",
     testCommand: "pnpm test",

--- a/packages/cli/src/skills/templates/push.test.ts
+++ b/packages/cli/src/skills/templates/push.test.ts
@@ -9,8 +9,6 @@ const mockCtx: SkillTemplateContext = {
   repositories: [{ owner: "acme", name: "platform" }],
   statusColumns: [{ id: "opt_todo", name: "Todo", role: "active" }],
   statusFieldId: "PVTF_field",
-  contextYamlPath: ".gh-symphony/context.yaml",
-  referenceWorkflowPath: ".gh-symphony/reference-workflow.md",
   detectedEnvironment: {
     packageManager: "pnpm",
     testCommand: "pnpm test",

--- a/packages/cli/src/skills/types.ts
+++ b/packages/cli/src/skills/types.ts
@@ -13,8 +13,6 @@ export type SkillTemplateContext = {
     role: "active" | "wait" | "terminal" | null;
   }>;
   statusFieldId: string; // field ID (needed for gh project item-edit --field-id)
-  contextYamlPath: string; // relative path
-  referenceWorkflowPath: string; // relative path
   detectedEnvironment: Pick<
     DetectedEnvironment,
     | "packageManager"


### PR DESCRIPTION
## TL;DR

- Stops `setup` / `workflow init` from generating repo-local `.gh-symphony/context.yaml` and `.gh-symphony/reference-workflow.md`.
- Keeps `--skip-context` accepted as a deprecated no-op for compatibility.
- Adds interactive cleanup for legacy `.gh-symphony/` files and moves rationale/docs to skill-local resource ownership.

## 변경 지점 다이어그램

```text
setup / workflow init
  ├─ WORKFLOW.md remains the repo policy/config source
  ├─ hooks/after_create.sh remains create-only hook scaffold
  ├─ .codex/.claude skills carry gh-symphony references/
  └─ legacy .gh-symphony files are detected and optionally removed
```

## 여기부터 보세요

- `packages/cli/src/commands/workflow-init.ts` — removes legacy ecosystem file planning/writing and adds cleanup helpers.
- `packages/cli/src/commands/setup.ts` — wires the same cleanup prompt into interactive setup.
- `packages/cli/src/skills/types.ts` and `packages/cli/src/skills/templates/*` — removes obsolete template path context.
- `packages/cli/src/commands/workflow-init.test.ts` — covers no-generation behavior and legacy cleanup.

## 위험 & 롤백

- Risk: users with automation passing `--skip-context` may expect an output file. The flag remains accepted and warns as a no-op for this compatibility release.
- Rollback: restore the previous `planEcosystem` context/reference file planning and skill template context fields.

## 변경 파일

- CLI generation: `workflow-init.ts`, `setup.ts`, `index.ts`, `workflow.ts`
- Skills: `skills/types.ts`, skill templates and tests
- Tests: setup/init/doctor/config robustness updates
- Docs/release: README, CLI CHANGELOG, ADR, changeset

## Evidence

- `pnpm lint` — passed
- `pnpm test` — passed
- `pnpm typecheck` — passed
- `pnpm build` — passed
- Docker E2E: N/A, this changes CLI file generation/setup behavior, not orchestrator dispatch, worker lifecycle, tracker adapters, or status API integration behavior.

## Issues

Closed #360

## 머지 후/사람 확인

- [ ] Confirm the deprecated `--skip-context` warning wording is acceptable for one release.
- [ ] Confirm the interactive legacy cleanup prompt copy is acceptable.
