### PR TITLE
feat(tracker-linear): filter pickup by labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,11 +441,20 @@ tracker:
   kind: linear
   api_key: $LINEAR_API_KEY
   project_slug: symphony-0c79b11b75ea
+  pickup_labels:
+    include:
+      - agent
+      - dev-ready
+    exclude:
+      - no-agent
+      - needs-spec
 ```
 
 `gh-symphony repo init` validates that `tracker.project_slug` is present and that the `tracker.api_key` reference resolves, for example through `LINEAR_API_KEY`. Linear config aliases such as `tracker.project_id`, `projectId`, `project_id`, and `teamId` are rejected. The legacy `.gh-symphony/config.json` file is not used as the Linear source of truth.
 
 `gh-symphony repo start --assigned-only` also applies to Linear trackers. Linear pushes the filter into GraphQL as `assignee.isMe = true`, so the result set is scoped to the user represented by the configured API key. With a personal API key this means issues assigned to that person; with a service-account key it means issues assigned to the service account, and Symphony does not fail fast because Linear does not expose enough token metadata in the issue query path to distinguish those cases reliably.
+
+Linear workflows may also configure `tracker.pickup_labels.include` and `tracker.pickup_labels.exclude` as pickup eligibility gates. Excluded labels always win; when include labels are configured, an issue needs at least one include label before a worker starts. Label changes are not an interruption control for already running workers; move the Linear issue state to drive lifecycle and handoff behavior.
 
 Linear orchestration is polling-only. There is intentionally no Linear webhook setup command; state transitions, workpad comments, and PR handoff policy belong in `WORKFLOW.md`. See `docs/examples/linear-WORKFLOW.md` for a complete example.
 

--- a/docs/examples/linear-WORKFLOW.md
+++ b/docs/examples/linear-WORKFLOW.md
@@ -8,6 +8,13 @@ tracker:
     - Todo
     - In Progress
     - Rework
+  pickup_labels:
+    include:
+      - agent
+      - dev-ready
+    exclude:
+      - no-agent
+      - needs-spec
   terminal_states:
     - Done
     - Canceled
@@ -47,6 +54,8 @@ runtime:
 `WORKFLOW.md` is the source of truth for Linear tracker setup. Use `tracker.kind: linear` with `tracker.project_slug`; do not use `tracker.project_id`, `projectId`, `project_id`, `teamId`, or `.gh-symphony/config.json` as Linear configuration inputs.
 
 `LINEAR_API_KEY` must be available when running `gh-symphony repo init`, `gh-symphony repo start`, or `gh-symphony workflow preview ENG-123`. The orchestrator reads Linear by polling the configured project. Linear webhook setup is a non-goal and no webhook command is expected.
+
+`tracker.pickup_labels` only controls whether active-state issues are eligible for new worker pickup. Exclude labels win over include labels. If `include` is omitted or empty, active-state issues remain pickup-eligible unless excluded. Do not use label changes to stop already running workers; move the Linear issue state to control interruption, review, and completion.
 
 ## Workpad Policy
 

--- a/packages/cli/src/commands/repo.test.ts
+++ b/packages/cli/src/commands/repo.test.ts
@@ -255,6 +255,12 @@ tracker:
   active_states:
     - Todo
     - In Progress
+  pickup_labels:
+    include:
+      - agent
+      - dev-ready
+    exclude:
+      - no-agent
 codex:
   command: codex app-server
 ---
@@ -288,6 +294,10 @@ Handle {{issue.identifier}}.
       settings: {
         projectSlug: "symphony-0c79b11b75ea",
         activeStates: "Todo\nIn Progress",
+        pickupLabels: {
+          include: ["agent", "dev-ready"],
+          exclude: ["no-agent"],
+        },
         repository: "acme/platform",
       },
     });

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -4,6 +4,7 @@ import { dirname, join, resolve } from "node:path";
 import { homedir } from "node:os";
 import type {
   OrchestratorProjectConfig,
+  OrchestratorTrackerSettingValue,
   RepositoryRef,
 } from "@gh-symphony/core";
 
@@ -21,7 +22,7 @@ export type CliGlobalConfig = {
 
 export type CliProjectTrackerSettings = Record<
   string,
-  string | number | boolean
+  OrchestratorTrackerSettingValue
 > & {
   projectId?: string;
   repository?: string;
@@ -132,7 +133,9 @@ export async function loadProjectConfig(
   configDir: string,
   projectId: string
 ): Promise<CliProjectConfig | null> {
-  return readJsonFile<CliProjectConfig>(projectConfigPath(configDir, projectId));
+  return readJsonFile<CliProjectConfig>(
+    projectConfigPath(configDir, projectId)
+  );
 }
 
 export async function saveProjectConfig(

--- a/packages/cli/src/repo-runtime.ts
+++ b/packages/cli/src/repo-runtime.ts
@@ -12,6 +12,7 @@ import { basename, dirname, join, resolve } from "node:path";
 import {
   parseWorkflowMarkdown,
   type OrchestratorProjectConfig,
+  type OrchestratorTrackerSettingValue,
   type RepositoryRef,
 } from "@gh-symphony/core";
 import {
@@ -77,7 +78,7 @@ export async function initRepoRuntime(flags: RepoInitFlags): Promise<{
   const trackerAdapter = workflow.tracker.kind ?? "github-project";
   const trackerBindingId =
     workflow.tracker.projectId ?? workflow.tracker.projectSlug ?? "";
-  const trackerSettings: Record<string, string | boolean> = {
+  const trackerSettings: Record<string, OrchestratorTrackerSettingValue> = {
     ...(workflow.tracker.projectId
       ? { projectId: workflow.tracker.projectId }
       : {}),
@@ -89,6 +90,13 @@ export async function initRepoRuntime(flags: RepoInitFlags): Promise<{
       : {}),
     repository: `${repository.owner}/${repository.name}`,
   };
+  if (
+    trackerAdapter === "linear" &&
+    (workflow.tracker.pickupLabels.include.length > 0 ||
+      workflow.tracker.pickupLabels.exclude.length > 0)
+  ) {
+    trackerSettings.pickupLabels = workflow.tracker.pickupLabels;
+  }
   if (workflow.tracker.priorityFieldName) {
     trackerSettings.priorityFieldName = workflow.tracker.priorityFieldName;
   }

--- a/packages/control-plane/client/src/routes/index.tsx
+++ b/packages/control-plane/client/src/routes/index.tsx
@@ -329,7 +329,9 @@ export function DataStatus(props: { projectState: ProjectState }) {
       <span>Last tick {formatRelativeTime(props.projectState.lastTickAt)}</span>
       <span>Repository {repository}</span>
       <span>Tracker {props.projectState.tracker.bindingId}</span>
-      {trackerProjectId ? <span>GitHub Project {trackerProjectId}</span> : null}
+      {typeof trackerProjectId === "string" && trackerProjectId.length > 0 ? (
+        <span>GitHub Project {trackerProjectId}</span>
+      ) : null}
       {props.projectState.lastError ? (
         <span className="text-status-failed-text">
           Last error: {props.projectState.lastError}

--- a/packages/core/src/contracts/status-surface.ts
+++ b/packages/core/src/contracts/status-surface.ts
@@ -8,12 +8,20 @@ import type { TrackerAdapterKind } from "./tracker-adapter.js";
 import type { RunAttemptPhase } from "./run-attempt-phase.js";
 import type { OrchestratorEvent } from "../observability/structured-events.js";
 
+export type OrchestratorTrackerSettingValue =
+  | string
+  | number
+  | boolean
+  | null
+  | OrchestratorTrackerSettingValue[]
+  | { [key: string]: OrchestratorTrackerSettingValue };
+
 export type OrchestratorTrackerConfig = {
   adapter: TrackerAdapterKind;
   bindingId: string;
   apiUrl?: string;
   priority?: WorkflowPriorityConfig | null;
-  settings?: Record<string, string | number | boolean>;
+  settings?: Record<string, OrchestratorTrackerSettingValue>;
 };
 
 export type OrchestratorProjectConfig = {
@@ -184,7 +192,7 @@ export type ProjectStatusSnapshot = {
     adapter: TrackerAdapterKind;
     bindingId: string;
     /** Public, non-secret tracker identifiers safe to expose on status APIs. */
-    settings?: Record<string, string | number | boolean>;
+    settings?: Record<string, OrchestratorTrackerSettingValue>;
   };
   lastTickAt: string;
   health: "idle" | "running" | "degraded";

--- a/packages/core/src/workflow-loader.test.ts
+++ b/packages/core/src/workflow-loader.test.ts
@@ -352,6 +352,32 @@ Prompt body.
     expect(workflow.tracker.projectId).toBeNull();
   });
 
+  it("parses Linear pickup label eligibility config", () => {
+    const workflow = parseWorkflowMarkdown(
+      `---
+tracker:
+  kind: linear
+  project_slug: symphony-0c79b11b75ea
+  pickup_labels:
+    include:
+      - agent
+      - dev-ready
+    exclude:
+      - no-agent
+      - needs-spec
+codex:
+  command: codex app-server
+---
+Prompt body.
+`
+    );
+
+    expect(workflow.tracker.pickupLabels).toEqual({
+      include: ["agent", "dev-ready"],
+      exclude: ["no-agent", "needs-spec"],
+    });
+  });
+
   it.each(["project_id", "projectId", "teamId", "team_id"])(
     "rejects Linear tracker alias %s",
     (key) => {
@@ -767,7 +793,11 @@ codex:
 Prompt body.
 `);
 
-    expect(workflow.tracker.activeStates).toEqual(["Ready", "In progress", "Land"]);
+    expect(workflow.tracker.activeStates).toEqual([
+      "Ready",
+      "In progress",
+      "Land",
+    ]);
     expect(workflow.lifecycle.activeStates).toContain("Land");
     expect(isStateActive("Land", workflow.lifecycle)).toBe(true);
     expect(isStateActive("In review", workflow.lifecycle)).toBe(false);

--- a/packages/core/src/workflow/config.ts
+++ b/packages/core/src/workflow/config.ts
@@ -16,6 +16,7 @@ export type WorkflowTrackerConfig = {
   endpoint: string | null;
   apiKey: string | null;
   projectSlug: string | null;
+  pickupLabels: WorkflowPickupLabelsConfig;
   activeStates: string[];
   terminalStates: string[];
   projectId: string | null;
@@ -24,6 +25,11 @@ export type WorkflowTrackerConfig = {
   priorityFieldName: string | null;
   blockerCheckStates: string[];
   planningStates: string[];
+};
+
+export type WorkflowPickupLabelsConfig = {
+  include: string[];
+  exclude: string[];
 };
 
 export type WorkflowPriorityConfig =
@@ -154,6 +160,10 @@ export const DEFAULT_WORKFLOW_TRACKER: WorkflowTrackerConfig = {
   endpoint: null,
   apiKey: null,
   projectSlug: null,
+  pickupLabels: {
+    include: [],
+    exclude: [],
+  },
   activeStates: DEFAULT_WORKFLOW_LIFECYCLE.activeStates,
   terminalStates: DEFAULT_WORKFLOW_LIFECYCLE.terminalStates,
   projectId: null,

--- a/packages/core/src/workflow/parser.ts
+++ b/packages/core/src/workflow/parser.ts
@@ -118,6 +118,7 @@ export function parseWorkflowMarkdown(
         (trackerKind === "linear" ? DEFAULT_LINEAR_GRAPHQL_URL : null),
       apiKey: readOptionalString(tracker, "api_key", env),
       projectSlug: readOptionalString(tracker, "project_slug", env),
+      pickupLabels: readPickupLabelsConfig(tracker),
       activeStates,
       terminalStates,
       projectId: readOptionalString(tracker, "project_id", env),
@@ -215,6 +216,26 @@ function validateTrackerConfig(
       );
     }
   }
+}
+
+function readPickupLabelsConfig(
+  tracker: Record<string, WorkflowFrontMatterNode>
+): ParsedWorkflow["tracker"]["pickupLabels"] {
+  const value = tracker.pickup_labels ?? tracker.pickupLabels;
+  if (value === undefined || value === null) {
+    return DEFAULT_WORKFLOW_TRACKER.pickupLabels;
+  }
+  if (Array.isArray(value) || typeof value !== "object") {
+    throw new Error(
+      'Workflow front matter field "tracker.pickup_labels" must be an object when provided.'
+    );
+  }
+
+  const input = value as Record<string, WorkflowFrontMatterNode>;
+  return {
+    include: readStringList(input, "include") ?? [],
+    exclude: readStringList(input, "exclude") ?? [],
+  };
 }
 
 function readPriorityConfig(

--- a/packages/tracker-linear/src/orchestrator-adapter.ts
+++ b/packages/tracker-linear/src/orchestrator-adapter.ts
@@ -176,7 +176,9 @@ export const linearTrackerAdapter: OrchestratorTrackerAdapter = {
     return listLinearIssues(
       project,
       project.tracker.settings?.activeStates,
-      dependencies
+      dependencies,
+      undefined,
+      { applyPickupLabels: true }
     );
   },
 
@@ -237,7 +239,8 @@ async function listLinearIssues(
   project: OrchestratorProjectConfig,
   stateNamesInput: unknown,
   dependencies: OrchestratorTrackerDependencies,
-  issueIds?: readonly string[]
+  issueIds?: readonly string[],
+  options: { applyPickupLabels?: boolean } = {}
 ): Promise<TrackedIssueList> {
   const config = resolveLinearTrackerConfig(project, dependencies);
   const client = createLinearGraphqlClient(config, dependencies.fetchImpl);
@@ -265,14 +268,14 @@ async function listLinearIssues(
   const fetchedIssues = result.nodes.map((node) =>
     normalizeLinearIssue(project, config.projectSlug, node, result.rateLimits)
   ) as TrackedIssueList;
-  const issues = issueIds
-    ? fetchedIssues
-    : filterIssuesByPickupLabels(
+  const filteredIssues = options.applyPickupLabels
+    ? filterIssuesByPickupLabels(
         fetchedIssues,
         config.pickupLabels,
         config.projectSlug
-      );
-  Object.defineProperty(issues, "rateLimits", {
+      )
+    : fetchedIssues;
+  Object.defineProperty(filteredIssues, "rateLimits", {
     configurable: true,
     enumerable: false,
     value: result.rateLimits,
@@ -282,11 +285,11 @@ async function listLinearIssues(
   if (config.assignedOnly) {
     emitAssignedOnlyFilterEvent({
       projectSlug: config.projectSlug,
-      includedCount: issues.length,
+      includedCount: filteredIssues.length,
     });
   }
 
-  return issues;
+  return filteredIssues;
 }
 
 async function fetchPaginatedLinearIssues(

--- a/packages/tracker-linear/src/orchestrator-adapter.ts
+++ b/packages/tracker-linear/src/orchestrator-adapter.ts
@@ -80,6 +80,11 @@ type LinearIssueFilter = {
   assignee?: { isMe: { eq: true } };
 };
 
+type PickupLabelConfig = {
+  include: string[];
+  exclude: string[];
+};
+
 const LINEAR_ISSUE_FIELDS = /* GraphQL */ `
   nodes {
     id
@@ -257,9 +262,16 @@ async function listLinearIssues(
     pageSize: config.pageSize,
   });
 
-  const issues = result.nodes.map((node) =>
+  const fetchedIssues = result.nodes.map((node) =>
     normalizeLinearIssue(project, config.projectSlug, node, result.rateLimits)
   ) as TrackedIssueList;
+  const issues = issueIds
+    ? fetchedIssues
+    : filterIssuesByPickupLabels(
+        fetchedIssues,
+        config.pickupLabels,
+        config.projectSlug
+      );
   Object.defineProperty(issues, "rateLimits", {
     configurable: true,
     enumerable: false,
@@ -544,6 +556,7 @@ function resolveLinearTrackerConfig(
     pageSize:
       readPositiveIntegerSetting(project.tracker, "pageSize") ??
       DEFAULT_PAGE_SIZE,
+    pickupLabels: resolvePickupLabels(project.tracker),
     projectSlug,
     token,
   };
@@ -620,6 +633,39 @@ function readBooleanSetting(
   return value === true || value === "true";
 }
 
+function resolvePickupLabels(
+  tracker: OrchestratorTrackerConfig
+): PickupLabelConfig {
+  const pickupLabels =
+    readObjectSetting(tracker, "pickupLabels") ??
+    readObjectSetting(tracker, "pickup_labels");
+
+  return {
+    include: normalizeConfiguredLabels(
+      readStringArray(pickupLabels?.include) ?? []
+    ),
+    exclude: normalizeConfiguredLabels(
+      readStringArray(pickupLabels?.exclude) ?? []
+    ),
+  };
+}
+
+function readObjectSetting(
+  tracker: OrchestratorTrackerConfig,
+  key: string
+): Record<string, unknown> | undefined {
+  const value = tracker.settings?.[key];
+  if (
+    value === undefined ||
+    value === null ||
+    Array.isArray(value) ||
+    typeof value !== "object"
+  ) {
+    return undefined;
+  }
+  return value as Record<string, unknown>;
+}
+
 function readStringArray(value: unknown): string[] | undefined {
   if (value === undefined) {
     return undefined;
@@ -636,6 +682,47 @@ function readStringArray(value: unknown): string[] | undefined {
   return value.filter((entry): entry is string => typeof entry === "string");
 }
 
+function normalizeConfiguredLabels(labels: string[]): string[] {
+  return Array.from(
+    new Set(
+      labels.map((label) => label.trim()).filter((label) => label.length > 0)
+    )
+  );
+}
+
+function filterIssuesByPickupLabels(
+  issues: TrackedIssueList,
+  config: PickupLabelConfig,
+  projectSlug: string
+): TrackedIssueList {
+  if (config.include.length === 0 && config.exclude.length === 0) {
+    return issues;
+  }
+
+  const includeLabels = new Set(config.include);
+  const excludeLabels = new Set(config.exclude);
+  const filtered = issues.filter((issue) => {
+    const issueLabels = new Set(issue.labels);
+    if (config.exclude.some((label) => issueLabels.has(label))) {
+      return false;
+    }
+    return (
+      includeLabels.size === 0 ||
+      config.include.some((label) => issueLabels.has(label))
+    );
+  }) as TrackedIssueList;
+
+  emitPickupLabelFilterEvent({
+    projectSlug,
+    include: [...includeLabels],
+    exclude: [...excludeLabels],
+    includedCount: filtered.length,
+    excludedCount: issues.length - filtered.length,
+  });
+
+  return filtered;
+}
+
 function emitAssignedOnlyFilterEvent(input: {
   projectSlug: string;
   includedCount: number;
@@ -648,6 +735,26 @@ function emitAssignedOnlyFilterEvent(input: {
       assigneeFilter: "isMe",
       includedCount: input.includedCount,
       excludedCount: null,
+    })
+  );
+}
+
+function emitPickupLabelFilterEvent(input: {
+  projectSlug: string;
+  include: string[];
+  exclude: string[];
+  includedCount: number;
+  excludedCount: number;
+}): void {
+  console.info(
+    JSON.stringify({
+      event: "tracker-pickup-label-filtered",
+      tracker: "linear",
+      projectSlug: input.projectSlug,
+      include: input.include,
+      exclude: input.exclude,
+      includedCount: input.includedCount,
+      excludedCount: input.excludedCount,
     })
   );
 }

--- a/packages/tracker-linear/src/tracker-linear.test.ts
+++ b/packages/tracker-linear/src/tracker-linear.test.ts
@@ -625,6 +625,70 @@ describe("linearTrackerAdapter", () => {
     }
   });
 
+  it("does not apply pickup label filtering to listIssuesByStates lifecycle lookups", async () => {
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+    try {
+      const fetchImpl = vi.fn().mockResolvedValue(
+        jsonResponse({
+          data: {
+            issues: {
+              nodes: [
+                linearIssueNode("ENG-1", ["no-agent"], {
+                  state: { name: "Done" },
+                }),
+                linearIssueNode("ENG-2", ["frontend"], {
+                  state: { name: "Done" },
+                }),
+                linearIssueNode("ENG-3", ["agent"], {
+                  state: { name: "Done" },
+                }),
+              ],
+              pageInfo: { hasNextPage: false, endCursor: null },
+            },
+          },
+        })
+      );
+
+      const issues = await linearTrackerAdapter.listIssuesByStates(
+        makeProject({
+          settings: {
+            projectSlug: "symphony-0c79b11b75ea",
+            activeStates: "Todo",
+            pickupLabels: {
+              include: ["agent", "dev-ready"],
+              exclude: ["no-agent", "needs-spec"],
+            },
+          },
+        }),
+        ["Done", "Canceled"],
+        {
+          fetchImpl,
+          token: "linear-token",
+        }
+      );
+
+      const request = JSON.parse(
+        String(fetchImpl.mock.calls[0]?.[1]?.body)
+      ) as {
+        variables: Record<string, unknown>;
+      };
+      expect(request.variables.filter).toMatchObject({
+        project: { slugId: { eq: "symphony-0c79b11b75ea" } },
+        state: { name: { in: ["Done", "Canceled"] } },
+      });
+      expect(issues.map((issue) => issue.identifier)).toEqual([
+        "ENG-1",
+        "ENG-2",
+        "ENG-3",
+      ]);
+      expect(infoSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining('"event":"tracker-pickup-label-filtered"')
+      );
+    } finally {
+      infoSpy.mockRestore();
+    }
+  });
+
   it("normalizes Linear rate-limit headers onto listed issues", async () => {
     const fetchImpl = vi.fn().mockResolvedValue(
       jsonResponseWithHeaders(

--- a/packages/tracker-linear/src/tracker-linear.test.ts
+++ b/packages/tracker-linear/src/tracker-linear.test.ts
@@ -48,6 +48,25 @@ function jsonResponseWithHeaders(
   });
 }
 
+function linearIssueNode(
+  identifier: string,
+  labels: string[],
+  overrides: Record<string, unknown> = {}
+): Record<string, unknown> {
+  const number = Number.parseInt(identifier.split("-").at(-1) ?? "0", 10);
+  return {
+    id: `issue-${identifier.toLowerCase()}`,
+    identifier,
+    number,
+    title: `${identifier} title`,
+    priority: null,
+    state: { name: "Todo" },
+    labels: { nodes: labels.map((name) => ({ name })) },
+    relations: { nodes: [] },
+    ...overrides,
+  };
+}
+
 describe("linearTrackerAdapter", () => {
   it("queries Linear by project slug and state names with cursor pagination", async () => {
     const fetchImpl = vi
@@ -262,7 +281,7 @@ describe("linearTrackerAdapter", () => {
     expect(request.variables.filter).not.toHaveProperty("assignee");
   });
 
-  it('falls back to legacy string assignedOnly tracker setting with a deprecation warning', async () => {
+  it("falls back to legacy string assignedOnly tracker setting with a deprecation warning", async () => {
     const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     try {
@@ -353,6 +372,253 @@ describe("linearTrackerAdapter", () => {
       );
       expect(infoSpy).toHaveBeenCalledWith(
         expect.stringContaining('"includedCount":1')
+      );
+    } finally {
+      infoSpy.mockRestore();
+    }
+  });
+
+  it("requires one configured include pickup label when include labels are set", async () => {
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+    try {
+      const fetchImpl = vi.fn().mockResolvedValue(
+        jsonResponse({
+          data: {
+            issues: {
+              nodes: [
+                linearIssueNode("ENG-1", ["agent"]),
+                linearIssueNode("ENG-2", ["dev-ready"]),
+                linearIssueNode("ENG-3", ["frontend"]),
+                linearIssueNode("ENG-4", []),
+              ],
+              pageInfo: { hasNextPage: false, endCursor: null },
+            },
+          },
+        })
+      );
+
+      const issues = await linearTrackerAdapter.listIssues(
+        makeProject({
+          settings: {
+            projectSlug: "symphony-0c79b11b75ea",
+            activeStates: "Todo",
+            pickupLabels: {
+              include: ["agent", "dev-ready"],
+            },
+          },
+        }),
+        {
+          fetchImpl,
+          token: "linear-token",
+        }
+      );
+
+      expect(issues.map((issue) => issue.identifier)).toEqual([
+        "ENG-1",
+        "ENG-2",
+      ]);
+      expect(infoSpy).toHaveBeenCalledWith(
+        expect.stringContaining('"event":"tracker-pickup-label-filtered"')
+      );
+      expect(infoSpy).toHaveBeenCalledWith(
+        expect.stringContaining('"includedCount":2')
+      );
+      expect(infoSpy).toHaveBeenCalledWith(
+        expect.stringContaining('"excludedCount":2')
+      );
+    } finally {
+      infoSpy.mockRestore();
+    }
+  });
+
+  it("skips issues with any configured exclude pickup label", async () => {
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+    try {
+      const fetchImpl = vi.fn().mockResolvedValue(
+        jsonResponse({
+          data: {
+            issues: {
+              nodes: [
+                linearIssueNode("ENG-1", ["frontend"]),
+                linearIssueNode("ENG-2", ["no-agent"]),
+                linearIssueNode("ENG-3", ["needs-spec"]),
+              ],
+              pageInfo: { hasNextPage: false, endCursor: null },
+            },
+          },
+        })
+      );
+
+      const issues = await linearTrackerAdapter.listIssues(
+        makeProject({
+          settings: {
+            projectSlug: "symphony-0c79b11b75ea",
+            activeStates: "Todo",
+            pickupLabels: {
+              exclude: ["no-agent", "needs-spec"],
+            },
+          },
+        }),
+        {
+          fetchImpl,
+          token: "linear-token",
+        }
+      );
+
+      expect(issues.map((issue) => issue.identifier)).toEqual(["ENG-1"]);
+      expect(infoSpy).toHaveBeenCalledWith(
+        expect.stringContaining('"exclude":["no-agent","needs-spec"]')
+      );
+    } finally {
+      infoSpy.mockRestore();
+    }
+  });
+
+  it("lets exclude pickup labels win over include pickup labels", async () => {
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+    try {
+      const fetchImpl = vi.fn().mockResolvedValue(
+        jsonResponse({
+          data: {
+            issues: {
+              nodes: [
+                linearIssueNode("ENG-1", ["agent"]),
+                linearIssueNode("ENG-2", ["dev-ready"]),
+                linearIssueNode("ENG-3", ["agent", "no-agent"]),
+                linearIssueNode("ENG-4", ["needs-spec"]),
+                linearIssueNode("ENG-5", []),
+                linearIssueNode("ENG-6", ["frontend"]),
+              ],
+              pageInfo: { hasNextPage: false, endCursor: null },
+            },
+          },
+        })
+      );
+
+      const issues = await linearTrackerAdapter.listIssues(
+        makeProject({
+          settings: {
+            projectSlug: "symphony-0c79b11b75ea",
+            activeStates: "Todo",
+            pickupLabels: {
+              include: ["agent", "dev-ready"],
+              exclude: ["no-agent", "needs-spec"],
+            },
+          },
+        }),
+        {
+          fetchImpl,
+          token: "linear-token",
+        }
+      );
+
+      expect(issues.map((issue) => issue.identifier)).toEqual([
+        "ENG-1",
+        "ENG-2",
+      ]);
+      expect(infoSpy).toHaveBeenCalledWith(
+        expect.stringContaining('"excludedCount":4')
+      );
+    } finally {
+      infoSpy.mockRestore();
+    }
+  });
+
+  it("treats an empty include pickup label list as no include requirement", async () => {
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+    try {
+      const fetchImpl = vi.fn().mockResolvedValue(
+        jsonResponse({
+          data: {
+            issues: {
+              nodes: [
+                linearIssueNode("ENG-1", []),
+                linearIssueNode("ENG-2", ["frontend"]),
+                linearIssueNode("ENG-3", ["no-agent"]),
+              ],
+              pageInfo: { hasNextPage: false, endCursor: null },
+            },
+          },
+        })
+      );
+
+      const issues = await linearTrackerAdapter.listIssues(
+        makeProject({
+          settings: {
+            projectSlug: "symphony-0c79b11b75ea",
+            activeStates: "Todo",
+            pickupLabels: {
+              include: [],
+              exclude: ["no-agent"],
+            },
+          },
+        }),
+        {
+          fetchImpl,
+          token: "linear-token",
+        }
+      );
+
+      expect(issues.map((issue) => issue.identifier)).toEqual([
+        "ENG-1",
+        "ENG-2",
+      ]);
+    } finally {
+      infoSpy.mockRestore();
+    }
+  });
+
+  it("composes assignedOnly GraphQL filtering with pickup label filtering", async () => {
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+    try {
+      const fetchImpl = vi.fn().mockResolvedValue(
+        jsonResponse({
+          data: {
+            issues: {
+              nodes: [
+                linearIssueNode("ENG-1", ["agent"]),
+                linearIssueNode("ENG-2", ["no-agent"]),
+              ],
+              pageInfo: { hasNextPage: false, endCursor: null },
+            },
+          },
+        })
+      );
+
+      const issues = await linearTrackerAdapter.listIssues(
+        makeProject({
+          settings: {
+            projectSlug: "symphony-0c79b11b75ea",
+            activeStates: "Todo",
+            pickupLabels: {
+              include: ["agent"],
+              exclude: ["no-agent"],
+            },
+          },
+        }),
+        {
+          assignedOnly: true,
+          fetchImpl,
+          token: "linear-token",
+        }
+      );
+
+      const request = JSON.parse(
+        String(fetchImpl.mock.calls[0]?.[1]?.body)
+      ) as {
+        variables: Record<string, unknown>;
+      };
+      expect(request.variables.filter).toMatchObject({
+        project: { slugId: { eq: "symphony-0c79b11b75ea" } },
+        state: { name: { in: ["Todo"] } },
+        assignee: { isMe: { eq: true } },
+      });
+      expect(issues.map((issue) => issue.identifier)).toEqual(["ENG-1"]);
+      expect(infoSpy).toHaveBeenCalledWith(
+        expect.stringContaining('"event":"tracker-assigned-only-filtered"')
+      );
+      expect(infoSpy).toHaveBeenCalledWith(
+        expect.stringContaining('"event":"tracker-pickup-label-filtered"')
       );
     } finally {
       infoSpy.mockRestore();
@@ -526,10 +792,14 @@ describe("linearTrackerAdapter", () => {
       })
     );
 
-    await linearTrackerAdapter.fetchIssueStatesByIds(makeProject(), ["ENG-123"], {
-      fetchImpl,
-      token: "linear-token",
-    });
+    await linearTrackerAdapter.fetchIssueStatesByIds(
+      makeProject(),
+      ["ENG-123"],
+      {
+        fetchImpl,
+        token: "linear-token",
+      }
+    );
 
     const request = JSON.parse(String(fetchImpl.mock.calls[0]?.[1]?.body)) as {
       query: string;


### PR DESCRIPTION
## TL;DR

Add Linear pickup eligibility filtering with `tracker.pickup_labels.include` and `tracker.pickup_labels.exclude`, applied only while listing active-state candidates before dispatch. Rework narrows the filter to the explicit pickup path so lifecycle lookups such as terminal-state cleanup are unchanged.

## 변경 지점 다이어그램

```text
WORKFLOW.md tracker.pickup_labels
  -> core workflow parser
  -> repo runtime project settings.pickupLabels
  -> Linear adapter listIssues() pickup candidates only
  -> normalize Linear labels
  -> exact include/exclude candidate filter
  -> structured console info event

listIssuesByStates() lifecycle lookups
  -> Linear adapter shared fetch
  -> no pickup-label gate
  -> terminal cleanup still sees Done/Canceled issues
```

## 여기부터 보세요

- `packages/tracker-linear/src/orchestrator-adapter.ts` — `listIssues()` explicitly opts into pickup label filtering; `listIssuesByStates()` and `fetchIssueStatesByIds()` remain lifecycle-safe.
- `packages/tracker-linear/src/tracker-linear.test.ts` — include-only, exclude-only, include+exclude, empty include, `assignedOnly` composition, and terminal-state lookup regression coverage.
- `packages/core/src/workflow/parser.ts` and `packages/cli/src/repo-runtime.ts` — `tracker.pickup_labels` parsing and persistence into tracker settings.
- `README.md` and `docs/examples/linear-WORKFLOW.md` — label filters documented as pickup-only, not interruption control.

## 위험 & 롤백

- Risk: nested tracker settings required widening status/config typing; the control-plane status display now renders only scalar `projectId` values.
- Rollback: remove `pickup_labels` from Linear workflows or revert this PR. With no configured include/exclude labels, active-state Linear issues remain eligible as before.

## 변경 파일

- `packages/tracker-linear/src/orchestrator-adapter.ts`
- `packages/tracker-linear/src/tracker-linear.test.ts`
- `packages/core/src/workflow/config.ts`
- `packages/core/src/workflow/parser.ts`
- `packages/core/src/workflow-loader.test.ts`
- `packages/core/src/contracts/status-surface.ts`
- `packages/cli/src/config.ts`
- `packages/cli/src/repo-runtime.ts`
- `packages/cli/src/commands/repo.test.ts`
- `packages/control-plane/client/src/routes/index.tsx`
- `README.md`
- `docs/examples/linear-WORKFLOW.md`

## Evidence

- `pnpm --filter @gh-symphony/tracker-linear test` — pass, 23 tests.
- `pnpm lint` — pass.
- `pnpm test` — pass.
- `pnpm typecheck` — pass.
- `pnpm build` — pass.
- `pnpm exec prettier --check packages/tracker-linear/src/orchestrator-adapter.ts packages/tracker-linear/src/tracker-linear.test.ts` — pass.
- `./e2e/run-e2e.sh happy 40` — pass; Docker blackbox dispatched one stub issue and returned final health `idle`.

## Issues

Closed #370

## 머지 후/사람 확인

- [ ] Confirm the configured Linear labels exist in the target Linear project.
- [ ] Confirm production workflows use issue state changes, not label changes, to interrupt or stop already running workers.
