### PR TITLE
fix(core): ignore workflow inline comments

### DIFF
--- a/.changeset/clean-workflow-inline-comments.md
+++ b/.changeset/clean-workflow-inline-comments.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Fix #363 by parsing YAML inline comments out of WORKFLOW frontmatter scalar values before repo init persists GitHub Project bindings.

--- a/packages/cli/src/commands/repo.test.ts
+++ b/packages/cli/src/commands/repo.test.ts
@@ -240,6 +240,36 @@ Handle {{issue.identifier}}.
     );
   });
 
+  it("persists a clean GitHub project id when WORKFLOW.md uses an inline comment", async () => {
+    const repoDir = await createGitRepo();
+    const stdout = captureWrites(process.stdout);
+    const repoCommand = await loadRepoCommand();
+    await writeFile(
+      join(repoDir, "WORKFLOW.md"),
+      VALID_WORKFLOW.replace(
+        "project_id: PVT_project_123",
+        "project_id: PVT_kwHOAPiKdM4BYPVD # Moncher Stack (hojinzs/projects/14)"
+      ),
+      "utf8"
+    );
+
+    try {
+      await repoCommand(
+        ["init", "--repo-dir", repoDir],
+        baseOptions(join(repoDir, "unused"))
+      );
+    } finally {
+      stdout.restore();
+    }
+
+    const projectConfig = await readRepoProjectConfig(repoDir);
+
+    expect(projectConfig.tracker.bindingId).toBe("PVT_kwHOAPiKdM4BYPVD");
+    expect(projectConfig.tracker.settings?.projectId).toBe(
+      "PVT_kwHOAPiKdM4BYPVD"
+    );
+  });
+
   it("initializes a Linear tracker runtime from WORKFLOW.md", async () => {
     const repoDir = await createGitRepo();
     const stdout = captureWrites(process.stdout);

--- a/packages/core/src/workflow-loader.test.ts
+++ b/packages/core/src/workflow-loader.test.ts
@@ -197,6 +197,47 @@ Prompt body.
     });
   });
 
+  it("ignores YAML inline comments on unquoted front matter scalars", () => {
+    const workflow = parseWorkflowMarkdown(`---
+tracker:
+  kind: github-project
+  project_id: PVT_kwHOAPiKdM4BYPVD # Moncher Stack (hojinzs/projects/14)
+  state_field: Status # Project single-select field
+  active_states:
+    - Ready # dispatchable
+    - In progress
+codex:
+  command: codex app-server # local runtime
+---
+Prompt body.
+`);
+
+    expect(workflow.githubProjectId).toBe("PVT_kwHOAPiKdM4BYPVD");
+    expect(workflow.tracker.projectId).toBe("PVT_kwHOAPiKdM4BYPVD");
+    expect(workflow.tracker.stateFieldName).toBe("Status");
+    expect(workflow.tracker.activeStates).toEqual(["Ready", "In progress"]);
+    expect(workflow.codex.command).toBe("codex app-server");
+  });
+
+  it("preserves hash characters inside quoted and plain non-comment scalars", () => {
+    const workflow = parseWorkflowMarkdown(`---
+tracker:
+  kind: github-project
+  project_id: "PVT_kwHOAPiKdM4BYPVD # quoted project marker" # trailing comment
+  state_field: Status#not-a-comment
+codex:
+  command: 'codex # app-server'
+---
+Prompt body.
+`);
+
+    expect(workflow.githubProjectId).toBe(
+      "PVT_kwHOAPiKdM4BYPVD # quoted project marker"
+    );
+    expect(workflow.tracker.stateFieldName).toBe("Status#not-a-comment");
+    expect(workflow.codex.command).toBe("codex # app-server");
+  });
+
   it("unescapes quoted priority field and mapping names", () => {
     const workflow = parseWorkflowMarkdown(`---
 tracker:

--- a/packages/core/src/workflow/parser.ts
+++ b/packages/core/src/workflow/parser.ts
@@ -361,7 +361,7 @@ function parseBlock(
         );
       }
       collectionType = "array";
-      const itemText = trimmed.slice(2).trim();
+      const itemText = stripYamlInlineComment(trimmed.slice(2)).trim();
 
       if (itemText === "|" || itemText === "|-") {
         const [multiline, nextIndex] = parseMultilineScalar(
@@ -403,7 +403,9 @@ function parseBlock(
       throw new Error(`Invalid workflow front matter key "${rawKey}".`);
     }
     const key = parsedKey;
-    const remainder = trimmed.slice(separatorIndex + 1).trim();
+    const remainder = stripYamlInlineComment(
+      trimmed.slice(separatorIndex + 1)
+    ).trim();
     if (remainder === "|" || remainder === "|-") {
       const [multiline, nextIndex] = parseMultilineScalar(
         lines,
@@ -486,6 +488,7 @@ function findMappingSeparator(value: string): number {
 }
 
 function parseScalar(value: string): WorkflowFrontMatterNode {
+  value = stripYamlInlineComment(value).trim();
   if (value === "null") return null;
   if (value === "true") return true;
   if (value === "false") return false;
@@ -508,6 +511,36 @@ function parseScalar(value: string): WorkflowFrontMatterNode {
   if (value.startsWith("'") && value.endsWith("'")) {
     return value.slice(1, -1).replace(/''/g, "'");
   }
+  return value;
+}
+
+function stripYamlInlineComment(value: string): string {
+  let quote: '"' | "'" | null = null;
+
+  for (let index = 0; index < value.length; index += 1) {
+    const char = value[index];
+
+    if (quote) {
+      if (quote === '"' && char === "\\") {
+        index += 1;
+        continue;
+      }
+      if (char === quote) {
+        quote = null;
+      }
+      continue;
+    }
+
+    if (char === '"' || char === "'") {
+      quote = char;
+      continue;
+    }
+
+    if (char === "#" && (index === 0 || /\s/.test(value[index - 1] ?? ""))) {
+      return value.slice(0, index).trimEnd();
+    }
+  }
+
   return value;
 }
 


### PR DESCRIPTION
## TL;DR

- `WORKFLOW.md` frontmatter plain scalars now ignore YAML-style inline comments such as `project_id: PVT_xxx # comment`.
- Quoted `#` characters and non-comment plain scalar hashes such as `Status#literal` are preserved.

## 변경 지점 다이어그램

```text
WORKFLOW.md frontmatter
  -> packages/core/src/workflow/parser.ts
      -> parse scalar with quote-aware inline comment stripping
  -> repo init runtime config
      -> tracker.bindingId/settings.projectId persist clean ProjectV2 id
```

## 여기부터 보세요

- `packages/core/src/workflow/parser.ts`: quote-aware `#` handling for scalar values.
- `packages/core/src/workflow-loader.test.ts`: parser regression for unquoted comments, quoted `#`, and plain non-comment `#`.
- `packages/cli/src/commands/repo.test.ts`: `repo init` persists `PVT_kwHOAPiKdM4BYPVD` without the trailing comment.

## 위험 & 롤백

- Risk: the hand-rolled YAML subset now treats `#` as a comment only when it begins a scalar or follows whitespace outside quotes. Plain values like `Status#literal` remain unchanged.
- Rollback: revert this PR and remove `.changeset/clean-workflow-inline-comments.md`.

## 변경 파일

- `.changeset/clean-workflow-inline-comments.md`
- `packages/core/src/workflow/parser.ts`
- `packages/core/src/workflow-loader.test.ts`
- `packages/cli/src/commands/repo.test.ts`

## Evidence

- `pnpm exec vitest run packages/core/src/workflow-loader.test.ts` — passed, 47 tests.
- `pnpm exec vitest run packages/cli/src/commands/repo.test.ts` — passed after `pnpm build:cli`, 16 tests.
- `pnpm lint && pnpm test && pnpm typecheck && pnpm build` — passed.
- Docker E2E: N/A; this is Configuration Layer parsing with CLI persistence unit coverage, not orchestrator dispatch/worker lifecycle/tracker adapter behavior.
- Spec conformance: aligns with `docs/symphony-spec.md` YAML front matter parsing expectations; no intentional divergence.

## 머지 후/사람 확인

- [ ] Optional local smoke: confirm `gh-symphony repo init` with `tracker.project_id: PVT_xxx # comment` writes a clean id in `.runtime/orchestrator/projects/repository/project.json`.

## Issues — Closed #363

