### PR TITLE
fix(cli): validate linear tracker in doctor

### DIFF
--- a/.changeset/linear-doctor-resolution.md
+++ b/.changeset/linear-doctor-resolution.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Fix `gh-symphony doctor` so Linear tracker runtime configs validate Linear project access instead of resolving the Linear project slug as a GitHub Project node ID.

--- a/packages/cli/src/commands/doctor.test.ts
+++ b/packages/cli/src/commands/doctor.test.ts
@@ -1223,7 +1223,7 @@ describe("runDoctorDiagnostics", () => {
               {
                 id: "project-1",
                 name: "Symphony",
-                slug: "symphony-0c79b11b75ea",
+                slugId: "symphony-0c79b11b75ea",
               },
             ],
           },
@@ -1247,6 +1247,8 @@ describe("runDoctorDiagnostics", () => {
         pathEnv,
       })
     );
+    const [, fetchInit] = fetchImpl.mock.calls[0] ?? [];
+    const requestBody = JSON.parse(String(fetchInit?.body));
 
     expect(report.ok).toBe(true);
     expect(getProjectDetail).not.toHaveBeenCalled();
@@ -1266,6 +1268,10 @@ describe("runDoctorDiagnostics", () => {
           exclude: ["no-agent"],
         },
       }),
+    });
+    expect(requestBody.query).toContain("slugId");
+    expect(requestBody.variables).toEqual({
+      slug: "symphony-0c79b11b75ea",
     });
     expect(fetchImpl).toHaveBeenCalledWith(
       "https://linear.test/graphql",

--- a/packages/cli/src/commands/doctor.test.ts
+++ b/packages/cli/src/commands/doctor.test.ts
@@ -75,6 +75,31 @@ function createProjectConfig(
   };
 }
 
+function createLinearProjectConfig(
+  workspaceDir: string,
+  overrides: Partial<CliProjectConfig["tracker"]> = {}
+): CliProjectConfig {
+  return {
+    projectId: "tenant-a",
+    slug: "tenant-a",
+    workspaceDir,
+    tracker: {
+      adapter: "linear",
+      bindingId: "symphony-0c79b11b75ea",
+      apiUrl: "https://linear.test/graphql",
+      settings: {
+        projectSlug: "symphony-0c79b11b75ea",
+        activeStates: "Todo\nIn Progress",
+        pickupLabels: {
+          include: ["agent", "dev-ready"],
+          exclude: ["no-agent"],
+        },
+      },
+      ...overrides,
+    },
+  };
+}
+
 function createTrackedIssue(
   overrides: Partial<TrackedIssue> = {}
 ): TrackedIssue {
@@ -153,6 +178,7 @@ function authDependencies(
 }
 
 const originalGraphQlToken = process.env.GITHUB_GRAPHQL_TOKEN;
+const originalLinearApiKey = process.env.LINEAR_API_KEY;
 const originalAnthropicApiKey = process.env.ANTHROPIC_API_KEY;
 const originalCredentialBrokerUrl = process.env.AGENT_CREDENTIAL_BROKER_URL;
 const originalCredentialBrokerSecret =
@@ -186,6 +212,19 @@ async function createWorkflowFixture(
     "utf8"
   );
   return { repoDir, pathEnv: binDir };
+}
+
+async function createLinearWorkflowFixture(command = "fake-agent"): Promise<{
+  repoDir: string;
+  pathEnv: string;
+}> {
+  const fixture = await createWorkflowFixture(command);
+  await writeFile(
+    join(fixture.repoDir, "WORKFLOW.md"),
+    `---\ntracker:\n  kind: linear\n  api_key: $LINEAR_API_KEY\n  project_slug: symphony-0c79b11b75ea\n  active_states:\n    - Todo\n    - In Progress\n  pickup_labels:\n    include:\n      - agent\n      - dev-ready\n    exclude:\n      - no-agent\ncodex:\n  command: ${command}\n---\nPrompt body\n`,
+    "utf8"
+  );
+  return fixture;
 }
 
 async function createWindowsWorkflowFixture(command = "agent"): Promise<{
@@ -362,6 +401,11 @@ afterEach(() => {
   } else {
     process.env.GITHUB_GRAPHQL_TOKEN = originalGraphQlToken;
   }
+  if (originalLinearApiKey === undefined) {
+    delete process.env.LINEAR_API_KEY;
+  } else {
+    process.env.LINEAR_API_KEY = originalLinearApiKey;
+  }
   if (originalAnthropicApiKey === undefined) {
     delete process.env.ANTHROPIC_API_KEY;
   } else {
@@ -382,6 +426,7 @@ afterEach(() => {
 
 beforeEach(() => {
   delete process.env.GITHUB_GRAPHQL_TOKEN;
+  delete process.env.LINEAR_API_KEY;
   delete process.env.ANTHROPIC_API_KEY;
 });
 
@@ -1159,6 +1204,115 @@ describe("runDoctorDiagnostics", () => {
       status: "fail",
       summary: expect.stringContaining("is not bound to a GitHub Project"),
       remediation: expect.stringContaining("workflow init"),
+    });
+  });
+
+  it("validates Linear tracker configs without resolving a GitHub Project node", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "doctor-config-"));
+    const workspaceDir = join(configDir, "workspaces");
+    await prepareDoctorPaths(configDir, workspaceDir);
+    const { repoDir, pathEnv } = await createLinearWorkflowFixture();
+    process.env.LINEAR_API_KEY = "lin_test_token";
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        data: {
+          projects: {
+            nodes: [
+              {
+                id: "project-1",
+                name: "Symphony",
+                slug: "symphony-0c79b11b75ea",
+              },
+            ],
+          },
+        },
+      }),
+    }));
+    const getProjectDetail = vi.fn(async () => {
+      throw new Error("GitHub project resolution should be skipped");
+    });
+
+    const report = await withCwd(repoDir, () =>
+      runDoctorDiagnostics(baseOptions(configDir), [], {
+        ...authDependencies(),
+        inspectManagedProjectSelection: async () => ({
+          kind: "resolved",
+          projectId: "tenant-a",
+          projectConfig: createLinearProjectConfig(workspaceDir),
+        }),
+        getProjectDetail: getProjectDetail as never,
+        fetchImpl: fetchImpl as never,
+        pathEnv,
+      })
+    );
+
+    expect(report.ok).toBe(true);
+    expect(getProjectDetail).not.toHaveBeenCalled();
+    expect(
+      report.checks.find((check) => check.id === "github_project_resolution")
+    ).toBeUndefined();
+    expect(
+      report.checks.find((check) => check.id === "linear_tracker_resolution")
+    ).toMatchObject({
+      status: "pass",
+      summary: expect.stringContaining("Resolved Linear project"),
+      details: expect.objectContaining({
+        projectSlug: "symphony-0c79b11b75ea",
+        activeStates: ["Todo", "In Progress"],
+        pickupLabels: {
+          include: ["agent", "dev-ready"],
+          exclude: ["no-agent"],
+        },
+      }),
+    });
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://linear.test/graphql",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          Authorization: "lin_test_token",
+        }),
+      })
+    );
+  });
+
+  it("reports missing LINEAR_API_KEY as a Linear tracker diagnostic", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "doctor-config-"));
+    const workspaceDir = join(configDir, "workspaces");
+    await prepareDoctorPaths(configDir, workspaceDir);
+    const { repoDir, pathEnv } = await createLinearWorkflowFixture();
+    const fetchImpl = vi.fn();
+
+    const report = await withCwd(repoDir, () =>
+      runDoctorDiagnostics(baseOptions(configDir), [], {
+        ...authDependencies(),
+        inspectManagedProjectSelection: async () => ({
+          kind: "resolved",
+          projectId: "tenant-a",
+          projectConfig: createLinearProjectConfig(workspaceDir),
+        }),
+        fetchImpl: fetchImpl as never,
+        pathEnv,
+      })
+    );
+
+    expect(report.ok).toBe(false);
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(
+      report.checks.find((check) => check.id === "github_project_resolution")
+    ).toBeUndefined();
+    expect(
+      report.checks.find((check) => check.id === "linear_tracker_resolution")
+    ).toMatchObject({
+      status: "fail",
+      summary: expect.stringContaining("LINEAR_API_KEY is not set"),
+      remediation: expect.stringContaining("Set LINEAR_API_KEY"),
+      details: expect.objectContaining({
+        reason: "missing_token",
+        projectSlug: "symphony-0c79b11b75ea",
+      }),
     });
   });
 

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -67,6 +67,7 @@ type DoctorCheckId =
   | "gh_scopes"
   | "managed_project"
   | "github_project_resolution"
+  | "linear_tracker_resolution"
   | "config_directory"
   | "runtime_root"
   | "workspace_root"
@@ -88,6 +89,12 @@ type ProjectResolutionReason =
   | "missing_binding"
   | "api_error"
   | "selection_failed";
+
+type LinearResolutionReason =
+  | "missing_project_slug"
+  | "missing_token"
+  | "api_error"
+  | "missing_active_states";
 
 type ResolvedManagedProjectSelection = Extract<
   Awaited<ReturnType<typeof inspectManagedProjectSelection>>,
@@ -682,6 +689,237 @@ function buildGithubTrackerConfig(input: {
         : undefined,
     timeoutMs:
       typeof settings?.timeoutMs === "number" ? settings.timeoutMs : undefined,
+  };
+}
+
+async function checkLinearTrackerResolution(input: {
+  projectConfig: ResolvedManagedProjectSelection;
+  deps: DoctorDependencies;
+}): Promise<DoctorCheckResult> {
+  const tracker = input.projectConfig.projectConfig.tracker;
+  const projectSlug =
+    readStringSetting(tracker.settings, "projectSlug")?.trim() ||
+    tracker.bindingId.trim();
+  const activeStates = readLinearActiveStates(tracker.settings);
+  const pickupLabels = readLinearPickupLabels(tracker.settings);
+
+  if (!projectSlug) {
+    return failCheck(
+      "linear_tracker_resolution",
+      "Linear tracker resolution",
+      "Linear tracker resolution could not run because the project slug is missing.",
+      "Run 'gh-symphony repo init' with WORKFLOW.md field 'tracker.project_slug' configured, then re-run 'gh-symphony doctor'.",
+      {
+        reason: "missing_project_slug" satisfies LinearResolutionReason,
+        adapter: tracker.adapter,
+      }
+    );
+  }
+
+  if (activeStates.length === 0) {
+    return failCheck(
+      "linear_tracker_resolution",
+      "Linear tracker resolution",
+      "Linear tracker resolution could not run because no active states are configured.",
+      "Add at least one active state to WORKFLOW.md under 'tracker.active_states', run 'gh-symphony repo init' again, then re-run 'gh-symphony doctor'.",
+      {
+        reason: "missing_active_states" satisfies LinearResolutionReason,
+        projectSlug,
+      }
+    );
+  }
+
+  const token = process.env.LINEAR_API_KEY?.trim();
+  if (!token) {
+    return failCheck(
+      "linear_tracker_resolution",
+      "Linear tracker resolution",
+      "Linear tracker resolution could not run because LINEAR_API_KEY is not set.",
+      "Set LINEAR_API_KEY in the environment and re-run 'gh-symphony doctor'.",
+      {
+        reason: "missing_token" satisfies LinearResolutionReason,
+        projectSlug,
+        activeStates,
+        pickupLabels,
+      }
+    );
+  }
+
+  try {
+    const project = await fetchLinearProjectBySlug({
+      endpoint: tracker.apiUrl?.trim() || "https://api.linear.app/graphql",
+      projectSlug,
+      token,
+      fetchImpl: input.deps.fetchImpl,
+    });
+
+    if (!project) {
+      return failCheck(
+        "linear_tracker_resolution",
+        "Linear tracker resolution",
+        `Linear project "${projectSlug}" was not found or is not accessible.`,
+        "Confirm LINEAR_API_KEY can read the configured Linear project, then re-run 'gh-symphony doctor'.",
+        {
+          reason: "api_error" satisfies LinearResolutionReason,
+          projectSlug,
+          activeStates,
+          pickupLabels,
+        }
+      );
+    }
+
+    return passCheck(
+      "linear_tracker_resolution",
+      "Linear tracker resolution",
+      `Resolved Linear project "${project.name}" (${project.slug}). ${formatLinearConfigSummary(activeStates, pickupLabels)}`,
+      {
+        projectId: project.id,
+        projectSlug: project.slug,
+        activeStates,
+        pickupLabels,
+      }
+    );
+  } catch (error) {
+    return failCheck(
+      "linear_tracker_resolution",
+      "Linear tracker resolution",
+      `Failed to resolve configured Linear project "${projectSlug}".`,
+      "Confirm LINEAR_API_KEY, tracker endpoint, project slug, and network access, then re-run 'gh-symphony doctor'.",
+      {
+        reason: "api_error" satisfies LinearResolutionReason,
+        projectSlug,
+        activeStates,
+        pickupLabels,
+        error: formatSmokeError(error),
+      }
+    );
+  }
+}
+
+function readStringSetting(
+  settings: ResolvedManagedProjectSelection["projectConfig"]["tracker"]["settings"],
+  key: string
+): string | null {
+  const value = settings?.[key];
+  return typeof value === "string" ? value : null;
+}
+
+function readLinearActiveStates(
+  settings: ResolvedManagedProjectSelection["projectConfig"]["tracker"]["settings"]
+): string[] {
+  const value = settings?.activeStates;
+  if (Array.isArray(value)) {
+    return value.filter(
+      (state): state is string =>
+        typeof state === "string" && state.trim().length > 0
+    );
+  }
+  if (typeof value === "string") {
+    return value
+      .split(/\r?\n/)
+      .map((state) => state.trim())
+      .filter((state) => state.length > 0);
+  }
+  return [];
+}
+
+function readLinearPickupLabels(
+  settings: ResolvedManagedProjectSelection["projectConfig"]["tracker"]["settings"]
+): { include: string[]; exclude: string[] } {
+  const value = settings?.pickupLabels;
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return { include: [], exclude: [] };
+  }
+  return {
+    include: readStringArraySetting(value, "include"),
+    exclude: readStringArraySetting(value, "exclude"),
+  };
+}
+
+function readStringArraySetting(
+  value: Record<string, unknown>,
+  key: string
+): string[] {
+  const field = value[key];
+  return Array.isArray(field)
+    ? field.filter(
+        (item): item is string =>
+          typeof item === "string" && item.trim().length > 0
+      )
+    : [];
+}
+
+function formatLinearConfigSummary(
+  activeStates: string[],
+  pickupLabels: { include: string[]; exclude: string[] }
+): string {
+  const labelSummary =
+    pickupLabels.include.length > 0 || pickupLabels.exclude.length > 0
+      ? `Pickup labels include=[${pickupLabels.include.join(", ") || "none"}], exclude=[${pickupLabels.exclude.join(", ") || "none"}].`
+      : "Pickup label filtering is not configured.";
+  return `Active states: ${activeStates.join(", ")}. ${labelSummary}`;
+}
+
+async function fetchLinearProjectBySlug(input: {
+  endpoint: string;
+  projectSlug: string;
+  token: string;
+  fetchImpl: typeof fetch;
+}): Promise<{ id: string; name: string; slug: string } | null> {
+  const response = await input.fetchImpl(input.endpoint, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: input.token,
+    },
+    body: JSON.stringify({
+      query: `query SymphonyLinearDoctorProject($slug: String!) {
+  projects(filter: { slug: { eq: $slug } }, first: 1) {
+    nodes {
+      id
+      name
+      slug
+    }
+  }
+}`,
+      variables: { slug: input.projectSlug },
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Linear GraphQL request failed with HTTP ${response.status}.`);
+  }
+
+  const payload = (await response.json()) as {
+    data?: {
+      projects?: {
+        nodes?: Array<{ id?: string; name?: string; slug?: string }>;
+      } | null;
+    };
+    errors?: Array<{ message?: string }>;
+  };
+  if (payload.errors?.length) {
+    const message =
+      payload.errors
+        .map((error) => error.message)
+        .filter(Boolean)
+        .join("; ") || "Unknown Linear GraphQL error";
+    throw new Error(`Linear GraphQL request failed: ${message}`);
+  }
+
+  const project = payload.data?.projects?.nodes?.[0];
+  if (
+    !project ||
+    typeof project.id !== "string" ||
+    typeof project.name !== "string" ||
+    typeof project.slug !== "string"
+  ) {
+    return null;
+  }
+  return {
+    id: project.id,
+    name: project.name,
+    slug: project.slug,
   };
 }
 
@@ -1541,7 +1779,17 @@ export async function runDoctorDiagnostics(
     );
   }
 
-  if (resolvedProjectConfig.kind === "resolved" && !auth) {
+  if (
+    resolvedProjectConfig.kind === "resolved" &&
+    resolvedProjectConfig.projectConfig.tracker.adapter === "linear"
+  ) {
+    checks.push(
+      await checkLinearTrackerResolution({
+        projectConfig: resolvedProjectConfig,
+        deps,
+      })
+    );
+  } else if (resolvedProjectConfig.kind === "resolved" && !auth) {
     checks.push(
       failCheck(
         "github_project_resolution",
@@ -2224,6 +2472,7 @@ async function runDoctorFixes(
       case "claude_binary":
       case "anthropic_api_key":
       case "claude_mcp_config":
+      case "linear_tracker_resolution":
         steps.push(
           remediationStep(
             `remediate_${check.id}`,

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -697,9 +697,7 @@ async function checkLinearTrackerResolution(input: {
   deps: DoctorDependencies;
 }): Promise<DoctorCheckResult> {
   const tracker = input.projectConfig.projectConfig.tracker;
-  const projectSlug =
-    readStringSetting(tracker.settings, "projectSlug")?.trim() ||
-    tracker.bindingId.trim();
+  const projectSlug = readStringSetting(tracker.settings, "projectSlug")?.trim();
   const activeStates = readLinearActiveStates(tracker.settings);
   const pickupLabels = readLinearPickupLabels(tracker.settings);
 
@@ -771,10 +769,10 @@ async function checkLinearTrackerResolution(input: {
     return passCheck(
       "linear_tracker_resolution",
       "Linear tracker resolution",
-      `Resolved Linear project "${project.name}" (${project.slug}). ${formatLinearConfigSummary(activeStates, pickupLabels)}`,
+      `Resolved Linear project "${project.name}" (${project.slugId}). ${formatLinearConfigSummary(activeStates, pickupLabels)}`,
       {
         projectId: project.id,
-        projectSlug: project.slug,
+        projectSlug: project.slugId,
         activeStates,
         pickupLabels,
       }
@@ -865,7 +863,7 @@ async function fetchLinearProjectBySlug(input: {
   projectSlug: string;
   token: string;
   fetchImpl: typeof fetch;
-}): Promise<{ id: string; name: string; slug: string } | null> {
+}): Promise<{ id: string; name: string; slugId: string } | null> {
   const response = await input.fetchImpl(input.endpoint, {
     method: "POST",
     headers: {
@@ -874,11 +872,11 @@ async function fetchLinearProjectBySlug(input: {
     },
     body: JSON.stringify({
       query: `query SymphonyLinearDoctorProject($slug: String!) {
-  projects(filter: { slug: { eq: $slug } }, first: 1) {
+  projects(filter: { slugId: { eq: $slug } }, first: 1) {
     nodes {
       id
       name
-      slug
+      slugId
     }
   }
 }`,
@@ -893,7 +891,7 @@ async function fetchLinearProjectBySlug(input: {
   const payload = (await response.json()) as {
     data?: {
       projects?: {
-        nodes?: Array<{ id?: string; name?: string; slug?: string }>;
+        nodes?: Array<{ id?: string; name?: string; slugId?: string }>;
       } | null;
     };
     errors?: Array<{ message?: string }>;
@@ -912,14 +910,14 @@ async function fetchLinearProjectBySlug(input: {
     !project ||
     typeof project.id !== "string" ||
     typeof project.name !== "string" ||
-    typeof project.slug !== "string"
+    typeof project.slugId !== "string"
   ) {
     return null;
   }
   return {
     id: project.id,
     name: project.name,
-    slug: project.slug,
+    slugId: project.slugId,
   };
 }
 
@@ -2472,7 +2470,6 @@ async function runDoctorFixes(
       case "claude_binary":
       case "anthropic_api_key":
       case "claude_mcp_config":
-      case "linear_tracker_resolution":
         steps.push(
           remediationStep(
             `remediate_${check.id}`,
@@ -2480,6 +2477,20 @@ async function runDoctorFixes(
             check.title,
             "manual",
             check.remediation ?? "Fix the Claude runtime readiness check.",
+            undefined,
+            check.details
+          )
+        );
+        break;
+      case "linear_tracker_resolution":
+        steps.push(
+          remediationStep(
+            `remediate_${check.id}`,
+            check.id,
+            check.title,
+            "manual",
+            check.remediation ??
+              "Fix the Linear tracker configuration or credentials.",
             undefined,
             check.details
           )


### PR DESCRIPTION
## TL;DR

Fixes #374 by making `gh-symphony doctor` validate Linear tracker runtime configs through a Linear-specific diagnostic instead of resolving the Linear project slug as a GitHub Project node ID.

## 변경 지점 다이어그램

```text
runtime project config
  -> doctor managed project check
  -> tracker.adapter
     -> github-project: existing GitHub Project node resolution
     -> linear: LINEAR_API_KEY + Linear project slugId GraphQL validation
```

## 여기부터 보세요

- `packages/cli/src/commands/doctor.ts`
  - Adds `linear_tracker_resolution` diagnostics.
  - Gates existing GitHub Project resolution to non-Linear runtime configs.
  - Validates Linear projects using `projects(filter: { slugId: { eq: $slug } })`, matching the runtime Linear adapter and Symphony spec.
  - Reports Linear project slugId, active states, and pickup label settings without exposing the token.
  - Keeps Linear remediation fallback text separate from Claude runtime checks.
- `packages/cli/src/commands/doctor.test.ts`
  - Adds regression coverage proving Linear doctor checks skip GitHub Project resolution.
  - Verifies the outbound Linear GraphQL request uses `slugId` and the configured project slug variable.
  - Adds missing `LINEAR_API_KEY` diagnostic coverage.

## 위험 & 롤백

- Risk: Linear project lookup depends on the Linear `projects(filter: { slugId })` GraphQL shape used by the runtime adapter.
- GitHub Project doctor behavior is intended to be unchanged because the existing branch remains in place for `github-project` trackers.
- Rollback: revert this PR to restore previous doctor resolution behavior.

## 변경 파일

- `packages/cli/src/commands/doctor.ts`
- `packages/cli/src/commands/doctor.test.ts`
- `.changeset/linear-doctor-resolution.md`

## Evidence

- `pnpm --filter @gh-symphony/cli test -- --run src/commands/doctor.test.ts` — passed
- `pnpm --filter @gh-symphony/cli typecheck` — passed
- `pnpm lint` — passed
- `pnpm test` — passed
- `pnpm typecheck` — passed
- `pnpm build` — passed
- Docker E2E: N/A; this is CLI doctor diagnostic routing and does not change orchestrator dispatch, worker lifecycle, tracker adapter runtime behavior, or status API behavior.

## Issues — Closed #374

Closes #374

## 머지 후/사람 확인

- [ ] Review CLI diagnostic wording for Linear tracker configs.
