### PR TITLE
feat(cli): add Linear workflow init path

### DIFF
--- a/.changeset/linear-workflow-init.md
+++ b/.changeset/linear-workflow-init.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Add `gh-symphony workflow init --tracker linear --linear-project-slug <slug>` so Linear-backed repositories can generate `WORKFLOW.md` without GitHub Project selection or GitHub tracker auth.

--- a/packages/cli/src/commands/workflow-init.test.ts
+++ b/packages/cli/src/commands/workflow-init.test.ts
@@ -287,6 +287,64 @@ describe("init command config output", () => {
     createClientSpy.mockRestore();
   });
 
+  it("generates a Linear claude-print workflow without GitHub auth preflight", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "cli-init-linear-claude-"));
+    const binDir = join(configDir, "bin");
+    await mkdir(binDir, { recursive: true });
+    const claude = join(binDir, "claude");
+    await writeFile(
+      claude,
+      '#!/bin/sh\nif [ "$1" = "--version" ]; then echo "claude 1.0.0"; fi\n',
+      "utf8"
+    );
+    await chmod(claude, 0o755);
+    process.env.PATH = binDir;
+    vi.stubEnv("ANTHROPIC_API_KEY", "sk-test");
+    vi.stubEnv("GITHUB_GRAPHQL_TOKEN", "");
+    vi.mocked(p.log.info).mockClear();
+    const stdout = vi
+      .spyOn(process.stdout, "write")
+      .mockReturnValue(true as never);
+    const ghAuthSpy = vi.spyOn(ghAuth, "getGhTokenWithSource");
+    const createClientSpy = vi.spyOn(githubClient, "createClient");
+
+    await initCommand(
+      [
+        "--non-interactive",
+        "--tracker",
+        "linear",
+        "--linear-project-slug",
+        "symphony-0c79b11b75ea",
+        "--runtime",
+        "claude-print",
+        "--dry-run",
+        "--output",
+        join(configDir, "WORKFLOW.md"),
+      ],
+      {
+        configDir,
+        verbose: false,
+        json: true,
+        noColor: true,
+      }
+    );
+
+    expect(process.exitCode).toBeUndefined();
+    expect(stdout.mock.calls.map(([chunk]) => String(chunk)).join("")).toContain(
+      '"projectId":"symphony-0c79b11b75ea"'
+    );
+    expect(p.log.info).toHaveBeenCalledWith(
+      expect.stringContaining("Claude runtime preflight")
+    );
+    expect(ghAuthSpy).not.toHaveBeenCalled();
+    expect(createClientSpy).not.toHaveBeenCalled();
+    stdout.mockRestore();
+    ghAuthSpy.mockRestore();
+    createClientSpy.mockRestore();
+    vi.unstubAllEnvs();
+    process.env.PATH = originalPath;
+  });
+
   it("requires a Linear project slug before GitHub auth lookup", async () => {
     const stderr = vi
       .spyOn(process.stderr, "write")
@@ -303,6 +361,69 @@ describe("init command config output", () => {
     expect(process.exitCode).toBe(1);
     expect(stderr).toHaveBeenCalledWith(
       "Error: --linear-project-slug is required when --tracker linear is used.\n"
+    );
+    expect(ghAuthSpy).not.toHaveBeenCalled();
+    stderr.mockRestore();
+    ghAuthSpy.mockRestore();
+  });
+
+  it("rejects Linear init flags in interactive mode instead of starting GitHub Project setup", async () => {
+    const stderr = vi
+      .spyOn(process.stderr, "write")
+      .mockReturnValue(true as never);
+    const authSpy = vi.spyOn(ghAuth, "resolveGitHubAuth");
+    vi.mocked(p.select).mockClear();
+
+    await initCommand(
+      [
+        "--tracker",
+        "linear",
+        "--linear-project-slug",
+        "symphony-0c79b11b75ea",
+      ],
+      {
+        configDir: await mkdtemp(join(tmpdir(), "cli-init-linear-int-")),
+        verbose: false,
+        json: false,
+        noColor: true,
+      }
+    );
+
+    expect(process.exitCode).toBe(1);
+    expect(stderr).toHaveBeenCalledWith(
+      "Error: Linear workflow init currently requires --non-interactive.\n"
+    );
+    expect(p.select).not.toHaveBeenCalled();
+    expect(authSpy).not.toHaveBeenCalled();
+    stderr.mockRestore();
+    authSpy.mockRestore();
+  });
+
+  it("rejects a Linear project slug with explicit GitHub Project tracker", async () => {
+    const stderr = vi
+      .spyOn(process.stderr, "write")
+      .mockReturnValue(true as never);
+    const ghAuthSpy = vi.spyOn(ghAuth, "getGhTokenWithSource");
+
+    await initCommand(
+      [
+        "--non-interactive",
+        "--tracker",
+        "github-project",
+        "--linear-project-slug",
+        "symphony-0c79b11b75ea",
+      ],
+      {
+        configDir: await mkdtemp(join(tmpdir(), "cli-init-linear-conflict-")),
+        verbose: false,
+        json: false,
+        noColor: true,
+      }
+    );
+
+    expect(process.exitCode).toBe(1);
+    expect(stderr).toHaveBeenCalledWith(
+      "Error: --linear-project-slug is only supported for --tracker linear.\n"
     );
     expect(ghAuthSpy).not.toHaveBeenCalled();
     stderr.mockRestore();
@@ -329,6 +450,7 @@ describe("init command config output", () => {
     expect(plan.workflowMd).toContain(
       "  project_slug: symphony-0c79b11b75ea\n"
     );
+    expect(plan.workflowMd).not.toContain("  pickup_labels:");
     expect(plan.workflowMd).not.toContain("  project_id:");
   });
 

--- a/packages/cli/src/commands/workflow-init.test.ts
+++ b/packages/cli/src/commands/workflow-init.test.ts
@@ -51,6 +51,7 @@ import initCommand from "./workflow-init.js";
 import {
   buildDryRunJsonResult,
   generateProjectId,
+  planLinearWorkflowArtifacts,
   planWorkflowArtifacts,
   planEcosystem,
   promptLegacyGhSymphonyCleanup,
@@ -231,6 +232,104 @@ describe("init command config output", () => {
     expect(stderr).toHaveBeenCalledWith(
       "Error: Unsupported runtime 'claud-print'. Choose one of: codex-app-server, claude-print.\n"
     );
+  });
+
+  it("generates a Linear workflow in non-interactive dry-run without GitHub auth", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "cli-init-linear-"));
+    const stdout = vi
+      .spyOn(process.stdout, "write")
+      .mockReturnValue(true as never);
+    const ghAuthSpy = vi.spyOn(ghAuth, "getGhTokenWithSource");
+    const createClientSpy = vi.spyOn(githubClient, "createClient");
+
+    await initCommand(
+      [
+        "--non-interactive",
+        "--tracker",
+        "linear",
+        "--linear-project-slug",
+        "symphony-0c79b11b75ea",
+        "--runtime",
+        "codex-app-server",
+        "--dry-run",
+        "--output",
+        join(configDir, "WORKFLOW.md"),
+      ],
+      {
+        configDir,
+        verbose: false,
+        json: true,
+        noColor: true,
+      }
+    );
+
+    const payload = JSON.parse(
+      stdout.mock.calls.map(([chunk]) => String(chunk)).join("")
+    ) as {
+      projectId: string;
+      githubProjectTitle: string;
+      files: Array<{ label: string }>;
+    };
+    const workflowFile = payload.files.find(
+      (file) => file.label === "WORKFLOW.md"
+    );
+
+    expect(process.exitCode).toBeUndefined();
+    expect(ghAuthSpy).not.toHaveBeenCalled();
+    expect(createClientSpy).not.toHaveBeenCalled();
+    expect(payload.projectId).toBe("symphony-0c79b11b75ea");
+    expect(payload.githubProjectTitle).toBe(
+      "Linear project symphony-0c79b11b75ea"
+    );
+    expect(workflowFile).toBeDefined();
+    stdout.mockRestore();
+    ghAuthSpy.mockRestore();
+    createClientSpy.mockRestore();
+  });
+
+  it("requires a Linear project slug before GitHub auth lookup", async () => {
+    const stderr = vi
+      .spyOn(process.stderr, "write")
+      .mockReturnValue(true as never);
+    const ghAuthSpy = vi.spyOn(ghAuth, "getGhTokenWithSource");
+
+    await initCommand(["--non-interactive", "--tracker", "linear"], {
+      configDir: await mkdtemp(join(tmpdir(), "cli-init-linear-missing-")),
+      verbose: false,
+      json: false,
+      noColor: true,
+    });
+
+    expect(process.exitCode).toBe(1);
+    expect(stderr).toHaveBeenCalledWith(
+      "Error: --linear-project-slug is required when --tracker linear is used.\n"
+    );
+    expect(ghAuthSpy).not.toHaveBeenCalled();
+    stderr.mockRestore();
+    ghAuthSpy.mockRestore();
+  });
+
+  it("renders Linear tracker front matter from the Linear artifact planner", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "cli-init-linear-plan-"));
+
+    const plan = await planLinearWorkflowArtifacts({
+      cwd,
+      outputPath: join(cwd, "WORKFLOW.md"),
+      projectSlug: "symphony-0c79b11b75ea",
+      runtime: "codex-app-server",
+      skipSkills: true,
+      skipContext: false,
+    });
+
+    expect(plan.workflowMd).toContain("tracker:\n  kind: linear\n");
+    expect(plan.workflowMd).toContain(
+      "  endpoint: https://api.linear.app/graphql\n"
+    );
+    expect(plan.workflowMd).toContain("  api_key: $LINEAR_API_KEY\n");
+    expect(plan.workflowMd).toContain(
+      "  project_slug: symphony-0c79b11b75ea\n"
+    );
+    expect(plan.workflowMd).not.toContain("  project_id:");
   });
 
   it("writes the simplified project config", async () => {

--- a/packages/cli/src/commands/workflow-init.ts
+++ b/packages/cli/src/commands/workflow-init.ts
@@ -214,7 +214,10 @@ export function warnDeprecatedSkipContext(): void {
   p.log.warn(SKIP_CONTEXT_DEPRECATION);
 }
 
-async function runInitRuntimePreflight(runtime: string): Promise<boolean> {
+async function runInitRuntimePreflight(
+  runtime: string,
+  opts: { includeGhAuth?: boolean } = {}
+): Promise<boolean> {
   if (!isClaudeRuntime(runtime)) {
     return true;
   }
@@ -229,7 +232,7 @@ async function runInitRuntimePreflight(runtime: string): Promise<boolean> {
       resolveClaudeCommandBinary(resolveRuntimeCommand(runtime)) ??
       resolveRuntimeCommand(runtime),
     authMode: "local-or-api-key",
-    includeGhAuth: !hasGitHubGraphqlToken,
+    includeGhAuth: opts.includeGhAuth ?? !hasGitHubGraphqlToken,
   });
   const message = formatClaudePreflightText(report);
   if (report.ok) {
@@ -254,6 +257,26 @@ const handler = async (
 
   if (flags.nonInteractive) {
     await runNonInteractive(flags, options);
+    return;
+  }
+
+  const trackerKind = resolveInitTrackerKind(flags);
+  if (trackerKind instanceof Error) {
+    process.stderr.write(`Error: ${trackerKind.message}\n`);
+    process.exitCode = 1;
+    return;
+  }
+  const trackerFlagError = validateInitTrackerFlags(flags, trackerKind);
+  if (trackerFlagError) {
+    process.stderr.write(`Error: ${trackerFlagError}\n`);
+    process.exitCode = 1;
+    return;
+  }
+  if (trackerKind === "linear") {
+    process.stderr.write(
+      "Error: Linear workflow init currently requires --non-interactive.\n"
+    );
+    process.exitCode = 1;
     return;
   }
 
@@ -1502,14 +1525,25 @@ async function runNonInteractive(
     process.exitCode = 1;
     return;
   }
-  if (!(await runInitRuntimePreflight(runtime))) {
-    process.exitCode = 1;
-    return;
-  }
 
   const trackerKind = resolveInitTrackerKind(flags);
   if (trackerKind instanceof Error) {
     process.stderr.write(`Error: ${trackerKind.message}\n`);
+    process.exitCode = 1;
+    return;
+  }
+  const trackerFlagError = validateInitTrackerFlags(flags, trackerKind);
+  if (trackerFlagError) {
+    process.stderr.write(`Error: ${trackerFlagError}\n`);
+    process.exitCode = 1;
+    return;
+  }
+
+  if (
+    !(await runInitRuntimePreflight(runtime, {
+      includeGhAuth: trackerKind === "linear" ? false : undefined,
+    }))
+  ) {
     process.exitCode = 1;
     return;
   }
@@ -1675,8 +1709,17 @@ function resolveInitTrackerKind(
     return flags.linearProjectSlug ? "linear" : "github-project";
   }
 
-  if (rawTracker === "github-project" || rawTracker === "linear") {
-    return rawTracker;
+  if (rawTracker === "github-project") {
+    if (flags.linearProjectSlug?.trim()) {
+      return new Error(
+        "--linear-project-slug is only supported for --tracker linear."
+      );
+    }
+    return "github-project";
+  }
+
+  if (rawTracker === "linear") {
+    return "linear";
   }
 
   return new Error(
@@ -1684,27 +1727,28 @@ function resolveInitTrackerKind(
   );
 }
 
+function validateInitTrackerFlags(
+  flags: InitFlags,
+  trackerKind: "github-project" | "linear"
+): string | null {
+  if (trackerKind === "linear") {
+    if (!flags.linearProjectSlug?.trim()) {
+      return "--linear-project-slug is required when --tracker linear is used.";
+    }
+    if (flags.project) {
+      return "--project is only supported for --tracker github-project.";
+    }
+  }
+
+  return null;
+}
+
 async function runLinearNonInteractive(
   flags: InitFlags,
   options: GlobalOptions,
   runtime: string
 ): Promise<void> {
-  const projectSlug = flags.linearProjectSlug?.trim();
-  if (!projectSlug) {
-    process.stderr.write(
-      "Error: --linear-project-slug is required when --tracker linear is used.\n"
-    );
-    process.exitCode = 1;
-    return;
-  }
-
-  if (flags.project) {
-    process.stderr.write(
-      "Error: --project is only supported for --tracker github-project.\n"
-    );
-    process.exitCode = 1;
-    return;
-  }
+  const projectSlug = flags.linearProjectSlug!.trim();
 
   const outputPath = resolve(flags.output ?? "WORKFLOW.md");
   const { workflowPlan, ecosystemPlan } = await planLinearWorkflowArtifacts({

--- a/packages/cli/src/commands/workflow-init.ts
+++ b/packages/cli/src/commands/workflow-init.ts
@@ -137,6 +137,8 @@ type InitFlags = {
   dryRun: boolean;
   nonInteractive: boolean;
   project?: string;
+  tracker?: string;
+  linearProjectSlug?: string;
   output?: string;
   runtime?: string;
   skipSkills: boolean;
@@ -178,6 +180,14 @@ function parseInitFlags(args: string[]): InitFlags {
         break;
       case "--project":
         flags.project = next;
+        i += 1;
+        break;
+      case "--tracker":
+        flags.tracker = next;
+        i += 1;
+        break;
+      case "--linear-project-slug":
+        flags.linearProjectSlug = next;
         i += 1;
         break;
       case "--output":
@@ -416,6 +426,16 @@ export type WorkflowArtifactsOptions = {
   includePriorityTemplates?: boolean;
   mappings: Record<string, StateMapping>;
   lifecycle?: WorkflowLifecycleConfig;
+  runtime: string;
+  skipSkills: boolean;
+  skipContext: boolean;
+  environment?: DetectedEnvironment;
+};
+
+type LinearWorkflowArtifactsOptions = {
+  cwd: string;
+  outputPath: string;
+  projectSlug: string;
   runtime: string;
   skipSkills: boolean;
   skipContext: boolean;
@@ -976,6 +996,155 @@ export async function planWorkflowArtifacts(
   };
 }
 
+const LINEAR_DEFAULT_STATUS_FIELD: ProjectStatusField = {
+  id: "linear-state",
+  name: "State",
+  options: [
+    {
+      id: "linear-todo",
+      name: "Todo",
+      description: null,
+      color: null,
+    },
+    {
+      id: "linear-in-progress",
+      name: "In Progress",
+      description: null,
+      color: null,
+    },
+    {
+      id: "linear-rework",
+      name: "Rework",
+      description: null,
+      color: null,
+    },
+    {
+      id: "linear-human-review",
+      name: "Human Review",
+      description: null,
+      color: null,
+    },
+    {
+      id: "linear-done",
+      name: "Done",
+      description: null,
+      color: null,
+    },
+    {
+      id: "linear-canceled",
+      name: "Canceled",
+      description: null,
+      color: null,
+    },
+    {
+      id: "linear-cancelled",
+      name: "Cancelled",
+      description: null,
+      color: null,
+    },
+    {
+      id: "linear-duplicate",
+      name: "Duplicate",
+      description: null,
+      color: null,
+    },
+  ],
+};
+
+const LINEAR_DEFAULT_MAPPINGS: Record<string, StateMapping> = {
+  Todo: { role: "active" },
+  "In Progress": { role: "active" },
+  Rework: { role: "active" },
+  "Human Review": { role: "wait" },
+  Done: { role: "terminal" },
+  Canceled: { role: "terminal" },
+  Cancelled: { role: "terminal" },
+  Duplicate: { role: "terminal" },
+};
+
+function buildLinearProjectDetail(projectSlug: string): ProjectDetail {
+  return {
+    id: projectSlug,
+    title: `Linear project ${projectSlug}`,
+    url: "",
+    statusFields: [LINEAR_DEFAULT_STATUS_FIELD],
+    textFields: [],
+    linkedRepositories: [],
+  };
+}
+
+function buildLinearWorkflowLifecycle(): WorkflowLifecycleConfig {
+  return toWorkflowLifecycleConfig("State", LINEAR_DEFAULT_MAPPINGS, {
+    blockerCheckStates: [],
+    planningStates: [],
+  });
+}
+
+export async function planLinearWorkflowArtifacts(
+  opts: LinearWorkflowArtifactsOptions
+): Promise<WorkflowArtifactsPlan> {
+  const environment = opts.environment ?? (await detectEnvironment(opts.cwd));
+  const projectDetail = buildLinearProjectDetail(opts.projectSlug);
+  const lifecycle = buildLinearWorkflowLifecycle();
+  const workflowMd = generateWorkflowMarkdown({
+    projectId: opts.projectSlug,
+    tracker: {
+      kind: "linear",
+      projectSlug: opts.projectSlug,
+    },
+    stateFieldName: LINEAR_DEFAULT_STATUS_FIELD.name,
+    priority: null,
+    mappings: LINEAR_DEFAULT_MAPPINGS,
+    lifecycle,
+    runtime: opts.runtime,
+    detectedEnvironment: environment,
+  });
+
+  const workflowPlan = await planFileChange({
+    path: opts.outputPath,
+    label: "WORKFLOW.md",
+    content: workflowMd,
+    mode: "overwrite",
+  });
+  const ecosystemPlan = await planEcosystem({
+    cwd: opts.cwd,
+    projectDetail,
+    statusField: LINEAR_DEFAULT_STATUS_FIELD,
+    priorityField: null,
+    priority: buildDisabledPriority(),
+    lifecycle,
+    includePriorityTemplates: false,
+    runtime: opts.runtime,
+    skipSkills: opts.skipSkills,
+    skipContext: opts.skipContext,
+    environment,
+  });
+
+  return {
+    outputPath: opts.outputPath,
+    workflowMd,
+    workflowPlan,
+    ecosystemPlan,
+  };
+}
+
+async function writeLinearEcosystem(
+  opts: Omit<LinearWorkflowArtifactsOptions, "outputPath" | "environment">
+): Promise<EcosystemResult> {
+  return writeEcosystem({
+    cwd: opts.cwd,
+    projectDetail: buildLinearProjectDetail(opts.projectSlug),
+    statusField: LINEAR_DEFAULT_STATUS_FIELD,
+    priorityField: null,
+    priority: buildDisabledPriority(),
+    lifecycle: buildLinearWorkflowLifecycle(),
+    includePriorityTemplates: false,
+    runtime: opts.runtime,
+    skipSkills: opts.skipSkills,
+    skipContext: opts.skipContext,
+  });
+}
+
 export async function writeWorkflowPlan(
   workflowPlan: PlannedFileChange
 ): Promise<boolean> {
@@ -1338,6 +1507,18 @@ async function runNonInteractive(
     return;
   }
 
+  const trackerKind = resolveInitTrackerKind(flags);
+  if (trackerKind instanceof Error) {
+    process.stderr.write(`Error: ${trackerKind.message}\n`);
+    process.exitCode = 1;
+    return;
+  }
+
+  if (trackerKind === "linear") {
+    await runLinearNonInteractive(flags, options, runtime);
+    return;
+  }
+
   let token: string;
   try {
     token = getGhTokenWithSource().token;
@@ -1469,6 +1650,90 @@ async function runNonInteractive(
     priority,
     includePriorityTemplates: !autoPriorityField,
     lifecycle,
+    runtime,
+    skipSkills: flags.skipSkills,
+    skipContext: flags.skipContext,
+  });
+
+  if (options.json) {
+    process.stdout.write(
+      JSON.stringify({ output: outputPath, status: workflowPlan.status }) + "\n"
+    );
+  } else {
+    printEcosystemSummary(ecosystemResult, outputPath, {
+      interactive: false,
+      nextSteps: "Run 'gh-symphony repo init' from the target repository.",
+    });
+  }
+}
+
+function resolveInitTrackerKind(
+  flags: InitFlags
+): "github-project" | "linear" | Error {
+  const rawTracker = flags.tracker?.trim();
+  if (!rawTracker) {
+    return flags.linearProjectSlug ? "linear" : "github-project";
+  }
+
+  if (rawTracker === "github-project" || rawTracker === "linear") {
+    return rawTracker;
+  }
+
+  return new Error(
+    `Unsupported tracker '${rawTracker}'. Choose one of: github-project, linear.`
+  );
+}
+
+async function runLinearNonInteractive(
+  flags: InitFlags,
+  options: GlobalOptions,
+  runtime: string
+): Promise<void> {
+  const projectSlug = flags.linearProjectSlug?.trim();
+  if (!projectSlug) {
+    process.stderr.write(
+      "Error: --linear-project-slug is required when --tracker linear is used.\n"
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  if (flags.project) {
+    process.stderr.write(
+      "Error: --project is only supported for --tracker github-project.\n"
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const outputPath = resolve(flags.output ?? "WORKFLOW.md");
+  const { workflowPlan, ecosystemPlan } = await planLinearWorkflowArtifacts({
+    cwd: process.cwd(),
+    outputPath,
+    projectSlug,
+    runtime,
+    skipSkills: flags.skipSkills,
+    skipContext: flags.skipContext,
+  });
+
+  if (flags.dryRun) {
+    if (options.json) {
+      process.stdout.write(
+        JSON.stringify(
+          buildDryRunJsonResult(outputPath, workflowPlan, ecosystemPlan)
+        ) + "\n"
+      );
+      return;
+    }
+    printDryRunPreview(outputPath, workflowPlan, ecosystemPlan);
+    return;
+  }
+
+  await writeWorkflowPlan(workflowPlan);
+
+  const ecosystemResult = await writeLinearEcosystem({
+    cwd: process.cwd(),
+    projectSlug,
     runtime,
     skipSkills: flags.skipSkills,
     skipContext: flags.skipContext,

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -313,7 +313,7 @@ Commands:
   preview    Render the final worker prompt from a sample or live issue
 
 Options:
-  workflow init [--non-interactive] [--project <id>] [--output <path>] [--skip-skills] [--skip-context (deprecated no-op)] [--dry-run]
+  workflow init [--non-interactive] [--tracker <github-project|linear>] [--project <id>] [--linear-project-slug <slug>] [--output <path>] [--skip-skills] [--skip-context (deprecated no-op)] [--dry-run]
   workflow validate [--file <path>]
   workflow preview [issue] [--file <path>] [--issue <owner/repo#number|ENG-123>] [--project-id <projectId>] [--sample <json>] [--attempt <n>]
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -47,6 +47,7 @@ type CliOptionValues = Partial<
     issue?: string;
     level?: string;
     logLevel?: string;
+    linearProjectSlug?: string;
     nonInteractive?: boolean;
     once?: boolean;
     output?: string;
@@ -67,6 +68,7 @@ type CliOptionValues = Partial<
     smoke?: boolean;
     bundle?: string | boolean;
     attempt?: string;
+    tracker?: string;
   }
 >;
 
@@ -241,7 +243,9 @@ function createProgram(): { program: Command; wasInvoked: () => boolean } {
       .command("init")
       .description("Generate WORKFLOW.md and workflow support files")
       .option("--non-interactive", "Run without prompts")
+      .option("--tracker <kind>", "Tracker kind: github-project or linear")
       .option("--project <id>", "GitHub Project ID or URL")
+      .option("--linear-project-slug <slug>", "Linear project slug")
       .option("--output <path>", "Write WORKFLOW.md to a custom path")
       .option(
         "--runtime <kind>",
@@ -256,7 +260,9 @@ function createProgram(): { program: Command; wasInvoked: () => boolean } {
     const values = this.optsWithGlobals<CliOptionValues>();
     const args: string[] = ["init"];
     pushOption(args, "--non-interactive", values.nonInteractive);
+    pushOption(args, "--tracker", values.tracker);
     pushOption(args, "--project", values.project);
+    pushOption(args, "--linear-project-slug", values.linearProjectSlug);
     pushOption(args, "--output", values.output);
     pushOption(args, "--runtime", values.runtime);
     pushOption(args, "--skip-skills", values.skipSkills);

--- a/packages/cli/src/workflow/generate-workflow-md.ts
+++ b/packages/cli/src/workflow/generate-workflow-md.ts
@@ -14,6 +14,18 @@ import {
 
 export type GenerateWorkflowInput = {
   projectId: string;
+  tracker?:
+    | { kind: "github-project" }
+    | {
+        kind: "linear";
+        endpoint?: string;
+        apiKey?: string;
+        projectSlug: string;
+        pickupLabels?: {
+          include?: string[];
+          exclude?: string[];
+        };
+      };
   stateFieldName: string;
   priority: WorkflowPriorityConfig | null;
   includePriorityTemplates?: boolean;
@@ -42,10 +54,19 @@ function buildFrontMatter(input: GenerateWorkflowInput): string {
   const lines: string[] = [];
 
   lines.push("tracker:");
-  lines.push("  kind: github-project");
-  lines.push(`  project_id: ${input.projectId}`);
-  lines.push(`  state_field: ${input.stateFieldName}`);
-  lines.push(...buildPriorityFrontMatter(input));
+  if (input.tracker?.kind === "linear") {
+    lines.push("  kind: linear");
+    lines.push(
+      `  endpoint: ${input.tracker.endpoint ?? "https://api.linear.app/graphql"}`
+    );
+    lines.push(`  api_key: ${input.tracker.apiKey ?? "$LINEAR_API_KEY"}`);
+    lines.push(`  project_slug: ${input.tracker.projectSlug}`);
+  } else {
+    lines.push("  kind: github-project");
+    lines.push(`  project_id: ${input.projectId}`);
+    lines.push(`  state_field: ${input.stateFieldName}`);
+    lines.push(...buildPriorityFrontMatter(input));
+  }
 
   if (input.lifecycle.activeStates.length > 0) {
     lines.push("  active_states:");
@@ -58,6 +79,32 @@ function buildFrontMatter(input: GenerateWorkflowInput): string {
     lines.push("  terminal_states:");
     for (const state of input.lifecycle.terminalStates) {
       lines.push(`    - ${state}`);
+    }
+  }
+
+  if (input.tracker?.kind === "linear") {
+    const include = input.tracker.pickupLabels?.include ?? [
+      "agent",
+      "dev-ready",
+    ];
+    const exclude = input.tracker.pickupLabels?.exclude ?? [
+      "no-agent",
+      "needs-spec",
+    ];
+    if (include.length > 0 || exclude.length > 0) {
+      lines.push("  pickup_labels:");
+      if (include.length > 0) {
+        lines.push("    include:");
+        for (const label of include) {
+          lines.push(`      - ${label}`);
+        }
+      }
+      if (exclude.length > 0) {
+        lines.push("    exclude:");
+        for (const label of exclude) {
+          lines.push(`      - ${label}`);
+        }
+      }
     }
   }
 

--- a/packages/cli/src/workflow/generate-workflow-md.ts
+++ b/packages/cli/src/workflow/generate-workflow-md.ts
@@ -83,14 +83,8 @@ function buildFrontMatter(input: GenerateWorkflowInput): string {
   }
 
   if (input.tracker?.kind === "linear") {
-    const include = input.tracker.pickupLabels?.include ?? [
-      "agent",
-      "dev-ready",
-    ];
-    const exclude = input.tracker.pickupLabels?.exclude ?? [
-      "no-agent",
-      "needs-spec",
-    ];
+    const include = input.tracker.pickupLabels?.include ?? [];
+    const exclude = input.tracker.pickupLabels?.exclude ?? [];
     if (include.length > 0 || exclude.length > 0) {
       lines.push("  pickup_labels:");
       if (include.length > 0) {


### PR DESCRIPTION
## TL;DR

Add a first-class Linear path for `gh-symphony workflow init`:

```bash
gh-symphony workflow init --non-interactive --tracker linear --linear-project-slug <slug> --runtime codex-app-server
```

This generates Linear tracker front matter without GitHub Project discovery or GitHub auth. Rework also rejects unsupported interactive Linear init explicitly, keeps Linear `claude-print` preflight independent from GitHub auth, and avoids label-gating freshly generated Linear workflows by default.

## 변경 지점 다이어그램

```text
workflow init
  ├─ --tracker github-project/default → existing GitHub Project auth + selection
  └─ --tracker linear + --linear-project-slug → Linear WORKFLOW.md planner
       ├─ validates Linear/GitHub flag combinations before auth/preflight
       ├─ skips GitHub auth in Linear Claude runtime preflight
       ├─ tracker.kind: linear
       ├─ endpoint/api_key/project_slug front matter
       └─ default Linear lifecycle states
```

## 여기부터 보세요

- `packages/cli/src/commands/workflow-init.ts` — parses `--tracker` / `--linear-project-slug`, validates tracker-specific flags before GitHub-dependent paths, routes Linear non-interactive init before GitHub auth, and rejects interactive Linear init with a clear error.
- `packages/cli/src/workflow/generate-workflow-md.ts` — renders Linear tracker front matter while preserving the GitHub Project default; Linear `pickup_labels` are omitted unless explicitly provided.
- `packages/cli/src/commands/workflow-init.test.ts` — verifies Linear dry-run avoids GitHub auth, Linear `claude-print` avoids GitHub auth preflight, interactive Linear flags fail clearly, conflicting tracker flags fail before auth, and generated Linear front matter is not label-gated by default.

## 위험 & 롤백

- Risk: generated Linear lifecycle defaults may still need user customization for teams with different Linear state names.
- Rollback: revert this PR; the existing GitHub Project init path remains unchanged and Linear users can continue manual `WORKFLOW.md` authoring.

## 변경 파일

- `.changeset/linear-workflow-init.md`
- `packages/cli/src/commands/workflow-init.ts`
- `packages/cli/src/commands/workflow-init.test.ts`
- `packages/cli/src/workflow/generate-workflow-md.ts`
- `packages/cli/src/index.ts`
- `packages/cli/src/commands/workflow.ts`

## Evidence

- `pnpm --filter @gh-symphony/cli test -- workflow-init.test.ts` — pass
- `pnpm lint` — pass
- `pnpm test` — pass
- `pnpm typecheck` — pass
- `pnpm build` — pass
- Docker E2E: N/A, CLI workflow generation/config path only; no orchestrator dispatch, worker lifecycle, or tracker adapter runtime behavior changed.

## 머지 후/사람 확인

- [ ] Confirm the generated Linear `WORKFLOW.md` lifecycle states match the intended Linear project workflow for a real repository.

## Issues — Closed #375

Closes #375
