### PR TITLE
fix(runtime-codex): use local Codex home by default

### DIFF
--- a/.changeset/local-codex-home.md
+++ b/.changeset/local-codex-home.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Stop forcing Codex app-server workers for #378 into a staged `.codex-agent` home by default, so local runs consistently use the caller's normal Codex home unless `CODEX_HOME` is explicitly provided.

--- a/packages/runtime-codex/src/launcher.test.ts
+++ b/packages/runtime-codex/src/launcher.test.ts
@@ -39,6 +39,22 @@ describe("resolveLocalRuntimeLaunchConfig", () => {
     expect(config.projectId).toBe("workspace-fallback");
   });
 
+  it("preserves CODEX_HOME provided through the launcher environment", () => {
+    const config = resolveLocalRuntimeLaunchConfig({
+      PROJECT_ID: "workspace-local",
+      WORKING_DIRECTORY: "/tmp/workspace-local",
+      CODEX_HOME: "/tmp/launcher-codex-home",
+      OPENAI_API_KEY: "sk-direct-runtime",
+    });
+
+    expect(config.extraEnv).toEqual({
+      CODEX_HOME: "/tmp/launcher-codex-home",
+    });
+    expect(config.agentEnv).toEqual({
+      OPENAI_API_KEY: "sk-direct-runtime",
+    });
+  });
+
   it("fails when the working directory is missing", () => {
     expect(() =>
       resolveLocalRuntimeLaunchConfig({

--- a/packages/runtime-codex/src/launcher.ts
+++ b/packages/runtime-codex/src/launcher.ts
@@ -33,6 +33,7 @@ export function resolveLocalRuntimeLaunchConfig(
     githubTokenBrokerSecret: env.GITHUB_TOKEN_BROKER_SECRET,
     githubTokenCachePath: env.GITHUB_TOKEN_CACHE_PATH,
     agentEnv: readDirectAgentEnvironment(env),
+    extraEnv: env.CODEX_HOME ? { CODEX_HOME: env.CODEX_HOME } : undefined,
     agentCredentialBrokerUrl: env.AGENT_CREDENTIAL_BROKER_URL,
     agentCredentialBrokerSecret: env.AGENT_CREDENTIAL_BROKER_SECRET,
     agentCredentialCachePath: env.AGENT_CREDENTIAL_CACHE_PATH,

--- a/packages/runtime-codex/src/runtime.test.ts
+++ b/packages/runtime-codex/src/runtime.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   AgentRuntimeResolutionError,
   CODEX_PROTOCOL_EVENT_NAMES,
@@ -13,8 +13,21 @@ import {
   resolvePreparedAgentEnvironment,
   resolveAgentRuntimeEnvironment,
   launchCodexAppServer,
-  resolveStagedCodexHome,
 } from "./runtime.js";
+
+const originalCodexHome = process.env.CODEX_HOME;
+
+beforeEach(() => {
+  delete process.env.CODEX_HOME;
+});
+
+afterEach(() => {
+  if (originalCodexHome === undefined) {
+    delete process.env.CODEX_HOME;
+  } else {
+    process.env.CODEX_HOME = originalCodexHome;
+  }
+});
 
 describe("createGitHubGraphQLToolDefinition", () => {
   it("builds a runtime tool definition for brokered GitHub GraphQL access", () => {
@@ -84,7 +97,36 @@ describe("buildCodexRuntimePlan", () => {
     expect(plan.env.GIT_CONFIG_VALUE_0).toContain("git-credential-helper.js");
     expect(plan.env.WORKER_PROFILE).toBe("test");
     expect(plan.env.OPENAI_API_KEY).toBe("sk-ready-runtime");
-    expect(plan.env.CODEX_HOME).toBe("/tmp/workspace-123/.codex-agent");
+    expect(plan.env.CODEX_HOME).toBeUndefined();
+  });
+
+  it("preserves CODEX_HOME when explicitly provided by the environment", () => {
+    const plan = buildCodexRuntimePlan({
+      projectId: "workspace-123",
+      workingDirectory: "/tmp/workspace-123",
+      agentEnv: {
+        OPENAI_API_KEY: "sk-ready-runtime",
+      },
+      extraEnv: {
+        CODEX_HOME: "/tmp/local-codex-home",
+      },
+    });
+
+    expect(plan.env.CODEX_HOME).toBe("/tmp/local-codex-home");
+  });
+
+  it("preserves CODEX_HOME when explicitly provided by process env", () => {
+    process.env.CODEX_HOME = "/tmp/process-codex-home";
+
+    const plan = buildCodexRuntimePlan({
+      projectId: "workspace-123",
+      workingDirectory: "/tmp/workspace-123",
+      agentEnv: {
+        OPENAI_API_KEY: "sk-ready-runtime",
+      },
+    });
+
+    expect(plan.env.CODEX_HOME).toBe("/tmp/process-codex-home");
   });
 
   it("exposes linear_graphql only when enabled for Linear tracker sessions", () => {
@@ -156,7 +198,7 @@ describe("buildCodexRuntimePlan", () => {
 });
 
 describe("resolvePreparedAgentEnvironment", () => {
-  it("filters direct agent env keys and stages CODEX_HOME", () => {
+  it("filters direct agent env keys without staging CODEX_HOME", () => {
     expect(
       resolvePreparedAgentEnvironment("/tmp/workspace-123", {
         OPENAI_API_KEY: "sk-openai",
@@ -166,7 +208,6 @@ describe("resolvePreparedAgentEnvironment", () => {
     ).toEqual({
       OPENAI_API_KEY: "sk-openai",
       OPENAI_BASE_URL: "https://example.test/v1",
-      CODEX_HOME: "/tmp/workspace-123/.codex-agent",
     });
   });
 });
@@ -252,7 +293,6 @@ describe("resolveAgentRuntimeEnvironment", () => {
 
     expect(env).toEqual({
       OPENAI_API_KEY: "sk-brokered-agent",
-      CODEX_HOME: "/tmp/workspace-123/.codex-agent",
     });
     expect(writeFileImpl).toHaveBeenCalledWith(
       "/workspace-runtime/.agent-runtime-auth.json",
@@ -298,7 +338,6 @@ describe("resolveAgentRuntimeEnvironment", () => {
     expect(env).toEqual({
       OPENAI_API_KEY: "sk-cached-agent",
       OPENAI_BASE_URL: "https://openai.example.test/v1",
-      CODEX_HOME: "/tmp/workspace-123/.codex-agent",
     });
     expect(fetchImpl).not.toHaveBeenCalled();
   });
@@ -342,7 +381,6 @@ describe("resolveAgentRuntimeEnvironment", () => {
 
     expect(env).toEqual({
       OPENAI_API_KEY: "sk-refreshed-agent",
-      CODEX_HOME: "/tmp/workspace-123/.codex-agent",
     });
     expect(writeFileImpl).toHaveBeenCalledOnce();
   });
@@ -373,7 +411,6 @@ describe("resolveAgentRuntimeEnvironment", () => {
 
     expect(env).toEqual({
       OPENAI_API_KEY: "sk-legacy-agent",
-      CODEX_HOME: "/tmp/workspace-123/.codex-agent",
     });
     expect(fetchImpl).not.toHaveBeenCalled();
   });
@@ -653,7 +690,7 @@ describe("prepareCodexRuntimePlan", () => {
     );
 
     expect(plan.env.OPENAI_API_KEY).toBe("sk-plan-agent");
-    expect(plan.env.CODEX_HOME).toBe("/tmp/workspace-123/.codex-agent");
+    expect(plan.env.CODEX_HOME).toBeUndefined();
   });
 });
 
@@ -674,9 +711,6 @@ describe("createCodexRuntimeAdapter", () => {
         },
       },
       {
-        mkdirImpl: vi.fn().mockResolvedValue(undefined),
-        writeFileImpl: vi.fn().mockResolvedValue(undefined),
-        copyFileImpl: vi.fn().mockResolvedValue(undefined),
         spawnImpl,
       }
     );
@@ -685,9 +719,7 @@ describe("createCodexRuntimeAdapter", () => {
     const result = await adapter.spawnTurn();
 
     expect(result.plan.env.OPENAI_API_KEY).toBe("sk-direct-runtime");
-    expect(result.plan.env.CODEX_HOME).toBe(
-      resolveStagedCodexHome("/tmp/workspace-123")
-    );
+    expect(result.plan.env.CODEX_HOME).toBeUndefined();
     expect(spawnImpl).toHaveBeenCalledOnce();
 
     await adapter.shutdown();
@@ -711,9 +743,6 @@ describe("createCodexRuntimeAdapter", () => {
         },
       },
       {
-        mkdirImpl: vi.fn().mockResolvedValue(undefined),
-        writeFileImpl: vi.fn().mockResolvedValue(undefined),
-        copyFileImpl: vi.fn().mockResolvedValue(undefined),
         spawnImpl,
       }
     );

--- a/packages/runtime-codex/src/runtime.test.ts
+++ b/packages/runtime-codex/src/runtime.test.ts
@@ -200,7 +200,7 @@ describe("buildCodexRuntimePlan", () => {
 describe("resolvePreparedAgentEnvironment", () => {
   it("filters direct agent env keys without staging CODEX_HOME", () => {
     expect(
-      resolvePreparedAgentEnvironment("/tmp/workspace-123", {
+      resolvePreparedAgentEnvironment({
         OPENAI_API_KEY: "sk-openai",
         OPENAI_BASE_URL: "https://example.test/v1",
         UNRELATED: "ignored",

--- a/packages/runtime-codex/src/runtime.ts
+++ b/packages/runtime-codex/src/runtime.ts
@@ -1,8 +1,6 @@
 import { spawn } from "node:child_process";
 import type { ChildProcess, SpawnOptions } from "node:child_process";
-import { copyFile, mkdir, readFile, writeFile } from "node:fs/promises";
-import { join } from "node:path";
-import { homedir } from "node:os";
+import { readFile, writeFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import {
   buildAgentInputRequiredReason,
@@ -20,7 +18,6 @@ import { createLinearGraphQLMcpServerEntry } from "@gh-symphony/tool-linear-grap
 
 const DEFAULT_GITHUB_GIT_HOST = "github.com";
 const DEFAULT_GITHUB_GIT_USERNAME = "x-access-token";
-const STAGED_CODEX_HOME_DIRNAME = ".codex-agent";
 const DIRECT_AGENT_ENV_KEYS = [
   "OPENAI_API_KEY",
   "OPENAI_BASE_URL",
@@ -91,8 +88,6 @@ export type CodexRuntimeEvent = AgentRuntimeEvent;
 export type CodexRuntimeDependencies = {
   fetchImpl?: typeof fetch;
   writeFileImpl?: typeof writeFile;
-  mkdirImpl?: typeof mkdir;
-  copyFileImpl?: typeof copyFile;
   spawnImpl?: SpawnLike;
 };
 
@@ -414,18 +409,11 @@ export function normalizeCodexRuntimeEvents(
   return events;
 }
 
-export function resolveStagedCodexHome(workingDirectory: string): string {
-  return join(workingDirectory, STAGED_CODEX_HOME_DIRNAME);
-}
-
 export function resolvePreparedAgentEnvironment(
-  workingDirectory: string,
+  _workingDirectory: string,
   env?: Record<string, string | undefined>
 ): Record<string, string> {
-  // Point codex to an isolated config dir so personal MCPs (playwright,
-  // chrome-devtools, context7, etc.) from the operator's ~/.codex/config.toml
-  // are not loaded and do not confuse the implementation agent.
-  const preparedEnv = Object.fromEntries(
+  return Object.fromEntries(
     DIRECT_AGENT_ENV_KEYS.flatMap((key) => {
       const value = env?.[key];
       return typeof value === "string" && value.length > 0
@@ -433,16 +421,10 @@ export function resolvePreparedAgentEnvironment(
         : [];
     })
   );
-
-  return {
-    ...preparedEnv,
-    CODEX_HOME: resolveStagedCodexHome(workingDirectory),
-  };
 }
 
 /**
- * Build the `codex app-server` launch plan after `stageCodexHome()` has prepared
- * the staged `CODEX_HOME` directory for the target working directory.
+ * Build the `codex app-server` launch plan for the target working directory.
  */
 export function buildCodexRuntimePlan(
   config: CodexRuntimeConfig
@@ -557,7 +539,6 @@ export class CodexRuntimeAdapter implements AgentRuntimeAdapter<
       this.dependencies,
       this
     );
-    await stageCodexHome(this.config, this.dependencies);
     this.plan = buildCodexRuntimePlan({
       ...this.config,
       agentEnv,
@@ -806,35 +787,6 @@ function resolveRuntimeCredentials(
         config.workingDirectory,
         brokerResponse.env
       );
-}
-
-async function stageCodexHome(
-  config: Pick<CodexRuntimeConfig, "workingDirectory">,
-  dependencies: Pick<
-    CodexRuntimeDependencies,
-    "mkdirImpl" | "writeFileImpl" | "copyFileImpl"
-  > = {}
-): Promise<void> {
-  const codexHomeDir = resolveStagedCodexHome(config.workingDirectory);
-  const mkdirImpl = dependencies.mkdirImpl ?? mkdir;
-  await mkdirImpl(codexHomeDir, { recursive: true });
-  const writeFileImpl = dependencies.writeFileImpl ?? writeFile;
-  await writeFileImpl(
-    join(codexHomeDir, "config.toml"),
-    "# Isolated agent config \u2014 no personal MCP servers\n",
-    "utf8"
-  );
-
-  const realCodexHome = process.env.CODEX_HOME ?? join(homedir(), ".codex");
-  const copyFileImpl = dependencies.copyFileImpl ?? copyFile;
-  try {
-    await copyFileImpl(
-      join(realCodexHome, "auth.json"),
-      join(codexHomeDir, "auth.json")
-    );
-  } catch {
-    // auth.json may not exist (e.g. when OPENAI_API_KEY is used instead)
-  }
 }
 
 function hasRunningChild(child: ChildProcess | null): child is ChildProcess {

--- a/packages/runtime-codex/src/runtime.ts
+++ b/packages/runtime-codex/src/runtime.ts
@@ -410,7 +410,6 @@ export function normalizeCodexRuntimeEvents(
 }
 
 export function resolvePreparedAgentEnvironment(
-  _workingDirectory: string,
   env?: Record<string, string | undefined>
 ): Record<string, string> {
   return Object.fromEntries(
@@ -447,10 +446,7 @@ export function buildCodexRuntimePlan(
     const cmd = config.agentCommand ?? "codex app-server";
     return cmd.startsWith("bash -lc ") ? cmd.slice("bash -lc ".length) : cmd;
   })();
-  const agentEnv = resolvePreparedAgentEnvironment(
-    config.workingDirectory,
-    config.agentEnv
-  );
+  const agentEnv = resolvePreparedAgentEnvironment(config.agentEnv);
   const linearGraphqlEnv = config.enableLinearGraphqlTool
     ? {
         LINEAR_GRAPHQL_TOOL_NAME: "linear_graphql",
@@ -581,10 +577,7 @@ export class CodexRuntimeAdapter implements AgentRuntimeAdapter<
   resolveCredentials(
     brokerResponse: CodexRuntimeCredentialBrokerResponse
   ): Record<string, string> {
-    return resolvePreparedAgentEnvironment(
-      this.config.workingDirectory,
-      brokerResponse.env
-    );
+    return resolvePreparedAgentEnvironment(brokerResponse.env);
   }
 
   async shutdown(): Promise<void> {
@@ -696,11 +689,11 @@ export async function resolveAgentRuntimeEnvironment(
   >
 ): Promise<Record<string, string>> {
   if (config.agentEnv) {
-    return resolveRuntimeCredentials(config, { env: config.agentEnv }, adapter);
+    return resolveRuntimeCredentials({ env: config.agentEnv }, adapter);
   }
 
   if (!config.agentCredentialBrokerUrl || !config.agentCredentialBrokerSecret) {
-    return resolvePreparedAgentEnvironment(config.workingDirectory);
+    return resolvePreparedAgentEnvironment();
   }
 
   const now = dependencies.now ?? new Date();
@@ -716,7 +709,7 @@ export async function resolveAgentRuntimeEnvironment(
     cachedCredentials &&
     shouldReuseAgentCredentialCache(cachedCredentials, now)
   ) {
-    return resolveRuntimeCredentials(config, cachedCredentials, adapter);
+    return resolveRuntimeCredentials(cachedCredentials, adapter);
   }
 
   const fetchImpl = dependencies.fetchImpl ?? fetch;
@@ -739,7 +732,7 @@ export async function resolveAgentRuntimeEnvironment(
             env: payload.env,
             expires_at: payload.expires_at,
           })
-        : resolvePreparedAgentEnvironment(config.workingDirectory, payload.env)
+        : resolvePreparedAgentEnvironment(payload.env)
       : null;
 
   if (
@@ -768,7 +761,6 @@ export async function resolveAgentRuntimeEnvironment(
 }
 
 function resolveRuntimeCredentials(
-  config: Pick<CodexRuntimeConfig, "workingDirectory">,
   brokerResponse: CodexRuntimeCredentialBrokerResponse,
   adapter?: Pick<
     AgentRuntimeAdapter<
@@ -783,10 +775,7 @@ function resolveRuntimeCredentials(
 ): Record<string, string> {
   return adapter
     ? adapter.resolveCredentials(brokerResponse)
-    : resolvePreparedAgentEnvironment(
-        config.workingDirectory,
-        brokerResponse.env
-      );
+    : resolvePreparedAgentEnvironment(brokerResponse.env);
 }
 
 function hasRunningChild(child: ChildProcess | null): child is ChildProcess {


### PR DESCRIPTION
## TL;DR

Codex app-server workers no longer get a staged `.codex-agent` home by default. Local runs now let Codex resolve its normal home, so config, auth, profiles, and MCP servers come from the same local Codex state unless the caller explicitly provides `CODEX_HOME`, including through the local launcher environment.

## 변경 지점 다이어그램

```text
runLocalRuntimeLauncher()
  └─ loadLauncherEnvironment()
       └─ resolveLocalRuntimeLaunchConfig()
            └─ forwards explicit CODEX_HOME via extraEnv

prepareCodexRuntimePlan()
  └─ resolveAgentRuntimeEnvironment()
       └─ resolvePreparedAgentEnvironment()
            ├─ keeps direct OPENAI_* env only
            └─ no default CODEX_HOME injection

buildCodexRuntimePlan()
  └─ env merge preserves process.env / extraEnv CODEX_HOME when explicitly set
```

## 여기부터 보세요

- `packages/runtime-codex/src/launcher.ts`
  - Preserves explicit launcher-provided `CODEX_HOME` by forwarding it through `extraEnv`.
- `packages/runtime-codex/src/runtime.ts`
  - Removed staged Codex home creation, `.codex-agent/config.toml` writing, and local `auth.json` copying.
  - Removed the forced `CODEX_HOME=<workingDirectory>/.codex-agent` injection.
  - Dropped the unused prepared-agent environment working-directory parameter left over from staging.
- `packages/runtime-codex/src/launcher.test.ts`
  - Adds coverage that `CODEX_HOME` from the launcher env survives into runtime config while staying out of direct OpenAI agent env.
- `packages/runtime-codex/src/runtime.test.ts`
  - Default launch plans assert `CODEX_HOME` is unset.
  - Explicit `CODEX_HOME` via `extraEnv` or process env is preserved.
- `.changeset/local-codex-home.md`
  - Patch changeset for the CLI-visible runtime behavior change.

## 위험 & 롤백

- Existing stale `.codex-agent` directories are not removed automatically; operators should manually clean old workspace copies that may contain copied `auth.json`.
- Workers now load the operator's local Codex config/MCP servers by default. That is the intended behavior for #378.
- This intentionally supersedes the older ADR note that Codex `CODEX_HOME` staging was kept as-is.
- Rollback: revert this PR to restore staged home creation and forced `CODEX_HOME`.

## 변경 파일

- `.changeset/local-codex-home.md`
- `packages/runtime-codex/src/launcher.ts`
- `packages/runtime-codex/src/launcher.test.ts`
- `packages/runtime-codex/src/runtime.ts`
- `packages/runtime-codex/src/runtime.test.ts`

## Evidence

- `pnpm --filter @gh-symphony/runtime-codex test` — pass (47 tests)
- `pnpm lint` — pass
- `pnpm test` — pass
- `pnpm typecheck` — pass
- `pnpm build` — pass
- Docker E2E TC-378 rework — pass; happy-path dispatch reached `/api/v1/state` `lastEvent=completed` with evidence at local ignored `evidence/tc-378-rework-result.json`.

## Issues

Closed #378

## 머지 후/사람 확인

- [ ] Confirm local Codex MCP servers from `~/.codex/config.toml` are visible in a real Codex worker session.
- [ ] Confirm no stale `.codex-agent/auth.json` files are committed from existing workspaces.
