### PR TITLE
docs(cli): document runtime prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ GitHub Symphony is a multi-tenant AI coding agent orchestration platform built o
 
 - **[Node.js](https://nodejs.org/)** (v24+) with npm
 - **[Git](https://git-scm.com/)**
+- At least one AI agent runtime on `PATH` before `gh-symphony repo start`:
+  - **[Codex CLI](https://developers.openai.com/codex/cli/)** (`codex`) - install from the official Codex CLI guide, then authenticate with `codex login`.
+  - **[Claude Code](https://code.claude.com/docs/en/quickstart)** (`claude`) - install from the official Claude Code quickstart, then authenticate with `ANTHROPIC_API_KEY` or a local Claude login for non-bare runs.
 - One GitHub auth source with required scopes (`repo`, `read:org`, `project`):
   - **[GitHub CLI (`gh`)](https://cli.github.com/)**:
     ```bash
@@ -249,7 +252,7 @@ The generated skill files (under `.codex/skills/` or `.claude/skills/`) define h
 
 You can further customize the agent's behavior by editing `WORKFLOW.md` or by adding repository-specific reference markdown under the `/gh-symphony` skill's `references/` directory. `WORKFLOW.md` remains the policy layer that controls what the agent does at each workflow phase.
 
-> Currently supported runtimes: **Codex**, **Claude Code**
+> Currently supported runtimes: **[Codex CLI](https://developers.openai.com/codex/cli/)** and **[Claude Code](https://code.claude.com/docs/en/quickstart)**. The selected runtime command must be installed and authenticated before `gh-symphony repo start` can dispatch worker runs.
 
 #### Explicit GitHub Priority Mapping
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -8,6 +8,9 @@ The following tools must be installed before using the CLI:
 
 - **[Node.js](https://nodejs.org/)** (v24+) with npm
 - **[Git](https://git-scm.com/)**
+- At least one AI agent runtime on `PATH` before `gh-symphony repo start`:
+  - **[Codex CLI](https://developers.openai.com/codex/cli/)** (`codex`) - install from the official Codex CLI guide, then authenticate with `codex login`.
+  - **[Claude Code](https://code.claude.com/docs/en/quickstart)** (`claude`) - install from the official Claude Code quickstart, then authenticate with `ANTHROPIC_API_KEY` or a local Claude login for non-bare runs.
 - One GitHub auth source with required scopes (`repo`, `read:org`, `project`):
   - **[GitHub CLI (`gh`)](https://cli.github.com/)**:
     ```bash
@@ -106,7 +109,7 @@ Examples of generated validation guidance include `make test`, `just build`, `uv
 
 You can further customize the agent's behavior by editing `WORKFLOW.md` — this is the policy layer that controls what the agent does at each workflow phase.
 
-> Currently supported runtimes: **Codex**, **Claude Code**
+> Currently supported runtimes: **[Codex CLI](https://developers.openai.com/codex/cli/)** and **[Claude Code](https://code.claude.com/docs/en/quickstart)**. The selected runtime command must be installed and authenticated before `gh-symphony repo start` can dispatch worker runs.
 
 ### Explicit Priority Mapping
 

--- a/packages/cli/src/commands/doctor.test.ts
+++ b/packages/cli/src/commands/doctor.test.ts
@@ -594,6 +594,48 @@ describe("runDoctorDiagnostics", () => {
     ).toMatchObject({ status: "warn" });
   });
 
+  it("includes official runtime install URLs when runtime commands are missing", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "doctor-config-"));
+    const workspaceDir = join(configDir, "workspaces");
+    await prepareDoctorPaths(configDir, workspaceDir);
+
+    for (const [command, expectedUrl] of [
+      ["codex", "https://developers.openai.com/codex/cli/"],
+      ["claude", "https://code.claude.com/docs/en/quickstart"],
+    ] as const) {
+      const { repoDir, pathEnv } = await createWorkflowFixture(command);
+
+      const report = await withCwd(repoDir, () =>
+        runDoctorDiagnostics(baseOptions(configDir), [], {
+          ...authDependencies(),
+          inspectManagedProjectSelection: async () => ({
+            kind: "resolved",
+            projectId: "tenant-a",
+            projectConfig: createProjectConfig(workspaceDir),
+          }),
+          getProjectDetail: (async () =>
+            ({
+              id: "PVT_test",
+              title: "Acme Platform",
+              url: "https://github.com/orgs/acme/projects/1",
+              statusFields: [],
+              textFields: [],
+              linkedRepositories: [],
+            }) as never) as never,
+          pathEnv,
+        })
+      );
+
+      expect(report.ok).toBe(false);
+      expect(
+        report.checks.find((check) => check.id === "runtime_command")
+      ).toMatchObject({
+        status: "fail",
+        remediation: expect.stringContaining(expectedUrl),
+      });
+    }
+  });
+
   it("uses injected fetch when checking brokered Claude credentials", async () => {
     const configDir = await mkdtemp(join(tmpdir(), "doctor-config-"));
     const workspaceDir = join(configDir, "workspaces");

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -2060,11 +2060,19 @@ function buildRuntimeInstallGuidance(
   platform: NodeJS.Platform
 ): string {
   if (binary === "codex") {
-    return "Install Codex CLI using its official installation instructions and ensure 'codex' is on PATH.";
+    return [
+      "Install Codex CLI from https://developers.openai.com/codex/cli/",
+      "and ensure 'codex' is on PATH.",
+      "Then authenticate with 'codex login'.",
+    ].join(" ");
   }
 
   if (binary === "claude" || binary === "claude-code") {
-    return "Install Claude Code using its official installation instructions and ensure the runtime binary is on PATH.";
+    return [
+      "Install Claude Code from https://code.claude.com/docs/en/quickstart",
+      "and ensure the runtime binary is on PATH.",
+      "Then set ANTHROPIC_API_KEY or complete a local Claude login for non-bare runs.",
+    ].join(" ");
   }
 
   if (platform === "win32" && binary) {


### PR DESCRIPTION
## TL;DR

- Documents Codex CLI / Claude Code as required AI agent runtimes in both root and CLI READMEs.
- Adds install/auth links and notes that at least one runtime must be on `PATH` before `gh-symphony repo start` can dispatch workers.
- Makes `gh-symphony doctor` runtime-command failures point to the official Codex and Claude Code install/auth paths.

## 변경 지점 다이어그램

```text
README Requirements
  -> Codex CLI / Claude Code install + auth prerequisite

packages/cli README Requirements
  -> Same runtime prerequisite for package consumers

 doctor runtime_command remediation
  -> official install URL + auth hint
  -> covered by doctor.test.ts
```

## 여기부터 보세요

- `README.md` Requirements section for the top-level onboarding copy.
- `packages/cli/README.md` Requirements section for package-local onboarding copy.
- `packages/cli/src/commands/doctor.ts` `buildRuntimeInstallGuidance` for actionable runtime install remediation.
- `packages/cli/src/commands/doctor.test.ts` for regression coverage of the official URLs.

## 위험 & 롤백

- Risk is low: docs plus diagnostic remediation text only.
- Rollback is reverting commit `70149c1` if the linked official URLs need to be changed later.

## 변경 파일

- `README.md`
- `packages/cli/README.md`
- `packages/cli/src/commands/doctor.ts`
- `packages/cli/src/commands/doctor.test.ts`

## Evidence

- `pnpm --filter @gh-symphony/cli test -- src/commands/doctor.test.ts` — pass
- `pnpm lint` — pass
- `pnpm test` — pass
- `pnpm typecheck` — pass
- `pnpm build` — pass

## Issues — Closed #384

Closes #384

## 머지 후/사람 확인

- [ ] Confirm the runtime prerequisite wording is clear for first-time users.
- [ ] Confirm the official Codex CLI and Claude Code docs links are acceptable long-term targets.
