### PR TITLE
fix(docker): run repo start by default

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,6 +154,25 @@ jobs:
             "${IMAGE_REF}" \
             sh -lc 'cd /var/lib/gh-symphony/repo && gh-symphony repo init && gh-symphony repo start --once'
 
+          default_container="$(docker run -d \
+            -v "${TMPDIR}/config:/var/lib/gh-symphony" \
+            -e GH_SYMPHONY_FILE_TRACKER_ISSUES_PATH=/var/lib/gh-symphony/issues.json \
+            -w /var/lib/gh-symphony/repo \
+            "${IMAGE_REF}")"
+          trap 'docker rm -f "${default_container}" >/dev/null 2>&1 || true' EXIT
+          sleep 5
+
+          if [ "$(docker inspect -f '{{.State.Running}}' "${default_container}")" != "true" ]; then
+            docker logs "${default_container}" || true
+            status="$(docker inspect -f '{{.State.ExitCode}}' "${default_container}")"
+            echo "Expected the image default CMD to keep the orchestrator running; got exit ${status}."
+            exit 1
+          fi
+
+          docker stop "${default_container}"
+          docker rm "${default_container}"
+          trap - EXIT
+
       - name: Tag and create GitHub Release
         if: steps.changesets.outputs.published == 'true'
         env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,4 +61,4 @@ VOLUME ["/var/lib/gh-symphony"]
 USER symphony
 
 ENTRYPOINT ["/usr/bin/tini", "--"]
-CMD ["gh-symphony", "start"]
+CMD ["gh-symphony", "repo", "start"]

--- a/README.md
+++ b/README.md
@@ -102,7 +102,9 @@ docker run --rm -it \
   gh-symphony setup --non-interactive
 ```
 
-Then start the long-running orchestrator:
+Then start the long-running orchestrator from the initialized repository. The image
+default command is `gh-symphony repo start`, so the mounted working directory must
+already contain `WORKFLOW.md` and the repository runtime config created by setup.
 
 ```bash
 docker run -d \
@@ -121,14 +123,15 @@ services:
   gh-symphony:
     image: ghcr.io/hojinzs/github-symphony:latest
     restart: unless-stopped
+    working_dir: /repo
     environment:
       GITHUB_GRAPHQL_TOKEN: ${GITHUB_GRAPHQL_TOKEN}
     volumes:
-      - gh-symphony-data:/var/lib/gh-symphony
-
-volumes:
-  gh-symphony-data:
+      - ./:/repo
 ```
+
+Run `gh-symphony setup` once before starting the service so the mounted repository
+has `WORKFLOW.md` and `.runtime/orchestrator/`.
 
 If you prefer a host bind mount in `docker compose`, align the container user with the host directory owner:
 
@@ -136,10 +139,12 @@ If you prefer a host bind mount in `docker compose`, align the container user wi
 services:
   gh-symphony:
     image: ghcr.io/hojinzs/github-symphony:latest
+    working_dir: /repo
     user: "${UID:-1000}:${GID:-1000}"
     environment:
       GITHUB_GRAPHQL_TOKEN: ${GITHUB_GRAPHQL_TOKEN}
     volumes:
+      - ./:/repo
       - ./data:/var/lib/gh-symphony
 ```
 


### PR DESCRIPTION
## TL;DR

- Fixes the official Docker image default command so it runs `gh-symphony repo start` instead of the removed `gh-symphony start`.
- Updates Docker deployment docs to make the initialized repository working directory requirement explicit.
- Adds a release smoke check that starts the published image without overriding CMD and fails if the default process exits immediately.

## 변경 지점 다이어그램

```text
Dockerfile CMD
  gh-symphony start          (removed, exits 2)
        ↓
  gh-symphony repo start     (current repository orchestrator entrypoint)

Release smoke
  explicit --version / repo start --once
        +
  default CMD detached container must stay running briefly
```

## 여기부터 보세요

- `Dockerfile`: image default CMD now matches the documented `gh-symphony repo start` path.
- `README.md`: docker run and compose examples now say the mounted working directory must already be initialized and set `working_dir: /repo` for compose.
- `.github/workflows/release.yml`: published-image smoke now starts the image with no command override and asserts the default process keeps running.

## 위험 & 롤백

- Risk is limited to container default startup behavior and documentation. Users who explicitly pass a command are unaffected.
- Rollback is the single Dockerfile CMD line plus README/release-smoke edits in this PR.

## 변경 파일

- `Dockerfile`
- `README.md`
- `.github/workflows/release.yml`

## Evidence

- `pnpm install --frozen-lockfile` — pass
- `pnpm lint` — pass
- `pnpm test` — pass
- `pnpm typecheck` — pass
- `pnpm build` — pass
- `git diff --check` — pass
- Local Docker smoke was not run because the Docker daemon is unavailable in this environment: `Cannot connect to the Docker daemon at unix:///Users/steve/.docker/run/docker.sock.`

## 머지 후/사람 확인

- [ ] Confirm the README Docker deployment wording matches the intended supported self-hosted usage.
- [ ] Confirm the release workflow smoke behaves as expected when the next published image is built in GitHub Actions.

## Issues — Closed #383
