### PR TITLE
Add GitHub issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,105 @@
+name: Bug report
+description: Report a setup, orchestration, CLI, or runtime failure.
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a GitHub Symphony bug. Please include the `doctor` output and attach a redacted support bundle when possible.
+
+  - type: textarea
+    id: background
+    attributes:
+      label: Background
+      description: Why this change is needed; include motivation, context, and what you expected to happen.
+      placeholder: I expected ..., but ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Symptoms / Reproduction Steps
+      description: List the commands or UI steps that reproduce the problem.
+      placeholder: |
+        1. Run ...
+        2. Configure ...
+        3. See ...
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+      placeholder: "macOS 15.5, Ubuntu 24.04, Windows 11, etc."
+    validations:
+      required: true
+
+  - type: input
+    id: node-version
+    attributes:
+      label: Node.js version
+      placeholder: "node --version"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: install-method
+    attributes:
+      label: Install method
+      options:
+        - npm
+        - Docker
+        - source checkout
+        - other
+    validations:
+      required: true
+
+  - type: input
+    id: runtime
+    attributes:
+      label: Worker/runtime command
+      description: Share the configured runtime or worker command, redacted as needed.
+      placeholder: "SYMPHONY_WORKER_COMMAND=..."
+
+  - type: textarea
+    id: doctor-json
+    attributes:
+      label: "`gh-symphony doctor --json` output"
+      description: Paste the output after redacting tokens, private URLs, and secrets.
+      render: json
+      placeholder: |
+        {
+          "ok": false
+        }
+    validations:
+      required: true
+
+  - type: textarea
+    id: support-bundle
+    attributes:
+      label: Support bundle
+      description: Run `gh-symphony doctor --bundle` and attach the generated redacted bundle, or explain why it cannot be shared.
+      placeholder: "Attached support bundle, or reason it cannot be attached."
+    validations:
+      required: true
+
+  - type: textarea
+    id: affected-files
+    attributes:
+      label: Affected Files
+      description: List known affected files or components, if you can identify them.
+      placeholder: |
+        | File | Change | Scope |
+        | --- | --- | --- |
+        | packages/cli/src/... | ... | ... |
+
+  - type: textarea
+    id: references
+    attributes:
+      label: References
+      description: Link related issues, ADRs, specs, logs, or documentation.
+

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,9 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Contributing guide
+    url: https://github.com/hojinzs/github-symphony/blob/main/CONTRIBUTING.md
+    about: Read the contribution workflow and pull request expectations.
+  - name: Project management conventions
+    url: https://github.com/hojinzs/github-symphony/blob/main/PROJECT_MANAGE.md
+    about: Review issue structure, priority, size, and estimate conventions.
+

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,72 @@
+name: Feature request
+description: Propose a scoped GitHub Symphony improvement.
+title: "[Feature]: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for scoped product, DX, documentation, and workflow improvements. Large architectural changes should start with an issue or discussion before implementation.
+
+  - type: textarea
+    id: background
+    attributes:
+      label: Background
+      description: Why this change is needed; include motivation and context.
+      placeholder: This would help because ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed-changes
+    attributes:
+      label: Proposed Changes
+      description: What should change and how.
+      placeholder: |
+        - Add ...
+        - Update ...
+        - Preserve ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: affected-files
+    attributes:
+      label: Affected Files
+      description: Use the project convention table where possible.
+      placeholder: |
+        | File | Change | Scope |
+        | --- | --- | --- |
+        | README.md | Document ... | docs |
+    validations:
+      required: true
+
+  - type: textarea
+    id: spec-reference
+    attributes:
+      label: Spec Reference
+      description: Include relevant Symphony spec sections and quotes for spec conformance issues.
+
+  - type: textarea
+    id: current-vs-spec
+    attributes:
+      label: Current Implementation vs Spec
+      description: Add a side-by-side comparison when proposing a spec conformance change.
+      placeholder: |
+        | Current | Spec / Desired |
+        | --- | --- |
+        | ... | ... |
+
+  - type: textarea
+    id: migration-notes
+    attributes:
+      label: Migration Notes
+      description: Describe any impact on existing data, API compatibility, deployment, or self-hosting.
+
+  - type: textarea
+    id: references
+    attributes:
+      label: References
+      description: Link related ADRs, specs, issues, pull requests, or external docs.
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,33 @@
+## Summary
+
+- 
+
+## User-visible behavior and operational impact
+
+- 
+
+## Related issue or design record
+
+Closes #
+
+## Validation
+
+- [ ] `pnpm lint`
+- [ ] `pnpm test`
+- [ ] `pnpm typecheck`
+- [ ] `pnpm build`
+- [ ] `pnpm format`
+- [ ] Not run; reason:
+
+## Change management
+
+- [ ] Added a changeset with `pnpm changeset`, or this change does not need a package release.
+- [ ] Documented deployment, self-hosting, or migration impact when relevant.
+- [ ] Included screenshots, terminal output, or logs for UX, CLI, or deployment flow changes.
+- [ ] Called out follow-up work explicitly.
+
+## Security checklist
+
+- [ ] No real GitHub tokens, private keys, `.env` files, generated installation tokens, or other secrets are committed.
+- [ ] Privileged integration changes, including Docker socket access, remain explicit and auditable.
+


### PR DESCRIPTION
## Summary

- Add a structured bug report issue form that asks for OS, Node version, install method, runtime command, `doctor --json` output, and a `doctor --bundle` attachment or explanation.
- Add a feature request issue form based on the repository's project management sections: Background, Proposed Changes, Affected Files, and optional spec/migration/reference fields.
- Add issue template config links plus a PR template that mirrors the contribution checklist and security expectations.

## Validation

- [x] Verified the new files are present on the fork via the GitHub contents API.
- [ ] `pnpm lint`
- [ ] `pnpm test`
- [ ] `pnpm typecheck`
- [ ] `pnpm build`
- [ ] `pnpm format`
- [x] Not run; docs/template-only change.

Closes #391