### PR TITLE
fix(cli): improve repo logs event output

### DIFF
--- a/.changeset/repo-logs-event-timeline.md
+++ b/.changeset/repo-logs-event-timeline.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Fix `gh-symphony repo logs` to show structured event reasons and print scanned run events in chronological order across runs.

--- a/packages/cli/src/commands/logs.test.ts
+++ b/packages/cli/src/commands/logs.test.ts
@@ -183,4 +183,114 @@ describe("logs command", () => {
     expect(output).not.toContain("acme/platform#1");
     expect(output).toContain("beta/api#2");
   });
+
+  it("prints formatter messages for run failure, suppression, retry, and session invalidation reasons", async () => {
+    const configDir = await createConfigFixture();
+    await writeRunEvents(configDir, "tenant-a", "run-1", [
+      {
+        at: "2026-03-16T00:00:00.000Z",
+        event: "run-failed",
+        issueIdentifier: "acme/platform#1",
+        projectId: "tenant-a",
+        attempt: 1,
+        lastError: "worker exited with code 1",
+      },
+      {
+        at: "2026-03-16T00:01:00.000Z",
+        event: "run-suppressed",
+        issueIdentifier: "acme/platform#2",
+        projectId: "tenant-a",
+        reason: "lease already active",
+      },
+      {
+        at: "2026-03-16T00:02:00.000Z",
+        event: "run-retried",
+        issueIdentifier: "acme/platform#3",
+        projectId: "tenant-a",
+        attempt: 2,
+        retryKind: "backoff",
+        nextRetryAt: "2026-03-16T00:05:00.000Z",
+      },
+      {
+        at: "2026-03-16T00:03:00.000Z",
+        event: "session_invalidated",
+        issueIdentifier: "acme/platform#4",
+        projectId: "tenant-a",
+        runId: "run-1",
+        sessionId: "old-session",
+        replacementSessionId: "new-session",
+        reason: "session expired",
+      },
+    ]);
+    const stdout = captureWrites(process.stdout);
+
+    try {
+      await logsCommand([], {
+        configDir,
+        verbose: false,
+        json: false,
+        noColor: false,
+      });
+    } finally {
+      stdout.restore();
+    }
+
+    const output = stdout.output();
+    expect(output).toContain(
+      "[2026-03-16T00:00:00.000Z] run-failed acme/platform#1 worker exited with code 1"
+    );
+    expect(output).toContain(
+      "[2026-03-16T00:01:00.000Z] run-suppressed acme/platform#2 lease already active"
+    );
+    expect(output).toContain(
+      "[2026-03-16T00:02:00.000Z] run-retried acme/platform#3 Retry 2 scheduled (backoff)"
+    );
+    expect(output).toContain(
+      "[2026-03-16T00:03:00.000Z] session_invalidated acme/platform#4 session expired"
+    );
+  });
+
+  it("sorts scanned events chronologically across project run directories", async () => {
+    const configDir = await createConfigFixture();
+    await writeRunEvents(configDir, "tenant-a", "run-later", [
+      {
+        at: "2026-03-16T00:03:00.000Z",
+        event: "run-started",
+        issueIdentifier: "acme/platform#3",
+        projectId: "tenant-a",
+      },
+    ]);
+    await writeRunEvents(configDir, "tenant-b", "run-earlier", [
+      {
+        at: "2026-03-16T00:01:00.000Z",
+        event: "run-started",
+        issueIdentifier: "beta/api#1",
+        projectId: "tenant-b",
+      },
+      {
+        at: "2026-03-16T00:02:00.000Z",
+        event: "run-started",
+        issueIdentifier: "beta/api#2",
+        projectId: "tenant-b",
+      },
+    ]);
+    const stdout = captureWrites(process.stdout);
+
+    try {
+      await logsCommand([], {
+        configDir,
+        verbose: false,
+        json: false,
+        noColor: false,
+      });
+    } finally {
+      stdout.restore();
+    }
+
+    expect(stdout.output().trim().split("\n")).toEqual([
+      "[2026-03-16T00:01:00.000Z] run-started beta/api#1",
+      "[2026-03-16T00:02:00.000Z] run-started beta/api#2",
+      "[2026-03-16T00:03:00.000Z] run-started acme/platform#3",
+    ]);
+  });
 });

--- a/packages/cli/src/commands/logs.ts
+++ b/packages/cli/src/commands/logs.ts
@@ -2,12 +2,15 @@ import { readFile, readdir, stat } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { createReadStream } from "node:fs";
 import { createInterface } from "node:readline";
+import { formatEventMessage, type OrchestratorEvent } from "@gh-symphony/core";
 import type { GlobalOptions } from "../index.js";
 import { orchestratorLogPath } from "../config.js";
 import {
   handleMissingManagedProjectConfig,
   resolveManagedProjectConfig,
 } from "../project-selection.js";
+
+type LoggedEvent = Record<string, unknown> & { at?: string };
 
 function parseLogsArgs(args: string[]): {
   follow: boolean;
@@ -76,10 +79,12 @@ const handler = async (
       const content = await readFile(eventsPath, "utf8");
       const lines = content.trim().split("\n").filter(Boolean);
       for (const line of lines) {
-        const event = JSON.parse(line) as Record<string, unknown>;
-        if (parsed.projectId && event.projectId !== parsed.projectId) continue;
-        if (parsed.level && event.level !== parsed.level) continue;
-        if (parsed.issue && event.issueIdentifier !== parsed.issue) continue;
+        const event = JSON.parse(line) as LoggedEvent;
+        if (parsed.projectId && getProjectId(event) !== parsed.projectId)
+          continue;
+        if (parsed.level && getLevel(event) !== parsed.level) continue;
+        if (parsed.issue && getIssueIdentifier(event) !== parsed.issue)
+          continue;
         process.stdout.write(formatEvent(event) + "\n");
       }
     } catch {
@@ -142,6 +147,7 @@ const handler = async (
     ? [join(runtimeRoot, "projects", parsed.projectId, "runs")]
     : await listProjectRunRoots(runtimeRoot);
   let foundRuns = false;
+  const events: LoggedEvent[] = [];
 
   try {
     for (const runsDir of runRoots) {
@@ -156,12 +162,13 @@ const handler = async (
           const content = await readFile(eventsPath, "utf8");
           const lines = content.trim().split("\n").filter(Boolean);
           for (const line of lines) {
-            const event = JSON.parse(line) as Record<string, unknown>;
-            if (parsed.projectId && event.projectId !== parsed.projectId)
+            const event = JSON.parse(line) as LoggedEvent;
+            if (parsed.projectId && getProjectId(event) !== parsed.projectId)
               continue;
-            if (parsed.level && event.level !== parsed.level) continue;
-            if (parsed.issue && event.issueIdentifier !== parsed.issue) continue;
-            process.stdout.write(formatEvent(event) + "\n");
+            if (parsed.level && getLevel(event) !== parsed.level) continue;
+            if (parsed.issue && getIssueIdentifier(event) !== parsed.issue)
+              continue;
+            events.push(event);
           }
         } catch {
           // Skip runs without events
@@ -174,17 +181,39 @@ const handler = async (
 
   if (!foundRuns) {
     process.stderr.write("No runs found. Start the orchestrator first.\n");
+    return;
+  }
+
+  events.sort((left, right) =>
+    String(left.at ?? "").localeCompare(String(right.at ?? ""))
+  );
+  for (const event of events) {
+    process.stdout.write(formatEvent(event) + "\n");
   }
 };
 
 export default handler;
 
-function formatEvent(event: Record<string, unknown>): string {
+function formatEvent(event: LoggedEvent): string {
   const at = event.at ?? "";
   const eventType = event.event ?? "unknown";
-  const issue = event.issueIdentifier ?? "";
-  const extra = event.error ? ` error=${event.error}` : "";
-  return `[${at}] ${eventType} ${issue}${extra}`;
+  const issue = getIssueIdentifier(event);
+  const message = formatEventMessage(event as OrchestratorEvent);
+  const subject = issue ? ` ${issue}` : "";
+  const extra = message ? ` ${message}` : "";
+  return `[${at}] ${eventType}${subject}${extra}`;
+}
+
+function getProjectId(event: LoggedEvent): string | undefined {
+  return typeof event.projectId === "string" ? event.projectId : undefined;
+}
+
+function getLevel(event: LoggedEvent): string | undefined {
+  return typeof event.level === "string" ? event.level : undefined;
+}
+
+function getIssueIdentifier(event: LoggedEvent): string {
+  return typeof event.issueIdentifier === "string" ? event.issueIdentifier : "";
 }
 
 async function listProjectRunRoots(runtimeRoot: string): Promise<string[]> {


### PR DESCRIPTION
## Issues — Closed #387

## TL;DR

- `gh-symphony repo logs` now uses the core observability event formatter, so failure/suppression/retry/session invalidation reasons are shown instead of being dropped.
- Project-wide log scans now collect matching events across run directories and sort them by `event.at` before printing, producing a readable chronological timeline.

## 변경 지점 다이어그램

`repo logs` -> read `events.ndjson` lines -> filter by project/level/issue -> collect scanned events -> sort by `at` -> format via `formatEventMessage` -> print operator-readable timeline.

## 여기부터 보세요

- `packages/cli/src/commands/logs.ts` — replaces bespoke `event.error` formatting with `formatEventMessage`, adds defensive field helpers, and globally sorts scanned events.
- `packages/cli/src/commands/logs.test.ts` — covers reason output for the event fields named in #387 and chronological ordering across projects/runs.
- `.changeset/repo-logs-event-timeline.md` — patch changeset for `@gh-symphony/cli`.

## 위험 & 롤백

- Risk: Human-readable `repo logs` output text changes for events that already had core formatter messages. Rollback is reverting this PR.
- No orchestrator dispatch, worker lifecycle, tracker adapter, or status API behavior changed.

## 변경 파일

- `packages/cli/src/commands/logs.ts`
- `packages/cli/src/commands/logs.test.ts`
- `.changeset/repo-logs-event-timeline.md`

## Evidence

- `pnpm --filter @gh-symphony/cli test -- src/commands/logs.test.ts` — pass
- `pnpm --filter @gh-symphony/cli typecheck` — pass
- `pnpm lint` — pass
- `pnpm test` — pass
- `pnpm typecheck` — pass
- `pnpm build` — pass
- Docker E2E: N/A, CLI log formatting only; no integration behavior changed.

## 머지 후/사람 확인

- [ ] Confirm `gh-symphony repo logs` shows failure/suppression/retry/session-invalidated reasons in a real repo runtime.
- [ ] Confirm cross-run output reads chronologically for concurrent runs.
