### PR TITLE
fix(cli): derive repo log levels

### DIFF
--- a/.changeset/repo-logs-level-filter.md
+++ b/.changeset/repo-logs-level-filter.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Fix `gh-symphony repo logs --level` to derive levels from structured event types, include turn failures in error results, validate unsupported level values, and report empty filtered results clearly for issue #386.

--- a/packages/cli/src/commands/logs.test.ts
+++ b/packages/cli/src/commands/logs.test.ts
@@ -52,7 +52,10 @@ async function createConfigFixture(): Promise<string> {
     "utf8"
   );
 
-  for (const project of [createProject("tenant-a"), createProject("tenant-b")]) {
+  for (const project of [
+    createProject("tenant-a"),
+    createProject("tenant-b"),
+  ]) {
     const projectDir = join(configDir, "projects", project.projectId);
     await mkdir(projectDir, { recursive: true });
     await writeFile(
@@ -276,6 +279,21 @@ describe("logs command", () => {
         retryKind: "backoff",
         nextRetryAt: "2026-03-16T00:05:00.000Z",
       },
+      {
+        at: "2026-03-16T00:03:00.000Z",
+        event: "turn_failed",
+        issueIdentifier: "acme/platform#4",
+        projectId: "tenant-a",
+        turnCount: 1,
+        startedAt: "2026-03-16T00:02:30.000Z",
+        durationMs: 30_000,
+        tokenUsage: {
+          inputTokens: 10,
+          outputTokens: 5,
+          totalTokens: 15,
+        },
+        error: "turn failed",
+      },
     ]);
     const stdout = captureWrites(process.stdout);
 
@@ -292,6 +310,7 @@ describe("logs command", () => {
 
     const output = stdout.output();
     expect(output).toContain("run-failed acme/platform#2 worker failed");
+    expect(output).toContain("turn_failed acme/platform#4 turn failed");
     expect(output).not.toContain("run-started");
     expect(output).not.toContain("run-retried");
   });
@@ -358,7 +377,64 @@ describe("logs command", () => {
     }
 
     expect(stdout.output()).toBe("");
-    expect(stderr.output()).toBe("No events matched --level error.\n");
+    expect(stderr.output()).toBe(
+      "No events matched the provided filters (--level error).\n"
+    );
+  });
+
+  it("prints a notice when --level matches no events for a specific run", async () => {
+    const configDir = await createConfigFixture();
+    await writeRunEvents(configDir, "tenant-a", "run-1", [
+      {
+        at: "2026-03-16T00:00:00.000Z",
+        event: "run-started",
+        issueIdentifier: "acme/platform#1",
+        projectId: "tenant-a",
+      },
+    ]);
+    const stdout = captureWrites(process.stdout);
+    const stderr = captureWrites(process.stderr);
+
+    try {
+      await logsCommand(["--run", "run-1", "--level", "error"], {
+        configDir,
+        verbose: false,
+        json: false,
+        noColor: false,
+      });
+    } finally {
+      stdout.restore();
+      stderr.restore();
+    }
+
+    expect(stdout.output()).toBe("");
+    expect(stderr.output()).toBe(
+      "No events matched the provided filters (--level error).\n"
+    );
+  });
+
+  it("rejects unsupported --level values", async () => {
+    const configDir = await createConfigFixture();
+    const stdout = captureWrites(process.stdout);
+    const stderr = captureWrites(process.stderr);
+
+    try {
+      await logsCommand(["--level", "debug"], {
+        configDir,
+        verbose: false,
+        json: false,
+        noColor: false,
+      });
+    } finally {
+      stdout.restore();
+      stderr.restore();
+    }
+
+    expect(stdout.output()).toBe("");
+    expect(stderr.output()).toBe(
+      'Unknown --level "debug". Valid values: error, warn, info.\n'
+    );
+    expect(process.exitCode).toBe(1);
   });
 
   it("sorts scanned events chronologically across project run directories", async () => {

--- a/packages/cli/src/commands/logs.test.ts
+++ b/packages/cli/src/commands/logs.test.ts
@@ -250,6 +250,117 @@ describe("logs command", () => {
     );
   });
 
+  it("filters scanned events by derived --level values", async () => {
+    const configDir = await createConfigFixture();
+    await writeRunEvents(configDir, "tenant-a", "run-1", [
+      {
+        at: "2026-03-16T00:00:00.000Z",
+        event: "run-started",
+        issueIdentifier: "acme/platform#1",
+        projectId: "tenant-a",
+      },
+      {
+        at: "2026-03-16T00:01:00.000Z",
+        event: "run-failed",
+        issueIdentifier: "acme/platform#2",
+        projectId: "tenant-a",
+        attempt: 1,
+        lastError: "worker failed",
+      },
+      {
+        at: "2026-03-16T00:02:00.000Z",
+        event: "run-retried",
+        issueIdentifier: "acme/platform#3",
+        projectId: "tenant-a",
+        attempt: 2,
+        retryKind: "backoff",
+        nextRetryAt: "2026-03-16T00:05:00.000Z",
+      },
+    ]);
+    const stdout = captureWrites(process.stdout);
+
+    try {
+      await logsCommand(["--level", "error"], {
+        configDir,
+        verbose: false,
+        json: false,
+        noColor: false,
+      });
+    } finally {
+      stdout.restore();
+    }
+
+    const output = stdout.output();
+    expect(output).toContain("run-failed acme/platform#2 worker failed");
+    expect(output).not.toContain("run-started");
+    expect(output).not.toContain("run-retried");
+  });
+
+  it("filters a specific run by derived warning level", async () => {
+    const configDir = await createConfigFixture();
+    await writeRunEvents(configDir, "tenant-a", "run-1", [
+      {
+        at: "2026-03-16T00:00:00.000Z",
+        event: "hook-failed",
+        projectId: "tenant-a",
+        hook: "after-create",
+        error: "hook failed",
+      },
+      {
+        at: "2026-03-16T00:01:00.000Z",
+        event: "run-suppressed",
+        issueIdentifier: "acme/platform#2",
+        projectId: "tenant-a",
+        reason: "lease already active",
+      },
+    ]);
+    const stdout = captureWrites(process.stdout);
+
+    try {
+      await logsCommand(["--run", "run-1", "--level", "warn"], {
+        configDir,
+        verbose: false,
+        json: false,
+        noColor: false,
+      });
+    } finally {
+      stdout.restore();
+    }
+
+    const output = stdout.output();
+    expect(output).toContain("run-suppressed acme/platform#2");
+    expect(output).not.toContain("hook-failed");
+  });
+
+  it("prints a notice when --level matches no scanned events", async () => {
+    const configDir = await createConfigFixture();
+    await writeRunEvents(configDir, "tenant-a", "run-1", [
+      {
+        at: "2026-03-16T00:00:00.000Z",
+        event: "run-started",
+        issueIdentifier: "acme/platform#1",
+        projectId: "tenant-a",
+      },
+    ]);
+    const stdout = captureWrites(process.stdout);
+    const stderr = captureWrites(process.stderr);
+
+    try {
+      await logsCommand(["--level", "error"], {
+        configDir,
+        verbose: false,
+        json: false,
+        noColor: false,
+      });
+    } finally {
+      stdout.restore();
+      stderr.restore();
+    }
+
+    expect(stdout.output()).toBe("");
+    expect(stderr.output()).toBe("No events matched --level error.\n");
+  });
+
   it("sorts scanned events chronologically across project run directories", async () => {
     const configDir = await createConfigFixture();
     await writeRunEvents(configDir, "tenant-a", "run-later", [

--- a/packages/cli/src/commands/logs.ts
+++ b/packages/cli/src/commands/logs.ts
@@ -11,6 +11,7 @@ import {
 } from "../project-selection.js";
 
 type LoggedEvent = Record<string, unknown> & { at?: string };
+type LogLevel = "error" | "warn" | "info";
 
 function parseLogsArgs(args: string[]): {
   follow: boolean;
@@ -78,6 +79,7 @@ const handler = async (
     try {
       const content = await readFile(eventsPath, "utf8");
       const lines = content.trim().split("\n").filter(Boolean);
+      let matchedEvents = 0;
       for (const line of lines) {
         const event = JSON.parse(line) as LoggedEvent;
         if (parsed.projectId && getProjectId(event) !== parsed.projectId)
@@ -86,6 +88,10 @@ const handler = async (
         if (parsed.issue && getIssueIdentifier(event) !== parsed.issue)
           continue;
         process.stdout.write(formatEvent(event) + "\n");
+        matchedEvents += 1;
+      }
+      if (parsed.level && matchedEvents === 0) {
+        process.stderr.write(`No events matched --level ${parsed.level}.\n`);
       }
     } catch {
       process.stderr.write(`No events found for run: ${parsed.run}\n`);
@@ -147,6 +153,7 @@ const handler = async (
     ? [join(runtimeRoot, "projects", parsed.projectId, "runs")]
     : await listProjectRunRoots(runtimeRoot);
   let foundRuns = false;
+  let matchedEvents = 0;
   const events: LoggedEvent[] = [];
 
   try {
@@ -169,6 +176,7 @@ const handler = async (
             if (parsed.issue && getIssueIdentifier(event) !== parsed.issue)
               continue;
             events.push(event);
+            matchedEvents += 1;
           }
         } catch {
           // Skip runs without events
@@ -181,6 +189,10 @@ const handler = async (
 
   if (!foundRuns) {
     process.stderr.write("No runs found. Start the orchestrator first.\n");
+    return;
+  }
+  if (parsed.level && matchedEvents === 0) {
+    process.stderr.write(`No events matched --level ${parsed.level}.\n`);
     return;
   }
 
@@ -208,8 +220,18 @@ function getProjectId(event: LoggedEvent): string | undefined {
   return typeof event.projectId === "string" ? event.projectId : undefined;
 }
 
-function getLevel(event: LoggedEvent): string | undefined {
-  return typeof event.level === "string" ? event.level : undefined;
+function getLevel(event: LoggedEvent): LogLevel {
+  switch (event.event) {
+    case "run-failed":
+    case "worker-error":
+    case "hook-failed":
+      return "error";
+    case "run-suppressed":
+    case "run-retried":
+      return "warn";
+    default:
+      return "info";
+  }
 }
 
 function getIssueIdentifier(event: LoggedEvent): string {

--- a/packages/cli/src/commands/logs.ts
+++ b/packages/cli/src/commands/logs.ts
@@ -12,6 +12,7 @@ import {
 
 type LoggedEvent = Record<string, unknown> & { at?: string };
 type LogLevel = "error" | "warn" | "info";
+const LOG_LEVELS: readonly LogLevel[] = ["error", "warn", "info"];
 
 function parseLogsArgs(args: string[]): {
   follow: boolean;
@@ -57,6 +58,16 @@ const handler = async (
   options: GlobalOptions
 ): Promise<void> => {
   const parsed = parseLogsArgs(args);
+  const level = parseLogLevel(parsed.level);
+  if (parsed.level && !level) {
+    process.stderr.write(
+      `Unknown --level "${parsed.level}". Valid values: ${LOG_LEVELS.join(
+        ", "
+      )}.\n`
+    );
+    process.exitCode = 1;
+    return;
+  }
   const runtimeRoot = resolve(options.configDir);
 
   // If --run is specified, read that run's events
@@ -84,14 +95,14 @@ const handler = async (
         const event = JSON.parse(line) as LoggedEvent;
         if (parsed.projectId && getProjectId(event) !== parsed.projectId)
           continue;
-        if (parsed.level && getLevel(event) !== parsed.level) continue;
+        if (level && getLevel(event) !== level) continue;
         if (parsed.issue && getIssueIdentifier(event) !== parsed.issue)
           continue;
         process.stdout.write(formatEvent(event) + "\n");
         matchedEvents += 1;
       }
-      if (parsed.level && matchedEvents === 0) {
-        process.stderr.write(`No events matched --level ${parsed.level}.\n`);
+      if (level && matchedEvents === 0) {
+        process.stderr.write(noMatchedEventsMessage(level));
       }
     } catch {
       process.stderr.write(`No events found for run: ${parsed.run}\n`);
@@ -172,7 +183,7 @@ const handler = async (
             const event = JSON.parse(line) as LoggedEvent;
             if (parsed.projectId && getProjectId(event) !== parsed.projectId)
               continue;
-            if (parsed.level && getLevel(event) !== parsed.level) continue;
+            if (level && getLevel(event) !== level) continue;
             if (parsed.issue && getIssueIdentifier(event) !== parsed.issue)
               continue;
             events.push(event);
@@ -191,8 +202,8 @@ const handler = async (
     process.stderr.write("No runs found. Start the orchestrator first.\n");
     return;
   }
-  if (parsed.level && matchedEvents === 0) {
-    process.stderr.write(`No events matched --level ${parsed.level}.\n`);
+  if (level && matchedEvents === 0) {
+    process.stderr.write(noMatchedEventsMessage(level));
     return;
   }
 
@@ -223,6 +234,7 @@ function getProjectId(event: LoggedEvent): string | undefined {
 function getLevel(event: LoggedEvent): LogLevel {
   switch (event.event) {
     case "run-failed":
+    case "turn_failed":
     case "worker-error":
     case "hook-failed":
       return "error";
@@ -232,6 +244,19 @@ function getLevel(event: LoggedEvent): LogLevel {
     default:
       return "info";
   }
+}
+
+function parseLogLevel(level: string | undefined): LogLevel | undefined {
+  if (!level) {
+    return undefined;
+  }
+  return LOG_LEVELS.includes(level as LogLevel)
+    ? (level as LogLevel)
+    : undefined;
+}
+
+function noMatchedEventsMessage(level: LogLevel): string {
+  return `No events matched the provided filters (--level ${level}).\n`;
 }
 
 function getIssueIdentifier(event: LoggedEvent): string {


### PR DESCRIPTION
## TL;DR

`gh-symphony repo logs --level` now filters historical structured events by a derived log level instead of reading the nonexistent `event.level` field. It also treats worker turn failures as errors, rejects unsupported level values, and reports empty filtered results without implying only `--level` was responsible.

## 변경 지점 다이어그램

`repo logs` args -> validate `--level` -> run event NDJSON -> derive level from `event` discriminator -> apply filters -> format matching events or print no-match notice

## 여기부터 보세요

- `packages/cli/src/commands/logs.ts`: validates `--level`, derives `error | warn | info` from event type, includes `turn_failed` in error-level output, and reports no matches for filtered log views.
- `packages/cli/src/commands/logs.test.ts`: covers scanned logs, explicit `--run`, warning/error filters, `turn_failed`, unsupported levels, and no-match notice behavior.
- `.changeset/repo-logs-level-filter.md`: patch changeset for the user-visible CLI behavior change.

## 위험 & 롤백

Risk is low: the change is limited to CLI read/filter behavior for existing event logs and does not alter event schema or append sites. Roll back by reverting the CLI helper, tests, and changeset in this PR.

## 변경 파일

- `.changeset/repo-logs-level-filter.md`
- `packages/cli/src/commands/logs.ts`
- `packages/cli/src/commands/logs.test.ts`

## Evidence

- `pnpm --filter @gh-symphony/cli test -- src/commands/logs.test.ts` — passed, 10 tests
- `pnpm lint` — passed
- `pnpm test` — passed
- `pnpm typecheck` — passed
- `pnpm build` — passed

## Issues — Closed #386

Closes #386

## 머지 후/사람 확인

- [ ] Confirm `gh-symphony repo logs --level error` shows failed historical events in a real runtime directory.
- [ ] Confirm no adjacent `repo logs` filters regress for operators.
