### PR TITLE
docs: add security and conduct policies

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,38 @@
+# Code of Conduct
+
+## Our Pledge
+
+We pledge to make participation in this project a respectful and harassment-free
+experience for everyone, regardless of background, identity, experience level,
+or point of view.
+
+## Expected Behavior
+
+- Be respectful and constructive.
+- Assume good intent, but accept responsibility for your impact.
+- Keep technical disagreement focused on the work, evidence, and tradeoffs.
+- Give and receive feedback in a way that helps the project move forward.
+
+## Unacceptable Behavior
+
+- Harassment, intimidation, threats, or sustained disruption.
+- Insults, personal attacks, or derogatory language.
+- Publishing another person's private information without clear permission.
+- Unwelcome sexual attention or other conduct that would reasonably make
+  participation unsafe or hostile.
+
+## Enforcement
+
+Maintainers may moderate, edit, or remove comments, issues, pull requests, and
+other contributions that violate this Code of Conduct. Maintainers may also
+temporarily or permanently limit participation when needed to protect the
+community.
+
+If you experience or observe unacceptable behavior, contact the maintainers
+privately. Reports will be reviewed with discretion and with respect for the
+privacy and safety of the people involved.
+
+## Scope
+
+This Code of Conduct applies in project spaces and when a person is representing
+the project in public or private community spaces.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,7 @@
 - Keep changes scoped. Separate refactors from feature work when possible.
 - Prefer additive changes over silent behavioral rewrites.
 - Keep design decisions reviewable. Use `docs/adr/` for architecture decision records when a change needs a durable rationale.
+- Follow the [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## Development workflow
 
@@ -49,3 +50,4 @@
 
 - Never commit real GitHub tokens, private keys, `.env` files, or generated installation tokens.
 - Treat `docker.sock` access as privileged. Self-hosting docs assume a trusted operator.
+- Report suspected vulnerabilities privately through the process in [SECURITY.md](SECURITY.md).

--- a/README.md
+++ b/README.md
@@ -764,6 +764,12 @@ pnpm typecheck
 pnpm build
 ```
 
+## Community and security
+
+- [Contributing guide](CONTRIBUTING.md)
+- [Security policy](SECURITY.md)
+- [Code of Conduct](CODE_OF_CONDUCT.md)
+
 ## License
 
 This project is released under the [MIT License](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,36 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are provided for the latest release published from `main`.
+Older releases are not supported unless maintainers explicitly state otherwise
+in a release note or advisory.
+
+## Reporting a Vulnerability
+
+Please do not report suspected vulnerabilities in public issues, pull requests,
+or discussions.
+
+Use GitHub's private vulnerability reporting flow:
+
+https://github.com/hojinzs/github-symphony/security/advisories/new
+
+Include as much of the following as you can:
+
+- The affected version or commit SHA.
+- A clear description of the vulnerability and its impact.
+- Reproduction steps, proof-of-concept details, or relevant logs.
+- Whether credentials, GitHub App installation tokens, private keys,
+  `docker.sock`, or generated worker environments are involved.
+
+Maintainers will acknowledge valid reports as soon as practical, coordinate on
+the fix privately, and publish an advisory or release note when disclosure is
+appropriate. If the GitHub private reporting form is unavailable, open a public
+issue that requests a private security contact without including technical
+details.
+
+## Scope
+
+Reports are especially useful when they affect credential handling, GitHub token
+brokering, repository checkout isolation, worker process boundaries, Docker
+socket access, or project/workflow data exposure.


### PR DESCRIPTION
## TL;DR

Adds repository community-health documentation for private vulnerability disclosure and contributor conduct.

## 변경 지점 다이어그램

```text
README.md
  -> CONTRIBUTING.md
  -> SECURITY.md
  -> CODE_OF_CONDUCT.md
```

## 여기부터 보세요

- `SECURITY.md` documents supported versions, private reporting through GitHub security advisories, and sensitive areas such as token brokering and `docker.sock`.
- `CODE_OF_CONDUCT.md` adds a concise project conduct and enforcement policy.
- `README.md` and `CONTRIBUTING.md` now link to the new policies.

## 위험 & 롤백

- Risk is low because this is documentation-only Policy Layer work.
- Rollback is reverting `2d418c6` if maintainers want different governance wording.

## 변경 파일

- `SECURITY.md`
- `CODE_OF_CONDUCT.md`
- `CONTRIBUTING.md`
- `README.md`

## Evidence

- `test -f SECURITY.md && test -f CODE_OF_CONDUCT.md && rg -n "SECURITY.md|CODE_OF_CONDUCT.md|do not report suspected vulnerabilities in public" README.md CONTRIBUTING.md SECURITY.md CODE_OF_CONDUCT.md` — passed
- `pnpm lint` — passed
- `pnpm test` — passed
- `pnpm typecheck` — passed
- `pnpm build` — passed
- `pnpm exec prettier --check SECURITY.md CODE_OF_CONDUCT.md CONTRIBUTING.md README.md` — passed
- `pnpm format` — failed on pre-existing formatting drift in 120 untouched files, including `docs/symphony-spec.md`; touched files pass Prettier.

## Issues — Closed #398

Closes #398

## 머지 후/사람 확인

- [ ] Enable GitHub private vulnerability reporting in repository settings if it is not already enabled.
