### PR TITLE
docs: add security and conduct policies

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,37 @@
+# Code of Conduct
+
+## Our Pledge
+
+We pledge to make participation in GitHub Symphony open, respectful, and
+focused on collaborative technical work. This applies to issues, pull requests,
+reviews, discussions, and any other project space.
+
+## Expected Behavior
+
+- Be respectful and considerate.
+- Keep feedback specific, actionable, and tied to the work.
+- Assume good intent while still asking for clarity when something is unclear.
+- Respect differing experience levels, backgrounds, and viewpoints.
+- Accept responsibility for mistakes and correct them promptly.
+
+## Unacceptable Behavior
+
+- Harassment, insults, intimidation, or sustained disruption.
+- Demeaning comments about identity, background, or personal characteristics.
+- Sexualized language or imagery in project spaces.
+- Publishing private information without explicit permission.
+- Bad-faith participation, including trolling or repeated off-topic conflict.
+
+## Enforcement
+
+Maintainers may remove comments, close threads, restrict participation, or take
+other reasonable action when behavior violates this Code of Conduct.
+
+If you need to report a conduct concern, contact the maintainers through a
+private GitHub security advisory when the concern includes sensitive
+information, or through a private maintainer contact channel when available.
+Avoid posting personal or sensitive details in public issues.
+
+Maintainers will review reports in good faith, protect privacy where practical,
+and apply consequences consistently with the severity and context of the
+behavior.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,7 @@
 
 ## Ground rules
 
+- Follow the [Code of Conduct](CODE_OF_CONDUCT.md).
 - Open an issue or discussion before making large architectural changes.
 - Keep changes scoped. Separate refactors from feature work when possible.
 - Prefer additive changes over silent behavioral rewrites.
@@ -49,3 +50,4 @@
 
 - Never commit real GitHub tokens, private keys, `.env` files, or generated installation tokens.
 - Treat `docker.sock` access as privileged. Self-hosting docs assume a trusted operator.
+- Report suspected vulnerabilities privately through the process in [SECURITY.md](SECURITY.md). Do not open a public issue for an unpatched vulnerability.

--- a/README.md
+++ b/README.md
@@ -764,6 +764,12 @@ pnpm typecheck
 pnpm build
 ```
 
+## Community
+
+- Read [CONTRIBUTING.md](CONTRIBUTING.md) before opening substantial changes.
+- Follow the [Code of Conduct](CODE_OF_CONDUCT.md) in project spaces.
+- Report vulnerabilities privately through [SECURITY.md](SECURITY.md).
+
 ## License
 
 This project is released under the [MIT License](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,38 @@
+# Security Policy
+
+GitHub Symphony handles GitHub tokens, GitHub App installation tokens,
+private keys, local token caches, and optional Docker socket access. Please
+report suspected vulnerabilities privately so maintainers can investigate
+before details are public.
+
+## Supported Versions
+
+Security fixes are prioritized for the `main` branch and the latest published
+`@gh-symphony/cli` release. Older releases may receive fixes when the impact
+and upgrade path justify it.
+
+## Reporting a Vulnerability
+
+Use GitHub private vulnerability reporting:
+
+<https://github.com/hojinzs/github-symphony/security/advisories/new>
+
+Do not open a public issue, pull request, discussion, or social media thread
+for an unpatched vulnerability.
+
+Include as much of the following as you can:
+
+- Affected version, commit, or package.
+- Deployment context, especially whether Docker socket access is enabled.
+- Steps to reproduce or a proof of concept.
+- Expected impact, affected secrets, or privilege boundary involved.
+- Any logs or screenshots that do not expose live credentials.
+
+Maintainers will acknowledge reports as soon as practical, assess impact, and
+coordinate a fix and disclosure timeline through the private advisory.
+
+## Secret Handling
+
+Never include live GitHub tokens, private keys, `.env` files, generated
+installation tokens, or broker secrets in reports. Redact secrets and rotate
+any credential that may have been exposed while reproducing an issue.


### PR DESCRIPTION
## TL;DR

Adds root-level community health documentation so contributors have a private vulnerability disclosure path and clear conduct expectations.

## 변경 지점 다이어그램

```text
README.md
  └─ Community links
       ├─ CONTRIBUTING.md
       ├─ CODE_OF_CONDUCT.md
       └─ SECURITY.md

CONTRIBUTING.md
  ├─ Code of Conduct expectation
  └─ Private vulnerability reporting pointer

SECURITY.md
  ├─ Supported versions
  ├─ GitHub private advisory reporting path
  └─ Secret handling guidance

CODE_OF_CONDUCT.md
  ├─ Expected behavior
  ├─ Unacceptable behavior
  └─ Enforcement guidance
```

## 여기부터 보세요

- `SECURITY.md` documents supported versions, private GitHub advisory reporting, public disclosure avoidance, and secret-handling expectations.
- `CODE_OF_CONDUCT.md` documents expected behavior, unacceptable behavior, and maintainer enforcement.
- `README.md` and `CONTRIBUTING.md` make both policies discoverable.

## 위험 & 롤백

- Risk: low; documentation-only Policy Layer change with no runtime, integration, or spec behavior changes.
- Rollback: revert `13d48b6`.

## 변경 파일

- `SECURITY.md`
- `CODE_OF_CONDUCT.md`
- `CONTRIBUTING.md`
- `README.md`

## Evidence

- Documentation TC: `test -f SECURITY.md && test -f CODE_OF_CONDUCT.md && rg -q "security/advisories/new" SECURITY.md && rg -q "Do not open a public issue" SECURITY.md && rg -q "Supported Versions" SECURITY.md && rg -q "Code of Conduct" CODE_OF_CONDUCT.md && rg -q "SECURITY.md" README.md CONTRIBUTING.md && rg -q "CODE_OF_CONDUCT.md" README.md CONTRIBUTING.md`
- `pnpm exec prettier --check SECURITY.md CODE_OF_CONDUCT.md CONTRIBUTING.md README.md`
- `pnpm lint`
- `pnpm test`
- `pnpm typecheck`
- `pnpm build`
- `pnpm format` was also run and fails on the existing repo-wide formatting baseline across unrelated files; the edited files pass targeted Prettier.
- Changeset: N/A; issue has no `changeset:*` label and this is documentation-only.
- Docker E2E: N/A; no integration behavior changed.

## 머지 후/사람 확인

- [ ] Enable GitHub private vulnerability reporting/advisories in repository settings if not already enabled.

## Issues — Closed #398
