### PR TITLE
fix(cli): honor repo config overrides

### DIFF
--- a/.changeset/fair-repo-configs.md
+++ b/.changeset/fair-repo-configs.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Fix issue #389 so `gh-symphony repo` subcommands honor the documented global `--config` / `GH_SYMPHONY_CONFIG_DIR` runtime override instead of silently falling back to the cwd repo runtime.

--- a/packages/cli/src/commands/repo.test.ts
+++ b/packages/cli/src/commands/repo.test.ts
@@ -11,6 +11,11 @@ async function loadRepoCommand() {
   return mod.default;
 }
 
+async function loadRepoModule() {
+  vi.resetModules();
+  return import("./repo.js");
+}
+
 function captureWrites(stream: NodeJS.WriteStream): {
   output: () => string;
   restore: () => void;
@@ -100,6 +105,78 @@ afterEach(() => {
 });
 
 describe("repo init runtime migration", () => {
+  it("preserves an explicit global config override for repo subcommands", async () => {
+    const { repoOptions } = await loadRepoModule();
+    const configDir = join(tmpdir(), "captured-runtime");
+
+    expect(
+      repoOptions({
+        ...baseOptions(configDir),
+        configDirOverride: true,
+      }).configDir
+    ).toBe(configDir);
+  });
+
+  it("preserves a non-default environment config override for repo subcommands", async () => {
+    const { repoOptions } = await loadRepoModule();
+    const configDir = join(tmpdir(), "captured-runtime-env");
+
+    expect(
+      repoOptions({
+        ...baseOptions(configDir),
+        configDirOverride: true,
+        configDirSource: "env",
+      }).configDir
+    ).toBe(configDir);
+  });
+
+  it("keeps the cwd repo runtime for the official Docker default env path", async () => {
+    const { repoOptions } = await loadRepoModule();
+    const repoDir = await mkdtemp(join(tmpdir(), "repo-options-docker-"));
+    const repoRuntimeDir = join(repoDir, ".runtime", "orchestrator");
+    const originalCwd = process.cwd();
+
+    await mkdir(repoRuntimeDir, { recursive: true });
+    await writeFile(
+      join(repoRuntimeDir, "config.json"),
+      JSON.stringify({ activeProject: "repository", projects: ["repository"] }),
+      "utf8"
+    );
+
+    try {
+      process.chdir(repoDir);
+      const expectedRepoRuntimeDir = join(
+        process.cwd(),
+        ".runtime",
+        "orchestrator"
+      );
+      expect(
+        repoOptions({
+          ...baseOptions("/var/lib/gh-symphony"),
+          configDirOverride: true,
+          configDirSource: "env",
+        }).configDir
+      ).toBe(expectedRepoRuntimeDir);
+    } finally {
+      process.chdir(originalCwd);
+    }
+  });
+
+  it("falls back to the cwd repo runtime when no config override was supplied", async () => {
+    const { repoOptions } = await loadRepoModule();
+    const repoDir = await mkdtemp(join(tmpdir(), "repo-options-"));
+    const originalCwd = process.cwd();
+
+    try {
+      process.chdir(repoDir);
+      expect(repoOptions(baseOptions(join(tmpdir(), "global"))).configDir).toBe(
+        join(process.cwd(), ".runtime", "orchestrator")
+      );
+    } finally {
+      process.chdir(originalCwd);
+    }
+  });
+
   it("does not advertise removed repo-set commands in fallback usage", async () => {
     const stderr = captureWrites(process.stderr);
     const repoCommand = await loadRepoCommand();

--- a/packages/cli/src/commands/repo.ts
+++ b/packages/cli/src/commands/repo.ts
@@ -1,4 +1,5 @@
 import type { GlobalOptions } from "../index.js";
+import { existsSync } from "node:fs";
 import logsCommand from "./logs.js";
 import recoverCommand from "./recover.js";
 import repoExplainCommand from "./repo-explain.js";
@@ -6,12 +7,15 @@ import runCommand from "./run.js";
 import startCommand from "./start.js";
 import statusCommand from "./status.js";
 import stopCommand from "./stop.js";
+import { configFilePath } from "../config.js";
 import {
   initRepoRuntime,
   parseRepoRuntimeFlags,
 } from "../repo-runtime.js";
 import { resolveRepoRuntimeRoot } from "../orchestrator-runtime.js";
 import { rejectRemovedProjectId } from "../removed-project-id.js";
+
+const DOCKER_DEFAULT_CONFIG_DIR = "/var/lib/gh-symphony";
 
 const handler = async (
   args: string[],
@@ -61,11 +65,33 @@ const handler = async (
 
 export default handler;
 
-function repoOptions(options: GlobalOptions): GlobalOptions {
+export function repoOptions(options: GlobalOptions): GlobalOptions {
+  const repoRuntimeRoot = resolveRepoRuntimeRoot();
   return {
     ...options,
-    configDir: resolveRepoRuntimeRoot(),
+    configDir: shouldUseConfigDirOverride(options, repoRuntimeRoot)
+      ? options.configDir
+      : repoRuntimeRoot,
   };
+}
+
+function shouldUseConfigDirOverride(
+  options: GlobalOptions,
+  repoRuntimeRoot: string
+): boolean {
+  if (!options.configDirOverride) {
+    return false;
+  }
+
+  if (
+    options.configDirSource === "env" &&
+    options.configDir === DOCKER_DEFAULT_CONFIG_DIR &&
+    existsSync(configFilePath(repoRuntimeRoot))
+  ) {
+    return false;
+  }
+
+  return true;
 }
 
 async function repoInit(args: string[], options: GlobalOptions): Promise<void> {

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -2,7 +2,7 @@ import { mkdtemp } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { runCli } from "./index.js";
+import { resolveGlobalOptions, runCli } from "./index.js";
 import {
   saveGlobalConfig,
   saveProjectConfig,
@@ -52,6 +52,46 @@ afterEach(() => {
 });
 
 describe("Commander CLI entrypoint", () => {
+  it("marks explicit config sources as config overrides", () => {
+    const originalConfigDir = process.env.GH_SYMPHONY_CONFIG_DIR;
+
+    try {
+      delete process.env.GH_SYMPHONY_CONFIG_DIR;
+      expect(
+        resolveGlobalOptions({ config: "/tmp/from-config" })
+          .configDirOverride
+      ).toBe(true);
+      expect(resolveGlobalOptions({ config: "/tmp/from-config" }))
+        .toMatchObject({
+          configDir: "/tmp/from-config",
+          configDirOverride: true,
+          configDirSource: "cli",
+        });
+      expect(
+        resolveGlobalOptions({ configDir: "/tmp/from-config-dir" })
+          .configDirOverride
+      ).toBe(true);
+      expect(resolveGlobalOptions({}).configDirOverride).toBe(false);
+      expect(resolveGlobalOptions({}).configDirSource).toBe("default");
+
+      process.env.GH_SYMPHONY_CONFIG_DIR = "/tmp/from-env";
+      expect(resolveGlobalOptions({}).configDirOverride).toBe(true);
+      expect(resolveGlobalOptions({}).configDir).toBe("/tmp/from-env");
+      expect(resolveGlobalOptions({}).configDirSource).toBe("env");
+
+      process.env.GH_SYMPHONY_CONFIG_DIR = "/var/lib/gh-symphony";
+      expect(resolveGlobalOptions({}).configDirOverride).toBe(false);
+      expect(resolveGlobalOptions({}).configDir).toBe("/var/lib/gh-symphony");
+      expect(resolveGlobalOptions({}).configDirSource).toBe("env");
+    } finally {
+      if (originalConfigDir === undefined) {
+        delete process.env.GH_SYMPHONY_CONFIG_DIR;
+      } else {
+        process.env.GH_SYMPHONY_CONFIG_DIR = originalConfigDir;
+      }
+    }
+  });
+
   it("supports global options after removed repo subcommands", async () => {
     const configDir = await mkdtemp(join(tmpdir(), "cli-index-"));
     const stderr = captureWrites(process.stderr);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -14,6 +14,8 @@ import { createRemovedCommandHandler } from "./commands/removed-command.js";
 
 export type GlobalOptions = {
   configDir: string;
+  configDirOverride?: boolean;
+  configDirSource?: "cli" | "env" | "default";
   verbose: boolean;
   json: boolean;
   noColor: boolean;
@@ -92,15 +94,25 @@ function addGlobalOptions(command: Command): Command {
     .option("--no-color", "Disable color output");
 }
 
-function resolveGlobalOptions(values: CliOptionValues): GlobalOptions {
+export function resolveGlobalOptions(values: CliOptionValues): GlobalOptions {
   const configInput =
     typeof values.config === "string"
       ? values.config
       : typeof values.configDir === "string"
         ? values.configDir
         : undefined;
+  const configDirSource =
+    configInput !== undefined
+      ? "cli"
+      : typeof process.env.GH_SYMPHONY_CONFIG_DIR === "string"
+        ? "env"
+        : "default";
+  const hasConfigOverride =
+    configDirSource === "cli" || hasExplicitConfigEnvOverride();
   const options: GlobalOptions = {
     configDir: resolveConfigDir(configInput),
+    configDirOverride: hasConfigOverride,
+    configDirSource,
     verbose: Boolean(values.verbose),
     json: Boolean(values.json),
     noColor: Boolean(values.noColor),
@@ -112,6 +124,14 @@ function resolveGlobalOptions(values: CliOptionValues): GlobalOptions {
   setNoColor(options.noColor);
 
   return options;
+}
+
+function hasExplicitConfigEnvOverride(): boolean {
+  const envConfigDir = process.env.GH_SYMPHONY_CONFIG_DIR;
+  if (!envConfigDir) {
+    return false;
+  }
+  return envConfigDir !== "/var/lib/gh-symphony";
 }
 
 function resolveProjectId(values: CliOptionValues): string | undefined {


### PR DESCRIPTION
## TL;DR

Fixes #389 by preserving explicit repo runtime overrides for `gh-symphony repo` subcommands. `--config`, hidden `--config-dir`, and non-default `GH_SYMPHONY_CONFIG_DIR` now survive the repo wrapper instead of being replaced with `<cwd>/.runtime/orchestrator`; the official Docker image default `GH_SYMPHONY_CONFIG_DIR=/var/lib/gh-symphony` does not count as an explicit repo override, so the documented container `repo init` → `repo start` flow continues to use the cwd runtime.

## 변경 지점 다이어그램

`index.ts` global option resolution
→ marks explicit CLI config and non-default env config as `configDirOverride`
→ leaves the official container default env as non-explicit
→ `commands/repo.ts` keeps `options.configDir` when override is true
→ otherwise repo subcommands default to `resolveRepoRuntimeRoot()`

## 여기부터 보세요

- `packages/cli/src/index.ts` — tracks whether config came from `--config`, `--config-dir`, or a non-default `GH_SYMPHONY_CONFIG_DIR`.
- `packages/cli/src/commands/repo.ts` — applies override-first repo config precedence.
- `packages/cli/src/commands/repo.test.ts` and `packages/cli/src/index.test.ts` — regression coverage for override, fallback, and official container default paths.

## 위험 & 롤백

- Risk: Low. The change only affects CLI config directory selection before repo subcommand dispatch.
- Rollback: Revert this PR to restore previous repo-local-only runtime selection.

## 변경 파일

- `.changeset/fair-repo-configs.md`
- `packages/cli/src/index.ts`
- `packages/cli/src/index.test.ts`
- `packages/cli/src/commands/repo.ts`
- `packages/cli/src/commands/repo.test.ts`

## Evidence

- `pnpm --filter @gh-symphony/cli test -- --run src/commands/repo.test.ts src/index.test.ts` — pass, 48 tests
- `pnpm lint` — pass
- `pnpm test` — pass
- `pnpm typecheck` — pass
- `pnpm build` — pass
- Container Smoke local: `docker build --build-arg INSTALLER_STAGE=installer-local --tag gh-symphony:test .` — pass
- Container Smoke local: `docker run --rm -v <tmp>/config:/var/lib/gh-symphony -e GH_SYMPHONY_FILE_TRACKER_ISSUES_PATH=/var/lib/gh-symphony/issues.json gh-symphony:test sh -lc 'cd /var/lib/gh-symphony/repo && gh-symphony repo init && gh-symphony repo start --once'` — pass; verified runtime `/var/lib/gh-symphony/repo/.runtime/orchestrator` and one tick `connected (idle)`
- Container Smoke note: the exact CI host `chown -R 1000:1000 <tmp>/config` step failed locally on macOS with `Operation not permitted`; rerun without that Linux-only ownership step passed the in-container CLI behavior under test.
- Changeset: `.changeset/fair-repo-configs.md`

## Issues

- Fixes #389

## 머지 후/사람 확인

- [ ] Confirm `gh-symphony repo logs --config <captured-runtime>` reads the captured runtime outside the current repository runtime.
- [ ] Confirm `GH_SYMPHONY_CONFIG_DIR=<captured-runtime> gh-symphony repo status` reads the configured runtime.
- [ ] Confirm official container default startup still uses the cwd repository runtime after `repo init`.
