### PR TITLE
docs(readme): document web dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,19 +137,33 @@ gh-symphony repo start                   # Start (foreground)
 gh-symphony repo start --daemon          # Start (background)
 gh-symphony repo stop                    # Stop the daemon
 gh-symphony repo stop --force            # Force stop with SIGKILL
+gh-symphony repo start --web             # Browser control-plane dashboard at http://127.0.0.1:4680/
 ```
 
-Monitor:
+Monitor from the terminal:
 
 ```bash
 gh-symphony repo status                  # Show current status
-gh-symphony repo status --watch          # Live dashboard
+gh-symphony repo status --watch          # Live terminal status
 gh-symphony repo logs                    # View event logs
 gh-symphony repo logs --follow           # Stream logs in real-time
 gh-symphony repo logs --issue org/repo#1 # Filter by issue
 gh-symphony repo logs --run <run-id>     # Read events for a specific run
 gh-symphony repo logs --level <level>    # Filter by log level
 ```
+
+### Observability Surfaces
+
+Use `gh-symphony repo start --web` when you want the browser-based
+control-plane dashboard. It starts the orchestrator and serves the React SPA at
+`http://127.0.0.1:4680/` by default. The dashboard includes the project
+overview at `/` and per-issue detail pages at `/issues/<identifier>`, backed by
+the same JSON API used for status snapshots and refresh.
+
+Use `gh-symphony repo start --http` when you only need the JSON status API, for
+example from CI, scripts, or another monitoring process. It exposes
+`/api/v1/state`, `/api/v1/<identifier>`, and refresh endpoints, but `/` is not a
+browser dashboard. Use `repo status --watch` for an interactive terminal view.
 
 Dispatch a single issue manually:
 
@@ -782,7 +796,8 @@ The orchestrator runs independently as long as the repository has been initializ
 # Via the CLI daemon
 gh-symphony repo start                    # continuous polling + status API on 127.0.0.1:4680
 gh-symphony repo start --once             # run startup cleanup + one poll/reconcile/dispatch tick
-gh-symphony repo start --once --http      # keep the dashboard/API available after the one-shot tick until Ctrl+C
+gh-symphony repo start --once --http      # keep the JSON status API available after the one-shot tick until Ctrl+C
+gh-symphony repo start --web              # continuous polling + browser dashboard on 127.0.0.1:4680
 gh-symphony repo run beta/api#42          # dispatch a single issue
 
 # Via the orchestrator package directly
@@ -805,9 +820,9 @@ Runtime state lives under `.runtime/orchestrator/`:
 | `runs/<run-id>/run.json`      | Run snapshot, retry state, worker assignment |
 | `runs/<run-id>/events.ndjson` | Structured orchestration events              |
 
-Read orchestration state via the status API (`/api/v1/projects/<id>/status`) rather than reading status files directly.
+Read orchestration state via the status API (`/api/v1/state`) rather than reading status files directly.
 
-Run `gh-symphony doctor --smoke` before the first `start --once` when you want a safe pre-dispatch readiness check. `gh-symphony repo start --once` is the first production-like run: it validates the real GitHub Project binding, repository `WORKFLOW.md`, and dispatch eligibility, then performs one poll/reconcile/dispatch tick instead of starting a long-lived poller. Add `--http` when you want the dashboard/API available; with `--once --http`, the one-shot tick still completes, but the HTTP server stays up afterward and the process keeps the project lock until you stop it with `Ctrl+C`.
+Run `gh-symphony doctor --smoke` before the first `start --once` when you want a safe pre-dispatch readiness check. `gh-symphony repo start --once` is the first production-like run: it validates the real GitHub Project binding, repository `WORKFLOW.md`, and dispatch eligibility, then performs one poll/reconcile/dispatch tick instead of starting a long-lived poller. Add `--http` when you want the JSON status API available; with `--once --http`, the one-shot tick still completes, but the HTTP server stays up afterward and the process keeps the project lock until you stop it with `Ctrl+C`. Add `--web` instead when you want the browser dashboard at `/` plus the JSON API.
 
 ## Verification
 

--- a/README.md
+++ b/README.md
@@ -157,13 +157,16 @@ gh-symphony repo logs --level <level>    # Filter by log level
 Use `gh-symphony repo start --web` when you want the browser-based
 control-plane dashboard. It starts the orchestrator and serves the React SPA at
 `http://127.0.0.1:4680/` by default. The dashboard includes the project
-overview at `/` and per-issue detail pages at `/issues/<identifier>`, backed by
-the same JSON API used for status snapshots and refresh.
+overview at `/` and per-issue detail pages at `/issues/<encoded-identifier>`,
+where issue identifiers such as `acme/web#42` are URL-encoded as
+`acme%2Fweb%2342`. It is backed by the same JSON API used for status snapshots
+and refresh.
 
 Use `gh-symphony repo start --http` when you only need the JSON status API, for
 example from CI, scripts, or another monitoring process. It exposes
-`/api/v1/state`, `/api/v1/<identifier>`, and refresh endpoints, but `/` is not a
-browser dashboard. Use `repo status --watch` for an interactive terminal view.
+`/api/v1/state`, `/api/v1/<encoded-identifier>`, and
+`POST /api/v1/refresh`, but `/` is not a browser dashboard. Use
+`repo status --watch` for an interactive terminal view.
 
 Dispatch a single issue manually:
 
@@ -794,8 +797,9 @@ The orchestrator runs independently as long as the repository has been initializ
 
 ```bash
 # Via the CLI daemon
-gh-symphony repo start                    # continuous polling + status API on 127.0.0.1:4680
+gh-symphony repo start                    # continuous polling
 gh-symphony repo start --once             # run startup cleanup + one poll/reconcile/dispatch tick
+gh-symphony repo start --http             # continuous polling + JSON status API on 127.0.0.1:4680
 gh-symphony repo start --once --http      # keep the JSON status API available after the one-shot tick until Ctrl+C
 gh-symphony repo start --web              # continuous polling + browser dashboard on 127.0.0.1:4680
 gh-symphony repo run beta/api#42          # dispatch a single issue

--- a/packages/cli/src/commands/start.test.ts
+++ b/packages/cli/src/commands/start.test.ts
@@ -928,7 +928,7 @@ describe("start command foreground locking", () => {
     expect(exitSpy).toHaveBeenCalledWith(0);
   });
 
-  it("serves dashboard routes and refresh over HTTP when --http is enabled", async () => {
+  it("serves status API routes and refresh over HTTP when --http is enabled", async () => {
     const configDir = await createConfigFixture({
       activeProject: "tenant-a",
       projects: [createProject("tenant-a", "acme", "platform")],
@@ -1175,7 +1175,7 @@ describe("start command foreground locking", () => {
     expect(exitSpy).toHaveBeenCalledWith(0);
   });
 
-  it("keeps the HTTP dashboard available after a one-shot tick until interrupted", async () => {
+  it("keeps the HTTP status API available after a one-shot tick until interrupted", async () => {
     const configDir = await createConfigFixture({
       activeProject: "tenant-a",
       projects: [createProject("tenant-a", "acme", "platform")],
@@ -1228,7 +1228,7 @@ describe("start command foreground locking", () => {
         method: "GET",
       });
       expect(stdout.output()).toContain(
-        "One-shot tick completed; HTTP dashboard remains available until Ctrl+C"
+        "One-shot tick completed; HTTP status API remains available until Ctrl+C"
       );
 
       process.emit("SIGINT");
@@ -1494,9 +1494,9 @@ async function waitForHttpUrl(
   while (Date.now() - startedAt < timeoutMs) {
     const match = output()
       .replace(ansiPattern, "")
-      .match(/(HTTP|Web) dashboard listening on .*?(http:\/\/[^\s]+)/);
-    if (match?.[2]) {
-      return match[2];
+      .match(/(?:HTTP status API|Web dashboard) listening on .*?(http:\/\/[^\s]+)/);
+    if (match?.[1]) {
+      return match[1];
     }
     await new Promise((resolve) => setTimeout(resolve, 20));
   }

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -876,7 +876,7 @@ const handler = async (
           cyan("\u25A1"),
           parsed.webPort !== undefined
             ? `Web dashboard listening on ${httpServer.url}`
-            : `HTTP dashboard listening on ${httpServer.url}`
+            : `HTTP status API listening on ${httpServer.url}`
         );
       }
       logLine(
@@ -900,7 +900,7 @@ const handler = async (
                 cyan("\u25A1"),
                 parsed.webPort !== undefined
                   ? "One-shot tick completed; web dashboard remains available until Ctrl+C"
-                  : "One-shot tick completed; HTTP dashboard remains available until Ctrl+C"
+                  : "One-shot tick completed; HTTP status API remains available until Ctrl+C"
               );
               if (shuttingDown) {
                 break;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -503,7 +503,7 @@ function createProgram(): { program: Command; wasInvoked: () => boolean } {
       .option("--assigned-only", "Limit this run to assigned issues")
       .option(
         "--http [port]",
-        "Expose dashboard and refresh endpoints over HTTP"
+        "Expose the JSON status API and refresh endpoints over HTTP"
       )
       .option(
         "--web [port]",


### PR DESCRIPTION
## TL;DR

- Document the browser-based `gh-symphony repo start --web` control-plane dashboard in the README.
- Reword `--http` as the JSON status API in README and CLI output/help so users do not expect a dashboard at `/`.
- Rework the README route examples to show URL-encoded issue identifiers and the exact `POST /api/v1/refresh` endpoint.

## 변경 지점 다이어그램

- `README.md`
  - Adds an Observability Surfaces subsection for terminal status, `--web`, and `--http`.
  - Documents default `--web` dashboard URL, overview route `/`, per-issue route `/issues/<encoded-identifier>`, and JSON API distinction.
  - Clarifies that issue identifiers such as `acme/web#42` must be URL-encoded as a single path segment.
  - Corrects the headless `repo start` example so plain start is continuous polling, while `--http`/`--web` start HTTP surfaces.
- `packages/cli/src/index.ts` / `packages/cli/src/commands/start.ts`
  - Updates `--http` help and runtime log wording from dashboard to HTTP status API.
- `packages/cli/src/commands/start.test.ts`
  - Updates assertions and helper matching for the new `--http` wording.

## 여기부터 보세요

- `README.md` for user-facing observability documentation and route examples.
- `packages/cli/src/commands/start.ts` for the `--http` runtime log wording.

## 위험 & 롤백

- Risk: low; documentation and user-facing wording only, with no API behavior changes.
- Rollback: revert commits `917540f` and `11fb4b2`.

## 변경 파일

- `README.md`
- `packages/cli/src/index.ts`
- `packages/cli/src/commands/start.ts`
- `packages/cli/src/commands/start.test.ts`

## Issues

- Fixes #394

## Issues — Closed #394

## Evidence

- `pnpm --filter @gh-symphony/cli test -- start.test.ts` — pass on commit `11fb4b2` (31 tests)
- `pnpm lint` — pass on commit `11fb4b2`
- `pnpm test` — pass on commit `11fb4b2`
- `pnpm typecheck` — pass on commit `11fb4b2`
- `pnpm build` — pass on commit `11fb4b2`
- Changeset: N/A; no `changeset:*` label on #394.
- Docker E2E: N/A; documentation and user-facing wording only; no integration behavior changed.

## 머지 후/사람 확인

- None.
