### PR TITLE
fix(cli): use English setup gh auth remediation

### DIFF
--- a/.changeset/english-setup-gh-auth.md
+++ b/.changeset/english-setup-gh-auth.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Use the shared English GitHub auth remediation in interactive `gh-symphony setup` failures, covering missing `gh`, unauthenticated, missing-scope, and token validation errors. Fixes #397.

--- a/packages/cli/src/commands/setup.test.ts
+++ b/packages/cli/src/commands/setup.test.ts
@@ -198,6 +198,71 @@ describe("setup command", () => {
     );
   });
 
+  it.each([
+    [
+      "not_installed",
+      "gh CLI is not installed.",
+      "Install gh CLI from https://cli.github.com or set GITHUB_GRAPHQL_TOKEN.",
+      false,
+    ],
+    [
+      "not_authenticated",
+      "gh CLI is not authenticated.",
+      "Run 'gh auth login --scopes repo,read:org,project', then re-run 'gh-symphony setup'.",
+      true,
+    ],
+    [
+      "missing_scopes",
+      "Run 'gh auth refresh --scopes repo,read:org,project'. Missing scopes: project",
+      "Run 'gh auth refresh --scopes project', then re-run 'gh-symphony setup'.",
+      true,
+    ],
+    [
+      "invalid_token",
+      "GITHUB_GRAPHQL_TOKEN is invalid or expired.",
+      "Run 'gh auth login --scopes repo,read:org,project' to re-authenticate, then re-run 'gh-symphony setup'.",
+      true,
+    ],
+    [
+      "token_failed",
+      "gh CLI token could not be validated.",
+      "Run 'gh auth login --scopes repo,read:org,project' to re-authenticate, then re-run 'gh-symphony setup'.",
+      true,
+    ],
+  ] as const)(
+    "reports shared English gh auth remediation for interactive setup %s failures",
+    async (code, message, expectedHint, expectsRetryCommand) => {
+      vi.mocked(ghAuth.ensureGhAuth).mockImplementation(() => {
+        throw new ghAuth.GhAuthError(code, message, {
+          missingScopes: code === "missing_scopes" ? ["project"] : undefined,
+          currentScopes:
+            code === "missing_scopes" ? ["repo", "read:org"] : undefined,
+        });
+      });
+
+      await setupCommand([], {
+        configDir: "/tmp/unused",
+        verbose: false,
+        json: false,
+        noColor: true,
+      });
+
+      const errorOutput = vi
+        .mocked(p.log.error)
+        .mock.calls.map(([line]) => line)
+        .join("\n");
+
+      expect(errorOutput).toContain(message);
+      expect(errorOutput).toContain(expectedHint);
+      if (expectsRetryCommand) {
+        expect(errorOutput).toContain("gh-symphony setup");
+      }
+      expect(errorOutput).not.toMatch(/[가-힣]/);
+      expect(githubClient.listUserProjects).not.toHaveBeenCalled();
+      expect(process.exitCode).toBe(1);
+    }
+  );
+
   it("writes workflow files and managed-project config in non-interactive mode", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "setup-non-interactive-cwd-"));
     const configDir = await mkdtemp(

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -14,6 +14,7 @@ import {
 } from "../github/client.js";
 import {
   ensureGhAuth,
+  formatGhAuthRemediation,
   getGhToken,
   GhAuthError,
   REQUIRED_GH_SCOPES,
@@ -102,6 +103,15 @@ function displayScopeError(
     `gh auth refresh --scopes ${scopeArg}\n\nThen re-run: ${retryCommand}`,
     "Fix missing scope"
   );
+}
+
+function displayGhAuthError(error: GhAuthError): void {
+  const remediation = formatGhAuthRemediation(error, {
+    retryCommand: "gh-symphony setup",
+  });
+
+  p.log.error(`${remediation.title}: ${remediation.message}`);
+  p.log.error(remediation.hint);
 }
 
 async function resolveProjectDetail(
@@ -351,21 +361,7 @@ async function runInteractive(
   } catch (error) {
     authSpinner.stop("Authentication failed.");
     if (error instanceof GhAuthError) {
-      if (error.code === "not_installed") {
-        p.log.error(
-          "gh CLI가 설치되어 있지 않습니다. https://cli.github.com 에서 설치하세요."
-        );
-      } else if (error.code === "not_authenticated") {
-        p.log.error(
-          "gh auth login --scopes repo,read:org,project 를 실행하세요."
-        );
-      } else if (error.code === "missing_scopes") {
-        p.log.error(
-          "gh auth refresh --scopes repo,read:org,project 를 실행하세요."
-        );
-      } else {
-        p.log.error(error.message);
-      }
+      displayGhAuthError(error);
     } else {
       p.log.error(error instanceof Error ? error.message : "Unknown error");
     }


### PR DESCRIPTION
## TL;DR

Interactive `gh-symphony setup` now uses the shared English `formatGhAuthRemediation` path for `GhAuthError` failures instead of hardcoded Korean strings.

## 변경 지점 다이어그램

`setup.ts` interactive auth preflight → `GhAuthError` → `formatGhAuthRemediation(error, { retryCommand: "gh-symphony setup" })` → clack `p.log.error` output

## 여기부터 보세요

- `packages/cli/src/commands/setup.ts` — adds the clack-specific auth remediation display helper and routes interactive setup auth failures through it.
- `packages/cli/src/commands/setup.test.ts` — covers all five `GhAuthError` codes, including `invalid_token` and `token_failed`.
- `.changeset/english-setup-gh-auth.md` — patch changeset for `@gh-symphony/cli`.

## 위험 & 롤백

Risk is low: this only changes the interactive setup auth failure presentation path. Roll back by reverting the setup helper/test changes and the changeset.

## 변경 파일

- `.changeset/english-setup-gh-auth.md`
- `packages/cli/src/commands/setup.ts`
- `packages/cli/src/commands/setup.test.ts`

## Evidence

- `pnpm exec vitest run packages/cli/src/commands/setup.test.ts` — passed
- `rg -n '[가-힣]' packages/cli/src --glob '*.ts' --glob '!*.test.ts'` — no matches
- `pnpm lint` — passed
- `pnpm test` — passed
- `pnpm typecheck` — passed
- `pnpm build` — passed
- Docker E2E: N/A, CLI message formatting only; no orchestrator dispatch, worker lifecycle, tracker adapter, or status API behavior changed

## Issues — Closed #397

Closes #397

## 머지 후/사람 확인

- [ ] Confirm `gh-symphony setup` shows readable English remediation when `gh` is missing, unauthenticated, or missing scopes.
