### PR TITLE
fix(cli): improve repo error/help UX

### DIFF
--- a/.changeset/friendly-repo-cli-errors.md
+++ b/.changeset/friendly-repo-cli-errors.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Improve repository CLI error/help UX for #399: missing `WORKFLOW.md` now points to `workflow init`, repo error paths honor `--json`, repo run/explain help shows the `<issue>` format, unknown repo/workflow subcommands are clearer, and removed repo commands are hidden from help.

--- a/packages/cli/src/cli-error.ts
+++ b/packages/cli/src/cli-error.ts
@@ -1,0 +1,41 @@
+export type CliErrorCode =
+  | "invalid_arguments"
+  | "missing_workflow_file"
+  | "repository_initialization_failed"
+  | "missing_repository_runtime_config"
+  | "status_snapshot_unavailable"
+  | "repository_not_configured"
+  | "repository_mismatch"
+  | "github_auth_required"
+  | "workflow_load_failed"
+  | "unknown_command";
+
+export function writeCliError(input: {
+  code: CliErrorCode;
+  message: string;
+  json?: boolean;
+  exitCode?: number;
+  usage?: string;
+}): void {
+  const exitCode = input.exitCode ?? 1;
+  if (input.json) {
+    process.stdout.write(
+      JSON.stringify(
+        {
+          error: {
+            code: input.code,
+            message: input.message,
+          },
+        },
+        null,
+        2
+      ) + "\n"
+    );
+  } else {
+    process.stderr.write(`${input.message}\n`);
+    if (input.usage) {
+      process.stderr.write(`${input.usage}\n`);
+    }
+  }
+  process.exitCode = exitCode;
+}

--- a/packages/cli/src/commands/lifecycle.test.ts
+++ b/packages/cli/src/commands/lifecycle.test.ts
@@ -168,6 +168,32 @@ describe("lifecycle command integration", () => {
     expect(process.exitCode).toBe(2);
   });
 
+  it("prints JSON when repo run cannot find a runtime config", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "run-missing-config-"));
+    const stdout = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+    const stderr = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+
+    await runModule.default(["acme/platform#42"], {
+      ...baseOptions(configDir),
+      json: true,
+    });
+
+    expect(orchestratorRunCli).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+    expect(stderr).not.toHaveBeenCalled();
+    expect(JSON.parse(String(stdout.mock.calls[0]?.[0]))).toEqual({
+      error: {
+        code: "missing_repository_runtime_config",
+        message:
+          "No repository runtime config found. Run 'gh-symphony repo init' first.",
+      },
+    });
+  });
+
   it("auto-selects the only configured project when start omits --project-id", async () => {
     const configDir = await createConfigFixture({
       activeProject: "tenant-a",

--- a/packages/cli/src/commands/repo-explain.test.ts
+++ b/packages/cli/src/commands/repo-explain.test.ts
@@ -56,6 +56,32 @@ describe("repo explain", () => {
     );
   });
 
+  it("prints JSON when repo explain cannot find a runtime config", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "repo-explain-missing-"));
+    const stdout = captureWrites(process.stdout);
+    const stderr = captureWrites(process.stderr);
+
+    try {
+      await repoExplainCommand(["acme/widgets#42"], {
+        ...baseOptions(configDir),
+        json: true,
+      });
+    } finally {
+      stdout.restore();
+      stderr.restore();
+    }
+
+    expect(process.exitCode).toBe(1);
+    expect(stderr.output()).toBe("");
+    expect(JSON.parse(stdout.output())).toEqual({
+      error: {
+        code: "missing_repository_runtime_config",
+        message:
+          "No repository runtime configured. Run 'gh-symphony repo init' in the target repository.",
+      },
+    });
+  });
+
   it("prints a friendly authentication error when gh auth is unavailable", async () => {
     const configDir = await mkdtemp(join(tmpdir(), "repo-explain-auth-"));
     const stderr = captureWrites(process.stderr);

--- a/packages/cli/src/commands/repo-explain.ts
+++ b/packages/cli/src/commands/repo-explain.ts
@@ -23,6 +23,7 @@ import {
 import { bold, green, red, stripAnsi, yellow } from "../ansi.js";
 import { loadActiveProjectConfig } from "../config.js";
 import { getGhToken, GhAuthError } from "../github/gh-auth.js";
+import { writeCliError } from "../cli-error.js";
 
 type RepoExplainFlags = {
   identifier?: string;
@@ -71,20 +72,25 @@ const handler = async (
 ): Promise<void> => {
   const parsed = parseRepoExplainFlags(args);
   if (parsed.error) {
-    process.stderr.write(`${parsed.error}\n`);
-    process.stderr.write(
-      "Usage: gh-symphony repo explain <owner/repo#number> [--workflow <path>]\n"
-    );
-    process.exitCode = 2;
+    writeCliError({
+      code: "invalid_arguments",
+      message: parsed.error,
+      usage:
+        "Usage: gh-symphony repo explain <owner/repo#number> [--workflow <path>]",
+      json: options.json,
+      exitCode: 2,
+    });
     return;
   }
 
   const projectConfig = await loadActiveProjectConfig(options.configDir);
   if (!projectConfig) {
-    process.stderr.write(
-      "No repository runtime configured. Run 'gh-symphony repo init' in the target repository.\n"
-    );
-    process.exitCode = 1;
+    writeCliError({
+      code: "missing_repository_runtime_config",
+      message:
+        "No repository runtime configured. Run 'gh-symphony repo init' in the target repository.",
+      json: options.json,
+    });
     return;
   }
 
@@ -102,13 +108,12 @@ const handler = async (
     token = getGhToken();
   } catch (error) {
     if (error instanceof GhAuthError) {
-      process.stderr.write(
-        `Error: GitHub authentication is required for repo explain. ${error.message}\n`
-      );
-      process.stderr.write(
-        "Run 'gh auth login --scopes repo,read:org,project' or set GITHUB_GRAPHQL_TOKEN, then re-run this command.\n"
-      );
-      process.exitCode = 2;
+      writeCliError({
+        code: "github_auth_required",
+        message: `Error: GitHub authentication is required for repo explain. ${error.message} Run 'gh auth login --scopes repo,read:org,project' or set GITHUB_GRAPHQL_TOKEN, then re-run this command.`,
+        json: options.json,
+        exitCode: 2,
+      });
       return;
     }
     throw error;
@@ -165,11 +170,12 @@ const handler = async (
     });
   } catch (error) {
     if (error instanceof RepoExplainWorkflowError) {
-      process.stderr.write(`Error: ${error.message}\n`);
-      process.stderr.write(
-        "Hint: pass --workflow <path-to-WORKFLOW.md> or run 'gh-symphony workflow preview --file <path>' to verify the workflow file.\n"
-      );
-      process.exitCode = 2;
+      writeCliError({
+        code: "workflow_load_failed",
+        message: `Error: ${error.message} Hint: pass --workflow <path-to-WORKFLOW.md> or run 'gh-symphony workflow preview --file <path>' to verify the workflow file.`,
+        json: options.json,
+        exitCode: 2,
+      });
       return;
     }
     throw error;

--- a/packages/cli/src/commands/repo.test.ts
+++ b/packages/cli/src/commands/repo.test.ts
@@ -270,6 +270,52 @@ describe("repo init runtime migration", () => {
     expect(stdout.output()).toContain("Repository initialized: acme/platform");
   });
 
+  it("prints a friendly remediation when repo init cannot find WORKFLOW.md", async () => {
+    const repoDir = await createGitRepo();
+    const stderr = captureWrites(process.stderr);
+    const repoCommand = await loadRepoCommand();
+
+    try {
+      await repoCommand(
+        ["init", "--repo-dir", repoDir],
+        baseOptions(join(repoDir, "unused"))
+      );
+    } finally {
+      stderr.restore();
+    }
+
+    expect(process.exitCode).toBe(1);
+    expect(stderr.output()).toContain("WORKFLOW.md was not found");
+    expect(stderr.output()).toContain("gh-symphony workflow init");
+    expect(stderr.output()).not.toContain("ENOENT");
+  });
+
+  it("prints JSON errors for repo init failures when --json is set", async () => {
+    const repoDir = await createGitRepo();
+    const stdout = captureWrites(process.stdout);
+    const stderr = captureWrites(process.stderr);
+    const repoCommand = await loadRepoCommand();
+
+    try {
+      await repoCommand(["init", "--repo-dir", repoDir], {
+        ...baseOptions(join(repoDir, "unused")),
+        json: true,
+      });
+    } finally {
+      stdout.restore();
+      stderr.restore();
+    }
+
+    expect(process.exitCode).toBe(1);
+    expect(stderr.output()).toBe("");
+    expect(JSON.parse(stdout.output())).toEqual({
+      error: {
+        code: "missing_workflow_file",
+        message: expect.stringContaining("gh-symphony workflow init"),
+      },
+    });
+  });
+
   it("persists explicit priority mapping from WORKFLOW.md into tracker settings", async () => {
     const repoDir = await createGitRepo();
     const stdout = captureWrites(process.stdout);

--- a/packages/cli/src/commands/repo.ts
+++ b/packages/cli/src/commands/repo.ts
@@ -10,10 +10,12 @@ import stopCommand from "./stop.js";
 import { configFilePath } from "../config.js";
 import {
   initRepoRuntime,
+  MissingWorkflowFileError,
   parseRepoRuntimeFlags,
 } from "../repo-runtime.js";
 import { resolveRepoRuntimeRoot } from "../orchestrator-runtime.js";
 import { rejectRemovedProjectId } from "../removed-project-id.js";
+import { writeCliError } from "../cli-error.js";
 
 const DOCKER_DEFAULT_CONFIG_DIR = "/var/lib/gh-symphony";
 
@@ -103,13 +105,14 @@ async function repoInit(args: string[], options: GlobalOptions): Promise<void> {
   try {
     flags = parseRepoRuntimeFlags(args);
   } catch (error) {
-    process.stderr.write(
-      `${error instanceof Error ? error.message : "Invalid arguments"}\n`
-    );
-    process.stderr.write(
-      "Usage: gh-symphony repo init [--repo-dir <path>] [--workflow-file <path>]\n"
-    );
-    process.exitCode = 2;
+    writeCliError({
+      code: "invalid_arguments",
+      message: error instanceof Error ? error.message : "Invalid arguments",
+      usage:
+        "Usage: gh-symphony repo init [--repo-dir <path>] [--workflow-file <path>]",
+      json: options.json,
+      exitCode: 2,
+    });
     return;
   }
 
@@ -127,10 +130,17 @@ async function repoInit(args: string[], options: GlobalOptions): Promise<void> {
       ].join("\n") + "\n"
     );
   } catch (error) {
-    process.stderr.write(
-      `${error instanceof Error ? error.message : "Repository initialization failed."}\n`
-    );
-    process.exitCode = 1;
+    writeCliError({
+      code:
+        error instanceof MissingWorkflowFileError
+          ? "missing_workflow_file"
+          : "repository_initialization_failed",
+      message:
+        error instanceof Error
+          ? error.message
+          : "Repository initialization failed.",
+      json: options.json,
+    });
   }
 }
 

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -5,6 +5,7 @@ import {
   handleMissingManagedProjectConfig,
   resolveManagedProjectConfig,
 } from "../project-selection.js";
+import { writeCliError } from "../cli-error.js";
 
 function parseRunArgs(args: string[]): {
   issue?: string;
@@ -60,23 +61,33 @@ const handler = async (
   const parsed = parseRunArgs(args);
 
   if (parsed.error) {
-    process.stderr.write(`${parsed.error}\n`);
-    process.exitCode = 2;
+    writeCliError({
+      code: "invalid_arguments",
+      message: parsed.error,
+      json: options.json,
+      exitCode: 2,
+    });
     return;
   }
 
   if (!parsed.issue) {
-    process.stderr.write("Usage: gh-symphony repo run <owner/repo#number>\n");
-    process.exitCode = 2;
+    writeCliError({
+      code: "invalid_arguments",
+      message: "Issue identifier argument missing",
+      usage: "Usage: gh-symphony repo run <owner/repo#number>",
+      json: options.json,
+      exitCode: 2,
+    });
     return;
   }
 
   const projectConfig = await resolveManagedProjectConfig({
     configDir: options.configDir,
     requestedProjectId: parsed.projectId,
+    json: options.json,
   });
   if (!projectConfig) {
-    handleMissingManagedProjectConfig();
+    handleMissingManagedProjectConfig({ json: options.json });
     return;
   }
 
@@ -85,26 +96,27 @@ const handler = async (
   // Validate the issue identifier belongs to a configured repo
   const [repoSpec] = parsed.issue.split("#");
   const configuredRepos = [projectConfig.repository]
-    .filter(
-      (repository): repository is NonNullable<typeof repository> =>
-        Boolean(repository?.owner && repository.name)
+    .filter((repository): repository is NonNullable<typeof repository> =>
+      Boolean(repository?.owner && repository.name)
     )
     .map((repository) => `${repository.owner}/${repository.name}`);
   const configuredRepoSet = new Set(configuredRepos);
   if (configuredRepoSet.size === 0) {
-    process.stderr.write(
-      "No repository is configured in this project. Run 'gh-symphony repo init' from the target repository first.\n"
-    );
-    process.exitCode = 1;
+    writeCliError({
+      code: "repository_not_configured",
+      message:
+        "No repository is configured in this project. Run 'gh-symphony repo init' from the target repository first.",
+      json: options.json,
+    });
     return;
   }
 
   if (repoSpec && !configuredRepoSet.has(repoSpec)) {
-    process.stderr.write(
-      `Repository "${repoSpec}" is not configured in this project.\n` +
-        `Configured repo: ${configuredRepos.join(", ")}\n`
-    );
-    process.exitCode = 1;
+    writeCliError({
+      code: "repository_mismatch",
+      message: `Repository "${repoSpec}" is not configured in this project. Configured repo: ${configuredRepos.join(", ")}`,
+      json: options.json,
+    });
     return;
   }
 

--- a/packages/cli/src/commands/status.test.ts
+++ b/packages/cli/src/commands/status.test.ts
@@ -126,6 +126,34 @@ afterEach(() => {
 });
 
 describe("status command", () => {
+  it("prints JSON for missing runtime config when --json is set", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "cli-status-missing-"));
+    const stdout = captureWrites(process.stdout);
+    const stderr = captureWrites(process.stderr);
+
+    try {
+      await statusCommand([], {
+        configDir,
+        verbose: false,
+        json: true,
+        noColor: true,
+      });
+    } finally {
+      stdout.restore();
+      stderr.restore();
+    }
+
+    expect(process.exitCode).toBe(1);
+    expect(stderr.output()).toBe("");
+    expect(JSON.parse(stdout.output())).toEqual({
+      error: {
+        code: "missing_repository_runtime_config",
+        message:
+          "No repository runtime config found. Run 'gh-symphony repo init' first.",
+      },
+    });
+  });
+
   it("renders project tokens from the flat runtime status snapshot", async () => {
     const configDir = await createConfigFixture();
     const stdout = captureWrites(process.stdout);

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -8,6 +8,7 @@ import {
   resolveManagedProjectConfig,
 } from "../project-selection.js";
 import { rejectRemovedProjectId } from "../removed-project-id.js";
+import { writeCliError } from "../cli-error.js";
 import { bold, dim, green, red, yellow, cyan, stripAnsi } from "../ansi.js";
 import { clearScreen, showCursor, hideCursor } from "../ansi.js";
 import { renderDashboard } from "../dashboard/renderer.js";
@@ -225,18 +226,23 @@ const handler = async (
   }
   const parsed = parseStatusArgs(args);
   if (parsed.error) {
-    process.stderr.write(`${parsed.error}\n`);
-    process.stderr.write("Usage: gh-symphony repo status [--watch]\n");
-    process.exitCode = 2;
+    writeCliError({
+      code: "invalid_arguments",
+      message: parsed.error,
+      usage: "Usage: gh-symphony repo status [--watch]",
+      json: options.json,
+      exitCode: 2,
+    });
     return;
   }
 
   const projectConfig = await resolveManagedProjectConfig({
     configDir: options.configDir,
     requestedProjectId: undefined,
+    json: options.json,
   });
   if (!projectConfig) {
-    handleMissingManagedProjectConfig();
+    handleMissingManagedProjectConfig({ json: options.json });
     return;
   }
 
@@ -311,8 +317,11 @@ const handler = async (
       );
     }
   } else {
-    process.stderr.write("Unable to read status snapshot.\n");
-    process.exitCode = 1;
+    writeCliError({
+      code: "status_snapshot_unavailable",
+      message: "Unable to read status snapshot.",
+      json: options.json,
+    });
   }
 };
 

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -350,6 +350,33 @@ describe("Commander CLI entrypoint", () => {
   );
 
   it.each([
+    [
+      ["repo", "run", "--json", "--watch"],
+      "Issue identifier argument missing",
+    ],
+    [["repo", "explain", "--json"], "Issue identifier argument missing"],
+  ])("prints JSON for missing issue in %s", async (argv, message) => {
+    const stdout = captureWrites(process.stdout);
+    const stderr = captureWrites(process.stderr);
+
+    try {
+      await runCli(argv);
+    } finally {
+      stdout.restore();
+      stderr.restore();
+    }
+
+    expect(process.exitCode).toBe(2);
+    expect(stderr.output()).toBe("");
+    expect(JSON.parse(stdout.output())).toEqual({
+      error: {
+        code: "invalid_arguments",
+        message,
+      },
+    });
+  });
+
+  it.each([
     [["repo", "badcmd"], "error: unknown command 'badcmd' for 'repo'"],
     [["workflow", "badcmd"], "error: unknown command 'badcmd' for 'workflow'"],
   ])("reports unknown namespace subcommands for %s", async (argv, message) => {
@@ -364,6 +391,46 @@ describe("Commander CLI entrypoint", () => {
     expect(process.exitCode).toBe(1);
     expect(stderr.output()).toContain(message);
     expect(stderr.output()).toContain("(run with --help for usage)");
+  });
+
+  it.each([
+    ["--json", "repo", "badcmd"],
+    ["repo", "--json", "badcmd"],
+    ["repo", "badcmd", "--json"],
+  ])("prints JSON for unknown repo subcommands with globals in %s", async (
+    ...argv
+  ) => {
+    const stdout = captureWrites(process.stdout);
+    const stderr = captureWrites(process.stderr);
+
+    try {
+      await runCli(argv);
+    } finally {
+      stdout.restore();
+      stderr.restore();
+    }
+
+    expect(process.exitCode).toBe(1);
+    expect(stderr.output()).toBe("");
+    expect(JSON.parse(stdout.output())).toEqual({
+      error: {
+        code: "unknown_command",
+        message: "error: unknown command 'badcmd' for 'repo'",
+      },
+    });
+  });
+
+  it("does not treat inherited property names as namespace commands", async () => {
+    const stderr = captureWrites(process.stderr);
+
+    try {
+      await runCli(["toString", "foo"]);
+    } finally {
+      stderr.restore();
+    }
+
+    expect(process.exitCode).toBe(1);
+    expect(stderr.output()).toContain("unknown command 'toString'");
   });
 
   it.each([["project"], ["project", "add", "--non-interactive"]])(

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -58,15 +58,15 @@ describe("Commander CLI entrypoint", () => {
     try {
       delete process.env.GH_SYMPHONY_CONFIG_DIR;
       expect(
-        resolveGlobalOptions({ config: "/tmp/from-config" })
-          .configDirOverride
+        resolveGlobalOptions({ config: "/tmp/from-config" }).configDirOverride
       ).toBe(true);
-      expect(resolveGlobalOptions({ config: "/tmp/from-config" }))
-        .toMatchObject({
-          configDir: "/tmp/from-config",
-          configDirOverride: true,
-          configDirSource: "cli",
-        });
+      expect(
+        resolveGlobalOptions({ config: "/tmp/from-config" })
+      ).toMatchObject({
+        configDir: "/tmp/from-config",
+        configDirOverride: true,
+        configDirSource: "cli",
+      });
       expect(
         resolveGlobalOptions({ configDir: "/tmp/from-config-dir" })
           .configDirOverride
@@ -281,21 +281,22 @@ describe("Commander CLI entrypoint", () => {
     expect(output).toContain("--skip-context");
   });
 
-  it("shows repo sync as removed in command help", async () => {
+  it("keeps hidden removed repo commands callable", async () => {
     const stdout = captureWrites(process.stdout);
     const stderr = captureWrites(process.stderr);
 
     try {
-      await runCli(["repo", "sync", "--help"]);
+      await runCli(["repo", "sync"]);
     } finally {
       stdout.restore();
       stderr.restore();
     }
 
     const output = stdout.output() + stderr.output();
-    expect(output).not.toContain("--dry-run");
-    expect(output).not.toContain("--prune");
-    expect(output).toContain("Removed");
+    expect(output).toContain(
+      "Removed. Single-repo model has no linked-repo set to sync."
+    );
+    expect(process.exitCode).toBe(2);
   });
 
   it("shows repo lifecycle and diagnostic commands in help", async () => {
@@ -314,6 +315,55 @@ describe("Commander CLI entrypoint", () => {
     expect(output).toContain("recover");
     expect(output).toContain("logs");
     expect(output).toContain("explain");
+    expect(output).not.toContain("list");
+    expect(output).not.toContain("add");
+    expect(output).not.toContain("remove");
+    expect(output).not.toContain("sync");
+  });
+
+  it.each([
+    ["repo", "run", "gh-symphony repo run [options] <issue>", "owner/repo#123"],
+    [
+      "repo",
+      "explain",
+      "gh-symphony repo explain [options] <issue>",
+      "owner/repo#123",
+    ],
+  ])(
+    "shows issue format in %s %s help",
+    async (namespace, command, usage, example) => {
+      const stdout = captureWrites(process.stdout);
+      const stderr = captureWrites(process.stderr);
+
+      try {
+        await runCli([namespace, command, "--help"]);
+      } finally {
+        stdout.restore();
+        stderr.restore();
+      }
+
+      const output = stdout.output() + stderr.output();
+      expect(output).toContain(usage);
+      expect(output).toContain("Issue identifier (owner/repo#number)");
+      expect(output).toContain(example);
+    }
+  );
+
+  it.each([
+    [["repo", "badcmd"], "error: unknown command 'badcmd' for 'repo'"],
+    [["workflow", "badcmd"], "error: unknown command 'badcmd' for 'workflow'"],
+  ])("reports unknown namespace subcommands for %s", async (argv, message) => {
+    const stderr = captureWrites(process.stderr);
+
+    try {
+      await runCli(argv);
+    } finally {
+      stderr.restore();
+    }
+
+    expect(process.exitCode).toBe(1);
+    expect(stderr.output()).toContain(message);
+    expect(stderr.output()).toContain("(run with --help for usage)");
   });
 
   it.each([["project"], ["project", "add", "--non-interactive"]])(

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -12,6 +12,7 @@ import { resolveConfigDir } from "./config.js";
 import { renderCompletionScript } from "./completion.js";
 import { renderHelp } from "./commands/help.js";
 import { createRemovedCommandHandler } from "./commands/removed-command.js";
+import { writeCliError } from "./cli-error.js";
 
 export type GlobalOptions = {
   configDir: string;
@@ -85,6 +86,24 @@ const COMMANDS: Record<LoaderKey, () => Promise<{ default: CommandHandler }>> =
     config: () => import("./commands/config-cmd.js"),
     version: () => import("./commands/version.js"),
   };
+
+const NAMESPACE_COMMANDS: Record<string, readonly string[]> = {
+  workflow: ["init", "validate", "preview"],
+  repo: [
+    "list",
+    "add",
+    "remove",
+    "sync",
+    "init",
+    "start",
+    "status",
+    "stop",
+    "run",
+    "recover",
+    "logs",
+    "explain",
+  ],
+};
 
 function addGlobalOptions(command: Command): Command {
   return command
@@ -180,6 +199,32 @@ function hasVersionFlag(argv: string[]): boolean {
   return argv.some((arg) => arg === "--version" || arg === "-V");
 }
 
+function handleUnknownNamespaceCommand(argv: string[]): boolean {
+  const namespace = argv[0];
+  const subcommand = argv[1];
+  if (
+    !namespace ||
+    !subcommand ||
+    subcommand.startsWith("-") ||
+    !(namespace in NAMESPACE_COMMANDS)
+  ) {
+    return false;
+  }
+
+  if (NAMESPACE_COMMANDS[namespace]!.includes(subcommand)) {
+    return false;
+  }
+
+  writeCliError({
+    code: "unknown_command",
+    message: `error: unknown command '${subcommand}' for '${namespace}'`,
+    usage: "(run with --help for usage)",
+    json: argv.includes("--json"),
+    exitCode: 1,
+  });
+  return true;
+}
+
 function resolveVersionOptions(argv: string[]): GlobalOptions {
   const options: GlobalOptions = {
     configDir: resolveConfigDir(),
@@ -247,7 +292,10 @@ function createProgram(): { program: Command; wasInvoked: () => boolean } {
   );
 
   const workflow = addGlobalOptions(
-    program.command("workflow").description("Manage WORKFLOW.md authoring")
+    program
+      .command("workflow")
+      .description("Manage WORKFLOW.md authoring")
+      .showHelpAfterError("(run with --help for usage)")
   );
 
   workflow.action(async function (this: Command) {
@@ -448,7 +496,10 @@ function createProgram(): { program: Command; wasInvoked: () => boolean } {
   });
 
   const repo = addGlobalOptions(
-    program.command("repo").description("Manage the current repository runtime")
+    program
+      .command("repo")
+      .description("Manage the current repository runtime")
+      .showHelpAfterError("(run with --help for usage)")
   );
 
   repo.action(async function (this: Command) {
@@ -456,19 +507,19 @@ function createProgram(): { program: Command; wasInvoked: () => boolean } {
     await invokeHandler("repo", [], this.optsWithGlobals<CliOptionValues>());
   });
 
-  addGlobalOptions(repo.command("list").description("Removed")).action(
-    async function (this: Command) {
-      markInvoked();
-      await invokeRemovedCommand(
-        "Removed. Repository identity is shown by 'repo status'.",
-        this.optsWithGlobals<CliOptionValues>()
-      );
-    }
-  );
+  addGlobalOptions(
+    repo.command("list", { hidden: true }).description("Removed")
+  ).action(async function (this: Command) {
+    markInvoked();
+    await invokeRemovedCommand(
+      "Removed. Repository identity is shown by 'repo status'.",
+      this.optsWithGlobals<CliOptionValues>()
+    );
+  });
 
   addGlobalOptions(
     repo
-      .command("add")
+      .command("add", { hidden: true })
       .description("Removed")
       .argument("[owner/name]", "Repository spec")
       .allowExcessArguments(false)
@@ -482,7 +533,7 @@ function createProgram(): { program: Command; wasInvoked: () => boolean } {
 
   addGlobalOptions(
     repo
-      .command("remove")
+      .command("remove", { hidden: true })
       .description("Removed")
       .argument("[owner/name]", "Repository spec")
       .allowExcessArguments(false)
@@ -495,7 +546,10 @@ function createProgram(): { program: Command; wasInvoked: () => boolean } {
   });
 
   addGlobalOptions(
-    repo.command("sync").description("Removed").allowExcessArguments(false)
+    repo
+      .command("sync", { hidden: true })
+      .description("Removed")
+      .allowExcessArguments(false)
   ).action(async function (this: Command) {
     markInvoked();
     await invokeRemovedCommand(
@@ -585,15 +639,19 @@ function createProgram(): { program: Command; wasInvoked: () => boolean } {
     repo
       .command("run")
       .description("Dispatch a single issue from the current repository")
-      .argument("[args...]", "Issue identifier and passthrough options")
+      .argument("<issue>", "Issue identifier (owner/repo#number)")
       .option("--log-level <level>", "Orchestrator lifecycle log level")
       .option("-w, --watch", "Watch status after dispatch")
       .allowUnknownOption(true)
       .allowExcessArguments(true)
-  ).action(async function (this: Command, passthrough: string[]) {
+      .addHelpText(
+        "after",
+        "\nExamples:\n  $ gh-symphony repo run owner/repo#123\n"
+      )
+  ).action(async function (this: Command, issue: string) {
     markInvoked();
     const values = this.optsWithGlobals<CliOptionValues>();
-    const args: string[] = ["run", ...passthrough];
+    const args: string[] = ["run", issue, ...this.args.slice(1)];
     pushOption(args, "--log-level", values.logLevel);
     pushOption(args, "--watch", values.watch);
     await invokeHandler("repo", args, values);
@@ -639,14 +697,18 @@ function createProgram(): { program: Command; wasInvoked: () => boolean } {
     repo
       .command("explain")
       .description("Explain why a repository issue is not dispatching")
-      .argument("[args...]", "Issue identifier and passthrough options")
+      .argument("<issue>", "Issue identifier (owner/repo#number)")
       .option("--workflow <path>", "Path to the WORKFLOW.md file to evaluate")
       .allowUnknownOption(true)
       .allowExcessArguments(true)
-  ).action(async function (this: Command, passthrough: string[]) {
+      .addHelpText(
+        "after",
+        "\nExamples:\n  $ gh-symphony repo explain owner/repo#123\n"
+      )
+  ).action(async function (this: Command, issue: string) {
     markInvoked();
     const values = this.optsWithGlobals<CliOptionValues>();
-    const args: string[] = ["explain", ...passthrough];
+    const args: string[] = ["explain", issue, ...this.args.slice(1)];
     pushOption(args, "--workflow", values.workflow);
     await invokeHandler("repo", args, values);
   });
@@ -731,6 +793,10 @@ export async function runCli(argv: string[]): Promise<void> {
   if (hasVersionFlag(argv)) {
     const versionModule = await COMMANDS.version();
     await versionModule.default([], resolveVersionOptions(argv));
+    return;
+  }
+
+  if (handleUnknownNamespaceCommand(argv)) {
     return;
   }
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -87,24 +87,6 @@ const COMMANDS: Record<LoaderKey, () => Promise<{ default: CommandHandler }>> =
     version: () => import("./commands/version.js"),
   };
 
-const NAMESPACE_COMMANDS: Record<string, readonly string[]> = {
-  workflow: ["init", "validate", "preview"],
-  repo: [
-    "list",
-    "add",
-    "remove",
-    "sync",
-    "init",
-    "start",
-    "status",
-    "stop",
-    "run",
-    "recover",
-    "logs",
-    "explain",
-  ],
-};
-
 function addGlobalOptions(command: Command): Command {
   return command
     .option("--config <dir>", "Config directory")
@@ -199,19 +181,66 @@ function hasVersionFlag(argv: string[]): boolean {
   return argv.some((arg) => arg === "--version" || arg === "-V");
 }
 
-function handleUnknownNamespaceCommand(argv: string[]): boolean {
-  const namespace = argv[0];
-  const subcommand = argv[1];
-  if (
-    !namespace ||
-    !subcommand ||
-    subcommand.startsWith("-") ||
-    !(namespace in NAMESPACE_COMMANDS)
-  ) {
+function extractNamespaceCommand(
+  argv: string[]
+): { namespace?: string; subcommand?: string } {
+  const positionals: string[] = [];
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (!arg) {
+      continue;
+    }
+    if (arg === "--config" || arg === "--config-dir") {
+      i += 1;
+      continue;
+    }
+    if (arg.startsWith("--config=") || arg.startsWith("--config-dir=")) {
+      continue;
+    }
+    if (
+      arg === "--json" ||
+      arg === "--no-color" ||
+      arg === "--verbose" ||
+      arg === "-v"
+    ) {
+      continue;
+    }
+    if (arg.startsWith("-")) {
+      continue;
+    }
+    positionals.push(arg);
+    if (positionals.length === 2) {
+      break;
+    }
+  }
+
+  return {
+    namespace: positionals[0],
+    subcommand: positionals[1],
+  };
+}
+
+function getChildCommandNames(command: Command): readonly string[] {
+  return command.commands.map((child) => child.name());
+}
+
+function handleUnknownNamespaceCommand(
+  argv: string[],
+  program: Command
+): boolean {
+  const { namespace, subcommand } = extractNamespaceCommand(argv);
+  if (!namespace || !subcommand) {
     return false;
   }
 
-  if (NAMESPACE_COMMANDS[namespace]!.includes(subcommand)) {
+  const namespaceCommand = program.commands.find(
+    (command) => command.name() === namespace
+  );
+  if (!namespaceCommand || !["repo", "workflow"].includes(namespace)) {
+    return false;
+  }
+
+  if (getChildCommandNames(namespaceCommand).includes(subcommand)) {
     return false;
   }
 
@@ -639,7 +668,8 @@ function createProgram(): { program: Command; wasInvoked: () => boolean } {
     repo
       .command("run")
       .description("Dispatch a single issue from the current repository")
-      .argument("<issue>", "Issue identifier (owner/repo#number)")
+      .usage("[options] <issue>")
+      .argument("[issue]", "Issue identifier (owner/repo#number)")
       .option("--log-level <level>", "Orchestrator lifecycle log level")
       .option("-w, --watch", "Watch status after dispatch")
       .allowUnknownOption(true)
@@ -648,10 +678,14 @@ function createProgram(): { program: Command; wasInvoked: () => boolean } {
         "after",
         "\nExamples:\n  $ gh-symphony repo run owner/repo#123\n"
       )
-  ).action(async function (this: Command, issue: string) {
+  ).action(async function (this: Command, issue: string | undefined) {
     markInvoked();
     const values = this.optsWithGlobals<CliOptionValues>();
-    const args: string[] = ["run", issue, ...this.args.slice(1)];
+    const args: string[] = ["run"];
+    if (issue) {
+      args.push(issue);
+    }
+    args.push(...this.args.slice(issue ? 1 : 0));
     pushOption(args, "--log-level", values.logLevel);
     pushOption(args, "--watch", values.watch);
     await invokeHandler("repo", args, values);
@@ -697,7 +731,8 @@ function createProgram(): { program: Command; wasInvoked: () => boolean } {
     repo
       .command("explain")
       .description("Explain why a repository issue is not dispatching")
-      .argument("<issue>", "Issue identifier (owner/repo#number)")
+      .usage("[options] <issue>")
+      .argument("[issue]", "Issue identifier (owner/repo#number)")
       .option("--workflow <path>", "Path to the WORKFLOW.md file to evaluate")
       .allowUnknownOption(true)
       .allowExcessArguments(true)
@@ -705,10 +740,14 @@ function createProgram(): { program: Command; wasInvoked: () => boolean } {
         "after",
         "\nExamples:\n  $ gh-symphony repo explain owner/repo#123\n"
       )
-  ).action(async function (this: Command, issue: string) {
+  ).action(async function (this: Command, issue: string | undefined) {
     markInvoked();
     const values = this.optsWithGlobals<CliOptionValues>();
-    const args: string[] = ["explain", issue, ...this.args.slice(1)];
+    const args: string[] = ["explain"];
+    if (issue) {
+      args.push(issue);
+    }
+    args.push(...this.args.slice(issue ? 1 : 0));
     pushOption(args, "--workflow", values.workflow);
     await invokeHandler("repo", args, values);
   });
@@ -796,7 +835,7 @@ export async function runCli(argv: string[]): Promise<void> {
     return;
   }
 
-  if (handleUnknownNamespaceCommand(argv)) {
+  if (handleUnknownNamespaceCommand(argv, program)) {
     return;
   }
 

--- a/packages/cli/src/project-selection.ts
+++ b/packages/cli/src/project-selection.ts
@@ -4,10 +4,12 @@ import {
   loadProjectConfig,
   type CliProjectConfig,
 } from "./config.js";
+import { writeCliError } from "./cli-error.js";
 
 type ResolveProjectSelectionInput = {
   configDir: string;
   requestedProjectId?: string;
+  json?: boolean;
 };
 
 export type ManagedProjectResolution =
@@ -63,7 +65,8 @@ export async function inspectManagedProjectSelection(
   if (!global) {
     return {
       kind: "missing_global_config",
-      message: "No repository runtime config found. Run 'gh-symphony repo init' first.",
+      message:
+        "No repository runtime config found. Run 'gh-symphony repo init' first.",
     };
   }
 
@@ -71,7 +74,8 @@ export async function inspectManagedProjectSelection(
   if (projectIds.length === 0) {
     return {
       kind: "no_projects",
-      message: "No repository runtime config is configured. Run 'gh-symphony repo init' first.",
+      message:
+        "No repository runtime config is configured. Run 'gh-symphony repo init' first.",
     };
   }
 
@@ -146,8 +150,11 @@ export async function resolveManagedProjectConfig(
   }
 
   if (!isInteractiveTerminal()) {
-    process.stderr.write(explicitProjectRequiredMessage());
-    process.exitCode = 1;
+    writeCliError({
+      code: "missing_repository_runtime_config",
+      message: explicitProjectRequiredMessage().trimEnd(),
+      json: input.json,
+    });
     return null;
   }
 
@@ -182,13 +189,19 @@ export async function resolveManagedProjectConfig(
   return loadProjectConfig(input.configDir, selected);
 }
 
-export function handleMissingManagedProjectConfig(): void {
+export function handleMissingManagedProjectConfig(options?: {
+  json?: boolean;
+  message?: string;
+}): void {
   if (process.exitCode) {
     return;
   }
 
-  process.stderr.write(
-    "No repository runtime config found. Run 'gh-symphony repo init' first.\n"
-  );
-  process.exitCode = 1;
+  writeCliError({
+    code: "missing_repository_runtime_config",
+    message:
+      options?.message ??
+      "No repository runtime config found. Run 'gh-symphony repo init' first.",
+    json: options?.json,
+  });
 }

--- a/packages/cli/src/repo-runtime.ts
+++ b/packages/cli/src/repo-runtime.ts
@@ -31,6 +31,14 @@ const INTERNAL_PROJECT_ID = "repository";
 
 export class RepoRuntimeMigrationError extends Error {}
 
+export class MissingWorkflowFileError extends Error {
+  constructor(readonly workflowPath: string) {
+    super(
+      `WORKFLOW.md was not found at ${workflowPath}. Run 'gh-symphony workflow init' in this repository or add a valid WORKFLOW.md at the repo root.`
+    );
+  }
+}
+
 export function parseRepoRuntimeFlags(args: readonly string[]): RepoInitFlags {
   const flags: RepoInitFlags = { repoDir: process.cwd() };
 
@@ -72,6 +80,9 @@ export async function initRepoRuntime(flags: RepoInitFlags): Promise<{
   await migrateLegacyRuntime(runtimeRoot);
 
   const workflowPath = resolve(repoDir, flags.workflowFile ?? "WORKFLOW.md");
+  if (!(await pathExists(workflowPath))) {
+    throw new MissingWorkflowFileError(workflowPath);
+  }
   const workflow = parseWorkflowMarkdown(await readFile(workflowPath, "utf8"));
   validateRepoInitWorkflow(workflow);
   const repository = resolveRepository(repoDir);


### PR DESCRIPTION
## TL;DR

- Fixes the repo CLI first-run/error UX from #399.
- `repo init` now reports a friendly missing `WORKFLOW.md` remediation, repo error paths honor `--json`, and repo run/explain help surfaces the `<issue>` format.
- Rework keeps missing-issue validation inside command handlers so `--json` remains structured even when the issue is omitted, and unknown-subcommand routing now tolerates global option placement.

## 변경 지점 다이어그램

- `packages/cli/src/repo-runtime.ts` → detects missing workflow files before parsing.
- `packages/cli/src/cli-error.ts` → centralizes text vs JSON error output.
- `packages/cli/src/commands/{repo,status,run,repo-explain}.ts` → uses structured error output on failure paths.
- `packages/cli/src/index.ts` → improves repo/workflow subcommand help and unknown-subcommand handling; derives namespace subcommands from Commander registration.
- `packages/cli/src/**/*.test.ts` → regression coverage for friendly errors, JSON errors, help text, hidden removed commands, unknown subcommands, and rework edge cases.

## 여기부터 보세요

- `packages/cli/src/cli-error.ts`
- `packages/cli/src/repo-runtime.ts`
- `packages/cli/src/index.ts`
- `packages/cli/src/commands/repo.test.ts`
- `packages/cli/src/index.test.ts`

## 위험 & 롤백

- Risk: low; changes are limited to CLI error/help paths and command metadata.
- Rollback: revert this PR to restore the previous CLI behavior.

## 변경 파일

- `.changeset/friendly-repo-cli-errors.md`
- `packages/cli/src/cli-error.ts`
- `packages/cli/src/repo-runtime.ts`
- `packages/cli/src/project-selection.ts`
- `packages/cli/src/commands/repo.ts`
- `packages/cli/src/commands/status.ts`
- `packages/cli/src/commands/run.ts`
- `packages/cli/src/commands/repo-explain.ts`
- `packages/cli/src/index.ts`
- CLI regression tests

## Evidence

- `pnpm --filter @gh-symphony/cli test -- src/index.test.ts src/commands/lifecycle.test.ts src/commands/repo-explain.test.ts`
- `pnpm lint`
- `pnpm test`
- `pnpm typecheck`
- `pnpm build`
- Built CLI smoke checks for `repo run --json --watch`, `repo explain --json`, `--json repo badcmd`, `repo --json badcmd`, `repo badcmd --json`, `toString foo`, `repo run --help`, and `repo explain --help`.

## Issues — Closed #399

Closes #399

## 머지 후/사람 확인

- [ ] Optional manual CLI sanity check from a clean install.
