### PR TITLE
Add GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,144 @@
+name: Bug report
+description: Report a setup, orchestration, runtime, or CLI failure with diagnostics.
+title: "Bug: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug. For setup and orchestration failures, attach a redacted support bundle from:
+
+        ```bash
+        gh-symphony doctor --bundle
+        ```
+
+        Also paste the JSON diagnostics from:
+
+        ```bash
+        gh-symphony doctor --json
+        ```
+
+  - type: textarea
+    id: background
+    attributes:
+      label: Background
+      description: What were you trying to do, and why was this flow needed?
+      placeholder: I was setting up gh-symphony for...
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Symptoms / Reproduction Steps
+      description: List the exact commands or actions that reproduce the issue.
+      placeholder: |
+        1. Run `gh-symphony ...`
+        2. Configure `...`
+        3. Observe `...`
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What should have happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What happened instead? Include relevant terminal output or logs.
+      render: shell
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: OS
+      description: Include distribution/version for Linux, macOS version, or Windows version.
+      placeholder: macOS 15.5, Ubuntu 24.04, Windows 11
+    validations:
+      required: true
+
+  - type: input
+    id: node-version
+    attributes:
+      label: Node.js Version
+      description: Output of `node --version`.
+      placeholder: v24.0.0
+    validations:
+      required: true
+
+  - type: dropdown
+    id: install-method
+    attributes:
+      label: Install Method
+      description: How did you install or run gh-symphony?
+      options:
+        - npm
+        - Docker
+        - Built from source
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: install-version
+    attributes:
+      label: gh-symphony Version or Image Tag
+      description: Include the npm package version, local git commit, or container image tag.
+      placeholder: 0.0.14, ghcr.io/hojinzs/github-symphony:latest, or git SHA
+    validations:
+      required: true
+
+  - type: input
+    id: runtime
+    attributes:
+      label: Chosen Runtime
+      description: Runtime command/provider configured for the worker.
+      placeholder: codex, claude, custom command, or Docker runtime command
+    validations:
+      required: true
+
+  - type: textarea
+    id: doctor-json
+    attributes:
+      label: "`gh-symphony doctor --json` Output"
+      description: Paste redacted JSON diagnostics. Remove secrets, tokens, and private URLs.
+      render: json
+    validations:
+      required: true
+
+  - type: textarea
+    id: doctor-bundle
+    attributes:
+      label: "`gh-symphony doctor --bundle` Attachment"
+      description: Drag the generated support bundle archive or folder output here. If you cannot attach it, explain why.
+      placeholder: Attach the bundle here, or explain why it is unavailable.
+    validations:
+      required: true
+
+  - type: textarea
+    id: affected-files
+    attributes:
+      label: Affected Files
+      description: If known, list files, commands, config paths, or runtime artifacts involved.
+      placeholder: |
+        | File or path | Change or symptom | Scope |
+        | --- | --- | --- |
+    validations:
+      required: false
+
+  - type: textarea
+    id: references
+    attributes:
+      label: References
+      description: Link related issues, PRs, docs, ADRs, or Symphony spec sections if relevant.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Contributing guide
+    url: https://github.com/hojinzs/github-symphony/blob/main/CONTRIBUTING.md
+    about: Read contribution workflow, validation, changeset, and security expectations.
+  - name: Project management conventions
+    url: https://github.com/hojinzs/github-symphony/blob/main/PROJECT_MANAGE.md
+    about: Review the Background, Proposed Changes, and Affected Files issue structure.
+  - name: Support bundle documentation
+    url: https://github.com/hojinzs/github-symphony/blob/main/README.md#repository-commands
+    about: See doctor commands, including doctor --json and doctor --bundle.
+  - name: Security policy
+    url: https://github.com/hojinzs/github-symphony/blob/main/SECURITY.md
+    about: Report suspected vulnerabilities privately instead of opening a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,80 @@
+name: Feature request
+description: Propose a scoped repository, CLI, runtime, or workflow improvement.
+title: "Feature: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please follow the project management structure from `PROJECT_MANAGE.md`.
+        Keep tracker-specific behavior layered on top of Symphony core behavior.
+
+  - type: textarea
+    id: background
+    attributes:
+      label: Background
+      description: Why is this change needed? Include motivation, user impact, and current limitations.
+      placeholder: This is needed because...
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed-changes
+    attributes:
+      label: Proposed Changes
+      description: What should change, and how should it behave?
+      placeholder: |
+        - Add ...
+        - Update ...
+        - Preserve ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: affected-files
+    attributes:
+      label: Affected Files
+      description: List likely files or packages and the expected scope.
+      placeholder: |
+        | File | Change | Scope |
+        | --- | --- | --- |
+        | packages/... | ... | ... |
+    validations:
+      required: true
+
+  - type: textarea
+    id: spec-reference
+    attributes:
+      label: Spec Reference
+      description: Relevant Symphony spec sections and quotes, if this touches spec conformance.
+      placeholder: docs/symphony-spec.md section ...
+    validations:
+      required: false
+
+  - type: textarea
+    id: current-vs-spec
+    attributes:
+      label: Current Implementation vs Spec
+      description: Side-by-side comparison if the request is about spec alignment.
+      placeholder: |
+        | Current implementation | Spec expectation | Gap |
+        | --- | --- | --- |
+    validations:
+      required: false
+
+  - type: textarea
+    id: migration-notes
+    attributes:
+      label: Migration Notes
+      description: Note compatibility, data, API, config, deployment, or self-hosting impact.
+    validations:
+      required: false
+
+  - type: textarea
+    id: references
+    attributes:
+      label: References
+      description: Link related issues, PRs, ADRs, discussions, docs, or external context.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,37 @@
+## Issues
+
+- Closes #
+
+## Summary
+
+- <!-- What changed and why? -->
+
+## User-Visible Behavior / Operational Impact
+
+- <!-- Include CLI/runtime behavior, deployment impact, or "None". -->
+
+## Validation
+
+- [ ] `pnpm lint`
+- [ ] `pnpm test`
+- [ ] `pnpm typecheck`
+- [ ] `pnpm build`
+- [ ] `pnpm format`
+- [ ] Screenshots or terminal output included when changing UX or deployment flows
+- [ ] Docker E2E or blackbox validation included when changing integration behavior
+
+## Changeset
+
+- [ ] Added a Changeset for released package behavior changes
+- [ ] Not needed because this is documentation, tests, tooling, or internal-only maintenance
+
+## Review Notes
+
+- Related ADR:
+- Follow-up work:
+- Rollback plan:
+
+## Security
+
+- [ ] No real GitHub tokens, private keys, `.env` files, or generated installation tokens are committed
+- [ ] Privileged Docker or host access changes are documented for trusted operators


### PR DESCRIPTION
## Issues — Closed #391

- Closes #391

## TL;DR

- Adds GitHub issue forms for bug reports and feature requests.
- Adds a pull request template that mirrors the repository contribution checklist.
- Adds issue template config links for contributing, project management conventions, support bundles, and security reporting.

## 변경 지점 다이어그램

```text
.github/
├── ISSUE_TEMPLATE/
│   ├── bug_report.yml          # environment + doctor diagnostics + support bundle
│   ├── feature_request.yml     # PROJECT_MANAGE.md structure
│   └── config.yml              # contributor/support/security links
└── PULL_REQUEST_TEMPLATE.md    # CONTRIBUTING.md checklist
```

## 여기부터 보세요

- `.github/ISSUE_TEMPLATE/bug_report.yml` collects OS, Node.js version, install method, chosen runtime, `gh-symphony doctor --json`, and `gh-symphony doctor --bundle` attachment context.
- `.github/ISSUE_TEMPLATE/feature_request.yml` follows `PROJECT_MANAGE.md` sections: Background, Proposed Changes, Affected Files, plus optional spec/reference sections.
- `.github/PULL_REQUEST_TEMPLATE.md` reflects `CONTRIBUTING.md` expectations for linked issues, behavior/operational impact, validation commands, Changesets, follow-up work, and security hygiene.

## 위험 & 롤백

- Risk is limited to GitHub UI metadata. It does not change runtime, package code, workflows, or the upstream Symphony spec.
- Rollback is deleting the four added `.github` template files.

## 변경 파일

- `.github/ISSUE_TEMPLATE/bug_report.yml`
- `.github/ISSUE_TEMPLATE/feature_request.yml`
- `.github/ISSUE_TEMPLATE/config.yml`
- `.github/PULL_REQUEST_TEMPLATE.md`

## Evidence

- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/ISSUE_TEMPLATE/bug_report.yml .github/ISSUE_TEMPLATE/feature_request.yml .github/ISSUE_TEMPLATE/config.yml` — passed
- `pnpm exec prettier --check .github/ISSUE_TEMPLATE/bug_report.yml .github/ISSUE_TEMPLATE/feature_request.yml .github/ISSUE_TEMPLATE/config.yml .github/PULL_REQUEST_TEMPLATE.md` — passed
- `pnpm lint` — passed
- `pnpm test` — passed
- `pnpm typecheck` — passed
- `pnpm build` — passed
- `pnpm format` — failed on pre-existing repository-wide formatting drift, including many files outside this PR; targeted changed files pass Prettier.

## 머지 후/사람 확인

- [ ] Confirm GitHub renders the bug report and feature request forms in the issue chooser.
- [ ] Confirm the support bundle contact link is useful from the issue chooser.
- [ ] Confirm the PR template checklist is acceptable for maintainers.
