### PR TITLE
docs(readme): polish OSS contributor paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
 # GitHub Symphony
 
+[![CI](https://github.com/hojinzs/github-symphony/actions/workflows/ci.yml/badge.svg)](https://github.com/hojinzs/github-symphony/actions/workflows/ci.yml)
+[![npm](https://img.shields.io/npm/v/@gh-symphony/cli?logo=npm)](https://www.npmjs.com/package/@gh-symphony/cli)
+[![Node.js 24+](https://img.shields.io/badge/node-24%2B-339933?logo=node.js&logoColor=white)](https://nodejs.org/)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
+[![Code of Conduct](https://img.shields.io/badge/code%20of%20conduct-active-blueviolet.svg)](CODE_OF_CONDUCT.md)
+
 GitHub Symphony is a multi-tenant AI coding agent orchestration platform built on the [OpenAI Symphony specification](https://github.com/openai/symphony). A CLI-first orchestrator polls GitHub Projects for open issues, dispatches worker runs per repository, and resolves all workflow policy from each repository's `WORKFLOW.md` at runtime.
+
+GitHub Symphony is an MIT-licensed open source project. Contributions are welcome: start with the [contributing guide](CONTRIBUTING.md), follow the [Code of Conduct](CODE_OF_CONDUCT.md), use the GitHub issue templates for bug reports and feature requests, and report security issues through [SECURITY.md](SECURITY.md). For setup or orchestration failures, include a redacted support bundle from `gh-symphony doctor --bundle` when opening a bug report.
 
 ## Requirements
 
@@ -884,9 +893,10 @@ pnpm build
 
 ## Community and security
 
-- [Contributing guide](CONTRIBUTING.md)
-- [Security policy](SECURITY.md)
-- [Code of Conduct](CODE_OF_CONDUCT.md)
+- [Contributing guide](CONTRIBUTING.md) — development setup, validation, and pull request expectations.
+- [Security policy](SECURITY.md) — supported reporting path for vulnerabilities and sensitive disclosures.
+- [Code of Conduct](CODE_OF_CONDUCT.md) — community expectations for issues, discussions, and pull requests.
+- [MIT License](LICENSE) — project license terms.
 
 ## License
 


### PR DESCRIPTION
## TL;DR

Polishes the README so first-time OSS users can immediately see project health, license, contribution, support, and security paths near the top of the repository page.

## 변경 지점 다이어그램

```text
README.md
├─ top badges: CI, npm, Node.js 24+, MIT, PRs welcome, Code of Conduct
├─ intro note: OSS contribution, support bundle, security reporting guidance
└─ Community and security: clearer links to contributing, security, conduct, license
```

## 여기부터 보세요

- `README.md` top section for badges and the contributor/support note.
- `README.md` `Community and security` section for the preserved and lightly improved community links.

## 위험 & 롤백

- Risk is low: documentation-only change with no runtime behavior impact.
- Rollback is a single README revert if wording or badge selection needs to change.

## 변경 파일

- `README.md` — add OSS-facing badges and early contributor/support guidance, then clarify bottom community links.

## Evidence

- `pnpm install --frozen-lockfile` — installed dependencies from the existing lockfile after initial lint showed missing `node_modules`.
- `pnpm lint` — pass.
- `pnpm test` — pass.
- `pnpm typecheck` — pass.
- `pnpm build` — pass.
- `pnpm exec prettier --check README.md` — pass.
- `npm view @gh-symphony/cli version --silent` — package resolves as `0.4.7`.
- `gh api repos/hojinzs/github-symphony/actions/workflows/ci.yml --jq '.name + " " + .state'` — `CI active`.
- Direct checks confirmed local links exist for `CONTRIBUTING.md`, `SECURITY.md`, `CODE_OF_CONDUCT.md`, `LICENSE`, and `.github/workflows/ci.yml`.
- Direct `curl -L --fail` checks passed for all added shields.io badge URLs.
- Note: full-repo `pnpm format` still fails on pre-existing formatting drift in unrelated files; `README.md` itself passes Prettier.

## Issues — Closed #422

Closes #422

## 머지 후/사람 확인

- [ ] Confirm the README wording and badge set fit the repository's desired OSS presentation.
