### PR TITLE
fix(status): hide stale cleanup recovery

### DIFF
--- a/.changeset/hide-stale-cleanup-recovery.md
+++ b/.changeset/hide-stale-cleanup-recovery.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Hide stale incomplete-turn recovery from repo status and repo explain after issue workspace cleanup removes the backing workspace for #421.

--- a/.changeset/silent-stale-recovery.md
+++ b/.changeset/silent-stale-recovery.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Fix #421: hide stale incomplete-turn recovery notices after the issue workspace has been removed so `repo status` and `repo explain` only report actionable recovery.

--- a/packages/cli/src/commands/repo-explain.ts
+++ b/packages/cli/src/commands/repo-explain.ts
@@ -4,6 +4,7 @@ import type { GlobalOptions } from "../index.js";
 import {
   WorkflowConfigStore,
   type IssueOrchestrationRecord,
+  type IssueWorkspaceRecord,
   type OrchestratorProjectConfig,
   type OrchestratorRunRecord,
   type ProjectItemsCache,
@@ -148,13 +149,17 @@ const handler = async (
                 identifier.trim().toLowerCase()
             ) ?? null
         );
-  const [issues, issue, issueRecords, runs, snapshot] = await Promise.all([
-    issuesPromise,
-    issuePromise,
-    readJsonFile<IssueOrchestrationRecord[]>(join(runtimeRoot, "issues.json")),
-    readRuns(runtimeRoot, projectConfig.projectId),
-    readJsonFile<ProjectStatusSnapshot>(join(runtimeRoot, "status.json")),
-  ]);
+  const [issues, issue, issueRecords, issueWorkspaces, runs, snapshot] =
+    await Promise.all([
+      issuesPromise,
+      issuePromise,
+      readJsonFile<IssueOrchestrationRecord[]>(
+        join(runtimeRoot, "issues.json")
+      ),
+      readIssueWorkspaces(runtimeRoot, projectConfig.projectId),
+      readRuns(runtimeRoot, projectConfig.projectId),
+      readJsonFile<ProjectStatusSnapshot>(join(runtimeRoot, "status.json")),
+    ]);
   const canonicalIssues = resolveCanonicalSubjectIssues(issues);
   const canonicalIssue =
     canonicalIssues.find((candidate) =>
@@ -191,6 +196,7 @@ const handler = async (
     allIssues: canonicalIssues,
     lifecycle: workflow.lifecycle,
     issueRecords: issueRecords ?? [],
+    issueWorkspaces,
     runs,
     activeRunCount,
     maxConcurrentAgents: workflow.maxConcurrentAgents,
@@ -358,6 +364,31 @@ async function readRuns(
   return runs.filter(
     (run): run is OrchestratorRunRecord =>
       run !== null && (!run.projectId || run.projectId === projectId)
+  );
+}
+
+async function readIssueWorkspaces(
+  runtimeRoot: string,
+  projectId: string
+): Promise<IssueWorkspaceRecord[]> {
+  let entries: string[];
+  try {
+    entries = await readdir(runtimeRoot);
+  } catch {
+    return [];
+  }
+
+  const records = await Promise.all(
+    entries.map((entry) =>
+      readJsonFile<IssueWorkspaceRecord>(
+        join(runtimeRoot, entry, "workspace.json")
+      )
+    )
+  );
+
+  return records.filter(
+    (record): record is IssueWorkspaceRecord =>
+      record !== null && (!record.projectId || record.projectId === projectId)
   );
 }
 

--- a/packages/cli/src/commands/repo-explain.ts
+++ b/packages/cli/src/commands/repo-explain.ts
@@ -3,6 +3,7 @@ import { join, resolve } from "node:path";
 import type { GlobalOptions } from "../index.js";
 import {
   WorkflowConfigStore,
+  type IssueWorkspaceRecord,
   type IssueOrchestrationRecord,
   type OrchestratorProjectConfig,
   type OrchestratorRunRecord,
@@ -148,13 +149,17 @@ const handler = async (
                 identifier.trim().toLowerCase()
             ) ?? null
         );
-  const [issues, issue, issueRecords, runs, snapshot] = await Promise.all([
-    issuesPromise,
-    issuePromise,
-    readJsonFile<IssueOrchestrationRecord[]>(join(runtimeRoot, "issues.json")),
-    readRuns(runtimeRoot, projectConfig.projectId),
-    readJsonFile<ProjectStatusSnapshot>(join(runtimeRoot, "status.json")),
-  ]);
+  const [issues, issue, issueRecords, issueWorkspaces, runs, snapshot] =
+    await Promise.all([
+      issuesPromise,
+      issuePromise,
+      readJsonFile<IssueOrchestrationRecord[]>(
+        join(runtimeRoot, "issues.json")
+      ),
+      readIssueWorkspaces(runtimeRoot, projectConfig.projectId),
+      readRuns(runtimeRoot, projectConfig.projectId),
+      readJsonFile<ProjectStatusSnapshot>(join(runtimeRoot, "status.json")),
+    ]);
   const canonicalIssues = resolveCanonicalSubjectIssues(issues);
   const canonicalIssue =
     canonicalIssues.find((candidate) =>
@@ -191,6 +196,7 @@ const handler = async (
     allIssues: canonicalIssues,
     lifecycle: workflow.lifecycle,
     issueRecords: issueRecords ?? [],
+    issueWorkspaces,
     runs,
     activeRunCount,
     maxConcurrentAgents: workflow.maxConcurrentAgents,
@@ -358,6 +364,30 @@ async function readRuns(
   return runs.filter(
     (run): run is OrchestratorRunRecord =>
       run !== null && (!run.projectId || run.projectId === projectId)
+  );
+}
+
+async function readIssueWorkspaces(
+  runtimeRoot: string,
+  projectId: string
+): Promise<IssueWorkspaceRecord[]> {
+  let workspaceKeys: string[];
+  try {
+    workspaceKeys = await readdir(runtimeRoot);
+  } catch {
+    return [];
+  }
+
+  const records = await Promise.all(
+    workspaceKeys.map((workspaceKey) =>
+      readJsonFile<IssueWorkspaceRecord>(
+        join(runtimeRoot, workspaceKey, "workspace.json")
+      )
+    )
+  );
+  return records.filter(
+    (record): record is IssueWorkspaceRecord =>
+      record !== null && record.projectId === projectId
   );
 }
 

--- a/packages/cli/src/commands/status.test.ts
+++ b/packages/cli/src/commands/status.test.ts
@@ -249,6 +249,58 @@ describe("status command", () => {
     );
   });
 
+  it("does not render incomplete-turn recovery details when snapshot recovery is null", async () => {
+    const configDir = await createConfigFixture();
+    const projectId = "tenant-a";
+    await writeFile(
+      join(configDir, "status.json"),
+      JSON.stringify(
+        {
+          projectId,
+          slug: projectId,
+          tracker: { adapter: "github-project", bindingId: "project-1" },
+          lastTickAt: "2026-03-30T11:00:00.000Z",
+          health: "idle",
+          summary: {
+            dispatched: 2,
+            suppressed: 1,
+            recovered: 0,
+            activeRuns: 0,
+          },
+          activeRuns: [],
+          retryQueue: [],
+          codexTotals: {
+            inputTokens: 1400,
+            outputTokens: 300,
+            totalTokens: 1700,
+            secondsRunning: 60,
+          },
+          lastError: null,
+          recovery: null,
+        },
+        null,
+        2
+      ) + "\n",
+      "utf8"
+    );
+    const stdout = captureWrites(process.stdout);
+
+    try {
+      await statusCommand([], {
+        configDir,
+        verbose: false,
+        json: false,
+        noColor: true,
+      });
+    } finally {
+      stdout.restore();
+    }
+
+    const output = stdout.output();
+    expect(output).not.toContain("Recoverable incomplete turn:");
+    expect(output).not.toContain("Workspace  /tmp/work/repository");
+  });
+
   it("falls back to the legacy per-project status snapshot path", async () => {
     const configDir = await createConfigFixture("legacy");
     const stdout = captureWrites(process.stdout);

--- a/packages/cli/src/commands/status.test.ts
+++ b/packages/cli/src/commands/status.test.ts
@@ -172,6 +172,56 @@ describe("status command", () => {
     expect(stdout.output()).toContain("Tokens: 600 / 1,700 total");
   });
 
+  it("does not render incomplete-turn recovery when snapshot recovery is null", async () => {
+    const configDir = await createConfigFixture();
+    const projectId = "tenant-a";
+    await writeFile(
+      join(configDir, "status.json"),
+      JSON.stringify(
+        {
+          projectId,
+          slug: projectId,
+          tracker: { adapter: "github-project", bindingId: "project-1" },
+          lastTickAt: "2026-03-30T11:00:00.000Z",
+          health: "idle",
+          summary: {
+            dispatched: 2,
+            suppressed: 1,
+            recovered: 0,
+            activeRuns: 0,
+          },
+          activeRuns: [],
+          retryQueue: [],
+          codexTotals: {
+            inputTokens: 1400,
+            outputTokens: 300,
+            totalTokens: 1700,
+            secondsRunning: 60,
+          },
+          lastError: null,
+          recovery: null,
+        },
+        null,
+        2
+      ) + "\n",
+      "utf8"
+    );
+    const stdout = captureWrites(process.stdout);
+
+    try {
+      await statusCommand([], {
+        configDir,
+        verbose: false,
+        json: false,
+        noColor: true,
+      });
+    } finally {
+      stdout.restore();
+    }
+
+    expect(stdout.output()).not.toContain("Recoverable incomplete turn:");
+  });
+
   it("renders incomplete-turn recovery details in text status output", async () => {
     const configDir = await createConfigFixture();
     const projectId = "tenant-a";

--- a/packages/core/src/observability/snapshot-builder.test.ts
+++ b/packages/core/src/observability/snapshot-builder.test.ts
@@ -7,6 +7,7 @@ import type {
   OrchestratorProjectConfig,
   OrchestratorRunRecord,
 } from "../contracts/status-surface.js";
+import type { IssueWorkspaceRecord } from "../domain/issue.js";
 
 /**
  * Helper to create a minimal OrchestratorProjectConfig for testing
@@ -65,6 +66,25 @@ function mockRun(
     completedAt: null,
     lastError: null,
     nextRetryAt: null,
+    ...overrides,
+  };
+}
+
+function mockIssueWorkspace(
+  overrides?: Partial<IssueWorkspaceRecord>
+): IssueWorkspaceRecord {
+  return {
+    workspaceKey: "key-001",
+    projectId: "tenant-123",
+    adapter: "github",
+    issueSubjectId: "subject-001",
+    issueIdentifier: "acme/platform#42",
+    workspacePath: "/tmp/workspace",
+    repositoryPath: "/tmp/workspace/repository",
+    status: "active",
+    createdAt: "2024-01-01T00:00:00Z",
+    updatedAt: "2024-01-01T00:00:00Z",
+    lastError: null,
     ...overrides,
   };
 }
@@ -475,6 +495,90 @@ describe("buildProjectSnapshot", () => {
     });
 
     expect(snapshot.recovery).toEqual(latestRetryingRun.recovery);
+  });
+
+  it("does not surface dirty-workspace recovery for a removed issue workspace", () => {
+    const run = mockRun({
+      runId: "run-removed-workspace",
+      status: "suppressed",
+      issueWorkspaceKey: "workspace-removed",
+      recovery: {
+        kind: "incomplete-turn-dirty-workspace",
+        runId: "run-removed-workspace",
+        issueId: "issue-001",
+        issueIdentifier: "acme/platform#42",
+        workspacePath: "/tmp/workspace/repository",
+        dirtyFiles: ["partial.txt"],
+        lastEvent: "heartbeat",
+        lastEventAt: "2024-01-01T00:04:00Z",
+        sessionId: "session-1",
+        threadId: "thread-1",
+        suggestedCommand:
+          "cd /tmp/workspace/repository && git status --short && git diff",
+        detectedAt: "2024-01-01T00:05:00Z",
+      },
+    });
+
+    const snapshot = buildProjectSnapshot({
+      project: mockProject(),
+      activeRuns: [],
+      allRuns: [run],
+      issueWorkspaces: [
+        mockIssueWorkspace({
+          workspaceKey: "workspace-removed",
+          issueSubjectId: "subject-001",
+          repositoryPath: "/tmp/workspace/repository",
+          status: "removed",
+        }),
+      ],
+      summary: { dispatched: 0, suppressed: 1, recovered: 0 },
+      lastTickAt: "2024-01-01T00:10:00Z",
+      lastError: null,
+    });
+
+    expect(snapshot.recovery).toBeNull();
+  });
+
+  it("still surfaces dirty-workspace recovery for an active issue workspace", () => {
+    const run = mockRun({
+      runId: "run-active-workspace",
+      status: "suppressed",
+      issueWorkspaceKey: "workspace-active",
+      recovery: {
+        kind: "incomplete-turn-dirty-workspace",
+        runId: "run-active-workspace",
+        issueId: "issue-001",
+        issueIdentifier: "acme/platform#42",
+        workspacePath: "/tmp/workspace/repository",
+        dirtyFiles: ["partial.txt"],
+        lastEvent: "heartbeat",
+        lastEventAt: "2024-01-01T00:04:00Z",
+        sessionId: "session-1",
+        threadId: "thread-1",
+        suggestedCommand:
+          "cd /tmp/workspace/repository && git status --short && git diff",
+        detectedAt: "2024-01-01T00:05:00Z",
+      },
+    });
+
+    const snapshot = buildProjectSnapshot({
+      project: mockProject(),
+      activeRuns: [],
+      allRuns: [run],
+      issueWorkspaces: [
+        mockIssueWorkspace({
+          workspaceKey: "workspace-active",
+          issueSubjectId: "subject-001",
+          repositoryPath: "/tmp/workspace/repository",
+          status: "active",
+        }),
+      ],
+      summary: { dispatched: 0, suppressed: 1, recovered: 0 },
+      lastTickAt: "2024-01-01T00:10:00Z",
+      lastError: null,
+    });
+
+    expect(snapshot.recovery).toEqual(run.recovery);
   });
 
   it("uses allRuns for token aggregation when provided, falls back to activeRuns", () => {

--- a/packages/core/src/observability/snapshot-builder.test.ts
+++ b/packages/core/src/observability/snapshot-builder.test.ts
@@ -7,6 +7,7 @@ import type {
   OrchestratorProjectConfig,
   OrchestratorRunRecord,
 } from "../contracts/status-surface.js";
+import type { IssueWorkspaceRecord } from "../domain/issue.js";
 
 /**
  * Helper to create a minimal OrchestratorProjectConfig for testing
@@ -65,6 +66,25 @@ function mockRun(
     completedAt: null,
     lastError: null,
     nextRetryAt: null,
+    ...overrides,
+  };
+}
+
+function mockIssueWorkspace(
+  overrides?: Partial<IssueWorkspaceRecord>
+): IssueWorkspaceRecord {
+  return {
+    workspaceKey: "key-001",
+    projectId: "tenant-123",
+    adapter: "github",
+    issueSubjectId: "subject-001",
+    issueIdentifier: "acme/platform#42",
+    workspacePath: "/tmp/workspace",
+    repositoryPath: "/tmp/work/repository",
+    status: "active",
+    createdAt: "2024-01-01T00:00:00Z",
+    updatedAt: "2024-01-01T00:00:00Z",
+    lastError: null,
     ...overrides,
   };
 }
@@ -380,6 +400,90 @@ describe("buildProjectSnapshot", () => {
     });
 
     expect(snapshot.recovery).toEqual(latestRun.recovery);
+  });
+
+  it("does not surface incomplete-turn recovery for a removed issue workspace", () => {
+    const run = mockRun({
+      runId: "run-removed",
+      status: "suppressed",
+      issueWorkspaceKey: "key-removed",
+      updatedAt: "2024-01-01T00:07:00Z",
+      recovery: {
+        kind: "incomplete-turn-dirty-workspace",
+        runId: "run-removed",
+        issueId: "issue-001",
+        issueIdentifier: "acme/platform#42",
+        workspacePath: "/tmp/work/removed-repository",
+        dirtyFiles: ["partial.txt"],
+        lastEvent: "heartbeat",
+        lastEventAt: "2024-01-01T00:06:30Z",
+        sessionId: "session-removed",
+        threadId: "thread-removed",
+        suggestedCommand:
+          "cd /tmp/work/removed-repository && git status --short && git diff",
+        detectedAt: "2024-01-01T00:07:00Z",
+      },
+    });
+
+    const snapshot = buildProjectSnapshot({
+      project: mockProject(),
+      activeRuns: [],
+      allRuns: [run],
+      issueWorkspaces: [
+        mockIssueWorkspace({
+          workspaceKey: "key-removed",
+          repositoryPath: "/tmp/work/removed-repository",
+          status: "removed",
+        }),
+      ],
+      summary: { dispatched: 0, suppressed: 1, recovered: 0 },
+      lastTickAt: "2024-01-01T00:10:00Z",
+      lastError: null,
+    });
+
+    expect(snapshot.recovery).toBeNull();
+  });
+
+  it("surfaces incomplete-turn recovery for an active issue workspace", () => {
+    const run = mockRun({
+      runId: "run-active",
+      status: "suppressed",
+      issueWorkspaceKey: "key-active",
+      updatedAt: "2024-01-01T00:07:00Z",
+      recovery: {
+        kind: "incomplete-turn-dirty-workspace",
+        runId: "run-active",
+        issueId: "issue-001",
+        issueIdentifier: "acme/platform#42",
+        workspacePath: "/tmp/work/active-repository",
+        dirtyFiles: ["partial.txt"],
+        lastEvent: "heartbeat",
+        lastEventAt: "2024-01-01T00:06:30Z",
+        sessionId: "session-active",
+        threadId: "thread-active",
+        suggestedCommand:
+          "cd /tmp/work/active-repository && git status --short && git diff",
+        detectedAt: "2024-01-01T00:07:00Z",
+      },
+    });
+
+    const snapshot = buildProjectSnapshot({
+      project: mockProject(),
+      activeRuns: [],
+      allRuns: [run],
+      issueWorkspaces: [
+        mockIssueWorkspace({
+          workspaceKey: "key-active",
+          repositoryPath: "/tmp/work/active-repository",
+          status: "active",
+        }),
+      ],
+      summary: { dispatched: 0, suppressed: 1, recovered: 0 },
+      lastTickAt: "2024-01-01T00:10:00Z",
+      lastError: null,
+    });
+
+    expect(snapshot.recovery).toEqual(run.recovery);
   });
 
   it("does not surface stale recovery after the recovery run completes", () => {

--- a/packages/core/src/observability/snapshot-builder.ts
+++ b/packages/core/src/observability/snapshot-builder.ts
@@ -11,6 +11,7 @@ import type {
   OrchestratorProjectConfig,
   ProjectStatusSnapshot,
 } from "../contracts/status-surface.js";
+import type { IssueWorkspaceRecord } from "../domain/issue.js";
 
 export type SnapshotInput = {
   project: OrchestratorProjectConfig;
@@ -24,6 +25,7 @@ export type SnapshotInput = {
   lastTickAt: string;
   lastError: string | null;
   rateLimits?: Record<string, unknown> | null;
+  issueWorkspaces?: readonly IssueWorkspaceRecord[];
 };
 
 /**
@@ -43,6 +45,7 @@ export function buildProjectSnapshot(
     lastTickAt,
     lastError,
     rateLimits,
+    issueWorkspaces,
   } = input;
   const cumulativeTokenUsageByIssue = aggregateTokenUsageByIssue(
     allRuns ?? activeRuns
@@ -92,7 +95,10 @@ export function buildProjectSnapshot(
         retryKind: run.retryKind ?? "failure",
         nextRetryAt: run.nextRetryAt,
       })),
-    recovery: findLatestRecovery([...(allRuns ?? []), ...activeRuns]),
+    recovery: findLatestRecovery(
+      [...(allRuns ?? []), ...activeRuns],
+      issueWorkspaces ?? []
+    ),
     lastError,
     codexTotals: aggregateTokenUsage(allRuns ?? activeRuns, lastTickAt),
     rateLimits: rateLimits ?? null,
@@ -100,11 +106,12 @@ export function buildProjectSnapshot(
 }
 
 function findLatestRecovery(
-  runs: OrchestratorRunRecord[]
+  runs: OrchestratorRunRecord[],
+  issueWorkspaces: readonly IssueWorkspaceRecord[]
 ): ProjectStatusSnapshot["recovery"] {
   return (
     [...runs]
-      .filter((run) => isUnresolvedRecoveryRun(run, runs))
+      .filter((run) => isUnresolvedRecoveryRun(run, runs, issueWorkspaces))
       .sort((left, right) => {
         const leftTime = new Date(left.updatedAt).getTime();
         const rightTime = new Date(right.updatedAt).getTime();
@@ -116,9 +123,14 @@ function findLatestRecovery(
 
 function isUnresolvedRecoveryRun(
   run: OrchestratorRunRecord,
-  runs: OrchestratorRunRecord[]
+  runs: OrchestratorRunRecord[],
+  issueWorkspaces: readonly IssueWorkspaceRecord[]
 ): boolean {
   if (!run.recovery) {
+    return false;
+  }
+
+  if (isRecoveryWorkspaceRemoved(run, issueWorkspaces)) {
     return false;
   }
 
@@ -143,6 +155,38 @@ function isUnresolvedRecoveryRun(
     (run.retryKind === "recovery" &&
       (run.status === "running" || run.status === "retrying"))
   );
+}
+
+function isRecoveryWorkspaceRemoved(
+  run: OrchestratorRunRecord,
+  issueWorkspaces: readonly IssueWorkspaceRecord[]
+): boolean {
+  if (run.recovery?.kind !== "incomplete-turn-dirty-workspace") {
+    return false;
+  }
+
+  if (run.issueWorkspaceKey !== null) {
+    const workspace = issueWorkspaces.find(
+      (candidate) => candidate.workspaceKey === run.issueWorkspaceKey
+    );
+    return workspace?.status === "removed";
+  }
+
+  const repositoryWorkspace = issueWorkspaces.find(
+    (candidate) => candidate.repositoryPath === run.recovery?.workspacePath
+  );
+  if (repositoryWorkspace) {
+    return repositoryWorkspace.status === "removed";
+  }
+
+  const workspace = issueWorkspaces.find(
+    (candidate) =>
+      candidate.issueSubjectId === run.issueSubjectId ||
+      candidate.issueSubjectId === run.recovery?.issueId ||
+      candidate.issueIdentifier === run.recovery?.issueIdentifier
+  );
+
+  return workspace?.status === "removed";
 }
 
 function aggregateTokenUsageByIssue(

--- a/packages/core/src/observability/snapshot-builder.ts
+++ b/packages/core/src/observability/snapshot-builder.ts
@@ -7,10 +7,12 @@
  */
 
 import type {
+  IncompleteTurnRecoveryInfo,
   OrchestratorRunRecord,
   OrchestratorProjectConfig,
   ProjectStatusSnapshot,
 } from "../contracts/status-surface.js";
+import type { IssueWorkspaceRecord } from "../domain/issue.js";
 
 export type SnapshotInput = {
   project: OrchestratorProjectConfig;
@@ -24,6 +26,7 @@ export type SnapshotInput = {
   lastTickAt: string;
   lastError: string | null;
   rateLimits?: Record<string, unknown> | null;
+  issueWorkspaces?: readonly IssueWorkspaceRecord[];
 };
 
 /**
@@ -43,6 +46,7 @@ export function buildProjectSnapshot(
     lastTickAt,
     lastError,
     rateLimits,
+    issueWorkspaces,
   } = input;
   const cumulativeTokenUsageByIssue = aggregateTokenUsageByIssue(
     allRuns ?? activeRuns
@@ -92,7 +96,10 @@ export function buildProjectSnapshot(
         retryKind: run.retryKind ?? "failure",
         nextRetryAt: run.nextRetryAt,
       })),
-    recovery: findLatestRecovery([...(allRuns ?? []), ...activeRuns]),
+    recovery: findLatestRecovery(
+      [...(allRuns ?? []), ...activeRuns],
+      issueWorkspaces ?? []
+    ),
     lastError,
     codexTotals: aggregateTokenUsage(allRuns ?? activeRuns, lastTickAt),
     rateLimits: rateLimits ?? null,
@@ -100,11 +107,12 @@ export function buildProjectSnapshot(
 }
 
 function findLatestRecovery(
-  runs: OrchestratorRunRecord[]
+  runs: OrchestratorRunRecord[],
+  issueWorkspaces: readonly IssueWorkspaceRecord[]
 ): ProjectStatusSnapshot["recovery"] {
   return (
     [...runs]
-      .filter((run) => isUnresolvedRecoveryRun(run, runs))
+      .filter((run) => isUnresolvedRecoveryRun(run, runs, issueWorkspaces))
       .sort((left, right) => {
         const leftTime = new Date(left.updatedAt).getTime();
         const rightTime = new Date(right.updatedAt).getTime();
@@ -116,9 +124,14 @@ function findLatestRecovery(
 
 function isUnresolvedRecoveryRun(
   run: OrchestratorRunRecord,
-  runs: OrchestratorRunRecord[]
+  runs: OrchestratorRunRecord[],
+  issueWorkspaces: readonly IssueWorkspaceRecord[]
 ): boolean {
   if (!run.recovery) {
+    return false;
+  }
+
+  if (!isRecoveryWorkspaceActionable(run, run.recovery, issueWorkspaces)) {
     return false;
   }
 
@@ -142,6 +155,61 @@ function isUnresolvedRecoveryRun(
     run.status === "suppressed" ||
     (run.retryKind === "recovery" &&
       (run.status === "running" || run.status === "retrying"))
+  );
+}
+
+export function isRecoveryWorkspaceActionable(
+  run: OrchestratorRunRecord,
+  recovery: IncompleteTurnRecoveryInfo,
+  issueWorkspaces: readonly IssueWorkspaceRecord[]
+): boolean {
+  const workspaceRecord = findRecoveryWorkspaceRecord(
+    run,
+    recovery,
+    issueWorkspaces
+  );
+
+  return !workspaceRecord || workspaceRecord.status === "active";
+}
+
+function findRecoveryWorkspaceRecord(
+  run: OrchestratorRunRecord,
+  recovery: IncompleteTurnRecoveryInfo,
+  issueWorkspaces: readonly IssueWorkspaceRecord[]
+): IssueWorkspaceRecord | null {
+  const projectWorkspaces = issueWorkspaces.filter(
+    (workspace) => workspace.projectId === run.projectId
+  );
+
+  if (run.issueWorkspaceKey) {
+    const byKey = projectWorkspaces.find(
+      (workspace) => workspace.workspaceKey === run.issueWorkspaceKey
+    );
+    if (byKey) {
+      return byKey;
+    }
+  }
+
+  const byPath = projectWorkspaces.find(
+    (workspace) =>
+      workspace.repositoryPath === recovery.workspacePath ||
+      workspace.workspacePath === recovery.workspacePath
+  );
+  if (byPath) {
+    return byPath;
+  }
+
+  const bySubject = projectWorkspaces.find(
+    (workspace) => workspace.issueSubjectId === run.issueSubjectId
+  );
+  if (bySubject) {
+    return bySubject;
+  }
+
+  return (
+    projectWorkspaces.find(
+      (workspace) => workspace.issueIdentifier === recovery.issueIdentifier
+    ) ?? null
   );
 }
 

--- a/packages/orchestrator/src/dispatch.test.ts
+++ b/packages/orchestrator/src/dispatch.test.ts
@@ -11,6 +11,7 @@ import type {
   OrchestratorProjectConfig,
   TrackedIssue,
   TrackedPullRequestContext,
+  IssueWorkspaceRecord,
 } from "@gh-symphony/core";
 import { OrchestratorFsStore } from "./fs-store.js";
 import * as trackerAdapters from "./tracker-adapters.js";
@@ -79,6 +80,25 @@ function makeRun(
     completedAt: null,
     lastError: null,
     nextRetryAt: null,
+    ...overrides,
+  };
+}
+
+function makeIssueWorkspace(
+  overrides: Partial<IssueWorkspaceRecord> & { workspaceKey: string }
+): IssueWorkspaceRecord {
+  return {
+    workspaceKey: overrides.workspaceKey,
+    projectId: "tenant-1",
+    adapter: "github-project",
+    issueSubjectId: "issue-1",
+    issueIdentifier: "acme/repo#1",
+    workspacePath: "/tmp/workspace",
+    repositoryPath: "/tmp/work",
+    status: "active",
+    createdAt: "2026-03-09T00:00:00.000Z",
+    updatedAt: "2026-03-09T00:00:00.000Z",
+    lastError: null,
     ...overrides,
   };
 }
@@ -365,6 +385,60 @@ describe("explainIssueDispatch", () => {
       expect.arrayContaining([
         expect.objectContaining({ id: "runtime_ownership", status: "block" }),
       ])
+    );
+  });
+
+  it("does not warn about dirty-workspace recovery for a removed issue workspace", () => {
+    const issue = makeIssue({ id: "issue-1", identifier: "acme/repo#1" });
+    const run = makeRun({
+      runId: "run-incomplete",
+      issueId: issue.id,
+      status: "suppressed",
+      updatedAt: "2026-03-09T00:05:00.000Z",
+      completedAt: "2026-03-09T00:05:00.000Z",
+      issueWorkspaceKey: "workspace-1",
+      recovery: {
+        kind: "incomplete-turn-dirty-workspace",
+        runId: "run-incomplete",
+        issueId: issue.id,
+        issueIdentifier: issue.identifier,
+        workspacePath: "/tmp/work",
+        dirtyFiles: ["partial.txt"],
+        lastEvent: "heartbeat",
+        lastEventAt: "2026-03-09T00:04:30.000Z",
+        sessionId: "session-1",
+        threadId: "thread-1",
+        suggestedCommand: "cd /tmp/work && git status --short && git diff",
+        detectedAt: "2026-03-09T00:05:00.000Z",
+      },
+    });
+    const report = explainIssueDispatch({
+      identifier: issue.identifier,
+      issue,
+      projectRepository,
+      allIssues: [issue],
+      lifecycle,
+      issueRecords: [],
+      issueWorkspaces: [
+        makeIssueWorkspace({
+          workspaceKey: "workspace-1",
+          repositoryPath: "/tmp/work",
+          status: "removed",
+        }),
+      ],
+      runs: [run],
+      activeRunCount: 0,
+      maxConcurrentAgents: 3,
+      maxConcurrentAgentsByState: {},
+    });
+
+    expect(report.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "runtime_ownership", status: "pass" }),
+      ])
+    );
+    expect(JSON.stringify(report)).not.toContain(
+      "dispatch will start a recovery turn"
     );
   });
 

--- a/packages/orchestrator/src/dispatch.test.ts
+++ b/packages/orchestrator/src/dispatch.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { OrchestratorService, sortCandidatesForDispatch } from "./service.js";
 import { explainIssueDispatch } from "./explain.js";
 import type {
+  IssueWorkspaceRecord,
   OrchestratorTrackerAdapter,
   OrchestratorRunRecord,
   OrchestratorProjectConfig,
@@ -366,6 +367,71 @@ describe("explainIssueDispatch", () => {
         expect.objectContaining({ id: "runtime_ownership", status: "block" }),
       ])
     );
+  });
+
+  it("does not warn about dirty-workspace recovery for a removed issue workspace", () => {
+    const issue = makeIssue({ id: "issue-1", identifier: "acme/repo#1" });
+    const run = makeRun({
+      runId: "run-removed-workspace",
+      issueId: issue.id,
+      status: "suppressed",
+      issueWorkspaceKey: "workspace-removed",
+      updatedAt: "2026-03-09T00:05:00.000Z",
+      completedAt: "2026-03-09T00:05:00.000Z",
+      recovery: {
+        kind: "incomplete-turn-dirty-workspace",
+        runId: "run-removed-workspace",
+        issueId: issue.id,
+        issueIdentifier: issue.identifier,
+        workspacePath: "/tmp/work/repository",
+        dirtyFiles: ["partial.txt"],
+        lastEvent: "heartbeat",
+        lastEventAt: "2026-03-09T00:04:00.000Z",
+        sessionId: "session-1",
+        threadId: "thread-1",
+        suggestedCommand:
+          "cd /tmp/work/repository && git status --short && git diff",
+        detectedAt: "2026-03-09T00:05:00.000Z",
+      },
+    });
+    const issueWorkspace: IssueWorkspaceRecord = {
+      workspaceKey: "workspace-removed",
+      projectId: "tenant-1",
+      adapter: "github-project",
+      issueSubjectId: issue.id,
+      issueIdentifier: issue.identifier,
+      workspacePath: "/tmp/work",
+      repositoryPath: "/tmp/work/repository",
+      status: "removed",
+      createdAt: "2026-03-09T00:00:00.000Z",
+      updatedAt: "2026-03-09T00:05:00.000Z",
+      lastError: null,
+    };
+
+    const report = explainIssueDispatch({
+      identifier: issue.identifier,
+      issue,
+      projectRepository,
+      allIssues: [issue],
+      lifecycle,
+      issueRecords: [],
+      issueWorkspaces: [issueWorkspace],
+      runs: [run],
+      activeRunCount: 0,
+      maxConcurrentAgents: 3,
+      maxConcurrentAgentsByState: {},
+    });
+
+    expect(report.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "runtime_ownership", status: "pass" }),
+      ])
+    );
+    expect(
+      report.checks.some((check) =>
+        check.message.includes("dispatch will start a recovery turn")
+      )
+    ).toBe(false);
   });
 
   it("explains project concurrency limits", () => {

--- a/packages/orchestrator/src/explain.ts
+++ b/packages/orchestrator/src/explain.ts
@@ -1,7 +1,9 @@
 import {
   isStateActive,
   isStateTerminal,
+  isRecoveryWorkspaceActionable,
   matchesWorkflowState,
+  type IssueWorkspaceRecord,
   type IssueOrchestrationRecord,
   type OrchestratorRunRecord,
   type RepositoryRef,
@@ -52,6 +54,7 @@ export type ExplainDispatchInput = {
   allIssues: readonly TrackedIssue[];
   lifecycle: WorkflowLifecycleConfig;
   issueRecords: readonly IssueOrchestrationRecord[];
+  issueWorkspaces?: readonly IssueWorkspaceRecord[];
   runs: readonly OrchestratorRunRecord[];
   activeRunCount: number;
   maxConcurrentAgents: number;
@@ -99,7 +102,14 @@ export function explainIssueDispatch(
 
   checks.push(explainWorkflowState(issue, input.lifecycle));
   checks.push(explainBlockers(issue, input.lifecycle, input.allIssues));
-  checks.push(explainRuntimeOwnership(issue, input.issueRecords, input.runs));
+  checks.push(
+    explainRuntimeOwnership(
+      issue,
+      input.issueRecords,
+      input.runs,
+      input.issueWorkspaces ?? []
+    )
+  );
   checks.push(
     explainDispatchLimits(
       issue,
@@ -345,7 +355,8 @@ function explainBlockers(
 function explainRuntimeOwnership(
   issue: TrackedIssue,
   issueRecords: readonly IssueOrchestrationRecord[],
-  runs: readonly OrchestratorRunRecord[]
+  runs: readonly OrchestratorRunRecord[],
+  issueWorkspaces: readonly IssueWorkspaceRecord[]
 ): DispatchExplainCheck {
   const record = issueRecords.find(
     (candidate) =>
@@ -439,7 +450,12 @@ function explainRuntimeOwnership(
 
   if (
     latestRun?.status === "suppressed" &&
-    latestRun.recovery?.kind === "incomplete-turn-dirty-workspace"
+    latestRun.recovery?.kind === "incomplete-turn-dirty-workspace" &&
+    isRecoveryWorkspaceActionable(
+      latestRun,
+      latestRun.recovery,
+      issueWorkspaces
+    )
   ) {
     return {
       id: "runtime_ownership",

--- a/packages/orchestrator/src/explain.ts
+++ b/packages/orchestrator/src/explain.ts
@@ -3,6 +3,7 @@ import {
   isStateTerminal,
   matchesWorkflowState,
   type IssueOrchestrationRecord,
+  type IssueWorkspaceRecord,
   type OrchestratorRunRecord,
   type RepositoryRef,
   type TrackedIssue,
@@ -52,6 +53,7 @@ export type ExplainDispatchInput = {
   allIssues: readonly TrackedIssue[];
   lifecycle: WorkflowLifecycleConfig;
   issueRecords: readonly IssueOrchestrationRecord[];
+  issueWorkspaces?: readonly IssueWorkspaceRecord[];
   runs: readonly OrchestratorRunRecord[];
   activeRunCount: number;
   maxConcurrentAgents: number;
@@ -99,7 +101,14 @@ export function explainIssueDispatch(
 
   checks.push(explainWorkflowState(issue, input.lifecycle));
   checks.push(explainBlockers(issue, input.lifecycle, input.allIssues));
-  checks.push(explainRuntimeOwnership(issue, input.issueRecords, input.runs));
+  checks.push(
+    explainRuntimeOwnership(
+      issue,
+      input.issueRecords,
+      input.issueWorkspaces ?? [],
+      input.runs
+    )
+  );
   checks.push(
     explainDispatchLimits(
       issue,
@@ -345,6 +354,7 @@ function explainBlockers(
 function explainRuntimeOwnership(
   issue: TrackedIssue,
   issueRecords: readonly IssueOrchestrationRecord[],
+  issueWorkspaces: readonly IssueWorkspaceRecord[],
   runs: readonly OrchestratorRunRecord[]
 ): DispatchExplainCheck {
   const record = issueRecords.find(
@@ -439,7 +449,8 @@ function explainRuntimeOwnership(
 
   if (
     latestRun?.status === "suppressed" &&
-    latestRun.recovery?.kind === "incomplete-turn-dirty-workspace"
+    latestRun.recovery?.kind === "incomplete-turn-dirty-workspace" &&
+    !isRecoveryWorkspaceRemoved(latestRun, issueWorkspaces)
   ) {
     return {
       id: "runtime_ownership",
@@ -474,6 +485,39 @@ function explainRuntimeOwnership(
         }
       : undefined,
   };
+}
+
+function isRecoveryWorkspaceRemoved(
+  run: OrchestratorRunRecord,
+  issueWorkspaces: readonly IssueWorkspaceRecord[]
+): boolean {
+  const recovery = run.recovery;
+  if (recovery?.kind !== "incomplete-turn-dirty-workspace") {
+    return false;
+  }
+
+  if (run.issueWorkspaceKey !== null) {
+    const workspace = issueWorkspaces.find(
+      (candidate) => candidate.workspaceKey === run.issueWorkspaceKey
+    );
+    return workspace?.status === "removed";
+  }
+
+  const repositoryWorkspace = issueWorkspaces.find(
+    (candidate) => candidate.repositoryPath === recovery.workspacePath
+  );
+  if (repositoryWorkspace) {
+    return repositoryWorkspace.status === "removed";
+  }
+
+  const workspace = issueWorkspaces.find(
+    (candidate) =>
+      candidate.issueSubjectId === run.issueSubjectId ||
+      candidate.issueSubjectId === recovery.issueId ||
+      candidate.issueIdentifier === recovery.issueIdentifier
+  );
+
+  return workspace?.status === "removed";
 }
 
 function explainDispatchLimits(

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -1317,6 +1317,46 @@ describe("OrchestratorService", () => {
       updatedAt: "2026-03-08T00:00:00.000Z",
       lastError: null,
     });
+    await store.saveRun({
+      runId: "run-incomplete",
+      projectId: "tenant-1",
+      projectSlug: "tenant-1",
+      issueId: "issue-1",
+      issueSubjectId: "issue-1",
+      issueIdentifier: "acme/platform#1",
+      issueState: "In progress",
+      repository,
+      status: "suppressed",
+      attempt: 1,
+      processId: null,
+      port: null,
+      workingDirectory: repositoryPath,
+      issueWorkspaceKey: workspaceKey,
+      workspaceRuntimeDir: join(tempRoot, "run-incomplete", "workspace"),
+      workflowPath: null,
+      retryKind: null,
+      createdAt: "2026-03-08T00:00:00.000Z",
+      updatedAt: "2026-03-08T00:01:00.000Z",
+      startedAt: "2026-03-08T00:00:00.000Z",
+      completedAt: "2026-03-08T00:01:00.000Z",
+      lastError:
+        "Run suppressed with recoverable incomplete-turn dirty workspace.",
+      nextRetryAt: null,
+      recovery: {
+        kind: "incomplete-turn-dirty-workspace",
+        runId: "run-incomplete",
+        issueId: "issue-1",
+        issueIdentifier: "acme/platform#1",
+        workspacePath: repositoryPath,
+        dirtyFiles: ["sentinel.txt"],
+        lastEvent: "heartbeat",
+        lastEventAt: "2026-03-08T00:00:30.000Z",
+        sessionId: "session-1",
+        threadId: "thread-1",
+        suggestedCommand: `cd '${repositoryPath}' && git status --short && git diff`,
+        detectedAt: "2026-03-08T00:01:00.000Z",
+      },
+    });
 
     const service = new OrchestratorService(store, projectConfig, {
       fetchImpl: vi
@@ -1338,8 +1378,15 @@ describe("OrchestratorService", () => {
       "tenant-1",
       workspaceKey
     );
+    const preservedRun = await store.loadRun("run-incomplete", "tenant-1");
+    const savedStatus = await store.loadProjectStatus();
     await expect(readFile(sentinelPath, "utf8")).rejects.toThrow();
     expect(workspaceRecord?.status).toBe("removed");
+    expect(savedStatus?.recovery).toBeNull();
+    expect(preservedRun?.recovery).toMatchObject({
+      kind: "incomplete-turn-dirty-workspace",
+      workspacePath: repositoryPath,
+    });
   });
 
   it("logs and ignores before_remove hook failures during startup cleanup", async () => {

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -1317,6 +1317,46 @@ describe("OrchestratorService", () => {
       updatedAt: "2026-03-08T00:00:00.000Z",
       lastError: null,
     });
+    await store.saveRun({
+      runId: "run-stale-recovery",
+      projectId: "tenant-1",
+      projectSlug: "tenant-1",
+      issueId: "issue-1",
+      issueSubjectId: "issue-1",
+      issueIdentifier: "acme/platform#1",
+      issueState: "In Review",
+      repository,
+      status: "suppressed",
+      attempt: 1,
+      processId: null,
+      port: null,
+      workingDirectory: repositoryPath,
+      issueWorkspaceKey: workspaceKey,
+      workspaceRuntimeDir: join(tempRoot, "run-stale-recovery", "workspace"),
+      workflowPath: null,
+      retryKind: null,
+      createdAt: "2026-03-08T00:00:00.000Z",
+      updatedAt: "2026-03-08T00:01:00.000Z",
+      startedAt: "2026-03-08T00:00:00.000Z",
+      completedAt: "2026-03-08T00:01:00.000Z",
+      lastError:
+        "Run suppressed with recoverable incomplete-turn dirty workspace.",
+      nextRetryAt: null,
+      recovery: {
+        kind: "incomplete-turn-dirty-workspace",
+        runId: "run-stale-recovery",
+        issueId: "issue-1",
+        issueIdentifier: "acme/platform#1",
+        workspacePath: repositoryPath,
+        dirtyFiles: ["partial.txt"],
+        lastEvent: "heartbeat",
+        lastEventAt: "2026-03-08T00:00:30.000Z",
+        sessionId: "session-1",
+        threadId: "thread-1",
+        suggestedCommand: `cd '${repositoryPath}' && git status --short && git diff`,
+        detectedAt: "2026-03-08T00:01:00.000Z",
+      },
+    });
 
     const service = new OrchestratorService(store, projectConfig, {
       fetchImpl: vi
@@ -1338,8 +1378,15 @@ describe("OrchestratorService", () => {
       "tenant-1",
       workspaceKey
     );
+    const preservedRun = await store.loadRun("run-stale-recovery", "tenant-1");
+    const status = await store.loadProjectStatus("tenant-1");
     await expect(readFile(sentinelPath, "utf8")).rejects.toThrow();
     expect(workspaceRecord?.status).toBe("removed");
+    expect(status?.recovery).toBeNull();
+    expect(preservedRun?.recovery).toMatchObject({
+      kind: "incomplete-turn-dirty-workspace",
+      workspacePath: repositoryPath,
+    });
   });
 
   it("logs and ignores before_remove hook failures during startup cleanup", async () => {

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -999,6 +999,9 @@ export class OrchestratorService {
     const allTenantRuns = (await this.store.loadAllRuns()).filter(
       (run) => run.projectId === tenant.projectId
     );
+    const issueWorkspaces = await this.store.loadIssueWorkspaces(
+      tenant.projectId
+    );
     const latestRuns = allTenantRuns.filter((run) =>
       isActiveRunRecordStatus(run.status)
     );
@@ -1011,6 +1014,7 @@ export class OrchestratorService {
       lastTickAt: now.toISOString(),
       lastError,
       rateLimits,
+      issueWorkspaces,
     });
     await this.store.saveProjectStatus(status);
     return status;

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -1002,6 +1002,9 @@ export class OrchestratorService {
     const latestRuns = allTenantRuns.filter((run) =>
       isActiveRunRecordStatus(run.status)
     );
+    const issueWorkspaces = await this.store.loadIssueWorkspaces(
+      tenant.projectId
+    );
     rateLimits = rateLimits ?? resolveProjectRateLimits(latestRuns, []);
     const status = buildProjectSnapshot({
       project: tenant,
@@ -1011,6 +1014,7 @@ export class OrchestratorService {
       lastTickAt: now.toISOString(),
       lastError,
       rateLimits,
+      issueWorkspaces,
     });
     await this.store.saveProjectStatus(status);
     return status;


### PR DESCRIPTION
## Issues

- Fixes #421

## TL;DR

- Suppresses stale `incomplete-turn-dirty-workspace` recovery in project status snapshots when the backing issue workspace record has been removed.
- Keeps preserved run history intact, including historical `run.recovery`, while `repo status` and `repo explain` only report currently actionable recovery.

## 변경 지점 다이어그램

`IssueWorkspaceRecord` lifecycle state → `buildProjectSnapshot()` recovery selection → saved `status.json.recovery` → `repo status` / `repo explain` rendering

## 여기부터 보세요

- `packages/core/src/observability/snapshot-builder.ts`
- `packages/orchestrator/src/service.ts`
- `packages/orchestrator/src/explain.ts`
- `packages/cli/src/commands/repo-explain.ts`

## 위험 & 롤백

- Risk: workspace matching must avoid suppressing recovery for an active replacement workspace; matching now prefers project/workspace key, then path, then legacy issue identity.
- Rollback: revert the status snapshot/explain filtering changes and the related tests.

## 변경 파일

- Core snapshot recovery filtering and tests.
- Orchestrator status assembly and terminal cleanup regression coverage.
- Repo explain workspace-record loading and runtime ownership warning suppression.
- CLI status rendering coverage for `recovery: null`.
- Patch changeset for `@gh-symphony/cli`.

## Evidence

- `pnpm exec vitest run packages/core/src/observability/snapshot-builder.test.ts packages/orchestrator/src/dispatch.test.ts packages/orchestrator/src/service.test.ts packages/cli/src/commands/status.test.ts packages/cli/src/commands/repo-explain.test.ts` — pass
- `pnpm lint && pnpm test && pnpm typecheck && pnpm build` — pass
- Docker E2E: `docker compose -f docker-compose.e2e.yml -f docker-compose.e2e.events.yml up -d --build`, `/healthz`, injected `happy-path.json`, `/api/v1/state` — pass; observed `health: running`, `summary.activeRuns: 1`, `recovery: null`

## 머지 후/사람 확인

- [ ] Confirm a cleaned-up removed issue workspace no longer shows a recoverable incomplete turn in `gh-symphony repo status`.
- [ ] Confirm an active dirty workspace recovery still appears and can be recovered.
