### PR TITLE
fix(status): expose gated tracker rate limits

### DIFF
--- a/packages/core/src/contracts/status-surface.ts
+++ b/packages/core/src/contracts/status-surface.ts
@@ -240,6 +240,7 @@ export type ProjectStatusSnapshot = {
     secondsRunning: number;
   };
   rateLimits?: Record<string, unknown> | null;
+  dispatchSuppressedUntil?: string | null;
   lastError: string | null;
 };
 

--- a/packages/core/src/observability/snapshot-builder.test.ts
+++ b/packages/core/src/observability/snapshot-builder.test.ts
@@ -666,6 +666,27 @@ describe("buildProjectSnapshot", () => {
     });
   });
 
+  it("handles dispatchSuppressedUntil when provided", () => {
+    const input: SnapshotInput = {
+      project: mockProject(),
+      activeRuns: [],
+      summary: { dispatched: 0, suppressed: 0, recovered: 0 },
+      lastTickAt: "2024-01-01T00:10:00Z",
+      lastError: "Rate limit near exhaustion",
+      rateLimits: {
+        source: "github",
+        remaining: 100,
+        limit: 5000,
+        resetAt: "2024-01-01T01:00:00Z",
+      },
+      dispatchSuppressedUntil: "2024-01-01T01:00:00Z",
+    };
+
+    const snapshot = buildProjectSnapshot(input);
+
+    expect(snapshot.dispatchSuppressedUntil).toBe("2024-01-01T01:00:00Z");
+  });
+
   it("defaults rateLimits to null when not provided", () => {
     const input: SnapshotInput = {
       project: mockProject(),
@@ -679,6 +700,7 @@ describe("buildProjectSnapshot", () => {
     const snapshot = buildProjectSnapshot(input);
 
     expect(snapshot.rateLimits).toBeNull();
+    expect(snapshot.dispatchSuppressedUntil).toBeNull();
   });
 
   it("maps all activeRun fields correctly", () => {

--- a/packages/core/src/observability/snapshot-builder.ts
+++ b/packages/core/src/observability/snapshot-builder.ts
@@ -26,6 +26,7 @@ export type SnapshotInput = {
   lastTickAt: string;
   lastError: string | null;
   rateLimits?: Record<string, unknown> | null;
+  dispatchSuppressedUntil?: string | null;
   issueWorkspaces?: readonly IssueWorkspaceRecord[];
 };
 
@@ -46,6 +47,7 @@ export function buildProjectSnapshot(
     lastTickAt,
     lastError,
     rateLimits,
+    dispatchSuppressedUntil,
     issueWorkspaces,
   } = input;
   const cumulativeTokenUsageByIssue = aggregateTokenUsageByIssue(
@@ -103,6 +105,7 @@ export function buildProjectSnapshot(
     lastError,
     codexTotals: aggregateTokenUsage(allRuns ?? activeRuns, lastTickAt),
     rateLimits: rateLimits ?? null,
+    dispatchSuppressedUntil: dispatchSuppressedUntil ?? null,
   };
 }
 

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -3115,6 +3115,314 @@ Prefer focused changes.
     );
   });
 
+  it("keeps tracker rate-limit data in degraded snapshots when dispatch is gated", async () => {
+    process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
+    const tempRoot = await mkdtemp(
+      join(tmpdir(), "orchestrator-gated-rate-limit-snapshot-")
+    );
+    const repository = await createRepositoryFixture(
+      tempRoot,
+      "acme",
+      "platform"
+    );
+    const store = new OrchestratorFsStore(tempRoot);
+    const projectConfig = createProjectConfig(tempRoot, repository);
+    await store.saveProjectConfig(projectConfig);
+    await store.saveRun({
+      runId: "run-1",
+      projectId: projectConfig.projectId,
+      projectSlug: projectConfig.slug,
+      issueId: "issue-1",
+      issueSubjectId: "issue-1",
+      issueIdentifier: "acme/platform#1",
+      issueState: "Todo",
+      repository,
+      status: "running",
+      attempt: 1,
+      processId: null,
+      port: null,
+      workingDirectory: join(tempRoot, "workspace"),
+      issueWorkspaceKey: deriveIssueWorkspaceKey("acme/platform#1"),
+      workspaceRuntimeDir: join(tempRoot, "workspace-runtime"),
+      workflowPath: null,
+      retryKind: null,
+      createdAt: "2026-03-08T00:00:00.000Z",
+      updatedAt: "2026-03-08T00:00:00.000Z",
+      startedAt: "2026-03-08T00:00:00.000Z",
+      completedAt: null,
+      lastError: null,
+      nextRetryAt: null,
+    });
+
+    const rateLimits = {
+      source: "github",
+      limit: 5000,
+      remaining: 163,
+      used: 4837,
+      reset: 1783094167,
+      resetAt: "2026-07-03T15:56:07.000Z",
+      resource: "graphql",
+    };
+    vi.spyOn(trackerAdapters, "resolveTrackerAdapter").mockReturnValue({
+      fetchIssueStatesByIds: vi.fn().mockResolvedValue([
+        {
+          id: "issue-1",
+          identifier: "acme/platform#1",
+          number: 1,
+          title: "Issue 1",
+          description: null,
+          priority: null,
+          state: "Todo",
+          branchName: null,
+          url: "https://github.com/acme/platform/issues/1",
+          labels: [],
+          blockedBy: [],
+          createdAt: "2026-03-08T00:00:00.000Z",
+          updatedAt: "2026-03-08T00:00:00.000Z",
+          repository,
+          tracker: {
+            adapter: "github-project",
+            bindingId: "project-123",
+            itemId: "item-1",
+          },
+          metadata: {},
+          rateLimits,
+        },
+      ]),
+      listIssues: vi
+        .fn()
+        .mockRejectedValue(new Error("Rate limit near exhaustion")),
+      listIssuesByStates: vi.fn().mockResolvedValue([]),
+      buildWorkerEnvironment: vi.fn().mockReturnValue({}),
+      reviveIssue: vi.fn(),
+    });
+
+    const stderr = {
+      write: vi.fn().mockReturnValue(true),
+    };
+    const service = new OrchestratorService(store, projectConfig, {
+      now: () => new Date("2026-03-08T00:06:00.000Z"),
+      stderr,
+    });
+
+    const snapshot = await service.runOnce();
+
+    expect(snapshot.health).toBe("degraded");
+    expect(snapshot.lastError).toBe("Rate limit near exhaustion");
+    expect(snapshot.rateLimits).toEqual(rateLimits);
+    expect(snapshot.dispatchSuppressedUntil).toBe("2026-07-03T15:56:07.000Z");
+    expect(stderr.write).toHaveBeenCalledWith(
+      expect.stringContaining(`rateLimits=${JSON.stringify(rateLimits)}`)
+    );
+  });
+
+  it("keeps cached tracker rate-limit data when throttled before discovering active runs", async () => {
+    const tempRoot = await mkdtemp(
+      join(tmpdir(), "orchestrator-cached-rate-limit-snapshot-")
+    );
+    const repository = await createRepositoryFixture(
+      tempRoot,
+      "acme",
+      "platform"
+    );
+    const store = new OrchestratorFsStore(tempRoot);
+    const projectConfig = createProjectConfig(tempRoot, repository);
+    await store.saveProjectConfig(projectConfig);
+
+    const rateLimits = {
+      source: "github",
+      limit: 5000,
+      remaining: 163,
+      used: 4837,
+      reset: 1783094167,
+      resetAt: "2026-07-03T15:56:07.000Z",
+      resource: "graphql",
+    };
+    const listedIssues = [] as TrackedIssueList;
+    listedIssues.rateLimits = rateLimits;
+    const listIssues = vi
+      .fn()
+      .mockResolvedValueOnce(listedIssues)
+      .mockRejectedValueOnce(new Error("Rate limit near exhaustion"));
+    vi.spyOn(trackerAdapters, "resolveTrackerAdapter").mockReturnValue({
+      listIssues,
+      listIssuesByStates: vi.fn().mockResolvedValue([]),
+      fetchIssueStatesByIds: vi.fn().mockResolvedValue([]),
+      buildWorkerEnvironment: vi.fn().mockReturnValue({}),
+      reviveIssue: vi.fn(),
+    });
+
+    const stderr = {
+      write: vi.fn().mockReturnValue(true),
+    };
+    const service = new OrchestratorService(store, projectConfig, {
+      now: () => new Date("2026-03-08T00:06:00.000Z"),
+      stderr,
+    });
+
+    await service.runOnce();
+    const snapshot = await service.runOnce();
+
+    expect(listIssues).toHaveBeenCalledTimes(2);
+    expect(snapshot.health).toBe("degraded");
+    expect(snapshot.lastError).toBe("Rate limit near exhaustion");
+    expect(snapshot.rateLimits).toEqual(rateLimits);
+    expect(snapshot.dispatchSuppressedUntil).toBe("2026-07-03T15:56:07.000Z");
+    expect(stderr.write).toHaveBeenLastCalledWith(
+      expect.stringContaining(`rateLimits=${JSON.stringify(rateLimits)}`)
+    );
+  });
+
+  it("keeps tracker rate-limit data from cached guard errors without active runs", async () => {
+    const tempRoot = await mkdtemp(
+      join(tmpdir(), "orchestrator-error-rate-limit-snapshot-")
+    );
+    const repository = await createRepositoryFixture(
+      tempRoot,
+      "acme",
+      "platform"
+    );
+    const store = new OrchestratorFsStore(tempRoot);
+    const projectConfig = createProjectConfig(tempRoot, repository);
+    await store.saveProjectConfig(projectConfig);
+
+    const rateLimits = {
+      source: "github",
+      limit: 5000,
+      remaining: 87,
+      used: 4913,
+      reset: 1783094167,
+      resetAt: "2026-07-03T15:56:07.000Z",
+      resource: "graphql",
+    };
+    const error = new Error("Rate limit near exhaustion") as Error & {
+      rateLimits: Record<string, unknown>;
+    };
+    error.rateLimits = rateLimits;
+    vi.spyOn(trackerAdapters, "resolveTrackerAdapter").mockReturnValue({
+      fetchIssueStatesByIds: vi.fn().mockResolvedValue([]),
+      listIssues: vi.fn().mockRejectedValue(error),
+      listIssuesByStates: vi.fn().mockResolvedValue([]),
+      buildWorkerEnvironment: vi.fn().mockReturnValue({}),
+      reviveIssue: vi.fn(),
+    });
+
+    const stderr = {
+      write: vi.fn().mockReturnValue(true),
+    };
+    const service = new OrchestratorService(store, projectConfig, {
+      now: () => new Date("2026-03-08T00:06:00.000Z"),
+      stderr,
+    });
+
+    const snapshot = await service.runOnce();
+
+    expect(snapshot.health).toBe("degraded");
+    expect(snapshot.lastError).toBe("Rate limit near exhaustion");
+    expect(snapshot.rateLimits).toEqual(rateLimits);
+    expect(snapshot.dispatchSuppressedUntil).toBe("2026-07-03T15:56:07.000Z");
+    expect(stderr.write).toHaveBeenCalledWith(
+      expect.stringContaining(`rateLimits=${JSON.stringify(rateLimits)}`)
+    );
+  });
+
+  it("does not derive dispatch suppression from non-tracker rate limits", async () => {
+    const tempRoot = await mkdtemp(
+      join(tmpdir(), "orchestrator-non-tracker-suppression-")
+    );
+    const repository = await createRepositoryFixture(
+      tempRoot,
+      "acme",
+      "platform"
+    );
+    const store = new OrchestratorFsStore(tempRoot);
+    const projectConfig = createProjectConfig(tempRoot, repository);
+    await store.saveProjectConfig(projectConfig);
+    await store.saveRun({
+      runId: "run-1",
+      projectId: projectConfig.projectId,
+      projectSlug: projectConfig.slug,
+      issueId: "issue-1",
+      issueSubjectId: "issue-1",
+      issueIdentifier: "acme/platform#1",
+      issueState: "Todo",
+      repository,
+      status: "running",
+      attempt: 1,
+      processId: null,
+      port: null,
+      workingDirectory: join(tempRoot, "workspace"),
+      issueWorkspaceKey: deriveIssueWorkspaceKey("acme/platform#1"),
+      workspaceRuntimeDir: join(tempRoot, "workspace-runtime"),
+      workflowPath: null,
+      retryKind: null,
+      createdAt: "2026-03-08T00:00:00.000Z",
+      updatedAt: "2026-03-08T00:00:00.000Z",
+      startedAt: "2026-03-08T00:00:00.000Z",
+      completedAt: null,
+      lastError: null,
+      nextRetryAt: null,
+      rateLimits: {
+        source: "codex",
+        limit: 100,
+        remaining: 1,
+        resetAt: "2026-07-03T15:56:07.000Z",
+      },
+    });
+
+    vi.spyOn(trackerAdapters, "resolveTrackerAdapter").mockReturnValue({
+      fetchIssueStatesByIds: vi.fn().mockResolvedValue([
+        {
+          id: "issue-1",
+          identifier: "acme/platform#1",
+          number: 1,
+          title: "Issue 1",
+          description: null,
+          priority: null,
+          state: "Todo",
+          branchName: null,
+          url: "https://github.com/acme/platform/issues/1",
+          labels: [],
+          blockedBy: [],
+          createdAt: "2026-03-08T00:00:00.000Z",
+          updatedAt: "2026-03-08T00:00:00.000Z",
+          repository,
+          tracker: {
+            adapter: "github-project",
+            bindingId: "project-123",
+            itemId: "item-1",
+          },
+          metadata: {},
+          rateLimits: null,
+        },
+      ]),
+      listIssues: vi
+        .fn()
+        .mockRejectedValue(new Error("Rate limit near exhaustion")),
+      listIssuesByStates: vi.fn().mockResolvedValue([]),
+      buildWorkerEnvironment: vi.fn().mockReturnValue({}),
+      reviveIssue: vi.fn(),
+    });
+
+    const service = new OrchestratorService(store, projectConfig, {
+      now: () => new Date("2026-03-08T00:06:00.000Z"),
+      stderr: {
+        write: vi.fn().mockReturnValue(true),
+      },
+    });
+
+    const snapshot = await service.runOnce();
+
+    expect(snapshot.lastError).toBe("Rate limit near exhaustion");
+    expect(snapshot.rateLimits).toEqual({
+      source: "codex",
+      limit: 100,
+      remaining: 1,
+      resetAt: "2026-07-03T15:56:07.000Z",
+    });
+    expect(snapshot.dispatchSuppressedUntil).toBeNull();
+  });
+
   it("ignores non-GitHub rate-limit payloads when computing the poll interval", async () => {
     process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
     const tempRoot = await mkdtemp(

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -311,6 +311,10 @@ export class OrchestratorService {
     WorkflowResolution
   >();
   private readonly lastReportedWorkflowErrors = new Map<string, string>();
+  private readonly lastTrackerRateLimitsByProject = new Map<
+    string,
+    Record<string, unknown>
+  >();
   private workflowResolutionCache: Map<
     string,
     Promise<WorkflowResolution>
@@ -638,6 +642,11 @@ export class OrchestratorService {
         currentActiveRuns,
         now
       );
+      trackerRateLimits = resolveTrackerRateLimits(
+        syncedIssuesByIdentifier.values()
+      );
+      this.rememberTrackerRateLimits(tenant.projectId, trackerRateLimits);
+      rateLimits = rateLimits ?? trackerRateLimits;
       const issues = await trackerAdapter.listIssues(
         tenant,
         trackerDependencies
@@ -688,6 +697,7 @@ export class OrchestratorService {
         trackedIssuesByIdentifier.values(),
         getTrackedIssueListRateLimits(issues)
       );
+      this.rememberTrackerRateLimits(tenant.projectId, trackerRateLimits);
       const concurrency = await this.getProjectConcurrency(tenant);
       const currentlyActive = issueRecords.filter((record) =>
         isIssueOrchestrationClaimedState(record.state)
@@ -965,7 +975,15 @@ export class OrchestratorService {
     } catch (error) {
       lastError =
         error instanceof Error ? error.message : "Unknown orchestration error";
+      trackerRateLimits =
+        trackerRateLimits ?? extractTrackerRateLimitsFromError(error);
+      rateLimits = rateLimits ?? trackerRateLimits;
     }
+    trackerRateLimits =
+      trackerRateLimits ??
+      this.lastTrackerRateLimitsByProject.get(tenant.projectId) ??
+      null;
+    rateLimits = rateLimits ?? trackerRateLimits;
 
     const effectivePollIntervalMs = resolveAdaptivePollIntervalMs(
       pollIntervalMs,
@@ -1005,7 +1023,11 @@ export class OrchestratorService {
     const latestRuns = allTenantRuns.filter((run) =>
       isActiveRunRecordStatus(run.status)
     );
-    rateLimits = rateLimits ?? resolveProjectRateLimits(latestRuns, []);
+    rateLimits =
+      rateLimits ??
+      trackerRateLimits ??
+      resolveProjectRateLimits(latestRuns, []);
+    const dispatchRateLimits = trackerRateLimits ?? rateLimits;
     const status = buildProjectSnapshot({
       project: tenant,
       activeRuns: latestRuns,
@@ -1014,6 +1036,10 @@ export class OrchestratorService {
       lastTickAt: now.toISOString(),
       lastError,
       rateLimits,
+      dispatchSuppressedUntil: resolveDispatchSuppressedUntil(
+        lastError,
+        dispatchRateLimits
+      ),
       issueWorkspaces,
     });
     await this.store.saveProjectStatus(status);
@@ -2974,6 +3000,15 @@ export class OrchestratorService {
     return Number.isFinite(limit) && limit >= 0 ? limit : DEFAULT_CONCURRENCY;
   }
 
+  private rememberTrackerRateLimits(
+    projectId: string,
+    rateLimits: Record<string, unknown> | null
+  ): void {
+    if (isTrackerGraphqlRateLimits(rateLimits)) {
+      this.lastTrackerRateLimitsByProject.set(projectId, rateLimits);
+    }
+  }
+
   private async resolveWorkflowResolution(
     repository: RepositoryRef,
     cacheRoot: string,
@@ -3328,6 +3363,21 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value);
 }
 
+function extractTrackerRateLimitsFromError(
+  error: unknown
+): Record<string, unknown> | null {
+  if (!isRecord(error)) {
+    return null;
+  }
+
+  const rateLimits = error.rateLimits;
+  if (!isRecord(rateLimits)) {
+    return null;
+  }
+
+  return isTrackerGraphqlRateLimits(rateLimits) ? rateLimits : null;
+}
+
 function getTrackedIssueListRateLimits(
   issues: readonly TrackedIssue[]
 ): Record<string, unknown> | null {
@@ -3476,6 +3526,20 @@ function isLowRateLimit(
 ): boolean {
   const ratio = extractRateLimitRatio(rateLimits);
   return ratio !== null && ratio < threshold;
+}
+
+function resolveDispatchSuppressedUntil(
+  lastError: string | null,
+  rateLimits: Record<string, unknown> | null
+): string | null {
+  if (
+    lastError !== "Rate limit near exhaustion" ||
+    !isTrackerGraphqlRateLimits(rateLimits)
+  ) {
+    return null;
+  }
+
+  return typeof rateLimits.resetAt === "string" ? rateLimits.resetAt : null;
 }
 
 function buildRuntimeSession(

--- a/packages/tracker-github/src/adapter.ts
+++ b/packages/tracker-github/src/adapter.ts
@@ -291,7 +291,14 @@ type PriorityResolutionInput =
   | PriorityResolutionConfig
   | LegacyPriorityResolutionConfig;
 
-export class GitHubTrackerError extends Error {}
+export class GitHubTrackerError extends Error {
+  constructor(
+    message: string,
+    readonly rateLimits: Record<string, unknown> | null = null
+  ) {
+    super(message);
+  }
+}
 
 export class GitHubTrackerHttpError extends GitHubTrackerError {
   constructor(
@@ -1498,12 +1505,12 @@ async function guardGraphQLRateLimit(tokenFingerprint: string): Promise<void> {
 
   const resetAtMs = parseTimestampMs(rateLimit.resetAt);
   if (resetAtMs === null) {
-    throw new GitHubTrackerError("Rate limit near exhaustion");
+    throw new GitHubTrackerError("Rate limit near exhaustion", rateLimit);
   }
 
   const waitMs = Math.max(0, resetAtMs - Date.now());
   if (waitMs > MAX_RATE_LIMIT_WAIT_MS) {
-    throw new GitHubTrackerError("Rate limit near exhaustion");
+    throw new GitHubTrackerError("Rate limit near exhaustion", rateLimit);
   }
 
   cachedGitHubGraphQLRateLimits.delete(tokenFingerprint);

--- a/packages/tracker-github/src/tracker-github.test.ts
+++ b/packages/tracker-github/src/tracker-github.test.ts
@@ -1612,8 +1612,9 @@ describe("resolveTrackerAdapter", () => {
       }
     );
 
-    await expect(
-      adapter.listIssues(
+    let thrown: unknown;
+    try {
+      await adapter.listIssues(
         {
           projectId: "workspace-1",
           slug: "workspace-1",
@@ -1635,8 +1636,22 @@ describe("resolveTrackerAdapter", () => {
           token: "dependencies-token",
           fetchImpl,
         }
-      )
-    ).rejects.toThrow("Rate limit near exhaustion");
+      );
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as Error).message).toBe("Rate limit near exhaustion");
+    expect((thrown as { rateLimits?: unknown }).rateLimits).toEqual({
+      source: "github",
+      limit: 5000,
+      remaining: 100,
+      used: null,
+      reset: 1773892920,
+      resetAt: "2026-03-19T04:02:00.000Z",
+      resource: "graphql",
+    });
     expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
 


### PR DESCRIPTION
## Issues — Closed #428

## TL;DR

- dispatch를 게이팅하는 tracker GitHub rate-limit 예산이 실패 경로에서도 `status.json`과 `/api/v1/status`의 `rateLimits`에 남도록 수정했습니다.
- `Rate limit near exhaustion`으로 dispatch가 억제될 때 `dispatchSuppressedUntil`에 tracker `resetAt`을 노출해 throttled 상태를 로그 없이 구분할 수 있게 했습니다.
- 리뷰 rework로 active run이 없는 상태에서 `listIssues()`가 cached low-budget guard에 막히는 경우도 마지막 tracker rate-limit cache와 adapter error payload로 보존합니다.
- Cycle 3 rework로 `dispatchSuppressedUntil`이 non-tracker rate-limit payload에서 파생되지 않도록 tracker GraphQL shape guard를 추가했습니다.

## 변경 지점 다이어그램

`GitHub tracker rateLimits` → `OrchestratorService.reconcileProject()` → `buildProjectSnapshot()` → `status.json` / `/api/v1/status`

## 여기부터 보세요

- `packages/orchestrator/src/service.ts`: 관측한 tracker GraphQL rate-limit을 project별로 기억하고, tracker 호출 실패 후 snapshot `rateLimits` fallback으로 사용합니다. cached guard error가 payload를 포함하면 그 값도 흡수합니다. `dispatchSuppressedUntil`은 tracker GraphQL shape를 통과한 payload에서만 계산합니다.
- `packages/tracker-github/src/adapter.ts`: cached low-budget guard가 `Rate limit near exhaustion` 예외를 던질 때 cached GraphQL rate-limit payload를 함께 싣습니다.
- `packages/core/src/contracts/status-surface.ts`: `ProjectStatusSnapshot.dispatchSuppressedUntil` optional field를 추가했습니다.
- `packages/core/src/observability/snapshot-builder.ts`: `rateLimits`와 `dispatchSuppressedUntil`를 null-safe로 직렬화합니다.
- `packages/orchestrator/src/service.test.ts`, `packages/tracker-github/src/tracker-github.test.ts`: active-run sync, no-active-run cached throttling, adapter cached guard payload, non-tracker suppression 방지 경로를 검증합니다.

## 위험 & 롤백

- 위험: status snapshot에 optional field가 하나 추가됩니다. 기존 소비자는 optional/null 필드라 후방 호환됩니다.
- 위험: service-level cached tracker rate-limit은 process memory 기반이라 재시작 후 첫 tracker 호출 전에는 이전 budget을 복원하지 않습니다. 기존 durable state contract는 변경하지 않았습니다.
- 롤백: `dispatchSuppressedUntil` 타입/빌더 추가, service fallback/cache, GitHub tracker error payload 변경을 되돌리면 기존 status surface로 복구됩니다.

## 변경 파일

- `packages/core/src/contracts/status-surface.ts`
- `packages/core/src/observability/snapshot-builder.ts`
- `packages/core/src/observability/snapshot-builder.test.ts`
- `packages/orchestrator/src/service.ts`
- `packages/orchestrator/src/service.test.ts`
- `packages/tracker-github/src/adapter.ts`
- `packages/tracker-github/src/tracker-github.test.ts`

## 검증

- `pnpm --filter @gh-symphony/orchestrator test -- --run src/service.test.ts` — pass (115 tests)
- `pnpm --filter @gh-symphony/tracker-github test -- --run src/tracker-github.test.ts` — pass (56 tests)
- `pnpm --filter @gh-symphony/core test -- --run src/observability/snapshot-builder.test.ts` — pass (27 tests)
- `pnpm lint && pnpm test && pnpm typecheck && pnpm build` — pass
- Docker E2E: `docker compose -f docker-compose.e2e.yml -f docker-compose.e2e.events.yml up -d --build`, `/healthz`, fixture 주입 후 `/api/v1/state` 확인 — pass (`health: running`, `activeRuns: 1`, `rateLimits: null`, `dispatchSuppressedUntil: null` 기본값 확인)
- Changeset: `N/A` (changeset label 없음)

## 머지 후/사람 확인

- [ ] 운영 status snapshot에서 `rateLimits`가 tracker GitHub budget으로 채워지는지 확인
- [ ] rate-limit 억제 상태가 로그 없이 `dispatchSuppressedUntil`로 구분되는지 확인
