### PR TITLE
fix(rate-limit): avoid GitHub dispatch dead zones

### DIFF
--- a/.changeset/bright-humans-poll.md
+++ b/.changeset/bright-humans-poll.md
@@ -1,0 +1,8 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Reduce GitHub GraphQL rate-limit dispatch dead zones by allowing positive
+remaining budget to continue polling while scaling the orchestrator poll
+interval continuously as token headroom drops. Documents token separation for
+co-hosted repository orchestrators. Refs #427.

--- a/.changeset/soft-rate-limit-dispatch.md
+++ b/.changeset/soft-rate-limit-dispatch.md
@@ -1,0 +1,7 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Keep GitHub Project dispatch alive under shared-token GraphQL pressure by
+turning low positive remaining budget into graceful polling degradation instead
+of a hard reset-window dead zone. References #427.

--- a/README.md
+++ b/README.md
@@ -648,6 +648,16 @@ export GITHUB_GRAPHQL_TOKEN=ghp_your_classic_token
 
 `GITHUB_GRAPHQL_TOKEN` takes priority over `gh` CLI. Interactive `gh-symphony workflow init` and `gh-symphony setup` will use the env token first when it is present and valid, and only fall back to `gh` when no usable env token is available. `gh-symphony doctor` also reports the resolved auth source as `env` or `gh`.
 
+### GitHub GraphQL Rate Limits
+
+GitHub GraphQL rate limits are shared by every orchestrator process using the
+same token. If one host runs several repository orchestrators, prefer a
+separate `GITHUB_GRAPHQL_TOKEN` per repository or per runtime identity when
+that is operationally practical. Shared-token deployments still degrade
+gracefully: GitHub tracker polling slows down as remaining GraphQL budget falls,
+and the cached pre-request guard only hard-stops after the cached budget is
+exhausted.
+
 ### GitHub Enterprise Server
 
 For GitHub Enterprise Server, configure the GraphQL endpoint in `WORKFLOW.md`

--- a/README.md
+++ b/README.md
@@ -648,6 +648,13 @@ export GITHUB_GRAPHQL_TOKEN=ghp_your_classic_token
 
 `GITHUB_GRAPHQL_TOKEN` takes priority over `gh` CLI. Interactive `gh-symphony workflow init` and `gh-symphony setup` will use the env token first when it is present and valid, and only fall back to `gh` when no usable env token is available. `gh-symphony doctor` also reports the resolved auth source as `env` or `gh`.
 
+When multiple repository orchestrators run on the same host, prefer a separate
+`GITHUB_GRAPHQL_TOKEN` per repository or orchestrator instance. GitHub GraphQL
+rate limits are token-scoped, so sharing one token across several polling loops
+combines their usage into one hourly budget. Symphony slows polling as headroom
+drops, but token separation keeps one busy repository from starving dispatch in
+the others.
+
 ### GitHub Enterprise Server
 
 For GitHub Enterprise Server, configure the GraphQL endpoint in `WORKFLOW.md`

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -3055,13 +3055,13 @@ Prefer focused changes.
       value: 2000,
     });
     await constrainedService.runOnce();
-    expect(constrainedService.getEffectivePollIntervalMs()).toBe(60_000);
+    expect(constrainedService.getEffectivePollIntervalMs()).toBe(37_500);
 
     const lowService = await createServiceWithRemaining("low", {
       value: 500,
     });
     await lowService.runOnce();
-    expect(lowService.getEffectivePollIntervalMs()).toBe(120_000);
+    expect(lowService.getEffectivePollIntervalMs()).toBe(150_000);
 
     const exhaustedRemaining = { value: 100 };
     const exhaustedService = await createServiceWithRemaining(

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -3476,15 +3476,8 @@ function resolveAdaptivePollIntervalMs(
     return basePollIntervalMs;
   }
 
-  if (ratio >= 0.2) {
-    return basePollIntervalMs * 2;
-  }
-
-  if (ratio >= LOW_RATE_LIMIT_WARNING_THRESHOLD) {
-    return basePollIntervalMs * 4;
-  }
-
-  return basePollIntervalMs * 10;
+  const multiplier = Math.min(10, Math.max(1, 0.5 / ratio));
+  return Math.ceil(basePollIntervalMs * multiplier);
 }
 
 function extractRateLimitRatio(

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -69,6 +69,8 @@ const CONTINUATION_RETRY_DELAY_MS = 1_000;
 const DEFAULT_WORKER_COMMAND = "node packages/worker/dist/index.js";
 const DEFAULT_MAX_NONPRODUCTIVE_TURNS = 3;
 const LOW_RATE_LIMIT_WARNING_THRESHOLD = 0.05;
+const ADAPTIVE_RATE_LIMIT_FULL_SPEED_RATIO = 0.5;
+const MAX_ADAPTIVE_POLL_INTERVAL_MULTIPLIER = 10;
 const MAX_RECOVERY_DIRTY_FILES_IN_CONTEXT = 50;
 const MAX_FAILURE_RETRIES_EXCEEDED_REASON = "max_failure_retries_exceeded";
 const LINKED_PR_ACTIVE_ISSUE_INACTIVE_MARKER_PREFIX =
@@ -3472,19 +3474,19 @@ function resolveAdaptivePollIntervalMs(
   }
 
   const ratio = extractRateLimitRatio(rateLimits);
-  if (ratio === null || ratio > 0.5) {
+  if (ratio === null || ratio > ADAPTIVE_RATE_LIMIT_FULL_SPEED_RATIO) {
     return basePollIntervalMs;
   }
 
-  if (ratio >= 0.2) {
-    return basePollIntervalMs * 2;
+  if (ratio <= 0) {
+    return basePollIntervalMs * MAX_ADAPTIVE_POLL_INTERVAL_MULTIPLIER;
   }
 
-  if (ratio >= LOW_RATE_LIMIT_WARNING_THRESHOLD) {
-    return basePollIntervalMs * 4;
-  }
-
-  return basePollIntervalMs * 10;
+  const multiplier = Math.min(
+    MAX_ADAPTIVE_POLL_INTERVAL_MULTIPLIER,
+    Math.max(1, ADAPTIVE_RATE_LIMIT_FULL_SPEED_RATIO / ratio)
+  );
+  return Math.ceil(basePollIntervalMs * multiplier);
 }
 
 function extractRateLimitRatio(

--- a/packages/tracker-github/src/adapter.ts
+++ b/packages/tracker-github/src/adapter.ts
@@ -9,7 +9,6 @@ import {
 const DEFAULT_API_URL = "https://api.github.com/graphql";
 const DEFAULT_PAGE_SIZE = 25;
 const DEFAULT_NETWORK_TIMEOUT_MS = 30_000;
-const RATE_LIMIT_THRESHOLD = 100;
 const MAX_RATE_LIMIT_WAIT_MS = 60_000;
 
 export type GitHubTrackerConfig = {
@@ -1499,7 +1498,7 @@ async function guardGraphQLRateLimit(tokenFingerprint: string): Promise<void> {
   }
 
   const remaining = rateLimit.remaining;
-  if (remaining === null || remaining > RATE_LIMIT_THRESHOLD) {
+  if (remaining === null || remaining > 0) {
     return;
   }
 

--- a/packages/tracker-github/src/adapter.ts
+++ b/packages/tracker-github/src/adapter.ts
@@ -9,7 +9,8 @@ import {
 const DEFAULT_API_URL = "https://api.github.com/graphql";
 const DEFAULT_PAGE_SIZE = 25;
 const DEFAULT_NETWORK_TIMEOUT_MS = 30_000;
-const RATE_LIMIT_THRESHOLD = 100;
+const RATE_LIMIT_SOFT_THRESHOLD = 100;
+const RATE_LIMIT_HARD_THRESHOLD = 0;
 const MAX_RATE_LIMIT_WAIT_MS = 60_000;
 
 export type GitHubTrackerConfig = {
@@ -471,13 +472,14 @@ export async function fetchProjectIssues(
   // state, so callers must fetch the project items and filter in memory.
   const issues: GitHubTrackedIssue[] = [];
   let cursor: string | null = null;
-  const priorityOptionIds = !config.priority && config.priorityFieldName
-    ? await fetchPriorityOptionOrder(
-        config,
-        config.priorityFieldName,
-        fetchImpl
-      )
-    : undefined;
+  const priorityOptionIds =
+    !config.priority && config.priorityFieldName
+      ? await fetchPriorityOptionOrder(
+          config,
+          config.priorityFieldName,
+          fetchImpl
+        )
+      : undefined;
   const currentUserLogin = config.assignedOnly
     ? await fetchCurrentUserLogin(config, fetchImpl)
     : null;
@@ -609,13 +611,14 @@ export async function fetchProjectIssueByRepositoryAndNumber(
   issueNumber: number,
   fetchImpl: FetchLike = fetch
 ): Promise<GitHubTrackedIssue | null> {
-  const priorityOptionIds = !config.priority && config.priorityFieldName
-    ? await fetchPriorityOptionOrder(
-        config,
-        config.priorityFieldName,
-        fetchImpl
-      )
-    : undefined;
+  const priorityOptionIds =
+    !config.priority && config.priorityFieldName
+      ? await fetchPriorityOptionOrder(
+          config,
+          config.priorityFieldName,
+          fetchImpl
+        )
+      : undefined;
   const result =
     await executeGraphQLQueryWithMetadata<GraphQLRepositoryIssueLookupResponse>(
       config,
@@ -1237,9 +1240,7 @@ function resolveLabelPriority(
   return chosenValue;
 }
 
-function rawLabelNames(
-  nodes: Array<{ name: string | null } | null>
-): string[] {
+function rawLabelNames(nodes: Array<{ name: string | null } | null>): string[] {
   return nodes.flatMap((label) => (label?.name ? [label.name] : []));
 }
 
@@ -1287,12 +1288,10 @@ function emitPriorityUnmapped(
   );
 }
 
-function issueEventMetadata(item: GraphQLProjectItem):
-  | {
-      identifier: string;
-      id: string;
-    }
-  | null {
+function issueEventMetadata(item: GraphQLProjectItem): {
+  identifier: string;
+  id: string;
+} | null {
   if (
     item.content?.__typename !== "Issue" &&
     item.content?.__typename !== "PullRequest"
@@ -1499,18 +1498,24 @@ async function guardGraphQLRateLimit(tokenFingerprint: string): Promise<void> {
   }
 
   const remaining = rateLimit.remaining;
-  if (remaining === null || remaining > RATE_LIMIT_THRESHOLD) {
+  if (remaining === null || remaining > RATE_LIMIT_SOFT_THRESHOLD) {
     return;
   }
 
   const resetAtMs = parseTimestampMs(rateLimit.resetAt);
   if (resetAtMs === null) {
-    throw new GitHubTrackerError("Rate limit near exhaustion", rateLimit);
+    if (remaining <= RATE_LIMIT_HARD_THRESHOLD) {
+      throw new GitHubTrackerError("Rate limit near exhaustion", rateLimit);
+    }
+    return;
   }
 
   const waitMs = Math.max(0, resetAtMs - Date.now());
   if (waitMs > MAX_RATE_LIMIT_WAIT_MS) {
-    throw new GitHubTrackerError("Rate limit near exhaustion", rateLimit);
+    if (remaining <= RATE_LIMIT_HARD_THRESHOLD) {
+      throw new GitHubTrackerError("Rate limit near exhaustion", rateLimit);
+    }
+    return;
   }
 
   cachedGitHubGraphQLRateLimits.delete(tokenFingerprint);

--- a/packages/tracker-github/src/tracker-github.test.ts
+++ b/packages/tracker-github/src/tracker-github.test.ts
@@ -1550,7 +1550,123 @@ describe("resolveTrackerAdapter", () => {
     expect(fetchImpl).toHaveBeenCalledTimes(2);
   });
 
-  it("skips the GraphQL request when the cached rate limit reset is too far away", async () => {
+  it("allows a soft-threshold GraphQL request when the cached reset is too far away", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-19T04:00:00.000Z"));
+
+    const adapter = resolveTrackerAdapter({
+      adapter: "github-project",
+      bindingId: "project-123",
+      settings: {
+        projectId: "project-123",
+      },
+    });
+
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              node: {
+                __typename: "ProjectV2",
+                items: {
+                  nodes: [],
+                  pageInfo: { endCursor: null, hasNextPage: false },
+                },
+              },
+            },
+          }),
+          {
+            status: 200,
+            headers: {
+              "content-type": "application/json",
+              "x-ratelimit-limit": "5000",
+              "x-ratelimit-remaining": "100",
+              "x-ratelimit-reset": "1773892920",
+              "x-ratelimit-resource": "graphql",
+            },
+          }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              node: {
+                __typename: "ProjectV2",
+                items: {
+                  nodes: [],
+                  pageInfo: { endCursor: null, hasNextPage: false },
+                },
+              },
+            },
+          }),
+          {
+            status: 200,
+            headers: {
+              "content-type": "application/json",
+              "x-ratelimit-limit": "5000",
+              "x-ratelimit-remaining": "99",
+              "x-ratelimit-reset": "1773892920",
+              "x-ratelimit-resource": "graphql",
+            },
+          }
+        )
+      );
+
+    await adapter.listIssues(
+      {
+        projectId: "workspace-1",
+        slug: "workspace-1",
+        workspaceDir: "/tmp/workspace-1",
+        repository: {
+          owner: "acme",
+          name: "platform",
+          cloneUrl: "https://github.com/acme/platform.git",
+        },
+        tracker: {
+          adapter: "github-project",
+          bindingId: "project-123",
+          settings: {
+            projectId: "project-123",
+          },
+        },
+      },
+      {
+        token: "dependencies-token",
+        fetchImpl,
+      }
+    );
+
+    await adapter.listIssues(
+      {
+        projectId: "workspace-1",
+        slug: "workspace-1",
+        workspaceDir: "/tmp/workspace-1",
+        repository: {
+          owner: "acme",
+          name: "platform",
+          cloneUrl: "https://github.com/acme/platform.git",
+        },
+        tracker: {
+          adapter: "github-project",
+          bindingId: "project-123",
+          settings: {
+            projectId: "project-123",
+          },
+        },
+      },
+      {
+        token: "dependencies-token",
+        fetchImpl,
+      }
+    );
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("skips the GraphQL request when the cached rate limit is exhausted and reset is too far away", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-03-19T04:00:00.000Z"));
 
@@ -1580,7 +1696,7 @@ describe("resolveTrackerAdapter", () => {
           headers: {
             "content-type": "application/json",
             "x-ratelimit-limit": "5000",
-            "x-ratelimit-remaining": "100",
+            "x-ratelimit-remaining": "0",
             "x-ratelimit-reset": "1773892920",
             "x-ratelimit-resource": "graphql",
           },
@@ -1646,7 +1762,7 @@ describe("resolveTrackerAdapter", () => {
     expect((thrown as { rateLimits?: unknown }).rateLimits).toEqual({
       source: "github",
       limit: 5000,
-      remaining: 100,
+      remaining: 0,
       used: null,
       reset: 1773892920,
       resetAt: "2026-03-19T04:02:00.000Z",

--- a/packages/tracker-github/src/tracker-github.test.ts
+++ b/packages/tracker-github/src/tracker-github.test.ts
@@ -1429,7 +1429,7 @@ describe("resolveTrackerAdapter", () => {
     });
   });
 
-  it("waits for the cached GraphQL rate limit reset when exhaustion is near", async () => {
+  it("waits for the cached GraphQL rate limit reset when exhausted", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-03-19T04:00:00.000Z"));
 
@@ -1461,7 +1461,7 @@ describe("resolveTrackerAdapter", () => {
             headers: {
               "content-type": "application/json",
               "x-ratelimit-limit": "5000",
-              "x-ratelimit-remaining": "100",
+              "x-ratelimit-remaining": "0",
               "x-ratelimit-reset": "1773892830",
               "x-ratelimit-resource": "graphql",
             },
@@ -1550,7 +1550,99 @@ describe("resolveTrackerAdapter", () => {
     expect(fetchImpl).toHaveBeenCalledTimes(2);
   });
 
-  it("skips the GraphQL request when the cached rate limit reset is too far away", async () => {
+  it("uses positive remaining GraphQL budget instead of skipping until reset", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-19T04:00:00.000Z"));
+
+    const adapter = resolveTrackerAdapter({
+      adapter: "github-project",
+      bindingId: "project-123",
+      settings: {
+        projectId: "project-123",
+      },
+    });
+
+    const createResponse = (remaining: string) =>
+      new Response(
+        JSON.stringify({
+          data: {
+            node: {
+              __typename: "ProjectV2",
+              items: {
+                nodes: [],
+                pageInfo: { endCursor: null, hasNextPage: false },
+              },
+            },
+          },
+        }),
+        {
+          status: 200,
+          headers: {
+            "content-type": "application/json",
+            "x-ratelimit-limit": "5000",
+            "x-ratelimit-remaining": remaining,
+            "x-ratelimit-reset": "1773892920",
+            "x-ratelimit-resource": "graphql",
+          },
+        }
+      );
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(createResponse("100"))
+      .mockResolvedValueOnce(createResponse("99"));
+
+    await adapter.listIssues(
+      {
+        projectId: "workspace-1",
+        slug: "workspace-1",
+        workspaceDir: "/tmp/workspace-1",
+        repository: {
+          owner: "acme",
+          name: "platform",
+          cloneUrl: "https://github.com/acme/platform.git",
+        },
+        tracker: {
+          adapter: "github-project",
+          bindingId: "project-123",
+          settings: {
+            projectId: "project-123",
+          },
+        },
+      },
+      {
+        token: "dependencies-token",
+        fetchImpl,
+      }
+    );
+
+    await adapter.listIssues(
+      {
+        projectId: "workspace-1",
+        slug: "workspace-1",
+        workspaceDir: "/tmp/workspace-1",
+        repository: {
+          owner: "acme",
+          name: "platform",
+          cloneUrl: "https://github.com/acme/platform.git",
+        },
+        tracker: {
+          adapter: "github-project",
+          bindingId: "project-123",
+          settings: {
+            projectId: "project-123",
+          },
+        },
+      },
+      {
+        token: "dependencies-token",
+        fetchImpl,
+      }
+    );
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("skips the GraphQL request when the exhausted cached rate limit reset is too far away", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-03-19T04:00:00.000Z"));
 
@@ -1580,7 +1672,7 @@ describe("resolveTrackerAdapter", () => {
           headers: {
             "content-type": "application/json",
             "x-ratelimit-limit": "5000",
-            "x-ratelimit-remaining": "100",
+            "x-ratelimit-remaining": "0",
             "x-ratelimit-reset": "1773892920",
             "x-ratelimit-resource": "graphql",
           },
@@ -1646,7 +1738,7 @@ describe("resolveTrackerAdapter", () => {
     expect((thrown as { rateLimits?: unknown }).rateLimits).toEqual({
       source: "github",
       limit: 5000,
-      remaining: 100,
+      remaining: 0,
       used: null,
       reset: 1773892920,
       resetAt: "2026-03-19T04:02:00.000Z",


### PR DESCRIPTION
## TL;DR

- GraphQL rate-limit 잔여량이 낮아졌을 때 `Rate limit near exhaustion` 예외로 dispatch가 완전히 멈추는 대신, positive remaining 예산은 계속 사용하고 poll interval을 잔여 비율에 따라 연속적으로 늘립니다.
- 동일 토큰을 여러 repo orchestrator가 공유하는 운영 구성을 README에 명시하고, 가능하면 repo별 토큰을 분리하도록 안내합니다.

## 변경 지점 다이어그램

```text
GitHub tracker GraphQL response
  -> token-scoped cached rateLimits
  -> remaining == 0 일 때만 reset 대기/throw guard
  -> positive remaining이면 요청 허용
  -> orchestrator가 remaining/limit 비율로 poll interval 연속 스케일
  -> 낮은 headroom에서도 hourly reset 전 dispatch dead zone 완화
```

## 여기부터 보세요

- `packages/tracker-github/src/adapter.ts` — positive remaining GraphQL budget은 계속 사용하고, exhausted 상태에서만 reset guard 적용
- `packages/orchestrator/src/service.ts` — rate-limit ratio 기반 continuous poll interval scaling
- `packages/tracker-github/src/tracker-github.test.ts` — positive remaining dead zone 회피와 exhausted guard TC
- `packages/orchestrator/src/service.test.ts` — adaptive interval 기대값 갱신
- `README.md` — co-hosted multi-repo 단일 토큰 운영 주의 문서화

## 위험 & 롤백

- 위험: rate-limit이 낮은 상태에서 poll interval이 기존보다 더 길어져 pickup latency가 증가할 수 있습니다. 의도한 graceful degradation입니다.
- 롤백: 이 PR을 revert하면 #137의 기존 threshold 기반 guard 동작으로 돌아갑니다.

## 변경 파일

- `.changeset/bright-humans-poll.md`
- `README.md`
- `packages/orchestrator/src/service.ts`
- `packages/orchestrator/src/service.test.ts`
- `packages/tracker-github/src/adapter.ts`
- `packages/tracker-github/src/tracker-github.test.ts`

## Issues — Closed #427

Closed #427

## 머지 후/사람 확인

- [ ] 공유 토큰을 쓰는 실제 운영 호스트에서 reset 직전 dispatch가 완전 정지하지 않고 poll interval만 늘어나는지 관찰
- [ ] 필요 시 repo별 GitHub token 분리 적용 여부 결정

## Evidence

- `pnpm --filter @gh-symphony/tracker-github test` — pass (57 tests; Draft PR 생성 전 최소 검증)
- `pnpm lint && pnpm test && pnpm typecheck && pnpm build` — pass
- Docker E2E TC: `happy-path` fixture 주입 → `/api/v1/refresh` → run dispatch/worker execution 관찰 → fixture 제거 → retry release 후 `idle` 확인
- Docker E2E evidence: `evidence/issue-427-docker-e2e-state.json`, `evidence/issue-427-docker-e2e-dispatched.json`, `evidence/issue-427-docker-e2e-cleanup.json`, `evidence/issue-427-docker-e2e-final.json`, `evidence/issue-427-docker-e2e-events.ndjson`, `evidence/issue-427-docker-e2e-container.log`
- Spec check: `docs/symphony-spec.md` 미수정, GitHub-specific 동작은 Integration Layer 확장으로 유지, upstream spec 의도적 divergence 없음
