### PR TITLE
fix(tracker-github): scope Project V2 dispatch to daemon repo

### DIFF
--- a/.changeset/quiet-suns-scope.md
+++ b/.changeset/quiet-suns-scope.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": minor
+---
+
+Fix #434 by scoping GitHub Project V2 dispatch to the daemon repository by default. GitHub tracker projects now use `project.repository` unless `tracker.settings.repository` overrides it with `owner/name`; set `tracker.settings.repository: "*"` to opt out and dispatch across all linked repositories.

--- a/packages/cli/src/commands/doctor.test.ts
+++ b/packages/cli/src/commands/doctor.test.ts
@@ -2310,6 +2310,49 @@ describe("doctor command handler", () => {
     });
   });
 
+  it("scopes smoke issue lookup to the configured repository", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "doctor-config-"));
+    const workspaceDir = join(configDir, "workspaces");
+    await prepareDoctorPaths(configDir, workspaceDir);
+    const { repoDir, pathEnv } = await createWorkflowFixture();
+    const fetchProjectIssues = vi.fn(async () => [
+      createTrackedIssue({ state: "In progress" }),
+    ]);
+    const projectConfig = createProjectConfig(workspaceDir, "PVT_test", {
+      owner: "acme",
+      name: "widgets",
+      url: "https://github.com/acme/widgets",
+      cloneUrl: "https://github.com/acme/widgets.git",
+    });
+
+    projectConfig.tracker.settings = {
+      repository: "acme/widgets",
+    };
+
+    const report = await withCwd(repoDir, () =>
+      runDoctorDiagnostics(baseOptions(configDir), ["--smoke"], {
+        ...authDependencies(),
+        inspectManagedProjectSelection: async () => ({
+          kind: "resolved",
+          projectId: "tenant-a",
+          projectConfig,
+        }),
+        getProjectDetail: (async () => createProjectDetail() as never) as never,
+        fetchProjectIssues: fetchProjectIssues as never,
+        pathEnv,
+      })
+    );
+
+    expect(
+      report.checks.find((check) => check.id === "smoke_issue")
+    ).toMatchObject({ status: "pass" });
+    expect(fetchProjectIssues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repositoryFilter: { owner: "acme", name: "widgets" },
+      })
+    );
+  });
+
   it("reports tracker fetch failures as smoke diagnostics", async () => {
     const configDir = await mkdtemp(join(tmpdir(), "doctor-config-"));
     const workspaceDir = join(configDir, "workspaces");

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -17,6 +17,7 @@ import {
 import {
   fetchGithubProjectIssueByRepositoryAndNumber,
   fetchGithubProjectIssues,
+  type GitHubTrackerConfig,
 } from "@gh-symphony/tracker-github";
 import {
   createClient,
@@ -701,7 +702,7 @@ function buildGithubTrackerConfig(input: {
   bindingId: string;
   token: string;
   workflow: ParsedWorkflow;
-}) {
+}): GitHubTrackerConfig {
   const settings = input.projectConfig.projectConfig.tracker.settings;
   return {
     projectId: input.bindingId,
@@ -709,6 +710,7 @@ function buildGithubTrackerConfig(input: {
     apiUrl: input.projectConfig.projectConfig.tracker.apiUrl,
     lifecycle: input.workflow.lifecycle,
     assignedOnly: settings?.assignedOnly === true,
+    repositoryFilter: resolveDoctorRepositoryFilter(input.projectConfig),
     priority: input.workflow.tracker.priority,
     priorityFieldName:
       typeof settings?.priorityFieldName === "string"
@@ -717,6 +719,38 @@ function buildGithubTrackerConfig(input: {
     timeoutMs:
       typeof settings?.timeoutMs === "number" ? settings.timeoutMs : undefined,
   };
+}
+
+function resolveDoctorRepositoryFilter(
+  selection: ResolvedManagedProjectSelection
+): GitHubTrackerConfig["repositoryFilter"] {
+  const repositorySetting =
+    typeof selection.projectConfig.tracker.settings?.repository === "string"
+      ? selection.projectConfig.tracker.settings.repository.trim()
+      : undefined;
+
+  if (!repositorySetting) {
+    const repository = selection.projectConfig.repository;
+    return repository
+      ? { owner: repository.owner, name: repository.name }
+      : undefined;
+  }
+
+  if (repositorySetting === "*") {
+    return null;
+  }
+
+  const segments = repositorySetting.split("/");
+  const owner = segments[0]?.trim();
+  const name = segments[1]?.trim();
+
+  if (segments.length !== 2 || !owner || !name) {
+    throw new Error(
+      `Tracker adapter "${selection.projectConfig.tracker.adapter}" requires the "repository" setting to be "*" or "owner/name" when provided.`
+    );
+  }
+
+  return { owner, name };
 }
 
 async function checkLinearTrackerResolution(input: {

--- a/packages/tracker-github/src/adapter.ts
+++ b/packages/tracker-github/src/adapter.ts
@@ -887,10 +887,12 @@ function isIssueInRepository(
   repository: { owner: string; name: string }
 ): boolean {
   const itemRepository = item.content.repository;
-  return (
-    itemRepository.owner.login === repository.owner &&
-    itemRepository.name === repository.name
-  );
+  const itemOwner = itemRepository.owner.login.toLowerCase();
+  const itemName = itemRepository.name.toLowerCase();
+  const filterOwner = repository.owner.toLowerCase();
+  const filterName = repository.name.toLowerCase();
+
+  return itemOwner === filterOwner && itemName === filterName;
 }
 
 function emitAssignedOnlyFilterEvent(input: {

--- a/packages/tracker-github/src/adapter.ts
+++ b/packages/tracker-github/src/adapter.ts
@@ -20,6 +20,7 @@ export type GitHubTrackerConfig = {
   lifecycle?: WorkflowLifecycleConfig;
   pageSize?: number;
   assignedOnly?: boolean;
+  repositoryFilter?: { owner: string; name: string } | null;
   timeoutMs?: number;
   priority?: WorkflowPriorityConfig | null;
   priorityFieldName?: string;
@@ -484,6 +485,7 @@ export async function fetchProjectIssues(
     ? await fetchCurrentUserLogin(config, fetchImpl)
     : null;
   let excludedCount = 0;
+  let repositoryExcludedCount = 0;
   let latestRateLimits: Record<string, unknown> | null = null;
 
   do {
@@ -492,6 +494,26 @@ export async function fetchProjectIssues(
     latestRateLimits = pageResult.rateLimits ?? latestRateLimits;
     const pageIssues = (page.nodes ?? []).flatMap((item) => {
       if (!item) {
+        return [];
+      }
+
+      if (!isRepositoryFilterableProjectItem(item)) {
+        if (config.repositoryFilter) {
+          repositoryExcludedCount += 1;
+        }
+        return [];
+      }
+
+      if (currentUserLogin && !isIssueAssignedToLogin(item, currentUserLogin)) {
+        excludedCount += 1;
+        return [];
+      }
+
+      if (
+        config.repositoryFilter &&
+        !isIssueInRepository(item, config.repositoryFilter)
+      ) {
+        repositoryExcludedCount += 1;
         return [];
       }
 
@@ -512,11 +534,6 @@ export async function fetchProjectIssues(
         return [];
       }
 
-      if (currentUserLogin && !isIssueAssignedToLogin(item, currentUserLogin)) {
-        excludedCount += 1;
-        return [];
-      }
-
       return [normalized];
     });
 
@@ -530,6 +547,15 @@ export async function fetchProjectIssues(
       currentUserLogin,
       includedCount: issues.length,
       excludedCount,
+    });
+  }
+
+  if (config.repositoryFilter) {
+    emitRepositoryFilterEvent({
+      projectId: config.projectId,
+      repository: `${config.repositoryFilter.owner}/${config.repositoryFilter.name}`,
+      includedCount: issues.length,
+      excludedCount: repositoryExcludedCount,
     });
   }
 
@@ -843,6 +869,30 @@ function isIssueAssignedToLogin(
   );
 }
 
+function isRepositoryFilterableProjectItem(
+  item: GraphQLProjectItem
+): item is GraphQLProjectItem & {
+  content: GraphQLIssueNode | GraphQLPullRequestNode;
+} {
+  return (
+    item.content?.__typename === "Issue" ||
+    item.content?.__typename === "PullRequest"
+  );
+}
+
+function isIssueInRepository(
+  item: GraphQLProjectItem & {
+    content: GraphQLIssueNode | GraphQLPullRequestNode;
+  },
+  repository: { owner: string; name: string }
+): boolean {
+  const itemRepository = item.content.repository;
+  return (
+    itemRepository.owner.login === repository.owner &&
+    itemRepository.name === repository.name
+  );
+}
+
 function emitAssignedOnlyFilterEvent(input: {
   projectId: string;
   currentUserLogin: string;
@@ -854,6 +904,23 @@ function emitAssignedOnlyFilterEvent(input: {
       event: "tracker-assigned-only-filtered",
       projectId: input.projectId,
       currentUserLogin: input.currentUserLogin,
+      includedCount: input.includedCount,
+      excludedCount: input.excludedCount,
+    })
+  );
+}
+
+function emitRepositoryFilterEvent(input: {
+  projectId: string;
+  repository: string;
+  includedCount: number;
+  excludedCount: number;
+}): void {
+  console.info(
+    JSON.stringify({
+      event: "tracker-repository-filtered",
+      projectId: input.projectId,
+      repository: input.repository,
       includedCount: input.includedCount,
       excludedCount: input.excludedCount,
     })

--- a/packages/tracker-github/src/orchestrator-adapter.ts
+++ b/packages/tracker-github/src/orchestrator-adapter.ts
@@ -150,12 +150,14 @@ function resolveGitHubTrackerConfig(
 
   const githubProjectId = requireTrackerSetting(project.tracker, "projectId");
   const assignedOnly = resolveAssignedOnly(project.tracker, dependencies);
+  const repositoryFilter = resolveRepositoryFilter(project);
 
   return {
     projectId: githubProjectId,
     token,
     apiUrl: project.tracker.apiUrl,
     assignedOnly,
+    repositoryFilter,
     priority: project.tracker.priority ?? null,
     priorityFieldName: readOptionalStringTrackerSetting(
       project.tracker,
@@ -189,6 +191,47 @@ function resolveAssignedOnly(
   return legacyAssignedOnly;
 }
 
+const warnedRepositoryScopeDisabledProjectIds = new Set<string>();
+
+function resolveRepositoryFilter(
+  project: Parameters<OrchestratorTrackerAdapter["listIssues"]>[0]
+): { owner: string; name: string } | null {
+  const repositorySetting = readOptionalStringTrackerSetting(
+    project.tracker,
+    "repository"
+  )?.trim();
+
+  if (!repositorySetting) {
+    return {
+      owner: project.repository.owner,
+      name: project.repository.name,
+    };
+  }
+
+  if (repositorySetting === "*") {
+    const warningKey = `${project.tracker.adapter}:${project.tracker.bindingId}`;
+    if (!warnedRepositoryScopeDisabledProjectIds.has(warningKey)) {
+      warnedRepositoryScopeDisabledProjectIds.add(warningKey);
+      console.warn(
+        "[gh-symphony] GitHub tracker repository scoping is disabled by tracker.settings.repository='*'. Multiple daemons watching the same Project V2 may dispatch the same issue."
+      );
+    }
+    return null;
+  }
+
+  const segments = repositorySetting.split("/");
+  const owner = segments[0]?.trim();
+  const name = segments[1]?.trim();
+
+  if (segments.length !== 2 || !owner || !name) {
+    throw new Error(
+      `Tracker adapter "${project.tracker.adapter}" requires the "repository" setting to be "*" or "owner/name" when provided.`
+    );
+  }
+
+  return { owner, name };
+}
+
 function buildProjectItemsCacheKey(
   config: ReturnType<typeof resolveGitHubTrackerConfig>,
   _dependencies: OrchestratorTrackerDependencies
@@ -200,6 +243,9 @@ function buildProjectItemsCacheKey(
     priority: config.priority ?? null,
     priorityFieldName: config.priorityFieldName ?? null,
     projectId: config.projectId,
+    repositoryFilter: config.repositoryFilter
+      ? `${config.repositoryFilter.owner}/${config.repositoryFilter.name}`
+      : null,
     timeoutMs: config.timeoutMs,
     tokenFingerprint: hashToken(config.token),
   });

--- a/packages/tracker-github/src/tracker-github.test.ts
+++ b/packages/tracker-github/src/tracker-github.test.ts
@@ -1352,6 +1352,343 @@ describe("resolveTrackerAdapter", () => {
     warnSpy.mockRestore();
   });
 
+  it("automatically scopes Project V2 dispatch to each daemon repository", async () => {
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+    const adapter = resolveTrackerAdapter({
+      adapter: "github-project",
+      bindingId: "project-repo-scope",
+      settings: {
+        projectId: "project-repo-scope",
+      },
+    });
+    const payload = makeProjectItemsPayload([
+      makeProjectItem({
+        itemId: "item-platform",
+        issueId: "issue-platform",
+        number: 1,
+        title: "Platform issue",
+        assignees: [],
+        repository: { owner: "acme", name: "platform" },
+      }),
+      makeProjectItem({
+        itemId: "item-web",
+        issueId: "issue-web",
+        number: 2,
+        title: "Web issue",
+        assignees: [],
+        repository: { owner: "acme", name: "web" },
+      }),
+    ]);
+    const fetchImpl = vi.fn(async () => makeJsonResponse(payload));
+    const cacheEntries = new Map<string, Promise<TrackedIssue[]>>();
+    const projectItemsCache: ProjectItemsCache = {
+      getOrLoad(key, load) {
+        const cached = cacheEntries.get(key);
+        if (cached) {
+          return cached;
+        }
+
+        const pending = load();
+        cacheEntries.set(key, pending);
+        return pending;
+      },
+    };
+
+    try {
+      const platformIssues = await adapter.listIssues(
+        makeProjectConfig({ repository: { owner: "acme", name: "platform" } }),
+        {
+          token: "dependencies-token",
+          fetchImpl,
+          projectItemsCache,
+        }
+      );
+      const webIssues = await adapter.listIssues(
+        makeProjectConfig({ repository: { owner: "acme", name: "web" } }),
+        {
+          token: "dependencies-token",
+          fetchImpl,
+          projectItemsCache,
+        }
+      );
+
+      expect(fetchImpl).toHaveBeenCalledTimes(2);
+      expect(platformIssues.map((issue) => issue.identifier)).toEqual([
+        "acme/platform#1",
+      ]);
+      expect(webIssues.map((issue) => issue.identifier)).toEqual([
+        "acme/web#2",
+      ]);
+      const webIssueIds = new Set(webIssues.map((issue) => issue.id));
+      expect(platformIssues.some((issue) => webIssueIds.has(issue.id))).toBe(
+        false
+      );
+      expect(infoSpy).toHaveBeenCalledWith(
+        expect.stringContaining('"event":"tracker-repository-filtered"')
+      );
+    } finally {
+      infoSpy.mockRestore();
+    }
+  });
+
+  it("defaults missing tracker repository settings to the project repository", async () => {
+    const adapter = resolveTrackerAdapter({
+      adapter: "github-project",
+      bindingId: "project-default-repo-scope",
+      settings: {
+        projectId: "project-default-repo-scope",
+      },
+    });
+
+    const issues = await adapter.listIssues(
+      makeProjectConfig({ repository: { owner: "acme", name: "platform" } }),
+      {
+        token: "dependencies-token",
+        fetchImpl: async () =>
+          makeJsonResponse(
+            makeProjectItemsPayload([
+              makeProjectItem({
+                itemId: "item-platform",
+                issueId: "issue-platform",
+                number: 1,
+                title: "Platform issue",
+                assignees: [],
+                repository: { owner: "acme", name: "platform" },
+              }),
+              makeProjectItem({
+                itemId: "item-web",
+                issueId: "issue-web",
+                number: 2,
+                title: "Web issue",
+                assignees: [],
+                repository: { owner: "acme", name: "web" },
+              }),
+            ])
+          ),
+      }
+    );
+
+    expect(issues.map((issue) => issue.identifier)).toEqual([
+      "acme/platform#1",
+    ]);
+  });
+
+  it("allows tracker repository '*' to opt out of repository dispatch scoping", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const adapter = resolveTrackerAdapter({
+      adapter: "github-project",
+      bindingId: "project-repo-opt-out",
+      settings: {
+        projectId: "project-repo-opt-out",
+      },
+    });
+
+    try {
+      const issues = await adapter.listIssues(
+        makeProjectConfig({
+          repository: { owner: "acme", name: "platform" },
+          trackerSettings: { repository: "*" },
+        }),
+        {
+          token: "dependencies-token",
+          fetchImpl: async () =>
+            makeJsonResponse(
+              makeProjectItemsPayload([
+                makeProjectItem({
+                  itemId: "item-platform",
+                  issueId: "issue-platform",
+                  number: 1,
+                  title: "Platform issue",
+                  assignees: [],
+                  repository: { owner: "acme", name: "platform" },
+                }),
+                makeProjectItem({
+                  itemId: "item-web",
+                  issueId: "issue-web",
+                  number: 2,
+                  title: "Web issue",
+                  assignees: [],
+                  repository: { owner: "acme", name: "web" },
+                }),
+              ])
+            ),
+        }
+      );
+
+      expect(issues.map((issue) => issue.identifier)).toEqual([
+        "acme/platform#1",
+        "acme/web#2",
+      ]);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("repository scoping is disabled")
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("uses tracker repository owner/name as an override when it differs from cwd origin", async () => {
+    const adapter = resolveTrackerAdapter({
+      adapter: "github-project",
+      bindingId: "project-repo-override",
+      settings: {
+        projectId: "project-repo-override",
+      },
+    });
+
+    const issues = await adapter.listIssues(
+      makeProjectConfig({
+        repository: { owner: "acme", name: "platform" },
+        trackerSettings: { repository: "acme/web" },
+      }),
+      {
+        token: "dependencies-token",
+        fetchImpl: async () =>
+          makeJsonResponse(
+            makeProjectItemsPayload([
+              makeProjectItem({
+                itemId: "item-platform",
+                issueId: "issue-platform",
+                number: 1,
+                title: "Platform issue",
+                assignees: [],
+                repository: { owner: "acme", name: "platform" },
+              }),
+              makeProjectItem({
+                itemId: "item-web",
+                issueId: "issue-web",
+                number: 2,
+                title: "Web issue",
+                assignees: [],
+                repository: { owner: "acme", name: "web" },
+              }),
+            ])
+          ),
+      }
+    );
+
+    expect(issues.map((issue) => issue.identifier)).toEqual(["acme/web#2"]);
+  });
+
+  it("excludes assigned issues from other repositories before dispatch", async () => {
+    const adapter = resolveTrackerAdapter({
+      adapter: "github-project",
+      bindingId: "project-repo-assignee-cross",
+      settings: {
+        projectId: "project-repo-assignee-cross",
+      },
+    });
+
+    const issues = await adapter.listIssues(
+      makeProjectConfig({ repository: { owner: "acme", name: "platform" } }),
+      {
+        assignedOnly: true,
+        token: "dependencies-token",
+        fetchImpl: async (url) => {
+          if (String(url).endsWith("/user")) {
+            return makeJsonResponse({ login: "machine-user" });
+          }
+
+          return makeJsonResponse(
+            makeProjectItemsPayload([
+              makeProjectItem({
+                itemId: "item-platform",
+                issueId: "issue-platform",
+                number: 1,
+                title: "Platform issue",
+                assignees: ["machine-user"],
+                repository: { owner: "acme", name: "platform" },
+              }),
+              makeProjectItem({
+                itemId: "item-web",
+                issueId: "issue-web",
+                number: 2,
+                title: "Web issue",
+                assignees: ["machine-user"],
+                repository: { owner: "acme", name: "web" },
+              }),
+            ])
+          );
+        },
+      }
+    );
+
+    expect(issues.map((issue) => issue.identifier)).toEqual([
+      "acme/platform#1",
+    ]);
+  });
+
+  it("excludes Project V2 draft items without repository content when scoped", async () => {
+    const adapter = resolveTrackerAdapter({
+      adapter: "github-project",
+      bindingId: "project-repo-draft",
+      settings: {
+        projectId: "project-repo-draft",
+      },
+    });
+
+    const issues = await adapter.listIssues(
+      makeProjectConfig({ repository: { owner: "acme", name: "platform" } }),
+      {
+        token: "dependencies-token",
+        fetchImpl: async () =>
+          makeJsonResponse(
+            makeProjectItemsPayload([
+              {
+                id: "item-draft",
+                updatedAt: "2026-03-14T00:00:00.000Z",
+                fieldValues: { nodes: [] },
+                content: {
+                  __typename: "DraftIssue",
+                  id: "draft-1",
+                  title: "Unsupported draft",
+                },
+              },
+              makeProjectItem({
+                itemId: "item-platform",
+                issueId: "issue-platform",
+                number: 1,
+                title: "Platform issue",
+                assignees: [],
+                repository: { owner: "acme", name: "platform" },
+              }),
+            ])
+          ),
+      }
+    );
+
+    expect(issues.map((issue) => issue.identifier)).toEqual([
+      "acme/platform#1",
+    ]);
+  });
+
+  it("rejects malformed tracker repository overrides", async () => {
+    const adapter = resolveTrackerAdapter({
+      adapter: "github-project",
+      bindingId: "project-repo-parse",
+      settings: {
+        projectId: "project-repo-parse",
+      },
+    });
+
+    for (const repository of ["acme", "/platform", "acme/", "acme/web/api"]) {
+      await expect(
+        adapter.listIssues(
+          makeProjectConfig({
+            trackerSettings: { repository },
+          }),
+          {
+            token: "dependencies-token",
+            fetchImpl: async () =>
+              makeJsonResponse(makeProjectItemsPayload([])),
+          }
+        )
+      ).rejects.toThrow(
+        'requires the "repository" setting to be "*" or "owner/name"'
+      );
+    }
+  });
+
   it("attaches GitHub API rate-limit headers to listed issues", async () => {
     const adapter = resolveTrackerAdapter({
       adapter: "github-project",
@@ -3603,7 +3940,13 @@ function makeProjectItem(input: {
   labels?: string[];
   priorityName?: string;
   priorityOptionId?: string;
+  repository?: {
+    owner: string;
+    name: string;
+  };
 }) {
+  const repository = input.repository ?? { owner: "acme", name: "platform" };
+
   return {
     id: input.itemId,
     updatedAt: "2026-03-14T00:00:00.000Z",
@@ -3632,7 +3975,7 @@ function makeProjectItem(input: {
       number: input.number,
       title: input.title,
       body: null,
-      url: `https://github.com/acme/platform/issues/${input.number}`,
+      url: `https://github.com/${repository.owner}/${repository.name}/issues/${input.number}`,
       createdAt: "2026-03-14T00:00:00.000Z",
       updatedAt: "2026-03-14T00:00:00.000Z",
       labels: {
@@ -3642,13 +3985,34 @@ function makeProjectItem(input: {
         nodes: input.assignees.map((login) => ({ login })),
       },
       repository: {
-        name: "platform",
-        url: "https://github.com/acme/platform",
-        owner: { login: "acme" },
+        name: repository.name,
+        url: `https://github.com/${repository.owner}/${repository.name}`,
+        owner: { login: repository.owner },
       },
       blockedBy: { nodes: [] },
     },
   };
+}
+
+function makeProjectItemsPayload(nodes: unknown[]) {
+  return {
+    data: {
+      node: {
+        __typename: "ProjectV2",
+        items: {
+          nodes,
+          pageInfo: { endCursor: null, hasNextPage: false },
+        },
+      },
+    },
+  };
+}
+
+function makeJsonResponse(payload: unknown): Response {
+  return new Response(JSON.stringify(payload), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
 }
 
 function makePullRequestProjectItem(input: {
@@ -3808,21 +4172,32 @@ function makePullRequestStateLookupNode(input: {
   };
 }
 
-function makeProjectConfig() {
+function makeProjectConfig(
+  input: {
+    repository?: {
+      owner: string;
+      name: string;
+    };
+    trackerSettings?: Record<string, string | number | boolean | null>;
+  } = {}
+) {
+  const repository = input.repository ?? { owner: "acme", name: "platform" };
+
   return {
     projectId: "tenant-1",
     slug: "tenant-1",
     workspaceDir: "/tmp/workspaces/tenant-1",
     repository: {
-      owner: "acme",
-      name: "platform",
-      cloneUrl: "https://github.com/acme/platform.git",
+      owner: repository.owner,
+      name: repository.name,
+      cloneUrl: `https://github.com/${repository.owner}/${repository.name}.git`,
     },
     tracker: {
       adapter: "github-project" as const,
       bindingId: "project-123",
       settings: {
         projectId: "project-123",
+        ...input.trackerSettings,
       },
     },
   };

--- a/packages/tracker-github/src/tracker-github.test.ts
+++ b/packages/tracker-github/src/tracker-github.test.ts
@@ -1570,6 +1570,51 @@ describe("resolveTrackerAdapter", () => {
     expect(issues.map((issue) => issue.identifier)).toEqual(["acme/web#2"]);
   });
 
+  it("matches repository filters case-insensitively", async () => {
+    const adapter = resolveTrackerAdapter({
+      adapter: "github-project",
+      bindingId: "project-repo-casing",
+      settings: {
+        projectId: "project-repo-casing",
+      },
+    });
+
+    const issues = await adapter.listIssues(
+      makeProjectConfig({
+        repository: { owner: "example", name: "other" },
+        trackerSettings: { repository: "Acme/Platform" },
+      }),
+      {
+        token: "dependencies-token",
+        fetchImpl: async () =>
+          makeJsonResponse(
+            makeProjectItemsPayload([
+              makeProjectItem({
+                itemId: "item-platform",
+                issueId: "issue-platform",
+                number: 1,
+                title: "Platform issue",
+                assignees: [],
+                repository: { owner: "acme", name: "platform" },
+              }),
+              makeProjectItem({
+                itemId: "item-web",
+                issueId: "issue-web",
+                number: 2,
+                title: "Web issue",
+                assignees: [],
+                repository: { owner: "acme", name: "web" },
+              }),
+            ])
+          ),
+      }
+    );
+
+    expect(issues.map((issue) => issue.identifier)).toEqual([
+      "acme/platform#1",
+    ]);
+  });
+
   it("excludes assigned issues from other repositories before dispatch", async () => {
     const adapter = resolveTrackerAdapter({
       adapter: "github-project",


### PR DESCRIPTION
## Issues — Closed #434

## TL;DR

- GitHub Project V2 dispatch를 기본적으로 daemon의 `project.repository`에 자동 스코프합니다.
- `tracker.settings.repository`는 `owner/name` 오버라이드와 `"*"` 전체 dispatch opt-out을 지원합니다.
- repo filter 비교를 case-insensitive로 정규화했고, `doctor --smoke`도 동일한 repository scope를 사용합니다.

## 변경 지점 다이어그램

```text
OrchestratorProjectConfig.repository
  + tracker.settings.repository
  -> resolveGitHubTrackerConfig.repositoryFilter
  -> fetchProjectIssues selection loop
  -> tracker-repository-filtered observability event

doctor --smoke
  -> buildGithubTrackerConfig.repositoryFilter
  -> same scoped Project V2 issue lookup
```

## 여기부터 보세요

- `packages/tracker-github/src/orchestrator-adapter.ts`: `repositoryFilter` 해석, `"*"` opt-out 경고, cache key 포함
- `packages/tracker-github/src/adapter.ts`: Project V2 item repo 필터, draft/unsupported item 제외, case-insensitive repo 비교, repository filter 이벤트
- `packages/tracker-github/src/tracker-github.test.ts`: 자동 스코프 disjoint, 기본값 회귀, opt-out, override, casing mismatch, assignee 교차 제외, draft 제외, 파싱 에러 TC
- `packages/cli/src/commands/doctor.ts`: `doctor --smoke`의 직접 GitHub tracker config 생성 경로에 repository filter 배선
- `packages/cli/src/commands/doctor.test.ts`: doctor smoke lookup repositoryFilter 전달 회귀 테스트
- `.changeset/quiet-suns-scope.md`: CLI minor changeset

## 위험 & 롤백

- 의도된 동작 변경: GitHub Project-bound daemon은 미설정 상태에서 전체 Project가 아니라 자기 repo item만 dispatch합니다.
- 기존 전체 Project dispatch가 필요하면 `tracker.settings.repository: "*"`로 opt out합니다. 이 경우 중복 dispatch 가능성 경고가 프로세스당 1회 출력됩니다.
- repo owner/name 비교는 GitHub semantics에 맞춰 대소문자 무시로 동작합니다.
- GraphQL query shape은 변경하지 않았습니다.

## 변경 파일

- `packages/tracker-github/src/adapter.ts`
- `packages/tracker-github/src/orchestrator-adapter.ts`
- `packages/tracker-github/src/tracker-github.test.ts`
- `packages/cli/src/commands/doctor.ts`
- `packages/cli/src/commands/doctor.test.ts`
- `.changeset/quiet-suns-scope.md`

## Evidence

- Cycle 3 recheck: `pnpm -r test` — pass
- Cycle 3 recheck: `pnpm lint && pnpm test && pnpm typecheck && pnpm build` — pass
- Cycle 3 recheck: Node v24.15.0 `doctor --smoke` — pass; emitted `tracker-repository-filtered` for `hojinzs/github-symphony`, `includedCount:31`, `excludedCount:34`
- Cycle 3 recheck: `repo start --once` — pass; emitted `tracker-repository-filtered` for `hojinzs/github-symphony`, `includedCount:31`, `excludedCount:34`
- Cycle 3 note: no code changes after HEAD `61f7330`; recheck confirms the prior case-insensitive repo comparison and `doctor --smoke` repositoryFilter rework remain present.
- Earlier targeted check: `pnpm --filter @gh-symphony/tracker-github test` — pass (65 tests)
- Earlier targeted check: `pnpm --filter @gh-symphony/cli test -- src/commands/doctor.test.ts` — pass (53 tests)
- Docker E2E blackbox from Cycle 2: compose build/up, health check, inject `happy-path.json`, refresh, stub worker emitted 4 `completed` events; evidence saved at `/tmp/ghs-434-rework-docker-summary.json` and `/tmp/ghs-434-rework-docker-worker.log`

## 머지 후/사람 확인

- [ ] 릴리스(changeset minor) 후 설치 버전 갱신
- [ ] daemon 재기동 후 실제 Project dispatch가 repo별로 분리되는지 확인
