### PR TITLE
fix(orchestrator): isolate project runtime state

### DIFF
--- a/.changeset/project-runtime-isolation.md
+++ b/.changeset/project-runtime-isolation.md
@@ -1,0 +1,8 @@
+---
+"@gh-symphony/cli": minor
+---
+
+Scope orchestrator runtime state and inherited worker environments per project.
+Project runtime files now live under project-specific `.runtime` directories
+with owner-only permissions, and worker/hook processes no longer inherit
+unscoped host secrets such as `GITHUB_GRAPHQL_TOKEN` by default. Fixes #439.

--- a/packages/cli/src/commands/start.test.ts
+++ b/packages/cli/src/commands/start.test.ts
@@ -913,7 +913,9 @@ describe("start command foreground locking", () => {
       startedAt: "2026-03-17T00:00:00.000Z",
     };
     acquireProjectLock.mockResolvedValue(lock);
-    run.mockRejectedValue(new githubClient.GitHubApiError("Bad credentials", 401));
+    run.mockRejectedValue(
+      new githubClient.GitHubApiError("Bad credentials", 401)
+    );
     const exitSpy = vi
       .spyOn(process, "exit")
       .mockImplementation(
@@ -1125,7 +1127,7 @@ describe("start command foreground locking", () => {
       expect(startControlPlaneServer).toHaveBeenCalledWith({
         host: "0.0.0.0",
         port: 4680,
-        runtimeRoot: configDir,
+        runtimeRoot: join(configDir, "projects", "tenant-a"),
         onRefreshRequest: expect.any(Function),
       });
 
@@ -1220,7 +1222,7 @@ describe("start command foreground locking", () => {
       expect(startControlPlaneServer).toHaveBeenCalledWith({
         host: "0.0.0.0",
         port: 4900,
-        runtimeRoot: configDir,
+        runtimeRoot: join(configDir, "projects", "tenant-a"),
         onRefreshRequest: expect.any(Function),
       });
     });
@@ -1550,7 +1552,9 @@ async function waitForHttpUrl(
   while (Date.now() - startedAt < timeoutMs) {
     const match = output()
       .replace(ansiPattern, "")
-      .match(/(?:HTTP status API|Web dashboard) listening on .*?(http:\/\/[^\s]+)/);
+      .match(
+        /(?:HTTP status API|Web dashboard) listening on .*?(http:\/\/[^\s]+)/
+      );
     if (match?.[1]) {
       return match[1];
     }

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -560,7 +560,9 @@ async function startHttpServer(input: {
   initialPort: number;
   service: { requestReconcile(): void };
 }): Promise<{ server: Server; port: number; url: string }> {
-  const reader = new DashboardFsReader(input.runtimeRoot);
+  const reader = new DashboardFsReader(
+    join(input.runtimeRoot, "projects", encodeURIComponent(input.projectId))
+  );
 
   for (let port = input.initialPort; port <= 65_535; port += 1) {
     const server = createServer((request, response) => {

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -840,7 +840,11 @@ const handler = async (
           ? await startControlPlaneServer({
               host: HTTP_HOST,
               port: parsed.webPort,
-              runtimeRoot,
+              runtimeRoot: join(
+                runtimeRoot,
+                "projects",
+                encodeURIComponent(projectId)
+              ),
               onRefreshRequest: () => service.requestReconcile(),
             })
           : parsed.httpPort !== undefined

--- a/packages/orchestrator/src/fs-store.test.ts
+++ b/packages/orchestrator/src/fs-store.test.ts
@@ -13,29 +13,61 @@ import { describe, expect, it, vi } from "vitest";
 import { OrchestratorFsStore } from "./fs-store.js";
 
 describe("OrchestratorFsStore.loadRecentRunEvents", () => {
-  it("uses the workspaceKey-root runtime layout", async () => {
+  it("uses a project-scoped runtime layout", async () => {
     const runtimeRoot = await mkdtemp(join(tmpdir(), "orchestrator-store-"));
     const store = new OrchestratorFsStore(runtimeRoot);
 
-    expect(store.projectDir("project-1")).toBe(runtimeRoot);
+    expect(store.projectDir("project-1")).toBe(
+      join(runtimeRoot, "projects", "project-1")
+    );
     expect(store.runDir("run-1", "project-1")).toBe(
-      join(runtimeRoot, "runs", "run-1")
+      join(runtimeRoot, "projects", "project-1", "runs", "run-1")
     );
     expect(store.issueWorkspaceDir("project-1", "acme_repo_1")).toBe(
-      join(runtimeRoot, "acme_repo_1")
+      join(runtimeRoot, "projects", "project-1", "acme_repo_1")
     );
   });
 
-  it("loads only issue workspace directories from the flat runtime root", async () => {
+  it("creates project directories with owner-only permissions", async () => {
     const runtimeRoot = await mkdtemp(join(tmpdir(), "orchestrator-store-"));
     const store = new OrchestratorFsStore(runtimeRoot);
 
-    await mkdir(join(runtimeRoot, "runs"), { recursive: true });
-    await mkdir(join(runtimeRoot, "cache"), { recursive: true });
-    await mkdir(join(runtimeRoot, ".lock"), { recursive: true });
-    await writeFile(join(runtimeRoot, "status.json"), "{}", "utf8");
+    const previousUmask = process.umask(0);
+    try {
+      await store.saveProjectConfig({
+        projectId: "project-1",
+        slug: "project-1",
+        workspaceDir: "/tmp/workspaces/project-1",
+        repository: {
+          owner: "acme",
+          name: "repo",
+          cloneUrl: "https://github.com/acme/repo.git",
+        },
+        tracker: {
+          adapter: "file",
+          bindingId: "file-project-1",
+        },
+      });
+
+      const stats = await stat(store.projectDir("project-1"));
+
+      expect(stats.mode & 0o777).toBe(0o700);
+    } finally {
+      process.umask(previousUmask);
+    }
+  });
+
+  it("loads only issue workspace directories from the project runtime root", async () => {
+    const runtimeRoot = await mkdtemp(join(tmpdir(), "orchestrator-store-"));
+    const store = new OrchestratorFsStore(runtimeRoot);
+    const projectDir = store.projectDir("project-1");
+
+    await mkdir(join(projectDir, "runs"), { recursive: true });
+    await mkdir(join(projectDir, "cache"), { recursive: true });
+    await mkdir(join(projectDir, ".lock"), { recursive: true });
+    await writeFile(join(projectDir, "status.json"), "{}", "utf8");
     await writeFile(
-      join(runtimeRoot, "runs", "workspace.json"),
+      join(projectDir, "runs", "workspace.json"),
       JSON.stringify({
         workspaceKey: "runs",
       }),
@@ -47,8 +79,8 @@ describe("OrchestratorFsStore.loadRecentRunEvents", () => {
       adapter: "github-project",
       issueSubjectId: "issue-1",
       issueIdentifier: "acme/repo#1",
-      workspacePath: join(runtimeRoot, "acme_repo_1"),
-      repositoryPath: join(runtimeRoot, "acme_repo_1", "repository"),
+      workspacePath: join(projectDir, "acme_repo_1"),
+      repositoryPath: join(projectDir, "acme_repo_1", "repository"),
       status: "active",
       createdAt: "2026-03-16T00:00:00.000Z",
       updatedAt: "2026-03-16T00:00:00.000Z",
@@ -251,7 +283,17 @@ describe("OrchestratorFsStore.loadRecentRunEvents", () => {
     });
 
     await expect(
-      readFile(join(eventsMirrorRoot, "runs", "run-1", "events.ndjson"), "utf8")
+      readFile(
+        join(
+          eventsMirrorRoot,
+          "projects",
+          "project-1",
+          "runs",
+          "run-1",
+          "events.ndjson"
+        ),
+        "utf8"
+      )
     ).resolves.toContain('"event":"hook-failed"');
   });
 
@@ -276,10 +318,24 @@ describe("OrchestratorFsStore.loadRecentRunEvents", () => {
       });
 
       const primaryStats = await stat(
-        join(runtimeRoot, "runs", "run-1", "events.ndjson")
+        join(
+          runtimeRoot,
+          "projects",
+          "project-1",
+          "runs",
+          "run-1",
+          "events.ndjson"
+        )
       );
       const mirroredStats = await stat(
-        join(eventsMirrorRoot, "runs", "run-1", "events.ndjson")
+        join(
+          eventsMirrorRoot,
+          "projects",
+          "project-1",
+          "runs",
+          "run-1",
+          "events.ndjson"
+        )
       );
 
       expect(primaryStats.mode & 0o644).toBe(0o644);
@@ -312,7 +368,14 @@ describe("OrchestratorFsStore.loadRecentRunEvents", () => {
 
       await expect(
         readFile(
-          join(eventsMirrorRoot, "runs", "run-1", "events.ndjson"),
+          join(
+            eventsMirrorRoot,
+            "projects",
+            "project-1",
+            "runs",
+            "run-1",
+            "events.ndjson"
+          ),
           "utf8"
         )
       ).resolves.toContain('"event":"hook-failed"');
@@ -343,7 +406,17 @@ describe("OrchestratorFsStore.loadRecentRunEvents", () => {
       ).resolves.toBeUndefined();
 
       await expect(
-        readFile(join(runtimeRoot, "runs", "run-1", "events.ndjson"), "utf8")
+        readFile(
+          join(
+            runtimeRoot,
+            "projects",
+            "project-1",
+            "runs",
+            "run-1",
+            "events.ndjson"
+          ),
+          "utf8"
+        )
       ).resolves.toContain('"event":"hook-failed"');
       expect(warnSpy).toHaveBeenCalledOnce();
     } finally {
@@ -356,9 +429,9 @@ describe("OrchestratorFsStore.loadProjectIssueOrchestrations", () => {
   it("defaults completedOnce to false for legacy persisted issue records", async () => {
     const runtimeRoot = await mkdtemp(join(tmpdir(), "orchestrator-store-"));
     const store = new OrchestratorFsStore(runtimeRoot);
-    await mkdir(runtimeRoot, { recursive: true });
+    await mkdir(store.projectDir("project-1"), { recursive: true });
     await writeFile(
-      join(runtimeRoot, "issues.json"),
+      join(store.projectDir("project-1"), "issues.json"),
       JSON.stringify([
         {
           issueId: "issue-1",

--- a/packages/orchestrator/src/fs-store.test.ts
+++ b/packages/orchestrator/src/fs-store.test.ts
@@ -94,6 +94,48 @@ describe("OrchestratorFsStore.loadRecentRunEvents", () => {
     ]);
   });
 
+  it("falls back to legacy flat workspaces on direct loads", async () => {
+    const runtimeRoot = await mkdtemp(join(tmpdir(), "orchestrator-store-"));
+    const store = new OrchestratorFsStore(runtimeRoot);
+    const workspaceKey = "acme_repo_1";
+    await mkdir(join(runtimeRoot, workspaceKey), { recursive: true });
+    await writeFile(
+      join(runtimeRoot, workspaceKey, "workspace.json"),
+      JSON.stringify({
+        workspaceKey,
+        projectId: "project-1",
+        adapter: "github-project",
+        issueSubjectId: "issue-1",
+        issueIdentifier: "acme/repo#1",
+        workspacePath: join(runtimeRoot, workspaceKey),
+        repositoryPath: join(runtimeRoot, workspaceKey, "repository"),
+        status: "active",
+        createdAt: "2026-03-16T00:00:00.000Z",
+        updatedAt: "2026-03-16T00:00:00.000Z",
+        lastError: null,
+      }),
+      "utf8"
+    );
+
+    await expect(
+      store.loadIssueWorkspace("project-1", workspaceKey)
+    ).resolves.toEqual(
+      expect.objectContaining({
+        workspaceKey,
+        projectId: "project-1",
+      })
+    );
+  });
+
+  it("requires projectId for new project status writes", async () => {
+    const runtimeRoot = await mkdtemp(join(tmpdir(), "orchestrator-store-"));
+    const store = new OrchestratorFsStore(runtimeRoot);
+
+    await expect(store.saveProjectStatus({} as never)).rejects.toThrow(
+      "Project status writes require a projectId."
+    );
+  });
+
   it("returns the most recent formatted events in order", async () => {
     const runtimeRoot = await mkdtemp(join(tmpdir(), "orchestrator-store-"));
     const store = new OrchestratorFsStore(runtimeRoot);
@@ -263,6 +305,55 @@ describe("OrchestratorFsStore.loadRecentRunEvents", () => {
     expect(eventsNdjson).not.toContain("lin_secret");
     expect(runJson).toContain("[REDACTED]");
     expect(eventsNdjson).toContain("[REDACTED]");
+  });
+
+  it("discovers project runs when project ids need path encoding", async () => {
+    const runtimeRoot = await mkdtemp(join(tmpdir(), "orchestrator-store-"));
+    const store = new OrchestratorFsStore(runtimeRoot);
+
+    await store.saveRun({
+      runId: "run-1",
+      projectId: "tenant:one",
+      issueId: "issue-1",
+      issueIdentifier: "ENG-123",
+      issueTitle: "Linear issue",
+      issueState: "Todo",
+      issueSubjectId: "issue-1",
+      repository: {
+        owner: "acme",
+        name: "repo",
+        cloneUrl: "https://github.com/acme/repo.git",
+        url: "https://github.com/acme/repo",
+      },
+      workspaceKey: "ENG-123",
+      workspacePath: "/tmp/workspace",
+      repositoryPath: "/tmp/workspace/repository",
+      status: "active",
+      attempt: 1,
+      maxAttempts: 1,
+      processId: null,
+      sessionId: null,
+      startedAt: "2026-05-14T00:00:00.000Z",
+      updatedAt: "2026-05-14T00:00:00.000Z",
+      completedAt: null,
+      lastError: null,
+      lastWorkerLog: null,
+      lastTurnSummary: null,
+      tokenUsage: undefined,
+    } as never);
+
+    await expect(store.loadAllRuns()).resolves.toEqual([
+      expect.objectContaining({
+        runId: "run-1",
+        projectId: "tenant:one",
+      }),
+    ]);
+    await expect(store.loadRun("run-1")).resolves.toEqual(
+      expect.objectContaining({
+        runId: "run-1",
+        projectId: "tenant:one",
+      })
+    );
   });
 
   it("mirrors events to an external directory when configured", async () => {
@@ -461,5 +552,37 @@ describe("OrchestratorFsStore.loadProjectIssueOrchestrations", () => {
         updatedAt: "2026-03-16T00:00:00.000Z",
       },
     ]);
+  });
+
+  it("migrates legacy flat leases when scoped issues are absent", async () => {
+    const runtimeRoot = await mkdtemp(join(tmpdir(), "orchestrator-store-"));
+    const store = new OrchestratorFsStore(runtimeRoot);
+    await writeFile(
+      join(runtimeRoot, "leases.json"),
+      JSON.stringify([
+        {
+          issueId: "issue-1",
+          issueIdentifier: "acme/repo#1",
+          runId: "run-1",
+          status: "active",
+          updatedAt: "2026-03-16T00:00:00.000Z",
+        },
+      ]) + "\n",
+      "utf8"
+    );
+
+    await expect(
+      store.loadProjectIssueOrchestrations("project-1")
+    ).resolves.toEqual([
+      expect.objectContaining({
+        issueId: "issue-1",
+        identifier: "acme/repo#1",
+        state: "claimed",
+        currentRunId: "run-1",
+      }),
+    ]);
+    await expect(
+      readFile(join(store.projectDir("project-1"), "issues.json"), "utf8")
+    ).resolves.toContain("acme/repo#1");
   });
 });

--- a/packages/orchestrator/src/fs-store.ts
+++ b/packages/orchestrator/src/fs-store.ts
@@ -1,4 +1,5 @@
 import {
+  chmod,
   mkdir,
   open,
   rename,
@@ -25,6 +26,9 @@ import {
   safeReadDir,
 } from "@gh-symphony/core";
 
+const PROJECTS_DIR = "projects";
+const SECURE_DIRECTORY_MODE = 0o700;
+
 export class OrchestratorFsStore implements OrchestratorStateStore {
   private readonly resolvedRuntimeRoot: string;
   private readonly resolvedEventsMirrorRoot: string | null;
@@ -41,27 +45,53 @@ export class OrchestratorFsStore implements OrchestratorStateStore {
       : null;
   }
 
-  projectDir(_projectId?: string): string {
+  projectDir(projectId?: string): string {
+    if (!projectId) {
+      return this.runtimeRoot;
+    }
+
+    return join(this.runtimeRoot, PROJECTS_DIR, encodeProjectId(projectId));
+  }
+
+  private legacyProjectDir(): string {
     return this.runtimeRoot;
   }
 
-  private runsDir(): string {
-    return join(this.runtimeRoot, "runs");
+  private async ensureProjectDirectory(projectId?: string): Promise<void> {
+    if (!projectId) {
+      return;
+    }
+
+    const path = this.projectDir(projectId);
+    await mkdir(path, { recursive: true, mode: SECURE_DIRECTORY_MODE });
+    await chmod(path, SECURE_DIRECTORY_MODE);
   }
 
-  runDir(runId: string, _projectId?: string): string {
-    return join(this.runsDir(), runId);
+  private runsDir(projectId?: string): string {
+    return join(this.projectDir(projectId), "runs");
+  }
+
+  runDir(runId: string, projectId?: string): string {
+    return join(this.runsDir(projectId), runId);
   }
 
   async loadProjectConfig(
     projectId?: string
   ): Promise<OrchestratorProjectConfig | null> {
-    return readJsonFile<OrchestratorProjectConfig>(
-      join(this.projectDir(projectId), "project.json")
+    return (
+      (await readJsonFile<OrchestratorProjectConfig>(
+        join(this.projectDir(projectId), "project.json")
+      )) ??
+      (projectId
+        ? await readJsonFile<OrchestratorProjectConfig>(
+            join(this.legacyProjectDir(), "project.json")
+          )
+        : null)
     );
   }
 
   async saveProjectConfig(config: OrchestratorProjectConfig): Promise<void> {
+    await this.ensureProjectDirectory(config.projectId);
     await writeJsonFile(
       join(this.projectDir(config.projectId), "project.json"),
       config
@@ -71,8 +101,15 @@ export class OrchestratorFsStore implements OrchestratorStateStore {
   async loadProjectIssueOrchestrations(
     projectId?: string
   ): Promise<IssueOrchestrationRecord[]> {
-    const issuesPath = join(this.projectDir(projectId), "issues.json");
-    const issues = await readJsonFile<IssueOrchestrationRecord[]>(issuesPath);
+    const issues =
+      (await readJsonFile<IssueOrchestrationRecord[]>(
+        join(this.projectDir(projectId), "issues.json")
+      )) ??
+      (projectId
+        ? await readJsonFile<IssueOrchestrationRecord[]>(
+            join(this.legacyProjectDir(), "issues.json")
+          )
+        : null);
     if (issues) {
       return issues.map((issue) => ({
         ...issue,
@@ -120,6 +157,7 @@ export class OrchestratorFsStore implements OrchestratorStateStore {
     projectId: string | undefined,
     issues: IssueOrchestrationRecord[]
   ): Promise<void> {
+    await this.ensureProjectDirectory(projectId);
     await writeJsonFile(
       join(this.projectDir(projectId), "issues.json"),
       issues
@@ -127,15 +165,30 @@ export class OrchestratorFsStore implements OrchestratorStateStore {
   }
 
   async saveProjectStatus(status: ProjectStatusSnapshot): Promise<void> {
-    await writeJsonFile(join(this.projectDir(), "status.json"), status);
+    const projectId =
+      "projectId" in status && typeof status.projectId === "string"
+        ? status.projectId
+        : undefined;
+    await this.ensureProjectDirectory(projectId);
+    await writeJsonFile(
+      join(this.projectDir(projectId), "status.json"),
+      status
+    );
   }
 
   async loadProjectStatus(
     projectId?: string
   ): Promise<ProjectStatusSnapshot | null> {
+    const status = await readJsonFile<ProjectStatusSnapshot>(
+      join(this.projectDir(projectId), "status.json")
+    );
+    if (status || !projectId) {
+      return status ?? null;
+    }
+
     return (
       (await readJsonFile<ProjectStatusSnapshot>(
-        join(this.projectDir(projectId), "status.json")
+        join(this.legacyProjectDir(), "status.json")
       )) ?? null
     );
   }
@@ -160,18 +213,26 @@ export class OrchestratorFsStore implements OrchestratorStateStore {
   }
 
   async loadAllRuns(): Promise<OrchestratorRunRecord[]> {
-    const runIds = await safeReadDir(this.runsDir());
-    const runs = await Promise.all(
-      runIds.map((runId) =>
-        readJsonFile<OrchestratorRunRecord>(
-          join(this.runDir(runId), "run.json")
+    const projectIds = await this.listProjectIds();
+    const runPaths = (await safeReadDir(this.runsDir())).map((runId) =>
+      join(this.runDir(runId), "run.json")
+    );
+    for (const projectId of projectIds) {
+      const runIds = await safeReadDir(this.runsDir(projectId));
+      runPaths.push(
+        ...runIds.map((runId) =>
+          join(this.runDir(runId, projectId), "run.json")
         )
-      )
+      );
+    }
+    const runs = await Promise.all(
+      runPaths.map((runPath) => readJsonFile<OrchestratorRunRecord>(runPath))
     );
     return runs.filter((run): run is OrchestratorRunRecord => Boolean(run));
   }
 
   async saveRun(run: OrchestratorRunRecord): Promise<void> {
+    await this.ensureProjectDirectory(run.projectId);
     await writeJsonFile(
       join(this.runDir(run.runId, run.projectId), "run.json"),
       redactObservabilitySecrets(run)
@@ -198,7 +259,12 @@ export class OrchestratorFsStore implements OrchestratorStateStore {
     const path = join(runDirectory, "events.ndjson");
     const resolvedPath = resolve(path);
     const serializedEvent = JSON.stringify(redactedEvent) + "\n";
-    await mkdir(dirname(path), { recursive: true });
+    await this.ensureProjectDirectory(resolvedProjectId);
+    await mkdir(dirname(path), {
+      recursive: true,
+      mode: SECURE_DIRECTORY_MODE,
+    });
+    await chmod(dirname(path), SECURE_DIRECTORY_MODE);
     await appendFile(path, serializedEvent, {
       encoding: "utf8",
       mode: 0o644,
@@ -284,7 +350,7 @@ export class OrchestratorFsStore implements OrchestratorStateStore {
     projectId: string | undefined,
     workspaceKey: string
   ): string {
-    return join(this.runtimeRoot, workspaceKey);
+    return join(this.projectDir(projectId), workspaceKey);
   }
 
   async loadIssueWorkspace(
@@ -301,14 +367,25 @@ export class OrchestratorFsStore implements OrchestratorStateStore {
   async loadIssueWorkspaces(
     projectId?: string
   ): Promise<IssueWorkspaceRecord[]> {
-    const entries = await safeReadDir(this.runtimeRoot);
+    const entries = [
+      ...(await safeReadDir(this.projectDir(projectId))),
+      ...(projectId ? await safeReadDir(this.legacyProjectDir()) : []),
+    ];
+    const uniqueEntries = [...new Set(entries)];
     const records = await Promise.all(
-      entries.map(async (entry) => {
-        if (!(await this.isIssueWorkspaceEntry(entry))) {
+      uniqueEntries.map(async (entry) => {
+        if (!(await this.isIssueWorkspaceEntry(projectId, entry))) {
           return null;
         }
 
-        return this.loadIssueWorkspace(projectId, entry);
+        return (
+          (await this.loadIssueWorkspace(projectId, entry)) ??
+          (projectId
+            ? await readJsonFile<IssueWorkspaceRecord>(
+                join(this.legacyProjectDir(), entry, "workspace.json")
+              )
+            : null)
+        );
       })
     );
     return records.filter((record): record is IssueWorkspaceRecord =>
@@ -316,11 +393,15 @@ export class OrchestratorFsStore implements OrchestratorStateStore {
     );
   }
 
-  private async isIssueWorkspaceEntry(entry: string): Promise<boolean> {
+  private async isIssueWorkspaceEntry(
+    projectId: string | undefined,
+    entry: string
+  ): Promise<boolean> {
     if (
       entry.startsWith(".") ||
       entry === "cache" ||
       entry === "issues.json" ||
+      entry === PROJECTS_DIR ||
       entry === "project.json" ||
       entry === "runs" ||
       entry === "status.json"
@@ -329,13 +410,24 @@ export class OrchestratorFsStore implements OrchestratorStateStore {
     }
 
     try {
-      return (await stat(join(this.runtimeRoot, entry))).isDirectory();
+      const primary = join(this.projectDir(projectId), entry);
+      if ((await pathExists(primary)) && (await stat(primary)).isDirectory()) {
+        return true;
+      }
+
+      if (!projectId) {
+        return false;
+      }
+
+      const legacy = join(this.legacyProjectDir(), entry);
+      return (await pathExists(legacy)) && (await stat(legacy)).isDirectory();
     } catch {
       return false;
     }
   }
 
   async saveIssueWorkspace(record: IssueWorkspaceRecord): Promise<void> {
+    await this.ensureProjectDirectory(record.projectId);
     await writeJsonFile(
       join(
         this.issueWorkspaceDir(record.projectId, record.workspaceKey),
@@ -362,7 +454,39 @@ export class OrchestratorFsStore implements OrchestratorStateStore {
       return candidate;
     }
 
+    for (const projectId of await this.listProjectIds()) {
+      const projectCandidate = this.runDir(runId, projectId);
+      const projectRun = await readJsonFile<OrchestratorRunRecord>(
+        join(projectCandidate, "run.json")
+      );
+      if (
+        projectRun ||
+        (await pathExists(join(projectCandidate, "events.ndjson")))
+      ) {
+        return projectCandidate;
+      }
+    }
+
     return null;
+  }
+
+  private async listProjectIds(): Promise<string[]> {
+    const entries = await safeReadDir(join(this.runtimeRoot, PROJECTS_DIR));
+    const ids: string[] = [];
+    for (const entry of entries) {
+      try {
+        if (
+          (
+            await stat(join(this.runtimeRoot, PROJECTS_DIR, entry))
+          ).isDirectory()
+        ) {
+          ids.push(entry);
+        }
+      } catch {
+        // Ignore entries that disappear during concurrent reads.
+      }
+    }
+    return ids;
   }
 
   private resolveMirroredEventsPath(primaryPath: string): string | null {
@@ -381,10 +505,18 @@ export class OrchestratorFsStore implements OrchestratorStateStore {
 }
 
 async function writeJsonFile(path: string, value: unknown): Promise<void> {
-  await mkdir(dirname(path), { recursive: true });
+  await mkdir(dirname(path), {
+    recursive: true,
+    mode: SECURE_DIRECTORY_MODE,
+  });
+  await chmod(dirname(path), SECURE_DIRECTORY_MODE);
   const temporaryPath = `${path}.tmp`;
   await writeFile(temporaryPath, JSON.stringify(value, null, 2) + "\n", "utf8");
   await rename(temporaryPath, path);
+}
+
+function encodeProjectId(projectId: string): string {
+  return encodeURIComponent(projectId);
 }
 
 async function pathExists(path: string): Promise<boolean> {

--- a/packages/orchestrator/src/fs-store.ts
+++ b/packages/orchestrator/src/fs-store.ts
@@ -127,7 +127,19 @@ export class OrchestratorFsStore implements OrchestratorStateStore {
           status: "active" | "released";
           updatedAt: string;
         }>
-      >(join(this.projectDir(projectId), "leases.json"))) ?? [];
+      >(join(this.projectDir(projectId), "leases.json"))) ??
+      (projectId
+        ? await readJsonFile<
+            Array<{
+              issueId: string;
+              issueIdentifier: string;
+              runId: string;
+              status: "active" | "released";
+              updatedAt: string;
+            }>
+          >(join(this.legacyProjectDir(), "leases.json"))
+        : null) ??
+      [];
 
     if (legacyLeases.length === 0) {
       return [];
@@ -165,10 +177,7 @@ export class OrchestratorFsStore implements OrchestratorStateStore {
   }
 
   async saveProjectStatus(status: ProjectStatusSnapshot): Promise<void> {
-    const projectId =
-      "projectId" in status && typeof status.projectId === "string"
-        ? status.projectId
-        : undefined;
+    const projectId = resolveProjectScopedStatusProjectId(status);
     await this.ensureProjectDirectory(projectId);
     await writeJsonFile(
       join(this.projectDir(projectId), "status.json"),
@@ -360,7 +369,12 @@ export class OrchestratorFsStore implements OrchestratorStateStore {
     return (
       (await readJsonFile<IssueWorkspaceRecord>(
         join(this.issueWorkspaceDir(projectId, workspaceKey), "workspace.json")
-      )) ?? null
+      )) ??
+      (projectId
+        ? await readJsonFile<IssueWorkspaceRecord>(
+            join(this.legacyProjectDir(), workspaceKey, "workspace.json")
+          )
+        : null)
     );
   }
 
@@ -480,7 +494,7 @@ export class OrchestratorFsStore implements OrchestratorStateStore {
             await stat(join(this.runtimeRoot, PROJECTS_DIR, entry))
           ).isDirectory()
         ) {
-          ids.push(entry);
+          ids.push(decodeProjectId(entry));
         }
       } catch {
         // Ignore entries that disappear during concurrent reads.
@@ -517,6 +531,24 @@ async function writeJsonFile(path: string, value: unknown): Promise<void> {
 
 function encodeProjectId(projectId: string): string {
   return encodeURIComponent(projectId);
+}
+
+function decodeProjectId(encodedProjectId: string): string {
+  try {
+    return decodeURIComponent(encodedProjectId);
+  } catch {
+    return encodedProjectId;
+  }
+}
+
+function resolveProjectScopedStatusProjectId(
+  status: ProjectStatusSnapshot
+): string {
+  if ("projectId" in status && typeof status.projectId === "string") {
+    return status.projectId;
+  }
+
+  throw new Error("Project status writes require a projectId.");
 }
 
 async function pathExists(path: string): Promise<boolean> {

--- a/packages/orchestrator/src/index.test.ts
+++ b/packages/orchestrator/src/index.test.ts
@@ -282,9 +282,11 @@ describe("orchestrator CLI", () => {
           resolveRun = resolve;
         })
     );
-    (service.shutdown as ReturnType<typeof vi.fn>).mockImplementation(async () => {
-      resolveRun?.();
-    });
+    (service.shutdown as ReturnType<typeof vi.fn>).mockImplementation(
+      async () => {
+        resolveRun?.();
+      }
+    );
 
     const runPromise = runCli(
       ["run", "--runtime-root", runtimeRoot, "--project-id", "tenant-1"],
@@ -312,7 +314,7 @@ describe("orchestrator CLI", () => {
     expect(service.shutdown).toHaveBeenCalledTimes(1);
     expect(exitProcess).toHaveBeenCalledWith(0);
     await expect(
-      access(join(runtimeRoot, ".lock"))
+      access(join(runtimeRoot, "projects", "tenant-1", ".lock"))
     ).rejects.toMatchObject({ code: "ENOENT" });
   });
 
@@ -328,16 +330,18 @@ describe("orchestrator CLI", () => {
     );
 
     await expect(
-      access(join(runtimeRoot, ".lock"))
+      access(join(runtimeRoot, "projects", "tenant-1", ".lock"))
     ).rejects.toMatchObject({ code: "ENOENT" });
   });
 
   it("fails before running the service when the project lock belongs to a live pid", async () => {
     const runtimeRoot = await mkdtemp(join(tmpdir(), "orchestrator-cli-"));
     const service = createMockService();
-    await mkdir(runtimeRoot, { recursive: true });
+    await mkdir(join(runtimeRoot, "projects", "tenant-1"), {
+      recursive: true,
+    });
     await writeFile(
-      join(runtimeRoot, ".lock"),
+      join(runtimeRoot, "projects", "tenant-1", ".lock"),
       JSON.stringify({
         ownerToken: "existing-owner",
         pid: process.pid,
@@ -366,13 +370,7 @@ describe("orchestrator CLI", () => {
 
     await expect(
       runCli(
-        [
-          "run",
-          "--runtime-root",
-          runtimeRoot,
-          "--project-id",
-          "../tenant-1",
-        ],
+        ["run", "--runtime-root", runtimeRoot, "--project-id", "../tenant-1"],
         {
           createService,
         }

--- a/packages/orchestrator/src/lock.test.ts
+++ b/packages/orchestrator/src/lock.test.ts
@@ -4,6 +4,7 @@ import {
   mkdir,
   readFile,
   rm,
+  stat,
   writeFile,
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -32,6 +33,10 @@ describe("project lock", () => {
     expect(contents.pid).toBe(4321);
     expect(contents.startedAt).toBe("2026-03-16T00:00:00.000Z");
     expect(contents.ownerToken).toBe(lock.ownerToken);
+    const projectDirStats = await stat(
+      join(runtimeRoot, "projects", "project-1")
+    );
+    expect(projectDirStats.mode & 0o777).toBe(0o700);
 
     await releaseProjectLock(lock);
   });

--- a/packages/orchestrator/src/lock.test.ts
+++ b/packages/orchestrator/src/lock.test.ts
@@ -59,8 +59,10 @@ describe("project lock", () => {
 
   it("takes over a stale lock when the recorded pid is no longer running", async () => {
     const runtimeRoot = await mkdtemp(join(tmpdir(), "orchestrator-lock-"));
-    const lockPath = join(runtimeRoot, ".lock");
-    await mkdir(runtimeRoot, { recursive: true });
+    const lockPath = join(runtimeRoot, "projects", "project-1", ".lock");
+    await mkdir(join(runtimeRoot, "projects", "project-1"), {
+      recursive: true,
+    });
     await writeFile(
       lockPath,
       JSON.stringify({
@@ -90,9 +92,11 @@ describe("project lock", () => {
 
   it("does not delete an unreadable lock file", async () => {
     const runtimeRoot = await mkdtemp(join(tmpdir(), "orchestrator-lock-"));
-    const lockPath = join(runtimeRoot, ".lock");
-    await mkdir(runtimeRoot, { recursive: true });
-    await writeFile(lockPath, "{\"ownerToken\":\"partial\"", "utf8");
+    const lockPath = join(runtimeRoot, "projects", "project-1", ".lock");
+    await mkdir(join(runtimeRoot, "projects", "project-1"), {
+      recursive: true,
+    });
+    await writeFile(lockPath, '{"ownerToken":"partial"', "utf8");
 
     await expect(
       acquireProjectLock({
@@ -104,7 +108,7 @@ describe("project lock", () => {
     ).rejects.toThrow('Project "project-1" lock file is unreadable');
 
     await expect(readFile(lockPath, "utf8")).resolves.toBe(
-      "{\"ownerToken\":\"partial\""
+      '{"ownerToken":"partial"'
     );
   });
 

--- a/packages/orchestrator/src/lock.ts
+++ b/packages/orchestrator/src/lock.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { mkdir, open, readFile, rm } from "node:fs/promises";
+import { chmod, mkdir, open, readFile, rm } from "node:fs/promises";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import { OrchestratorFsStore } from "./fs-store.js";
@@ -19,6 +19,7 @@ export type ProjectLockHandle = {
 
 const LOCK_READ_RETRY_DELAY_MS = 10;
 const LOCK_READ_RETRY_LIMIT = 20;
+const SECURE_DIRECTORY_MODE = 0o700;
 
 export async function acquireProjectLock(input: {
   runtimeRoot: string;
@@ -37,7 +38,7 @@ export async function acquireProjectLock(input: {
 
   for (;;) {
     try {
-      await mkdir(dirname(lockPath), { recursive: true });
+      await ensureSecureDirectory(dirname(lockPath));
       const handle = await open(lockPath, "wx");
       try {
         await handle.writeFile(JSON.stringify(record, null, 2) + "\n", "utf8");
@@ -79,6 +80,11 @@ export async function acquireProjectLock(input: {
 
     await rm(lockPath, { force: true });
   }
+}
+
+async function ensureSecureDirectory(path: string): Promise<void> {
+  await mkdir(path, { recursive: true, mode: SECURE_DIRECTORY_MODE });
+  await chmod(path, SECURE_DIRECTORY_MODE);
 }
 
 export async function releaseProjectLock(
@@ -145,16 +151,16 @@ export function assertValidProjectId(projectId: string): void {
   }
 }
 
-function resolveProjectLockPath(runtimeRoot: string, projectId: string): string {
+function resolveProjectLockPath(
+  runtimeRoot: string,
+  projectId: string
+): string {
   const store = new OrchestratorFsStore(runtimeRoot);
   const projectDir = resolve(store.projectDir(projectId));
   const resolvedRuntimeRoot = resolve(runtimeRoot);
   const relativeProjectDir = relative(resolvedRuntimeRoot, projectDir);
 
-  if (
-    relativeProjectDir.startsWith("..") ||
-    isAbsolute(relativeProjectDir)
-  ) {
+  if (relativeProjectDir.startsWith("..") || isAbsolute(relativeProjectDir)) {
     throw new Error(
       `Invalid project ID "${projectId}". Project lock path must stay within "${resolvedRuntimeRoot}".`
     );

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -107,20 +107,13 @@ describe("OrchestratorService", () => {
     expect(issueRecords[0]?.state).toBe("retry_queued");
     await expect(
       readFile(join(tempRoot, workspaceKey, "workspace.json"), "utf8")
-    ).resolves.toContain(`"workspaceKey": "${workspaceKey}"`);
+    ).rejects.toThrow();
     await expect(
       readFile(
-        join(
-          tempRoot,
-          "projects",
-          "tenant-1",
-          "issues",
-          workspaceKey,
-          "workspace.json"
-        ),
+        join(tempRoot, "projects", "tenant-1", workspaceKey, "workspace.json"),
         "utf8"
       )
-    ).rejects.toThrow();
+    ).resolves.toContain(`"workspaceKey": "${workspaceKey}"`);
     expect(spawnImpl).toHaveBeenCalledTimes(1);
     expect(spawnImpl).toHaveBeenCalledWith(
       "bash",
@@ -1379,7 +1372,7 @@ describe("OrchestratorService", () => {
       workspaceKey
     );
     const preservedRun = await store.loadRun("run-incomplete", "tenant-1");
-    const savedStatus = await store.loadProjectStatus();
+    const savedStatus = await store.loadProjectStatus("tenant-1");
     await expect(readFile(sentinelPath, "utf8")).rejects.toThrow();
     expect(workspaceRecord?.status).toBe("removed");
     expect(savedStatus?.recovery).toBeNull();
@@ -9082,7 +9075,7 @@ Prefer focused changes.
     ).resolves.toBe("from-project-env\n");
   });
 
-  it("applies project .env to inline hooks, with process env override and symphony context precedence", async () => {
+  it("applies project .env to inline hooks, with scoped inheritance and symphony context precedence", async () => {
     process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
     const originalStagingApiHost = process.env.STAGING_API_HOST;
     const originalSymphonyRepositoryPath = process.env.SYMPHONY_REPOSITORY_PATH;
@@ -9166,7 +9159,7 @@ Prefer focused changes.
 
       await expect(
         readFile(join(repositoryPath, ".before_run_host"), "utf8")
-      ).resolves.toBe("https://ci.example.com\n");
+      ).resolves.toBe("https://staging.example.com\n");
       await expect(
         readFile(join(repositoryPath, ".before_run_file_only"), "utf8")
       ).resolves.toBe("from-project-env\n");
@@ -9188,7 +9181,7 @@ Prefer focused changes.
     }
   });
 
-  it("includes project .env in worker spawn env and lets process env override it", async () => {
+  it("includes project .env in worker spawn env without inheriting unscoped host secrets", async () => {
     process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
     const originalStagingApiHost = process.env.STAGING_API_HOST;
     process.env.STAGING_API_HOST = "https://ci.example.com";
@@ -9224,10 +9217,11 @@ Prefer focused changes.
       await service.runOnce();
 
       const spawnEnv = spawnImpl.mock.calls[0]?.[2]?.env;
-      expect(spawnEnv?.STAGING_API_HOST).toBe("https://ci.example.com");
+      expect(spawnEnv?.STAGING_API_HOST).toBe("https://staging.example.com");
       expect(spawnEnv?.FILE_ONLY).toBe("from-project-env");
       expect(spawnEnv?.SYMPHONY_ISSUE_SUBJECT_ID).toBe("issue-1");
       expect(spawnEnv?.SYMPHONY_ISSUE_WORKSPACE_KEY).toBeTruthy();
+      expect(spawnEnv?.GITHUB_GRAPHQL_TOKEN).toBeUndefined();
     } finally {
       if (originalStagingApiHost === undefined) {
         delete process.env.STAGING_API_HOST;

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -9184,7 +9184,9 @@ Prefer focused changes.
   it("includes project .env in worker spawn env without inheriting unscoped host secrets", async () => {
     process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
     const originalStagingApiHost = process.env.STAGING_API_HOST;
+    const originalSshAuthSock = process.env.SSH_AUTH_SOCK;
     process.env.STAGING_API_HOST = "https://ci.example.com";
+    process.env.SSH_AUTH_SOCK = "/tmp/ssh-agent.sock";
 
     try {
       const tempRoot = await mkdtemp(
@@ -9222,11 +9224,17 @@ Prefer focused changes.
       expect(spawnEnv?.SYMPHONY_ISSUE_SUBJECT_ID).toBe("issue-1");
       expect(spawnEnv?.SYMPHONY_ISSUE_WORKSPACE_KEY).toBeTruthy();
       expect(spawnEnv?.GITHUB_GRAPHQL_TOKEN).toBeUndefined();
+      expect(spawnEnv?.SSH_AUTH_SOCK).toBeUndefined();
     } finally {
       if (originalStagingApiHost === undefined) {
         delete process.env.STAGING_API_HOST;
       } else {
         process.env.STAGING_API_HOST = originalStagingApiHost;
+      }
+      if (originalSshAuthSock === undefined) {
+        delete process.env.SSH_AUTH_SOCK;
+      } else {
+        process.env.SSH_AUTH_SOCK = originalSshAuthSock;
       }
     }
   });

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -75,6 +75,19 @@ const MAX_RECOVERY_DIRTY_FILES_IN_CONTEXT = 50;
 const MAX_FAILURE_RETRIES_EXCEEDED_REASON = "max_failure_retries_exceeded";
 const LINKED_PR_ACTIVE_ISSUE_INACTIVE_MARKER_PREFIX =
   "gh-symphony:linked-pr-active-while-issue-inactive";
+const INHERITED_ENV_ALLOWLIST = new Set([
+  "CI",
+  "HOME",
+  "LANG",
+  "LOGNAME",
+  "PATH",
+  "PWD",
+  "SHELL",
+  "SSH_AUTH_SOCK",
+  "TERM",
+  "TMPDIR",
+  "USER",
+]);
 
 type ProjectWorkflowResolution = Awaited<
   ReturnType<typeof loadRepositoryWorkflow>
@@ -1044,7 +1057,10 @@ export class OrchestratorService {
       ),
       issueWorkspaces,
     });
-    await this.store.saveProjectStatus(status);
+    await this.store.saveProjectStatus({
+      ...status,
+      projectId: tenant.projectId,
+    } as ProjectStatusSnapshot & { projectId: string });
     return status;
   }
 
@@ -1608,7 +1624,6 @@ export class OrchestratorService {
       {
         cwd: process.cwd(),
         env: this.buildProjectExecutionEnv(tenant.projectId, {
-          GITHUB_GRAPHQL_TOKEN: process.env.GITHUB_GRAPHQL_TOKEN ?? "",
           CODEX_PROJECT_ID: tenant.projectId,
           PROJECT_ID: tenant.projectId,
           WORKING_DIRECTORY: repositoryDirectory,
@@ -2797,7 +2812,8 @@ export class OrchestratorService {
   ): Record<string, string> {
     const inheritedEnv = Object.fromEntries(
       Object.entries(process.env).filter(
-        (entry): entry is [string, string] => typeof entry[1] === "string"
+        (entry): entry is [string, string] =>
+          typeof entry[1] === "string" && shouldInheritProcessEnvKey(entry[0])
       )
     );
     const explicitEnv = Object.fromEntries(
@@ -3348,6 +3364,10 @@ export class OrchestratorService {
       return DEFAULT_MAX_FAILURE_RETRIES;
     }
   }
+}
+
+function shouldInheritProcessEnvKey(key: string): boolean {
+  return INHERITED_ENV_ALLOWLIST.has(key) || key.startsWith("LC_");
 }
 
 function hasTokenUsage(

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -83,7 +83,6 @@ const INHERITED_ENV_ALLOWLIST = new Set([
   "PATH",
   "PWD",
   "SHELL",
-  "SSH_AUTH_SOCK",
   "TERM",
   "TMPDIR",
   "USER",


### PR DESCRIPTION
## TL;DR

- 오케스트레이터 런타임 상태를 `projects/<projectId>` 아래로 분리하고 project 디렉터리 권한을 `0700`으로 강제했습니다.
- worker/hook 실행 env는 allowlist 기반으로만 `process.env`를 상속하며, 호스트 `GITHUB_GRAPHQL_TOKEN` 및 `SSH_AUTH_SOCK` 직접 전달을 제거했습니다.
- rework에서 legacy flat layout 업그레이드 fallback, `--web` control-plane scoped status 경로, status write fail-fast, encoded project id run discovery를 보완했습니다.

## 변경 지점 다이어그램

```text
.runtime/orchestrator
└── projects
    └── <encodeURIComponent(projectId)>  (0700)
        ├── project.json
        ├── issues.json
        ├── status.json
        ├── runs/<runId>/...
        └── <workspaceKey>/...

legacy flat root
├── issues.json / leases.json / status.json / <workspaceKey>/workspace.json
└── 읽기 fallback only; 신규 write는 project-scoped only
```

## 여기부터 보세요

- `packages/orchestrator/src/fs-store.ts`: project별 runtime path, legacy read fallback, `saveProjectStatus()` projectId fail-fast, project id decode, `0700` 보장
- `packages/orchestrator/src/lock.ts`: lock acquisition 경로에서도 project directory `0700` 강제
- `packages/orchestrator/src/service.ts`: inherited env allowlist와 host token/SSH agent 전달 제거
- `packages/cli/src/commands/start.ts`: `--web` control-plane reader를 project-scoped runtime root로 연결
- `packages/orchestrator/src/fs-store.test.ts`, `lock.test.ts`, `service.test.ts`, `packages/cli/src/commands/start.test.ts`: 격리/권한/env/마이그레이션 회귀 TC

## 위험 & 롤백

- 기존 flat runtime 파일은 읽기 fallback을 유지하지만 신규 쓰기는 project별 경로로만 발생합니다.
- `saveProjectStatus()`는 `projectId` 없는 신규 write를 거부하므로, 누락 호출자가 있다면 즉시 오류로 드러납니다.
- 롤백은 이 PR revert로 가능합니다. 이미 생성된 `projects/<projectId>` 상태는 flat layout으로 자동 역마이그레이션하지 않습니다.

## 변경 파일

- `.changeset/project-runtime-isolation.md`
- `packages/cli/src/commands/start.ts`
- `packages/orchestrator/src/fs-store.ts`
- `packages/orchestrator/src/lock.ts`
- `packages/orchestrator/src/service.ts`
- 관련 TC: `packages/cli/src/commands/start.test.ts`, `packages/orchestrator/src/fs-store.test.ts`, `lock.test.ts`, `service.test.ts`

## 검증

- `pnpm lint` — pass (2026-07-07 Cycle 4)
- `pnpm test` — pass (orchestrator 199 tests, cli 483 tests 포함)
- `pnpm typecheck` — pass
- `pnpm build` — pass
- Docker E2E blackbox — pass (`health=running`, `activeRuns=1`, `projects/repository` mode `700`, flat root `status.json` absent)
- PR inline comments — 모두 답변 완료
- Symphony spec 확인 — upstream spec 수정 없음, per-issue/workspace 격리 및 runtime observability 방향과 정합, 의도적 divergence 없음

## 머지 후/사람 확인

- [ ] 머지 후 오케스트레이터 배포

## Issues — Closed #439
