### PR TITLE
fix(orchestrator): recover dirty crash retries

### DIFF
--- a/.changeset/dirty-workspace-crash-recovery.md
+++ b/.changeset/dirty-workspace-crash-recovery.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": minor
+---
+
+Recover dirty issue workspaces after worker crashes by preserving git-status-based recovery context across retry restarts, fixing #446.

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -425,6 +425,159 @@ describe("OrchestratorService", () => {
     ).toContain("?? partial.txt");
   });
 
+  it("recovers a dirty workspace after a crash even when session metadata is stale", async () => {
+    process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
+    const tempRoot = await mkdtemp(
+      join(tmpdir(), "orchestrator-crashed-dirty-recovery-")
+    );
+    const repository = await createRepositoryFixture(
+      tempRoot,
+      "acme",
+      "platform"
+    );
+    const store = new OrchestratorFsStore(tempRoot);
+    const projectConfig = createProjectConfig(tempRoot, repository);
+    await store.saveProjectConfig(projectConfig);
+
+    const workspaceKey = deriveIssueWorkspaceKey(
+      {
+        adapter: "github-project",
+        issueSubjectId: "issue-1",
+      },
+      "acme/platform#1"
+    );
+    const issueWorkspacePath = resolveIssueWorkspaceDirectory(
+      store.projectDir(projectConfig.projectId),
+      workspaceKey
+    );
+    const repositoryDirectory = await gitModule.ensureIssueWorkspaceRepository({
+      repository,
+      issueWorkspacePath,
+      existingWorkspace: false,
+    });
+    await store.saveIssueWorkspace({
+      workspaceKey,
+      projectId: projectConfig.projectId,
+      adapter: "github-project",
+      issueSubjectId: "issue-1",
+      issueIdentifier: "acme/platform#1",
+      workspacePath: issueWorkspacePath,
+      repositoryPath: repositoryDirectory,
+      status: "active",
+      createdAt: "2026-03-08T00:00:00.000Z",
+      updatedAt: "2026-03-08T00:00:00.000Z",
+      lastError: null,
+    });
+    await writeFile(
+      join(repositoryDirectory, "partial.txt"),
+      "partial turn output\n",
+      "utf8"
+    );
+    await store.saveProjectIssueOrchestrations("tenant-1", [
+      {
+        issueId: "issue-1",
+        identifier: "acme/platform#1",
+        workspaceKey,
+        completedOnce: false,
+        failureRetryCount: 0,
+        state: "running",
+        currentRunId: "run-crashed",
+        retryEntry: null,
+        updatedAt: "2026-03-08T00:04:00.000Z",
+      },
+    ]);
+    await store.saveRun({
+      runId: "run-crashed",
+      projectId: "tenant-1",
+      projectSlug: "tenant-1",
+      issueId: "issue-1",
+      issueSubjectId: "issue-1",
+      issueIdentifier: "acme/platform#1",
+      issueState: "Todo",
+      repository,
+      status: "running",
+      attempt: 1,
+      processId: 4410,
+      port: null,
+      workingDirectory: repositoryDirectory,
+      issueWorkspaceKey: workspaceKey,
+      workspaceRuntimeDir: join(tempRoot, "run-crashed", "workspace"),
+      workflowPath: null,
+      retryKind: null,
+      createdAt: "2026-03-08T00:00:00.000Z",
+      updatedAt: "2026-03-08T00:04:30.000Z",
+      startedAt: "2026-03-08T00:00:00.000Z",
+      completedAt: null,
+      lastError: null,
+      nextRetryAt: null,
+      threadId: "thread-1",
+      cumulativeTurnCount: 7,
+      turnCount: 7,
+      lastEvent: "heartbeat",
+      lastEventAt: "2026-03-08T00:04:30.000Z",
+      runtimeSession: {
+        sessionId: "thread-1-turn-7",
+        threadId: "thread-1",
+        status: "completed",
+        startedAt: "2026-03-08T00:00:00.000Z",
+        updatedAt: "2026-03-08T00:04:30.000Z",
+        exitClassification: "completed",
+      },
+    });
+
+    const spawnImpl = vi.fn().mockReturnValue({
+      pid: 4411,
+      unref: vi.fn(),
+    });
+    let currentTime = new Date("2026-03-08T00:05:00.000Z");
+    const service = new OrchestratorService(store, projectConfig, {
+      fetchImpl: vi.fn().mockResolvedValue(createTrackerResponse(repository)),
+      spawnImpl: spawnImpl as never,
+      isProcessRunning: () => false,
+      now: () => currentTime,
+    });
+
+    const scheduled = await service.runOnce();
+    const retryRun = await store.loadRun("run-crashed", "tenant-1");
+
+    expect(scheduled.summary.dispatched).toBe(0);
+    expect(retryRun).toMatchObject({
+      status: "retrying",
+      retryKind: "recovery",
+      recovery: expect.objectContaining({
+        kind: "incomplete-turn-dirty-workspace",
+        dirtyFiles: ["partial.txt"],
+        sessionId: "thread-1-turn-7",
+        threadId: "thread-1",
+      }),
+    });
+
+    currentTime = new Date("2026-03-08T00:06:01.000Z");
+    const restarted = await service.runOnce();
+    const runs = await store.loadAllRuns();
+    const recoveryRun = runs.find((run) => run.runId !== "run-crashed");
+    const spawnEnv = spawnImpl.mock.calls[0]?.[2]?.env;
+
+    expect(restarted.summary.recovered).toBe(1);
+    expect(recoveryRun).toMatchObject({
+      status: "running",
+      retryKind: "recovery",
+      recovery: expect.objectContaining({
+        kind: "incomplete-turn-dirty-workspace",
+        dirtyFiles: ["partial.txt"],
+      }),
+    });
+    expect(spawnEnv?.SYMPHONY_RECOVERY_KIND).toBe(
+      "incomplete-turn-dirty-workspace"
+    );
+    expect(spawnEnv?.SYMPHONY_RECOVERY_DIRTY_FILES).toContain("partial.txt");
+    expect(
+      execSync(`git -C ${shell(repositoryDirectory)} status --porcelain`, {
+        encoding: "utf8",
+      })
+    ).toContain("?? partial.txt");
+  });
+
   it("clears legacy issue-budget and cross-session resume env before spawning a worker", async () => {
     process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
     process.env.SYMPHONY_GLOBAL_MAX_TURNS = "12";

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -2073,22 +2073,33 @@ export class OrchestratorService {
       );
     }
 
+    const recovery = await this.classifyIncompleteTurnDirtyWorkspace(
+      tenant,
+      runWithTokens,
+      now
+    );
+
     // Determine retry kind: continuation (issue still actionable) vs failure
     const retryKind = await this.classifyRetryKind(
       tenant,
       run,
       trackerDependencies
     );
+    const persistedRetryKind = recovery ? "recovery" : retryKind;
 
     const failureRetryCount =
-      retryKind === "failure"
+      retryKind === "failure" && !recovery
         ? (this.resolveFailureRetryCount(issueRecords, run.issueId) ?? 0) + 1
         : (this.resolveFailureRetryCount(issueRecords, run.issueId) ?? 0);
     const maxFailureRetries = await this.loadMaxFailureRetries(
       tenant,
       run.repository
     );
-    if (retryKind === "failure" && failureRetryCount >= maxFailureRetries) {
+    if (
+      retryKind === "failure" &&
+      !recovery &&
+      failureRetryCount >= maxFailureRetries
+    ) {
       const lastError = [
         `Run suppressed: ${MAX_FAILURE_RETRIES_EXCEEDED_REASON}.`,
         `failureRetryCount=${failureRetryCount}.`,
@@ -2141,7 +2152,7 @@ export class OrchestratorService {
     }
 
     let nextRetryAt: string;
-    if (retryKind === "continuation") {
+    if (recovery || retryKind === "continuation") {
       nextRetryAt = new Date(
         now.getTime() + CONTINUATION_RETRY_DELAY_MS
       ).toISOString();
@@ -2164,7 +2175,7 @@ export class OrchestratorService {
       processId: null,
       updatedAt: now.toISOString(),
       nextRetryAt,
-      retryKind,
+      retryKind: persistedRetryKind,
       threadId:
         runWithTokens.threadId ??
         runWithTokens.runtimeSession?.threadId ??
@@ -2177,13 +2188,14 @@ export class OrchestratorService {
         runWithTokens.lastTurnSummary ?? run.lastTurnSummary ?? null,
       runPhase: runWithTokens.runPhase ?? "failed",
       lastError:
-        retryKind === "continuation"
+        recovery || retryKind === "continuation"
           ? null
           : "Worker process exited unexpectedly.",
+      recovery,
     };
     await this.store.saveRun(retryRecord);
     this.logVerbose(
-      `[retry-scheduled] ${retryRecord.runId} kind=${retryKind} attempt=${retryRecord.attempt} nextAt=${nextRetryAt}`
+      `[retry-scheduled] ${retryRecord.runId} kind=${persistedRetryKind} attempt=${retryRecord.attempt} nextAt=${nextRetryAt}`
     );
     this.logVerbose(
       `[run-completed] ${retryRecord.runId} status=${retryRecord.status}`
@@ -2583,11 +2595,7 @@ export class OrchestratorService {
     run: OrchestratorRunRecord,
     now: Date
   ): Promise<IncompleteTurnRecoveryContext | null> {
-    if (
-      run.runtimeSession?.status !== "active" ||
-      run.runtimeSession.exitClassification !== null ||
-      run.lastEvent === "turn_completed"
-    ) {
+    if (run.lastEvent === "turn_completed") {
       return null;
     }
 
@@ -2621,8 +2629,8 @@ export class OrchestratorService {
       dirtyFiles: dirtyStatus.dirtyFiles,
       lastEvent: run.lastEvent ?? null,
       lastEventAt: run.lastEventAt ?? null,
-      sessionId: run.runtimeSession.sessionId ?? null,
-      threadId: run.threadId ?? run.runtimeSession.threadId ?? null,
+      sessionId: run.runtimeSession?.sessionId ?? null,
+      threadId: run.threadId ?? run.runtimeSession?.threadId ?? null,
       suggestedCommand: `cd ${shellQuote(dirtyStatus.repositoryDirectory)} && git status --short && git diff`,
       detectedAt: now.toISOString(),
     };
@@ -2660,6 +2668,43 @@ export class OrchestratorService {
       ...recovery,
       issueId: issue.id,
       issueIdentifier: issue.identifier,
+      workspacePath: dirtyStatus.repositoryDirectory,
+      dirtyFiles: dirtyStatus.dirtyFiles,
+      suggestedCommand: `cd ${shellQuote(dirtyStatus.repositoryDirectory)} && git status --short && git diff`,
+    };
+  }
+
+  private async resolveRetryRunRecoveryContext(
+    tenant: OrchestratorProjectConfig,
+    run: OrchestratorRunRecord
+  ): Promise<IncompleteTurnRecoveryContext | null> {
+    const recovery = run.recovery;
+    if (recovery?.kind !== "incomplete-turn-dirty-workspace") {
+      return null;
+    }
+
+    const workspaceKey =
+      run.issueWorkspaceKey ??
+      deriveIssueWorkspaceKey(
+        {
+          adapter: tenant.tracker.adapter,
+          issueSubjectId: run.issueSubjectId,
+        },
+        run.issueIdentifier
+      );
+    const dirtyStatus = await inspectIssueWorkspaceDirtyStatus({
+      issueWorkspacePath: resolveIssueWorkspaceDirectory(
+        this.store.projectDir(tenant.projectId),
+        workspaceKey
+      ),
+    });
+
+    if (!dirtyStatus?.dirty) {
+      return null;
+    }
+
+    return {
+      ...recovery,
       workspacePath: dirtyStatus.repositoryDirectory,
       dirtyFiles: dirtyStatus.dirtyFiles,
       suggestedCommand: `cd ${shellQuote(dirtyStatus.repositoryDirectory)} && git status --short && git diff`,
@@ -2840,7 +2885,8 @@ export class OrchestratorService {
       tenant,
       run
     );
-    const restarted = await this.startRun(tenant, issue);
+    const recovery = await this.resolveRetryRunRecoveryContext(tenant, run);
+    const restarted = await this.startRun(tenant, issue, { recovery });
     const recoveredRecord: OrchestratorRunRecord = {
       ...restarted,
       attempt: run.attempt,


### PR DESCRIPTION
## TL;DR

- dirty issue workspace 복구 판정을 세션 메타가 아니라 실제 `git status --porcelain` 결과 중심으로 전환했습니다.
- 워커 크래시 후 retry 레코드에 recovery context를 보존하고, retry 재시작 시 dirty workspace를 허용해 `running` 고착을 막습니다.
- 세션 메타가 `completed/completed`처럼 stale/inconsistent해도 `turn_completed`가 아니고 workspace가 dirty이면 recovery retry로 복구되는 TC를 추가했습니다.

## 변경 지점 다이어그램

```text
worker crash / stale session meta
  -> recoverActiveRun()
  -> inspectIssueWorkspaceDirtyStatus(git status --porcelain)
  -> retry record(retryKind=recovery, recovery context)
  -> restartRun()
  -> startRun({ recovery })
  -> allowDirtyExistingWorkspace=true + recovery prompt/env
```

## 여기부터 보세요

- `packages/orchestrator/src/service.ts`
  - `classifyIncompleteTurnDirtyWorkspace`가 `runtimeSession.status`/`exitClassification`에 의존하지 않고 `turn_completed` 여부와 git dirty 상태를 분리해 판정합니다.
  - unexpected worker exit retry 레코드에 `recovery`를 저장하고 `restartRun`이 dirty 상태를 재확인한 뒤 `startRun`에 recovery context를 넘깁니다.
- `packages/orchestrator/src/service.test.ts`
  - 세션 메타가 stale이어도 dirty workspace crash retry가 recovery로 재시작되는 회귀 TC를 추가했습니다.
- `.changeset/dirty-workspace-crash-recovery.md`
  - `changeset:minor` 라벨에 맞춰 `@gh-symphony/cli` minor changeset을 추가했습니다.

## 위험 & 롤백

- 위험: dirty workspace가 실제로 남아 있는 crash/retry 케이스에서 retryKind가 `failure` 대신 `recovery`가 됩니다. `turn_completed`는 제외하고, 재시작 직전 dirty 상태를 다시 확인해 이미 정리된 workspace에는 recovery를 적용하지 않도록 제한했습니다.
- 롤백: 이 PR의 commit을 revert하면 기존 failure retry 동작으로 돌아갑니다.

## 변경 파일

- `packages/orchestrator/src/service.ts`
- `packages/orchestrator/src/service.test.ts`
- `.changeset/dirty-workspace-crash-recovery.md`

## 검증

- `pnpm --filter @gh-symphony/orchestrator test -- service.test.ts` — pass, 116 tests
- `pnpm lint` — pass
- `pnpm test` — pass
- `pnpm typecheck` — pass
- `pnpm build` — pass
- `pnpm exec prettier --check packages/orchestrator/src/service.ts packages/orchestrator/src/service.test.ts .changeset/dirty-workspace-crash-recovery.md` — pass
- Docker E2E: `docker compose -f docker-compose.e2e.yml -f docker-compose.e2e.events.yml up -d --build` + happy-path fixture + `/api/v1/refresh` + `/api/v1/state` — pass (`health=idle`, `activeRuns=0`, `retryQueue=[]`, `lastError=null` after cleanup)
- `PATH=/Users/steve/.nvm/versions/node/v24.15.0/bin:$PATH node packages/cli/dist/index.js doctor --smoke --issue hojinzs/github-symphony#446 --json` — pass (`ok=true`)
- `pnpm format` — repo-wide pre-existing format drift로 fail; changed files only Prettier check는 pass

## 머지 후/사람 확인

- 머지 후 누적 배포 확인

## Issues — Closed #446

Closed #446
