### PR TITLE
fix(security): harden workflow shell execution

### DIFF
--- a/.changeset/workflow-shell-hardening.md
+++ b/.changeset/workflow-shell-hardening.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Harden WORKFLOW.md execution for #437: repo hooks now require explicit trust approval, hook environments are allowlisted to strip secrets, and Codex agent commands launch as argv without `bash -lc`.

--- a/packages/core/src/workspace/hooks.test.ts
+++ b/packages/core/src/workspace/hooks.test.ts
@@ -1,8 +1,15 @@
-import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import {
+  chmod,
+  mkdtemp,
+  mkdir,
+  readFile,
+  rm,
+  writeFile,
+} from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, describe, expect, it } from "vitest";
-import { executeWorkspaceHook } from "./hooks.js";
+import { buildHookExecutionEnv, executeWorkspaceHook } from "./hooks.js";
 
 const tempDirs: string[] = [];
 
@@ -15,14 +22,15 @@ afterEach(async () => {
 });
 
 describe("executeWorkspaceHook", () => {
-  it("executes inline hook bodies via bash -lc", async () => {
-    const repositoryPath = await mkdtemp(join(tmpdir(), "hook-inline-"));
+  it("skips WORKFLOW.md hooks unless explicit trust is granted", async () => {
+    const repositoryPath = await mkdtemp(join(tmpdir(), "hook-untrusted-"));
     tempDirs.push(repositoryPath);
 
     const result = await executeWorkspaceHook({
       kind: "after_create",
       hooks: {
-        afterCreate: 'printf "ok" > "$SYMPHONY_REPOSITORY_PATH/.hook-result"',
+        afterCreate:
+          'printf "unsafe" > "$SYMPHONY_REPOSITORY_PATH/.hook-result"',
         beforeRun: null,
         afterRun: null,
         beforeRemove: null,
@@ -34,26 +42,33 @@ describe("executeWorkspaceHook", () => {
       timeoutMs: 5000,
     });
 
-    expect(result.outcome).toBe("success");
-    expect(await readFile(join(repositoryPath, ".hook-result"), "utf8")).toBe(
-      "ok"
-    );
+    expect(result.outcome).toBe("skipped");
+    await expect(
+      readFile(join(repositoryPath, ".hook-result"), "utf8")
+    ).rejects.toThrow();
   });
 
   it("times out long-running hook commands", async () => {
     const repositoryPath = await mkdtemp(join(tmpdir(), "hook-timeout-"));
     tempDirs.push(repositoryPath);
+    await writeFile(
+      join(repositoryPath, "sleep.sh"),
+      "#!/usr/bin/env bash\nsleep 1\n",
+      "utf8"
+    );
+    await chmod(join(repositoryPath, "sleep.sh"), 0o755);
 
     const result = await executeWorkspaceHook({
       kind: "before_run",
       hooks: {
         afterCreate: null,
-        beforeRun: "sleep 1",
+        beforeRun: "sleep.sh",
         afterRun: null,
         beforeRemove: null,
       },
       repositoryPath,
       env: {},
+      trusted: true,
       timeoutMs: 10,
     });
 
@@ -69,6 +84,7 @@ describe("executeWorkspaceHook", () => {
       '#!/usr/bin/env bash\nprintf "path-ok" > "$SYMPHONY_REPOSITORY_PATH/.path-hook"\n',
       "utf8"
     );
+    await chmod(join(repositoryPath, "hooks", "after_run.sh"), 0o755);
 
     const result = await executeWorkspaceHook({
       kind: "after_run",
@@ -82,6 +98,7 @@ describe("executeWorkspaceHook", () => {
       env: {
         SYMPHONY_REPOSITORY_PATH: repositoryPath,
       },
+      trusted: true,
       timeoutMs: 5000,
     });
 
@@ -89,5 +106,46 @@ describe("executeWorkspaceHook", () => {
     expect(await readFile(join(repositoryPath, ".path-hook"), "utf8")).toBe(
       "path-ok"
     );
+  });
+
+  it("rejects approved hooks that contain shell syntax", async () => {
+    const repositoryPath = await mkdtemp(join(tmpdir(), "hook-shell-syntax-"));
+    tempDirs.push(repositoryPath);
+
+    const result = await executeWorkspaceHook({
+      kind: "after_run",
+      hooks: {
+        afterCreate: null,
+        beforeRun: null,
+        afterRun: "hooks/after_run.sh; echo injected",
+        beforeRemove: null,
+      },
+      repositoryPath,
+      env: {},
+      trusted: true,
+      timeoutMs: 5000,
+    });
+
+    expect(result.outcome).toBe("failure");
+    expect(result.error).toContain("without shell syntax");
+  });
+
+  it("builds hook env from an allowlist and strips secrets", () => {
+    expect(
+      buildHookExecutionEnv(
+        {
+          PATH: "/bin",
+          SYMPHONY_REPOSITORY_PATH: "/repo",
+          STAGING_API_HOST: "https://staging.example.com",
+          GITHUB_GRAPHQL_TOKEN: "ghs_secret",
+          SSH_AUTH_SOCK: "/tmp/agent.sock",
+        },
+        ["STAGING_API_HOST"]
+      )
+    ).toEqual({
+      PATH: "/bin",
+      SYMPHONY_REPOSITORY_PATH: "/repo",
+      STAGING_API_HOST: "https://staging.example.com",
+    });
   });
 });

--- a/packages/core/src/workspace/hooks.ts
+++ b/packages/core/src/workspace/hooks.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import { isAbsolute } from "node:path";
 
 /**
  * Hook kinds matching WORKFLOW.md `hooks` configuration keys.
@@ -29,6 +30,7 @@ export type HookExecutionOptions = {
   command: string;
   cwd: string;
   env: Record<string, string>;
+  envAllowlist?: readonly string[];
   timeoutMs: number;
 };
 
@@ -37,17 +39,26 @@ const DEFAULT_HOOK_TIMEOUT_MS = 60_000;
 export async function executeHook(
   options: HookExecutionOptions
 ): Promise<HookResult> {
-  const { kind, command, cwd, env, timeoutMs } = options;
+  const { kind, command, cwd, env, envAllowlist = [], timeoutMs } = options;
   const start = Date.now();
-  const normalizedCommand = normalizeHookCommand(command);
+  const hookCommand = resolveHookCommandSpawn(command);
+  if (!hookCommand.ok) {
+    return {
+      kind,
+      outcome: "failure",
+      exitCode: null,
+      durationMs: Date.now() - start,
+      error: hookCommand.error,
+    };
+  }
 
   return new Promise<HookResult>((resolveResult) => {
     let timedOut = false;
     let timer: ReturnType<typeof setTimeout> | null = null;
 
-    const child = spawn("bash", ["-lc", normalizedCommand], {
+    const child = spawn(hookCommand.command, hookCommand.args, {
       cwd,
-      env: { ...process.env, ...env },
+      env: buildHookExecutionEnv(env, envAllowlist),
       stdio: "pipe",
     });
 
@@ -184,6 +195,8 @@ export async function executeWorkspaceHook(options: {
   };
   repositoryPath: string;
   env: Record<string, string>;
+  trusted?: boolean;
+  envAllowlist?: readonly string[];
   timeoutMs?: number;
 }): Promise<HookResult> {
   const hookCommand = resolveHookCommand(options.hooks, options.kind);
@@ -198,25 +211,78 @@ export async function executeWorkspaceHook(options: {
     };
   }
 
+  if (!options.trusted) {
+    return {
+      kind: options.kind,
+      outcome: "skipped",
+      exitCode: null,
+      durationMs: 0,
+      error: `Workflow hook "${options.kind}" skipped because WORKFLOW.md hooks require explicit trust approval.`,
+    };
+  }
+
   return executeHook({
     kind: options.kind,
     command: hookCommand,
     cwd: options.repositoryPath,
     env: options.env,
+    envAllowlist: options.envAllowlist,
     timeoutMs: options.timeoutMs ?? DEFAULT_HOOK_TIMEOUT_MS,
   });
 }
 
-function normalizeHookCommand(command: string): string {
+const DEFAULT_HOOK_ENV_KEYS = new Set([
+  "HOME",
+  "LANG",
+  "LOGNAME",
+  "PATH",
+  "PWD",
+  "SHELL",
+  "TERM",
+  "TMPDIR",
+  "USER",
+]);
+
+const SHELL_METACHARACTER_PATTERN = /[;&|`$<>()[\]{}*?!#~="'\\\n\r]/;
+
+export function buildHookExecutionEnv(
+  env: Record<string, string>,
+  allowlist: readonly string[] = []
+): Record<string, string> {
+  const allowed = new Set([...DEFAULT_HOOK_ENV_KEYS, ...allowlist]);
+  return Object.fromEntries(
+    Object.entries(env).filter(([key]) => {
+      return (
+        allowed.has(key) ||
+        key.startsWith("SYMPHONY_") ||
+        key.startsWith("LC_")
+      );
+    })
+  );
+}
+
+function resolveHookCommandSpawn(
+  command: string
+): { ok: true; command: string; args: string[] } | { ok: false; error: string } {
   const trimmed = command.trim();
-  if (
-    trimmed.includes("/") &&
-    !trimmed.startsWith("/") &&
-    !trimmed.startsWith("./") &&
-    !trimmed.startsWith("../") &&
-    !/\s/.test(trimmed)
-  ) {
-    return `bash ./${trimmed}`;
+  if (!trimmed) {
+    return { ok: false, error: "Hook command is empty." };
   }
-  return command;
+  if (/\s/.test(trimmed) || SHELL_METACHARACTER_PATTERN.test(trimmed)) {
+    return {
+      ok: false,
+      error:
+        "Workflow hooks must reference a script path without shell syntax or arguments.",
+    };
+  }
+  if (isAbsolute(trimmed)) {
+    return { ok: true, command: trimmed, args: [] };
+  }
+  if (trimmed.startsWith("./") || trimmed.startsWith("../")) {
+    return { ok: true, command: trimmed, args: [] };
+  }
+  if (trimmed.includes("/")) {
+    return { ok: true, command: `./${trimmed}`, args: [] };
+  }
+  return { ok: true, command: `./${trimmed}`, args: [] };
 }

--- a/packages/orchestrator/src/runtime-factory.test.ts
+++ b/packages/orchestrator/src/runtime-factory.test.ts
@@ -91,7 +91,8 @@ describe("createWorkflowRuntimeAdapter", () => {
     await codexAdapter.prepare();
 
     const plan = codexAdapter.getPreparedPlan();
-    expect(plan?.args).toEqual(["-lc", "codex app-server --model gpt-5"]);
+    expect(plan?.command).toBe("codex");
+    expect(plan?.args).toEqual(["app-server", "--model", "gpt-5"]);
   });
 
   it("uses the default codex-app-server command when runtime command is absent", async () => {
@@ -114,7 +115,8 @@ describe("createWorkflowRuntimeAdapter", () => {
     await codexAdapter.prepare();
 
     const plan = codexAdapter.getPreparedPlan();
-    expect(plan?.args).toEqual(["-lc", "codex app-server"]);
+    expect(plan?.command).toBe("codex");
+    expect(plan?.args).toEqual(["app-server"]);
   });
 
   it("creates a claude-print adapter with isolation argv context", async () => {

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -28,6 +28,7 @@ import * as trackerAdapters from "./tracker-adapters.js";
 
 describe("OrchestratorService", () => {
   const originalToken = process.env.GITHUB_GRAPHQL_TOKEN;
+  const originalAllowWorkflowHooks = process.env.SYMPHONY_ALLOW_WORKFLOW_HOOKS;
 
   afterEach(() => {
     vi.restoreAllMocks();
@@ -35,6 +36,11 @@ describe("OrchestratorService", () => {
       delete process.env.GITHUB_GRAPHQL_TOKEN;
     } else {
       process.env.GITHUB_GRAPHQL_TOKEN = originalToken;
+    }
+    if (originalAllowWorkflowHooks === undefined) {
+      delete process.env.SYMPHONY_ALLOW_WORKFLOW_HOOKS;
+    } else {
+      process.env.SYMPHONY_ALLOW_WORKFLOW_HOOKS = originalAllowWorkflowHooks;
     }
   });
 
@@ -1537,6 +1543,7 @@ describe("OrchestratorService", () => {
 
   it("logs and ignores before_remove hook failures during startup cleanup", async () => {
     process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
+    process.env.SYMPHONY_ALLOW_WORKFLOW_HOOKS = "1";
     const tempRoot = await mkdtemp(
       join(tmpdir(), "orchestrator-startup-before-remove-failure-")
     );
@@ -1591,12 +1598,18 @@ Prefer focused changes.
     const sentinelPath = join(workspacePath, "sentinel.txt");
 
     await mkdir(repositoryPath, { recursive: true });
+    await writeFile(
+      join(repositoryPath, "WORKFLOW.md"),
+      await readFile(join(repository.path, "WORKFLOW.md"), "utf8"),
+      "utf8"
+    );
     await mkdir(join(repositoryPath, "hooks"), { recursive: true });
     await writeFile(
       join(repositoryPath, "hooks", "before_remove.sh"),
       "#!/usr/bin/env bash\nset -eu\nprintf 'cleanup hook failed' >&2\nexit 1\n",
       "utf8"
     );
+    await chmod(join(repositoryPath, "hooks", "before_remove.sh"), 0o755);
     await writeFile(sentinelPath, "cleanup me", "utf8");
     await store.saveProjectIssueOrchestrations("tenant-1", [
       {
@@ -1653,6 +1666,7 @@ Prefer focused changes.
       "[orchestrator] before_remove hook failed for acme/platform#1; continuing cleanup: cleanup hook failed"
     );
     warnSpy.mockRestore();
+    delete process.env.SYMPHONY_ALLOW_WORKFLOW_HOOKS;
   });
 
   it("logs a warning and continues startup when terminal issue fetch fails", async () => {
@@ -9182,6 +9196,7 @@ Prefer focused changes.
       '#!/usr/bin/env bash\nset -eu\nprintf "%s\\n" "$STAGING_API_HOST" > "$SYMPHONY_REPOSITORY_PATH/.after_create_host"\nprintf "%s\\n" "$FILE_ONLY" > "$SYMPHONY_REPOSITORY_PATH/.after_create_file_only"\n',
       "utf8"
     );
+    await chmod(join(repository.path, "scripts", "setup-env.sh"), 0o755);
     execSync(`git -C ${shell(repository.path)} add scripts/setup-env.sh`, {
       stdio: "ignore",
     });
@@ -9194,7 +9209,7 @@ Prefer focused changes.
     await store.saveProjectConfig(projectConfig);
     await writeFile(
       join(store.projectDir(projectConfig.projectId), ".env"),
-      "STAGING_API_HOST=https://staging.example.com\nFILE_ONLY=from-project-env\n",
+      "SYMPHONY_ALLOW_WORKFLOW_HOOKS=1\nSYMPHONY_WORKFLOW_HOOK_ENV_ALLOWLIST=STAGING_API_HOST,FILE_ONLY\nSTAGING_API_HOST=https://staging.example.com\nFILE_ONLY=from-project-env\n",
       "utf8"
     );
 
@@ -9228,7 +9243,7 @@ Prefer focused changes.
     ).resolves.toBe("from-project-env\n");
   });
 
-  it("applies project .env to inline hooks, with scoped inheritance and symphony context precedence", async () => {
+  it("applies allowlisted project .env to approved script hooks, with symphony context precedence", async () => {
     process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
     const originalStagingApiHost = process.env.STAGING_API_HOST;
     const originalSymphonyRepositoryPath = process.env.SYMPHONY_REPOSITORY_PATH;
@@ -9256,10 +9271,7 @@ tracker:
   blocker_check_states:
     - Todo
 hooks:
-  before_run: |
-    printf "%s\\n" "$STAGING_API_HOST" > .before_run_host
-    printf "%s\\n" "$FILE_ONLY" > .before_run_file_only
-    printf "%s\\n" "$SYMPHONY_REPOSITORY_PATH" > .before_run_repository_path
+  before_run: scripts/before-run.sh
 polling:
   interval_ms: 30000
 workspace:
@@ -9278,12 +9290,25 @@ Prefer focused changes.
 `,
         }
       );
+      await mkdir(join(repository.path, "scripts"), { recursive: true });
+      await writeFile(
+        join(repository.path, "scripts", "before-run.sh"),
+        '#!/usr/bin/env bash\nset -eu\nprintf "%s\\n" "$STAGING_API_HOST" > .before_run_host\nprintf "%s\\n" "$FILE_ONLY" > .before_run_file_only\nprintf "%s\\n" "$SYMPHONY_REPOSITORY_PATH" > .before_run_repository_path\n',
+        "utf8"
+      );
+      await chmod(join(repository.path, "scripts", "before-run.sh"), 0o755);
+      execSync(`git -C ${shell(repository.path)} add scripts/before-run.sh`, {
+        stdio: "ignore",
+      });
+      execSync(`git -C ${shell(repository.path)} commit -m add-before-run-hook`, {
+        stdio: "ignore",
+      });
       const store = new OrchestratorFsStore(tempRoot);
       const projectConfig = createProjectConfig(tempRoot, repository);
       await store.saveProjectConfig(projectConfig);
       await writeFile(
         join(store.projectDir(projectConfig.projectId), ".env"),
-        "STAGING_API_HOST=https://staging.example.com\nFILE_ONLY=from-project-env\nSYMPHONY_REPOSITORY_PATH=/tmp/from-project-env\n",
+        "SYMPHONY_ALLOW_WORKFLOW_HOOKS=1\nSYMPHONY_WORKFLOW_HOOK_ENV_ALLOWLIST=STAGING_API_HOST,FILE_ONLY\nSTAGING_API_HOST=https://staging.example.com\nFILE_ONLY=from-project-env\nSYMPHONY_REPOSITORY_PATH=/tmp/from-project-env\n",
         "utf8"
       );
 
@@ -9599,7 +9624,7 @@ Prefer focused changes.
     await store.saveProjectConfig(projectConfig);
     await writeFile(
       join(store.projectDir(projectConfig.projectId), ".env"),
-      "STAGING_API_HOST=https://staging.example.com\n",
+      "SYMPHONY_ALLOW_WORKFLOW_HOOKS=1\nSYMPHONY_WORKFLOW_HOOK_ENV_ALLOWLIST=STAGING_API_HOST\nSTAGING_API_HOST=https://staging.example.com\n",
       "utf8"
     );
 
@@ -9630,7 +9655,7 @@ Prefer focused changes.
     ).resolves.toBe("https://staging.example.com\n");
   });
 
-  it("preserves existing behavior when the project .env file is missing", async () => {
+  it("skips WORKFLOW.md hooks by default when explicit approval is missing", async () => {
     process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
     const tempRoot = await mkdtemp(
       join(tmpdir(), "orchestrator-missing-project-env-")
@@ -9652,8 +9677,7 @@ tracker:
   blocker_check_states:
     - Todo
 hooks:
-  before_run: |
-    printf "%s\\n" "\${FILE_ONLY:-missing}" > .before_run_missing_project_env
+  before_run: scripts/before-run.sh
 polling:
   interval_ms: 30000
 workspace:
@@ -9672,6 +9696,19 @@ Prefer focused changes.
 `,
       }
     );
+    await mkdir(join(repository.path, "scripts"), { recursive: true });
+    await writeFile(
+      join(repository.path, "scripts", "before-run.sh"),
+      '#!/usr/bin/env bash\nset -eu\nprintf "%s\\n" "${FILE_ONLY:-missing}" > .before_run_missing_project_env\n',
+      "utf8"
+    );
+    await chmod(join(repository.path, "scripts", "before-run.sh"), 0o755);
+    execSync(`git -C ${shell(repository.path)} add scripts/before-run.sh`, {
+      stdio: "ignore",
+    });
+    execSync(`git -C ${shell(repository.path)} commit -m add-missing-env-hook`, {
+      stdio: "ignore",
+    });
     const store = new OrchestratorFsStore(tempRoot);
     const projectConfig = createProjectConfig(tempRoot, repository);
     await store.saveProjectConfig(projectConfig);
@@ -9701,7 +9738,7 @@ Prefer focused changes.
 
     await expect(
       readFile(join(repositoryPath, ".before_run_missing_project_env"), "utf8")
-    ).resolves.toBe("missing\n");
+    ).rejects.toThrow();
     expect(spawnImpl.mock.calls[0]?.[2]?.env?.FILE_ONLY).toBeUndefined();
   });
 
@@ -9715,11 +9752,51 @@ Prefer focused changes.
       "acme",
       "platform",
       {
-        includeAfterRunHook: true,
-        afterRunCommand:
-          'printf "%s" "$SYMPHONY_WORKSPACE_PATH" > "$SYMPHONY_REPOSITORY_PATH/.after_run_workspace_path"\nprintf "%s" "$SYMPHONY_REPOSITORY_PATH" > "$SYMPHONY_REPOSITORY_PATH/.after_run_repository_path"',
+        rawWorkflow: `---
+tracker:
+  kind: github-project
+  project_id: project-123
+  state_field: Status
+  active_states:
+    - Todo
+    - In Progress
+  terminal_states:
+    - Done
+  blocker_check_states:
+    - Todo
+hooks:
+  after_run: hooks/after_run.sh
+polling:
+  interval_ms: 30000
+workspace:
+  root: .runtime/symphony-workspaces
+agent:
+  max_concurrent_agents: 10
+  max_retry_backoff_ms: 30000
+  retry_base_delay_ms: 1000
+codex:
+  command: codex app-server
+  read_timeout_ms: 5000
+  stall_timeout_ms: 300000
+  turn_timeout_ms: 3600000
+---
+Prefer focused changes.
+`,
       }
     );
+    await mkdir(join(repository.path, "hooks"), { recursive: true });
+    await writeFile(
+      join(repository.path, "hooks", "after_run.sh"),
+      '#!/usr/bin/env bash\nset -eu\nprintf "%s" "$SYMPHONY_WORKSPACE_PATH" > "$SYMPHONY_REPOSITORY_PATH/.after_run_workspace_path"\nprintf "%s" "$SYMPHONY_REPOSITORY_PATH" > "$SYMPHONY_REPOSITORY_PATH/.after_run_repository_path"\n',
+      "utf8"
+    );
+    await chmod(join(repository.path, "hooks", "after_run.sh"), 0o755);
+    execSync(`git -C ${shell(repository.path)} add hooks/after_run.sh`, {
+      stdio: "ignore",
+    });
+    execSync(`git -C ${shell(repository.path)} commit -m add-after-run-hook`, {
+      stdio: "ignore",
+    });
 
     const store = new OrchestratorFsStore(tempRoot);
     const workspaceDir = join(tempRoot, "workspace-runtime-root");
@@ -9729,6 +9806,11 @@ Prefer focused changes.
       workspaceDir
     );
     await store.saveProjectConfig(projectConfig);
+    await writeFile(
+      join(store.projectDir(projectConfig.projectId), ".env"),
+      "SYMPHONY_ALLOW_WORKFLOW_HOOKS=1\n",
+      "utf8"
+    );
 
     const workspaceKey = deriveIssueWorkspaceKey("acme/platform#1");
     const expectedWorkspacePath = resolveIssueWorkspaceDirectory(

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -87,6 +87,8 @@ const INHERITED_ENV_ALLOWLIST = new Set([
   "TMPDIR",
   "USER",
 ]);
+const WORKFLOW_HOOK_APPROVAL_ENV = "SYMPHONY_ALLOW_WORKFLOW_HOOKS";
+const WORKFLOW_HOOK_ENV_ALLOWLIST_ENV = "SYMPHONY_WORKFLOW_HOOK_ENV_ALLOWLIST";
 
 type ProjectWorkflowResolution = Awaited<
   ReturnType<typeof loadRepositoryWorkflow>
@@ -2828,6 +2830,10 @@ export class OrchestratorService {
         hooks: workflowResolution.workflow.hooks,
         repositoryPath: repositoryDirectory,
         env: hookEnv,
+        trusted: isWorkflowHookExecutionAllowed(hookEnv),
+        envAllowlist: parseCommaSeparatedEnvList(
+          hookEnv[WORKFLOW_HOOK_ENV_ALLOWLIST_ENV]
+        ),
         timeoutMs: workflowResolution.workflow.hooks.timeoutMs,
       });
     } catch {
@@ -3413,6 +3419,23 @@ export class OrchestratorService {
 
 function shouldInheritProcessEnvKey(key: string): boolean {
   return INHERITED_ENV_ALLOWLIST.has(key) || key.startsWith("LC_");
+}
+
+function isWorkflowHookExecutionAllowed(env: Record<string, string>): boolean {
+  const value =
+    env[WORKFLOW_HOOK_APPROVAL_ENV] ??
+    process.env[WORKFLOW_HOOK_APPROVAL_ENV];
+  return value === "1" || value?.toLowerCase() === "true";
+}
+
+function parseCommaSeparatedEnvList(value: string | undefined): string[] {
+  if (!value) {
+    return [];
+  }
+  return value
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter((entry) => /^[A-Z_][A-Z0-9_]*$/.test(entry));
 }
 
 function hasTokenUsage(

--- a/packages/runtime-codex/src/runtime.test.ts
+++ b/packages/runtime-codex/src/runtime.test.ts
@@ -10,6 +10,7 @@ import {
   getCodexObservabilityEventName,
   normalizeCodexRuntimeEvents,
   prepareCodexRuntimePlan,
+  parseAgentCommand,
   resolvePreparedAgentEnvironment,
   resolveAgentRuntimeEnvironment,
   launchCodexAppServer,
@@ -86,8 +87,8 @@ describe("buildCodexRuntimePlan", () => {
       },
     });
 
-    expect(plan.command).toBe("bash");
-    expect(plan.args).toEqual(["-lc", "codex app-server"]);
+    expect(plan.command).toBe("codex");
+    expect(plan.args).toEqual(["app-server"]);
     expect(plan.cwd).toBe("/tmp/workspace-123");
     expect(plan.tools).toHaveLength(1);
     expect(plan.env.CODEX_PROJECT_ID).toBe("workspace-123");
@@ -127,6 +128,24 @@ describe("buildCodexRuntimePlan", () => {
     });
 
     expect(plan.env.CODEX_HOME).toBe("/tmp/process-codex-home");
+  });
+
+  it("does not inherit unallowlisted process env secrets", () => {
+    process.env.GITHUB_GRAPHQL_TOKEN = "ghs_secret";
+
+    try {
+      const plan = buildCodexRuntimePlan({
+        projectId: "workspace-123",
+        workingDirectory: "/tmp/workspace-123",
+        agentEnv: {
+          OPENAI_API_KEY: "sk-ready-runtime",
+        },
+      });
+
+      expect(plan.env.GITHUB_GRAPHQL_TOKEN).toBeUndefined();
+    } finally {
+      delete process.env.GITHUB_GRAPHQL_TOKEN;
+    }
   });
 
   it("exposes linear_graphql only when enabled for Linear tracker sessions", () => {
@@ -212,6 +231,27 @@ describe("resolvePreparedAgentEnvironment", () => {
   });
 });
 
+describe("parseAgentCommand", () => {
+  it("parses codex agentCommand into argv without shell wrapping", () => {
+    expect(parseAgentCommand("codex app-server --model gpt-5")).toEqual({
+      command: "codex",
+      args: ["app-server", "--model", "gpt-5"],
+    });
+  });
+
+  it("rejects shell metacharacters in agentCommand", () => {
+    expect(() => parseAgentCommand("codex; curl attacker")).toThrow(
+      AgentRuntimeResolutionError
+    );
+  });
+
+  it("rejects non-allowlisted agentCommand executables", () => {
+    expect(() => parseAgentCommand("node worker.js")).toThrow(
+      AgentRuntimeResolutionError
+    );
+  });
+});
+
 describe("createGitCredentialHelperEnvironment", () => {
   it("configures git to use a renewable credential helper", () => {
     const env = createGitCredentialHelperEnvironment({
@@ -246,8 +286,8 @@ describe("launchCodexAppServer", () => {
     const child = launchCodexAppServer(plan, spawnImpl);
 
     expect(spawnImpl).toHaveBeenCalledWith(
-      "bash",
-      ["-lc", "codex app-server"],
+      "codex",
+      ["app-server"],
       {
         cwd: "/tmp/workspace-123",
         env: plan.env,

--- a/packages/runtime-codex/src/runtime.ts
+++ b/packages/runtime-codex/src/runtime.ts
@@ -57,7 +57,7 @@ export type CodexRuntimeConfig = {
   linearAuthorization?: string;
   linearGraphqlUrl?: string;
   extraEnv?: NodeJS.ProcessEnv;
-  /** Shell command to launch codex app-server. Leading "bash -lc " is stripped if present, since the runtime always wraps in bash -lc. */
+  /** Command line to launch codex app-server. Parsed into argv and spawned without a shell. */
   agentCommand?: string;
 };
 
@@ -96,6 +96,22 @@ type SpawnLike = (
   args: ReadonlyArray<string>,
   options: SpawnOptions
 ) => ChildProcess;
+
+const SAFE_RUNTIME_ENV_KEYS = new Set([
+  "CI",
+  "CODEX_HOME",
+  "HOME",
+  "LANG",
+  "LOGNAME",
+  "PATH",
+  "PWD",
+  "SHELL",
+  "TERM",
+  "TMPDIR",
+  "USER",
+]);
+
+const ALLOWED_CODEX_AGENT_COMMANDS = new Set(["codex"]);
 
 export const CODEX_PROTOCOL_EVENT_NAMES = {
   turnStarted: "turn/started",
@@ -422,6 +438,84 @@ export function resolvePreparedAgentEnvironment(
   );
 }
 
+export function parseAgentCommand(command: string): {
+  command: string;
+  args: string[];
+} {
+  const tokens: string[] = [];
+  let current = "";
+  let quote: "'" | '"' | null = null;
+  let escaped = false;
+
+  for (const char of command.trim()) {
+    if (escaped) {
+      current += char;
+      escaped = false;
+      continue;
+    }
+    if (char === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (quote) {
+      if (char === quote) {
+        quote = null;
+      } else {
+        current += char;
+      }
+      continue;
+    }
+    if (char === "'" || char === '"') {
+      quote = char;
+      continue;
+    }
+    if (/\s/.test(char)) {
+      if (current) {
+        tokens.push(current);
+        current = "";
+      }
+      continue;
+    }
+    if (";&|`$<>".includes(char)) {
+      throw new AgentRuntimeResolutionError(
+        `Unsupported shell metacharacter in agentCommand: ${char}`
+      );
+    }
+    current += char;
+  }
+
+  if (escaped || quote) {
+    throw new AgentRuntimeResolutionError("Unterminated agentCommand quoting.");
+  }
+  if (current) {
+    tokens.push(current);
+  }
+  if (tokens.length === 0) {
+    throw new AgentRuntimeResolutionError("agentCommand must not be empty.");
+  }
+  const [binary, ...args] = tokens;
+  if (!ALLOWED_CODEX_AGENT_COMMANDS.has(binary!)) {
+    throw new AgentRuntimeResolutionError(
+      `Unsupported agentCommand executable "${binary}". Allowed executables: ${[
+        ...ALLOWED_CODEX_AGENT_COMMANDS,
+      ].join(", ")}.`
+    );
+  }
+  return { command: binary!, args };
+}
+
+function resolveRuntimeProcessEnv(
+  env: NodeJS.ProcessEnv = process.env
+): NodeJS.ProcessEnv {
+  return Object.fromEntries(
+    Object.entries(env).filter(
+      (entry): entry is [string, string] =>
+        typeof entry[1] === "string" &&
+        (SAFE_RUNTIME_ENV_KEYS.has(entry[0]) || entry[0].startsWith("LC_"))
+    )
+  );
+}
+
 /**
  * Build the `codex app-server` launch plan for the target working directory.
  */
@@ -442,10 +536,9 @@ export function buildCodexRuntimePlan(
   ];
   const gitCredentialHelper = createGitCredentialHelperEnvironment(config);
 
-  const shellCmd = (() => {
-    const cmd = config.agentCommand ?? "codex app-server";
-    return cmd.startsWith("bash -lc ") ? cmd.slice("bash -lc ".length) : cmd;
-  })();
+  const agentCommand = parseAgentCommand(
+    config.agentCommand ?? "codex app-server"
+  );
   const agentEnv = resolvePreparedAgentEnvironment(config.agentEnv);
   const linearGraphqlEnv = config.enableLinearGraphqlTool
     ? {
@@ -472,10 +565,10 @@ export function buildCodexRuntimePlan(
 
   return {
     cwd: config.workingDirectory,
-    command: "bash",
-    args: ["-lc", shellCmd],
+    command: agentCommand.command,
+    args: agentCommand.args,
     env: {
-      ...process.env,
+      ...resolveRuntimeProcessEnv(),
       ...config.extraEnv,
       ...config.agentEnv,
       CODEX_PROJECT_ID: config.projectId,


### PR DESCRIPTION
## TL;DR

- WORKFLOW.md hook은 기본 skip으로 바꾸고 `SYMPHONY_ALLOW_WORKFLOW_HOOKS=1` 또는 `true`가 있을 때만 실행합니다.
- 승인된 hook도 shell 문자열이 아니라 스크립트 경로 argv로 실행하며, hook env는 allowlist 기반으로 구성해 `GITHUB_GRAPHQL_TOKEN` 같은 시크릿을 제거합니다.
- Codex `agentCommand`는 `bash -lc` 없이 argv로 spawn하고, 허용 실행 파일을 `codex`로 제한합니다.

## 변경 지점 다이어그램

```text
WORKFLOW.md hooks
  -> orchestrator trust gate
  -> core script-path validation
  -> spawn(script, argv, allowlisted env)

WORKFLOW.md codex.command / runtime command
  -> runtime-codex argv parser
  -> executable allowlist
  -> spawn(codex, args, filtered env)
```

## 여기부터 보세요

- `packages/core/src/workspace/hooks.ts`: hook trust gate, shell syntax rejection, hook env allowlist
- `packages/orchestrator/src/service.ts`: local approval/env allowlist wiring
- `packages/runtime-codex/src/runtime.ts`: `agentCommand` argv parsing and shell-free spawn
- `packages/core/src/workspace/hooks.test.ts`, `packages/runtime-codex/src/runtime.test.ts`, `packages/orchestrator/src/service.test.ts`: regression coverage

## 위험 & 롤백

- 위험: 기존 inline hook command는 더 이상 실행되지 않습니다. 승인된 hook은 스크립트 파일 경로로 옮겨야 합니다.
- 위험: hook에서 project `.env` 값을 쓰려면 `SYMPHONY_WORKFLOW_HOOK_ENV_ALLOWLIST=KEY1,KEY2`로 명시해야 합니다.
- 롤백: 이 커밋을 되돌리면 기존 shell 실행 동작으로 돌아가지만, C1/C2 보안 위험도 함께 복구됩니다.

## 변경 파일

- `.changeset/workflow-shell-hardening.md`
- `packages/core/src/workspace/hooks.ts`
- `packages/core/src/workspace/hooks.test.ts`
- `packages/orchestrator/src/service.ts`
- `packages/orchestrator/src/service.test.ts`
- `packages/orchestrator/src/runtime-factory.test.ts`
- `packages/runtime-codex/src/runtime.ts`
- `packages/runtime-codex/src/runtime.test.ts`

## Evidence

- `pnpm lint` — pass
- `pnpm test` — pass
- `pnpm typecheck` — pass
- `pnpm build` — pass
- Docker E2E: `docker compose -f docker-compose.e2e.yml -f docker-compose.e2e.events.yml up -d --build`, `curl /healthz`, happy-path fixture injection, `/api/v1/refresh`, worker `completed` event observed in `docker logs symphony-e2e`; fixture stayed Ready so final status remained retrying before teardown.
- `pnpm format` — fail, existing repository-wide formatting drift in 114 files; not part of Completion Bar.

## Issues — Closed #437

Closed #437

## 머지 후/사람 확인

- [ ] 릴리스, 설치본 갱신, 데몬 재기동으로 운영 배포 확인
