### PR TITLE
fix: secure token and MCP config file modes

### DIFF
--- a/.changeset/secure-secret-file-modes.md
+++ b/.changeset/secure-secret-file-modes.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Harden token cache and Claude MCP runtime config writes for #443 by forcing secret files to `0600` and dedicated parent directories to `0700`.

--- a/packages/runtime-claude/src/mcp-compose.test.ts
+++ b/packages/runtime-claude/src/mcp-compose.test.ts
@@ -1,5 +1,12 @@
 import { execFile } from "node:child_process";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import {
+  chmod,
+  mkdtemp,
+  readFile,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { promisify } from "node:util";
@@ -59,30 +66,51 @@ describe("composeClaudeMcpConfig", () => {
     });
   });
 
+  it("stores runtime mcp config with owner-only permissions", async () => {
+    const workspaceRoot = await createTempWorkspace();
+    const runtimeRoot = join(workspaceRoot, "runtime");
+    const mcpPath = join(runtimeRoot, "mcp.json");
+    await composeClaudeMcpConfig(workspaceRoot, false, {
+      GITHUB_TOKEN_BROKER_SECRET: "broker-secret",
+      WORKSPACE_RUNTIME_DIR: runtimeRoot,
+    });
+    await chmod(runtimeRoot, 0o755);
+    await chmod(mcpPath, 0o644);
+
+    await composeClaudeMcpConfig(workspaceRoot, false, {
+      GITHUB_TOKEN_BROKER_SECRET: "broker-secret",
+      WORKSPACE_RUNTIME_DIR: runtimeRoot,
+    });
+
+    expect((await stat(runtimeRoot)).mode & 0o777).toBe(0o700);
+    expect((await stat(mcpPath)).mode & 0o777).toBe(0o600);
+  });
+
   it("preserves user-authored keys and overwrites github_graphql", async () => {
     const workspaceRoot = await createTempWorkspace();
     const runtimeRoot = join(workspaceRoot, "runtime");
     const workspaceMcpPath = join(workspaceRoot, ".mcp.json");
-    const originalConfig = JSON.stringify({
-      customTopLevel: true,
-      mcpServers: {
-        user_server: {
-          command: "node",
-          args: ["user-server.js"],
-        },
-        github_graphql: {
-          command: "old",
-          env: {
-            GITHUB_GRAPHQL_TOKEN: "old-token",
+    const originalConfig =
+      JSON.stringify(
+        {
+          customTopLevel: true,
+          mcpServers: {
+            user_server: {
+              command: "node",
+              args: ["user-server.js"],
+            },
+            github_graphql: {
+              command: "old",
+              env: {
+                GITHUB_GRAPHQL_TOKEN: "old-token",
+              },
+            },
           },
         },
-      },
-    }, null, 2) + "\n";
-    await writeFile(
-      workspaceMcpPath,
-      originalConfig,
-      "utf8"
-    );
+        null,
+        2
+      ) + "\n";
+    await writeFile(workspaceMcpPath, originalConfig, "utf8");
 
     const result = await composeClaudeMcpConfig(workspaceRoot, false, {
       GITHUB_GRAPHQL_TOKEN: "token-2",
@@ -267,14 +295,11 @@ describe("composeClaudeMcpConfig", () => {
     const workspaceRoot = await createTempWorkspace();
     const runtimeRoot = join(workspaceRoot, "runtime");
     const workspaceMcpPath = join(workspaceRoot, ".mcp.json");
-    const originalConfig = JSON.stringify({
-      mcpServers: null,
-    }) + "\n";
-    await writeFile(
-      workspaceMcpPath,
-      originalConfig,
-      "utf8"
-    );
+    const originalConfig =
+      JSON.stringify({
+        mcpServers: null,
+      }) + "\n";
+    await writeFile(workspaceMcpPath, originalConfig, "utf8");
 
     const result = await composeClaudeMcpConfig(workspaceRoot, false, {
       WORKSPACE_RUNTIME_DIR: runtimeRoot,
@@ -299,14 +324,19 @@ describe("composeClaudeMcpConfig", () => {
     const workspaceRoot = await createTempWorkspace();
     const runtimeRoot = await createTempWorkspace();
     const workspaceMcpPath = join(workspaceRoot, ".mcp.json");
-    const userConfig = JSON.stringify({
-      mcpServers: {
-        user_server: {
-          command: "node",
-          args: ["user-server.js"],
+    const userConfig =
+      JSON.stringify(
+        {
+          mcpServers: {
+            user_server: {
+              command: "node",
+              args: ["user-server.js"],
+            },
+          },
         },
-      },
-    }, null, 2) + "\n";
+        null,
+        2
+      ) + "\n";
     await writeFile(workspaceMcpPath, userConfig, "utf8");
     await execFileAsync("git", ["init"], { cwd: workspaceRoot });
     await execFileAsync("git", ["add", ".mcp.json"], { cwd: workspaceRoot });

--- a/packages/runtime-claude/src/mcp-compose.ts
+++ b/packages/runtime-claude/src/mcp-compose.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { chmod, mkdir, readFile, writeFile } from "node:fs/promises";
 import { basename, dirname, join, resolve } from "node:path";
 import { createGitHubGraphQLMcpServerEntry } from "@gh-symphony/tool-github-graphql";
 import { createLinearGraphQLMcpServerEntry } from "@gh-symphony/tool-linear-graphql";
@@ -40,12 +40,13 @@ export async function composeClaudeMcpConfig(
   const baseConfig = await readBaseMcpConfig(workspaceMcpPath);
   const mergedConfig = mergeSymphonyMcpServers(baseConfig, symphonyTokenEnv);
 
-  await mkdir(dirname(finalPath), { recursive: true });
-  await writeFile(
-    finalPath,
-    JSON.stringify(mergedConfig, null, 2) + "\n",
-    "utf8"
-  );
+  await mkdir(dirname(finalPath), { recursive: true, mode: 0o700 });
+  await chmod(dirname(finalPath), 0o700);
+  await writeFile(finalPath, JSON.stringify(mergedConfig, null, 2) + "\n", {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+  await chmod(finalPath, 0o600);
 
   return {
     finalPath,

--- a/packages/runtime-claude/src/mcp-compose.ts
+++ b/packages/runtime-claude/src/mcp-compose.ts
@@ -1,4 +1,5 @@
 import { chmod, mkdir, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
 import { createGitHubGraphQLMcpServerEntry } from "@gh-symphony/tool-github-graphql";
 import { createLinearGraphQLMcpServerEntry } from "@gh-symphony/tool-linear-graphql";
@@ -40,8 +41,8 @@ export async function composeClaudeMcpConfig(
   const baseConfig = await readBaseMcpConfig(workspaceMcpPath);
   const mergedConfig = mergeSymphonyMcpServers(baseConfig, symphonyTokenEnv);
 
-  await mkdir(dirname(finalPath), { recursive: true, mode: 0o700 });
-  await chmod(dirname(finalPath), 0o700);
+  await ensureSecureConfigParent(dirname(finalPath));
+  await chmodExistingSecretFile(finalPath);
   await writeFile(finalPath, JSON.stringify(mergedConfig, null, 2) + "\n", {
     encoding: "utf8",
     mode: 0o600,
@@ -55,6 +56,41 @@ export async function composeClaudeMcpConfig(
       : ["--mcp-config", finalPath],
     cleanupPath: finalPath,
   };
+}
+
+async function ensureSecureConfigParent(path: string): Promise<void> {
+  await mkdir(path, { recursive: true, mode: 0o700 });
+  if (shouldSecureConfigParent(path)) {
+    await chmod(path, 0o700);
+  }
+}
+
+function shouldSecureConfigParent(path: string): boolean {
+  if (path === ".") {
+    return false;
+  }
+
+  const normalizedPath = resolve(path);
+  const sharedOrRootPaths = new Set([
+    resolve(tmpdir()),
+    resolve("/tmp"),
+    resolve("/private/tmp"),
+    resolve("/"),
+  ]);
+
+  return !sharedOrRootPaths.has(normalizedPath);
+}
+
+async function chmodExistingSecretFile(path: string): Promise<void> {
+  try {
+    await chmod(path, 0o600);
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return;
+    }
+
+    throw error;
+  }
 }
 
 async function readBaseMcpConfig(workspaceMcpPath: string): Promise<McpConfig> {

--- a/packages/tool-github-graphql/src/tool.test.ts
+++ b/packages/tool-github-graphql/src/tool.test.ts
@@ -31,6 +31,7 @@ describe("resolveGitHubGraphQLToken", () => {
   });
 
   it("reuses a cached broker token when it is still fresh", async () => {
+    const chmodImpl = vi.fn().mockResolvedValue(undefined);
     const fetchImpl = vi.fn();
 
     const token = await resolveGitHubGraphQLToken(
@@ -40,6 +41,7 @@ describe("resolveGitHubGraphQLToken", () => {
         tokenCachePath: "/tmp/github-token-cache.json",
       },
       {
+        chmodImpl: chmodImpl as never,
         fetchImpl: fetchImpl as typeof fetch,
         now: new Date("2026-03-07T10:00:00.000Z"),
         readFileImpl: vi.fn().mockResolvedValue(
@@ -53,6 +55,10 @@ describe("resolveGitHubGraphQLToken", () => {
     );
 
     expect(token).toBe("ghs_cached");
+    expect(chmodImpl).toHaveBeenCalledWith(
+      "/tmp/github-token-cache.json",
+      0o600
+    );
     expect(fetchImpl).not.toHaveBeenCalled();
   });
 
@@ -97,13 +103,22 @@ describe("resolveGitHubGraphQLToken", () => {
       recursive: true,
       mode: 0o700,
     });
-    expect(chmodImpl).toHaveBeenCalledWith(
+    expect(chmodImpl).toHaveBeenNthCalledWith(
+      1,
       "/tmp/github-token-cache.json",
       0o600
     );
+    expect(chmodImpl).toHaveBeenNthCalledWith(
+      2,
+      "/tmp/github-token-cache.json",
+      0o600
+    );
+    expect(chmodImpl.mock.invocationCallOrder[0]).toBeLessThan(
+      writeFileImpl.mock.invocationCallOrder[0] ?? 0
+    );
   });
 
-  it("stores broker token cache with owner-only permissions", async () => {
+  it("corrects a reused broker token cache to owner-only permissions", async () => {
     const cacheDir = await mkdtemp(join(tmpdir(), "github-token-cache-"));
     tempRoots.push(cacheDir);
     const cachePath = join(cacheDir, "token.json");
@@ -111,12 +126,35 @@ describe("resolveGitHubGraphQLToken", () => {
     await writeFile(
       cachePath,
       JSON.stringify({
-        token: "ghs_stale",
-        expiresAt: "2026-03-07T09:00:00.000Z",
+        token: "ghs_cached",
+        expiresAt: "2026-03-07T10:10:00.000Z",
       }),
       "utf8"
     );
     await chmod(cachePath, 0o644);
+
+    await expect(
+      resolveGitHubGraphQLToken(
+        {
+          tokenBrokerUrl: "http://127.0.0.1/runtime-token",
+          tokenBrokerSecret: "runtime-secret",
+          tokenCachePath: cachePath,
+        },
+        {
+          fetchImpl: vi.fn() as never,
+          now: new Date("2026-03-07T10:00:00.000Z"),
+        }
+      )
+    ).resolves.toBe("ghs_cached");
+
+    expect((await stat(cachePath)).mode & 0o777).toBe(0o600);
+  });
+
+  it("stores broker token cache with owner-only permissions in a new parent", async () => {
+    const tempRoot = await mkdtemp(join(tmpdir(), "github-token-cache-"));
+    tempRoots.push(tempRoot);
+    const cacheDir = join(tempRoot, "cache");
+    const cachePath = join(cacheDir, "token.json");
 
     await expect(
       resolveGitHubGraphQLToken(
@@ -142,6 +180,44 @@ describe("resolveGitHubGraphQLToken", () => {
 
     expect((await stat(cacheDir)).mode & 0o777).toBe(0o700);
     expect((await stat(cachePath)).mode & 0o777).toBe(0o600);
+  });
+
+  it("does not chmod caller-owned token cache parents", async () => {
+    const chmodImpl = vi.fn().mockResolvedValue(undefined);
+    const mkdirImpl = vi.fn().mockResolvedValue(undefined);
+    const writeFileImpl = vi.fn().mockResolvedValue(undefined);
+
+    await expect(
+      resolveGitHubGraphQLToken(
+        {
+          tokenBrokerUrl: "http://127.0.0.1/runtime-token",
+          tokenBrokerSecret: "runtime-secret",
+          tokenCachePath: ".github-token-cache.json",
+        },
+        {
+          chmodImpl: chmodImpl as never,
+          fetchImpl: vi.fn().mockResolvedValue(
+            new Response(
+              JSON.stringify({
+                token: "ghs_brokered",
+                expiresAt: "2026-03-07T10:20:00.000Z",
+              }),
+              { status: 200 }
+            )
+          ) as never,
+          mkdirImpl: mkdirImpl as never,
+          readFileImpl: vi.fn().mockRejectedValue(new Error("missing")) as never,
+          writeFileImpl: writeFileImpl as never,
+        }
+      )
+    ).resolves.toBe("ghs_brokered");
+
+    expect(mkdirImpl).toHaveBeenCalledWith(".", {
+      recursive: true,
+      mode: 0o700,
+    });
+    expect(chmodImpl).not.toHaveBeenCalledWith(".", 0o700);
+    expect(chmodImpl).toHaveBeenCalledWith(".github-token-cache.json", 0o600);
   });
 });
 

--- a/packages/tool-github-graphql/src/tool.test.ts
+++ b/packages/tool-github-graphql/src/tool.test.ts
@@ -1,11 +1,27 @@
-import { describe, expect, it, vi } from "vitest";
+import { chmod, mkdtemp, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   DEFAULT_GITHUB_GRAPHQL_API_URL,
   createGitHubGraphQLMcpServerEntry,
 } from "./mcp-entry.js";
 import { resolveGitHubGraphQLToken } from "./tool.js";
 
+const tempRoots: string[] = [];
+
 describe("resolveGitHubGraphQLToken", () => {
+  afterEach(async () => {
+    await Promise.all(
+      tempRoots.splice(0).map((root) =>
+        rm(root, {
+          force: true,
+          recursive: true,
+        })
+      )
+    );
+  });
+
   it("returns a static token when provided", async () => {
     await expect(
       resolveGitHubGraphQLToken({
@@ -41,6 +57,8 @@ describe("resolveGitHubGraphQLToken", () => {
   });
 
   it("refreshes through the broker when the cache is missing", async () => {
+    const chmodImpl = vi.fn().mockResolvedValue(undefined);
+    const mkdirImpl = vi.fn().mockResolvedValue(undefined);
     const writeFileImpl = vi.fn().mockResolvedValue(undefined);
 
     const token = await resolveGitHubGraphQLToken(
@@ -50,6 +68,7 @@ describe("resolveGitHubGraphQLToken", () => {
         tokenCachePath: "/tmp/github-token-cache.json",
       },
       {
+        chmodImpl: chmodImpl as never,
         fetchImpl: vi.fn().mockResolvedValue(
           new Response(
             JSON.stringify({
@@ -59,6 +78,7 @@ describe("resolveGitHubGraphQLToken", () => {
             { status: 200 }
           )
         ) as never,
+        mkdirImpl: mkdirImpl as never,
         readFileImpl: vi.fn().mockRejectedValue(new Error("missing")) as never,
         writeFileImpl: writeFileImpl as never,
       }
@@ -71,8 +91,57 @@ describe("resolveGitHubGraphQLToken", () => {
         token: "ghs_brokered",
         expiresAt: "2026-03-07T10:20:00.000Z",
       }),
+      { encoding: "utf8", mode: 0o600 }
+    );
+    expect(mkdirImpl).toHaveBeenCalledWith("/tmp", {
+      recursive: true,
+      mode: 0o700,
+    });
+    expect(chmodImpl).toHaveBeenCalledWith(
+      "/tmp/github-token-cache.json",
+      0o600
+    );
+  });
+
+  it("stores broker token cache with owner-only permissions", async () => {
+    const cacheDir = await mkdtemp(join(tmpdir(), "github-token-cache-"));
+    tempRoots.push(cacheDir);
+    const cachePath = join(cacheDir, "token.json");
+    await chmod(cacheDir, 0o755);
+    await writeFile(
+      cachePath,
+      JSON.stringify({
+        token: "ghs_stale",
+        expiresAt: "2026-03-07T09:00:00.000Z",
+      }),
       "utf8"
     );
+    await chmod(cachePath, 0o644);
+
+    await expect(
+      resolveGitHubGraphQLToken(
+        {
+          tokenBrokerUrl: "http://127.0.0.1/runtime-token",
+          tokenBrokerSecret: "runtime-secret",
+          tokenCachePath: cachePath,
+        },
+        {
+          fetchImpl: vi.fn().mockResolvedValue(
+            new Response(
+              JSON.stringify({
+                token: "ghs_brokered",
+                expiresAt: "2026-03-07T10:20:00.000Z",
+              }),
+              { status: 200 }
+            )
+          ) as never,
+          now: new Date("2026-03-07T10:00:00.000Z"),
+        }
+      )
+    ).resolves.toBe("ghs_brokered");
+
+    expect((await stat(cacheDir)).mode & 0o777).toBe(0o700);
+    expect((await stat(cachePath)).mode & 0o777).toBe(0o600);
   });
 });
 
@@ -88,14 +157,16 @@ describe("createGitHubGraphQLMcpServerEntry", () => {
   });
 
   it("includes only provided optional environment values", () => {
-    expect(createGitHubGraphQLMcpServerEntry({
-      githubToken: "ghs_token",
-      githubTokenBrokerUrl: "http://127.0.0.1/runtime-token",
-      githubTokenBrokerSecret: "secret",
-      githubTokenCachePath: "/tmp/github-token-cache.json",
-      githubProjectId: "project-1",
-      githubGraphqlApiUrl: "https://github.example/api/graphql",
-    })).toEqual({
+    expect(
+      createGitHubGraphQLMcpServerEntry({
+        githubToken: "ghs_token",
+        githubTokenBrokerUrl: "http://127.0.0.1/runtime-token",
+        githubTokenBrokerSecret: "secret",
+        githubTokenCachePath: "/tmp/github-token-cache.json",
+        githubProjectId: "project-1",
+        githubGraphqlApiUrl: "https://github.example/api/graphql",
+      })
+    ).toEqual({
       command: "node",
       args: [expect.stringContaining("mcp-server.js")],
       env: {

--- a/packages/tool-github-graphql/src/tool.ts
+++ b/packages/tool-github-graphql/src/tool.ts
@@ -1,4 +1,6 @@
-import { readFile, writeFile } from "node:fs/promises";
+import { chmod, mkdir, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, resolve } from "node:path";
 
 const DEFAULT_GITHUB_GRAPHQL_API_URL = "https://api.github.com/graphql";
 const TOKEN_REUSE_WINDOW_MS = 60 * 1000;
@@ -58,6 +60,8 @@ export async function resolveGitHubGraphQLToken(
   config: GitHubGraphQLToolConfig,
   dependencies: {
     fetchImpl?: typeof fetch;
+    chmodImpl?: typeof chmod;
+    mkdirImpl?: typeof mkdir;
     readFileImpl?: typeof readFile;
     writeFileImpl?: typeof writeFile;
     now?: Date;
@@ -74,6 +78,8 @@ export async function resolveGitHubGraphQLToken(
   }
 
   const now = dependencies.now ?? new Date();
+  const chmodImpl = dependencies.chmodImpl ?? chmod;
+  const mkdirImpl = dependencies.mkdirImpl ?? mkdir;
   const readFileImpl = dependencies.readFileImpl ?? readFile;
   const writeFileImpl = dependencies.writeFileImpl ?? writeFile;
   const cachedToken = config.tokenCachePath
@@ -109,10 +115,43 @@ export async function resolveGitHubGraphQLToken(
   }
 
   if (config.tokenCachePath) {
-    await writeFileImpl(config.tokenCachePath, JSON.stringify(payload), "utf8");
+    await writeSecretFile(
+      config.tokenCachePath,
+      JSON.stringify(payload),
+      mkdirImpl,
+      chmodImpl,
+      writeFileImpl
+    );
   }
 
   return payload.token;
+}
+
+async function writeSecretFile(
+  path: string,
+  data: string,
+  mkdirImpl: typeof mkdir,
+  chmodImpl: typeof chmod,
+  writeFileImpl: typeof writeFile
+): Promise<void> {
+  const parentDir = dirname(path);
+  await mkdirImpl(parentDir, { recursive: true, mode: 0o700 });
+  if (shouldSecureParentDirectory(parentDir)) {
+    await chmodImpl(parentDir, 0o700);
+  }
+  await writeFileImpl(path, data, { encoding: "utf8", mode: 0o600 });
+  await chmodImpl(path, 0o600);
+}
+
+function shouldSecureParentDirectory(path: string): boolean {
+  const normalizedPath = resolve(path);
+  const sharedTempRoots = new Set([
+    resolve(tmpdir()),
+    resolve("/tmp"),
+    resolve("/private/tmp"),
+  ]);
+
+  return !sharedTempRoots.has(normalizedPath);
 }
 
 async function readStdin(): Promise<string> {

--- a/packages/tool-github-graphql/src/tool.ts
+++ b/packages/tool-github-graphql/src/tool.ts
@@ -1,6 +1,5 @@
 import { chmod, mkdir, readFile, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { dirname, resolve } from "node:path";
+import { dirname } from "node:path";
 
 const DEFAULT_GITHUB_GRAPHQL_API_URL = "https://api.github.com/graphql";
 const TOKEN_REUSE_WINDOW_MS = 60 * 1000;
@@ -82,14 +81,17 @@ export async function resolveGitHubGraphQLToken(
   const mkdirImpl = dependencies.mkdirImpl ?? mkdir;
   const readFileImpl = dependencies.readFileImpl ?? readFile;
   const writeFileImpl = dependencies.writeFileImpl ?? writeFile;
-  const cachedToken = config.tokenCachePath
-    ? await readCachedToken(config.tokenCachePath, readFileImpl)
+  const tokenCachePath = config.tokenCachePath;
+  const cachedToken = tokenCachePath
+    ? await readCachedToken(tokenCachePath, readFileImpl)
     : null;
 
   if (
     cachedToken &&
+    tokenCachePath &&
     cachedToken.expiresAt.getTime() - now.getTime() > TOKEN_REUSE_WINDOW_MS
   ) {
+    await chmodExistingSecretFile(tokenCachePath, chmodImpl);
     return cachedToken.token;
   }
 
@@ -114,9 +116,9 @@ export async function resolveGitHubGraphQLToken(
     );
   }
 
-  if (config.tokenCachePath) {
+  if (tokenCachePath) {
     await writeSecretFile(
-      config.tokenCachePath,
+      tokenCachePath,
       JSON.stringify(payload),
       mkdirImpl,
       chmodImpl,
@@ -135,23 +137,31 @@ async function writeSecretFile(
   writeFileImpl: typeof writeFile
 ): Promise<void> {
   const parentDir = dirname(path);
-  await mkdirImpl(parentDir, { recursive: true, mode: 0o700 });
-  if (shouldSecureParentDirectory(parentDir)) {
+  const createdDir = await mkdirImpl(parentDir, {
+    recursive: true,
+    mode: 0o700,
+  });
+  if (createdDir !== undefined) {
     await chmodImpl(parentDir, 0o700);
   }
+  await chmodExistingSecretFile(path, chmodImpl);
   await writeFileImpl(path, data, { encoding: "utf8", mode: 0o600 });
   await chmodImpl(path, 0o600);
 }
 
-function shouldSecureParentDirectory(path: string): boolean {
-  const normalizedPath = resolve(path);
-  const sharedTempRoots = new Set([
-    resolve(tmpdir()),
-    resolve("/tmp"),
-    resolve("/private/tmp"),
-  ]);
+async function chmodExistingSecretFile(
+  path: string,
+  chmodImpl: typeof chmod
+): Promise<void> {
+  try {
+    await chmodImpl(path, 0o600);
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return;
+    }
 
-  return !sharedTempRoots.has(normalizedPath);
+    throw error;
+  }
 }
 
 async function readStdin(): Promise<string> {
@@ -208,4 +218,8 @@ async function readCachedToken(
   } catch {
     return null;
   }
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
 }


### PR DESCRIPTION
## TL;DR

토큰 캐시와 Claude MCP 런타임 설정 파일을 소유자 전용 권한으로 저장하도록 강화했고, 리뷰에서 지적된 기존 파일 rewrite 노출 창과 caller-owned parent chmod 문제를 닫았습니다. Cycle 3에서는 최신 커밋/CI/로컬 검증과 인라인 답변 상태를 재확인했습니다.

## 변경 지점 다이어그램

Issue #443
→ `tool-github-graphql` broker token cache read/rewrite
→ `runtime-claude` MCP config rewrite
→ existing secret file pre-chmod `0600`
→ newly-created dedicated parent `0700`
→ file permission regression tests

## 여기부터 보세요

- `packages/tool-github-graphql/src/tool.ts`: fresh cache 재사용 전 기존 cache file을 `0600`으로 보정하고, refresh write 전 기존 파일을 먼저 `0600`으로 낮춰 write→chmod 노출 창 제거
- `packages/tool-github-graphql/src/tool.ts`: token cache parent는 `mkdir({ recursive: true })`가 실제 생성한 전용 parent일 때만 `0700` chmod
- `packages/runtime-claude/src/mcp-compose.ts`: 기존 `mcp.json`을 write 전에 `0600`으로 보정하고, root/temp/dot parent chmod를 회피
- `packages/tool-github-graphql/src/tool.test.ts`: fresh cache 권한 보정, write 전 chmod 순서, caller-owned parent 미변경, 신규 parent/file 권한 TC 추가
- `packages/runtime-claude/src/mcp-compose.test.ts`: runtime MCP config file/dir 권한 보정 TC 유지

## 위험 & 롤백

- 위험: 명시적으로 상대경로나 공유 디렉터리에 token cache file을 두는 경우, caller-owned parent는 더 이상 chmod하지 않고 secret file `0600`만 보장합니다. 이 PR은 우리가 새로 만든 전용 parent만 `0700`으로 보정합니다.
- 롤백: 이번 PR을 revert하면 기존 umask 기반 파일 생성 동작으로 돌아갑니다.

## 변경 파일

- `.changeset/secure-secret-file-modes.md`
- `packages/tool-github-graphql/src/tool.ts`
- `packages/tool-github-graphql/src/tool.test.ts`
- `packages/runtime-claude/src/mcp-compose.ts`
- `packages/runtime-claude/src/mcp-compose.test.ts`

## Evidence

- `pnpm --filter @gh-symphony/tool-github-graphql test` — pass
- `pnpm --filter @gh-symphony/runtime-claude test` — pass
- `pnpm lint` — pass
- `pnpm test` — pass
- `pnpm typecheck` — pass
- `pnpm build` — pass
- PR checks — pass: `Test`, `Container Smoke`
- `pnpm cli doctor --smoke` — fail: local Node.js v22.22.2 is below required v24.0.0; `.runtime` managed project config/runtime dirs are absent in this checkout

## Issues — Closed #443

Fixes #443

## 머지 후/사람 확인

- [ ] 실제 운영 runtime config 경로에서 parent dir `0700`, secret file `0600`인지 확인
