### PR TITLE
fix(cli): serialize workflow front matter safely

### DIFF
--- a/.changeset/safe-workflow-front-matter.md
+++ b/.changeset/safe-workflow-front-matter.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Generate WORKFLOW.md front matter through a YAML-safe serializer path so Linear tracker endpoint, project slug, and label input cannot inject sibling runtime configuration (fixes #445).

--- a/packages/cli/src/workflow/generate-workflow-md.test.ts
+++ b/packages/cli/src/workflow/generate-workflow-md.test.ts
@@ -182,6 +182,39 @@ describe("generateWorkflowMarkdown", () => {
     expect(parsed.polling.intervalMs).toBe(15000);
   });
 
+  it("keeps injected Linear tracker strings from changing front matter structure", () => {
+    const injectedEndpoint =
+      "https://linear.example/graphql\nruntime:\n  kind: custom\n  command: malicious";
+    const injectedProjectSlug =
+      "valid\nruntime:\n  kind: custom\n  command: malicious";
+    const markdown = generateWorkflowMarkdown({
+      ...defaultInput,
+      tracker: {
+        kind: "linear",
+        endpoint: injectedEndpoint,
+        apiKey: "lin_test_token",
+        projectSlug: injectedProjectSlug,
+        pickupLabels: {
+          include: ["ready\nruntime:\n  command: malicious", "security:high"],
+          exclude: ["blocked # not a comment"],
+        },
+      },
+    });
+    const parsed = parseWorkflowMarkdown(markdown, {});
+
+    expect(markdown).toContain(JSON.stringify(injectedEndpoint));
+    expect(markdown).toContain(JSON.stringify(injectedProjectSlug));
+    expect(parsed.tracker.kind).toBe("linear");
+    expect(parsed.tracker.endpoint).toBe(injectedEndpoint);
+    expect(parsed.tracker.projectSlug).toBe(injectedProjectSlug);
+    expect(parsed.tracker.pickupLabels).toEqual({
+      include: ["ready\nruntime:\n  command: malicious", "security:high"],
+      exclude: ["blocked # not a comment"],
+    });
+    expect(parsed.runtime?.kind).toBe("codex-app-server");
+    expect(parsed.runtime?.command).toBe("codex");
+  });
+
   it("resolves runtime agent command for codex", () => {
     const markdown = generateWorkflowMarkdown(defaultInput);
 

--- a/packages/cli/src/workflow/generate-workflow-md.test.ts
+++ b/packages/cli/src/workflow/generate-workflow-md.test.ts
@@ -158,6 +158,76 @@ describe("generateWorkflowMarkdown", () => {
     expect(parsed.tracker.priority).toEqual(priority);
   });
 
+  it("quotes reserved YAML scalar priority label keys", () => {
+    const priority = {
+      source: "labels" as const,
+      labels: {
+        true: 0,
+        false: 1,
+        null: 2,
+      },
+    };
+    const markdown = generateWorkflowMarkdown({
+      ...defaultInput,
+      priority,
+    });
+    const parsed = parseWorkflowMarkdown(markdown, {});
+
+    expect(markdown).toContain('"true": 0');
+    expect(markdown).toContain('"false": 1');
+    expect(markdown).toContain('"null": 2');
+    expect(parsed.tracker.priority).toEqual(priority);
+  });
+
+  it("quotes reserved YAML scalar priority project option keys", () => {
+    const priority = {
+      source: "project-field" as const,
+      field: "Priority",
+      values: {
+        true: 0,
+        false: 1,
+        null: 2,
+      },
+    };
+    const markdown = generateWorkflowMarkdown({
+      ...defaultInput,
+      priority,
+    });
+    const parsed = parseWorkflowMarkdown(markdown, {});
+
+    expect(markdown).toContain('"true": 0');
+    expect(markdown).toContain('"false": 1');
+    expect(markdown).toContain('"null": 2');
+    expect(parsed.tracker.priority).toEqual(priority);
+  });
+
+  it("keeps disabled priority templates nested under tracker when uncommented", () => {
+    const markdown = generateWorkflowMarkdown({
+      ...defaultInput,
+      priority: { source: "disabled" as const },
+      includePriorityTemplates: true,
+    });
+    const uncommented = markdown
+      .replace("  # priority:", "  priority:")
+      .replace("  #   source: project-field", "    source: project-field")
+      .replace("  #   field: Priority", "    field: Priority")
+      .replace("  #   values:", "    values:")
+      .replace("  #     Urgent: 0", "      Urgent: 0")
+      .replace("  #     High: 1", "      High: 1");
+    const parsed = parseWorkflowMarkdown(uncommented, {});
+
+    expect(markdown).toContain("  # priority:");
+    expect(markdown).not.toContain("\n# priority:");
+    expect(parsed.tracker.priority).toEqual({
+      source: "project-field",
+      field: "Priority",
+      values: {
+        Urgent: 0,
+        High: 1,
+      },
+    });
+  });
+
   it("includes a Status Map section in the prompt body", () => {
     const markdown = generateWorkflowMarkdown(defaultInput);
 

--- a/packages/cli/src/workflow/generate-workflow-md.ts
+++ b/packages/cli/src/workflow/generate-workflow-md.ts
@@ -8,8 +8,10 @@ import { CLAUDE_RUNTIME_PROMPT_PREAMBLE } from "../prompts/runtime-claude-constr
 import { DEFAULT_AFTER_CREATE_HOOK_PATH } from "./default-hooks.js";
 import { buildRepositoryValidationGuidance } from "./repository-guidance.js";
 import {
-  buildRuntimeFrontMatter,
+  DEFAULT_CLAUDE_PRINT_ARGS,
+  DEFAULT_CODEX_APP_SERVER_ARGS,
   isClaudeRuntime,
+  normalizeInitRuntime,
 } from "./workflow-runtime.js";
 
 export type GenerateWorkflowInput = {
@@ -50,166 +52,334 @@ export function generateWorkflowMarkdown(input: GenerateWorkflowInput): string {
   return `---\n${frontMatter}---\n${promptBody}\n`;
 }
 
-function buildFrontMatter(input: GenerateWorkflowInput): string {
-  const lines: string[] = [];
+type YamlFrontMatterNode =
+  | string
+  | number
+  | boolean
+  | null
+  | YamlQuotedString
+  | YamlFrontMatterNode[]
+  | { [key: string]: YamlFrontMatterNode };
 
-  lines.push("tracker:");
+type YamlQuotedString = {
+  readonly __yamlQuotedString: true;
+  readonly value: string;
+};
+
+function buildFrontMatter(input: GenerateWorkflowInput): string {
+  const tracker = buildTrackerFrontMatter(input);
+  const frontMatter: Record<string, YamlFrontMatterNode> = {
+    tracker,
+    polling: {
+      interval_ms: input.pollIntervalMs ?? 30000,
+    },
+    workspace: {
+      root: ".runtime/symphony-workspaces",
+    },
+    hooks: {
+      after_create: DEFAULT_AFTER_CREATE_HOOK_PATH,
+    },
+    agent: {
+      max_concurrent_agents: 10,
+      max_retry_backoff_ms: 30000,
+      retry_base_delay_ms: 10000,
+    },
+    runtime: buildRuntimeFrontMatterConfig(input.runtime),
+  };
+
+  return `${stringifyYamlFrontMatter(frontMatter)}${buildStaticFrontMatterComments(input)}`;
+}
+
+function buildTrackerFrontMatter(
+  input: GenerateWorkflowInput
+): Record<string, YamlFrontMatterNode> {
+  const tracker: Record<string, YamlFrontMatterNode> = {};
   if (input.tracker?.kind === "linear") {
-    lines.push("  kind: linear");
-    lines.push(
-      `  endpoint: ${input.tracker.endpoint ?? "https://api.linear.app/graphql"}`
-    );
-    lines.push(`  api_key: ${input.tracker.apiKey ?? "$LINEAR_API_KEY"}`);
-    lines.push(`  project_slug: ${input.tracker.projectSlug}`);
+    tracker.kind = "linear";
+    tracker.endpoint =
+      input.tracker.endpoint ?? "https://api.linear.app/graphql";
+    tracker.api_key = input.tracker.apiKey ?? "$LINEAR_API_KEY";
+    tracker.project_slug = input.tracker.projectSlug;
   } else {
-    lines.push("  kind: github-project");
-    lines.push(`  project_id: ${input.projectId}`);
-    lines.push(`  state_field: ${input.stateFieldName}`);
-    lines.push(...buildPriorityFrontMatter(input));
+    tracker.kind = "github-project";
+    tracker.project_id = input.projectId;
+    tracker.state_field = input.stateFieldName;
+    const priority = buildPriorityFrontMatter(input);
+    if (priority) {
+      tracker.priority = priority;
+    }
   }
 
   if (input.lifecycle.activeStates.length > 0) {
-    lines.push("  active_states:");
-    for (const state of input.lifecycle.activeStates) {
-      lines.push(`    - ${state}`);
-    }
+    tracker.active_states = input.lifecycle.activeStates;
   }
 
   if (input.lifecycle.terminalStates.length > 0) {
-    lines.push("  terminal_states:");
-    for (const state of input.lifecycle.terminalStates) {
-      lines.push(`    - ${state}`);
-    }
+    tracker.terminal_states = input.lifecycle.terminalStates;
   }
 
   if (input.tracker?.kind === "linear") {
     const include = input.tracker.pickupLabels?.include ?? [];
     const exclude = input.tracker.pickupLabels?.exclude ?? [];
     if (include.length > 0 || exclude.length > 0) {
-      lines.push("  pickup_labels:");
+      const pickupLabels: Record<string, YamlFrontMatterNode> = {};
       if (include.length > 0) {
-        lines.push("    include:");
-        for (const label of include) {
-          lines.push(`      - ${label}`);
-        }
+        pickupLabels.include = include;
       }
       if (exclude.length > 0) {
-        lines.push("    exclude:");
-        for (const label of exclude) {
-          lines.push(`      - ${label}`);
-        }
+        pickupLabels.exclude = exclude;
       }
+      tracker.pickup_labels = pickupLabels;
     }
   }
 
-  lines.push(
-    ...buildStringListFrontMatter(
-      "blocker_check_states",
-      input.lifecycle.blockerCheckStates
-    )
-  );
-  lines.push(
-    ...buildStringListFrontMatter(
-      "planning_states",
-      input.lifecycle.planningStates
-    )
-  );
+  tracker.blocker_check_states = input.lifecycle.blockerCheckStates;
+  tracker.planning_states = input.lifecycle.planningStates;
 
-  lines.push("polling:");
-  lines.push(`  interval_ms: ${input.pollIntervalMs ?? 30000}`);
-
-  lines.push("workspace:");
-  lines.push("  root: .runtime/symphony-workspaces");
-
-  lines.push("hooks:");
-  lines.push(`  after_create: ${DEFAULT_AFTER_CREATE_HOOK_PATH}`);
-
-  lines.push("agent:");
-  lines.push("  max_concurrent_agents: 10");
-  lines.push("  max_retry_backoff_ms: 30000");
-  lines.push("  retry_base_delay_ms: 10000");
-
-  lines.push(...buildRuntimeFrontMatter(input.runtime));
-
-  return lines.join("\n") + "\n";
+  return tracker;
 }
 
-function buildStringListFrontMatter(key: string, values: string[]): string[] {
-  if (values.length === 0) {
-    return [`  ${key}: []`];
+function buildRuntimeFrontMatterConfig(
+  runtime: string
+): Record<string, YamlFrontMatterNode> {
+  const normalized = normalizeInitRuntime(runtime);
+  const base = {
+    isolation: {
+      bare: false,
+      strict_mcp_config: false,
+    },
+  };
+
+  if (normalized === "codex-app-server") {
+    return {
+      kind: "codex-app-server",
+      command: "codex",
+      args: [...DEFAULT_CODEX_APP_SERVER_ARGS],
+      ...base,
+      timeouts: {
+        read_timeout_ms: 5000,
+        turn_timeout_ms: 3600000,
+        stall_timeout_ms: 300000,
+      },
+    };
   }
 
-  return [`  ${key}:`, ...values.map((value) => `    - ${value}`)];
+  if (normalized === "claude-print") {
+    return {
+      kind: "claude-print",
+      command: "claude",
+      args: [...DEFAULT_CLAUDE_PRINT_ARGS],
+      ...base,
+      timeouts: {
+        read_timeout_ms: 5000,
+        turn_timeout_ms: 3600000,
+        stall_timeout_ms: 900000,
+      },
+    };
+  }
+
+  return {
+    kind: "custom",
+    command: runtime,
+    ...base,
+    timeouts: {
+      read_timeout_ms: 5000,
+      turn_timeout_ms: 3600000,
+      stall_timeout_ms: 300000,
+    },
+  };
 }
 
 function buildPriorityFrontMatter(
   input: Pick<GenerateWorkflowInput, "priority" | "includePriorityTemplates">
-): string[] {
-  const lines: string[] = [];
+): Record<string, YamlFrontMatterNode> | null {
   if (!input.priority) {
-    return lines;
+    return null;
   }
-
-  if (input.priority.source === "disabled") {
-    lines.push(
-      "  # Priority dispatch is disabled until an operator chooses one explicit source."
-    );
-  } else {
-    lines.push(
-      "  # Priority is explicit. Numbers below are editable policy (lower = higher priority)."
-    );
-  }
-  lines.push(
-    "  # See docs/adr/2026-05-18_explicit-dispatch-priority-mappings.md"
-  );
-  lines.push("  priority:");
 
   if (input.priority.source === "project-field") {
-    lines.push("    source: project-field");
-    lines.push(`    field: ${formatYamlScalar(input.priority.field)}`);
-    lines.push("    values:");
-    for (const [name, value] of Object.entries(input.priority.values)) {
-      lines.push(`      ${formatYamlKey(name)}: ${value}`);
-    }
-    return lines;
+    return {
+      source: "project-field",
+      field: yamlQuotedString(input.priority.field),
+      values: input.priority.values,
+    };
   }
 
   if (input.priority.source === "labels") {
-    lines.push("    source: labels");
-    lines.push("    labels:");
-    for (const [name, value] of Object.entries(input.priority.labels)) {
-      lines.push(`      ${formatYamlKey(name)}: ${value}`);
-    }
-    return lines;
+    return {
+      source: "labels",
+      labels: input.priority.labels,
+    };
   }
 
-  lines.push("    source: disabled");
-  if (input.includePriorityTemplates) {
-    lines.push("");
-    lines.push("  # Optional template: project-field priority source.");
-    lines.push("  # priority:");
-    lines.push("  #   source: project-field");
-    lines.push("  #   field: Priority");
-    lines.push("  #   values:");
-    lines.push("  #     Urgent: 0");
-    lines.push("  #     High: 1");
-    lines.push("");
-    lines.push("  # Optional template: labels priority source.");
-    lines.push("  # priority:");
-    lines.push("  #   source: labels");
-    lines.push("  #   labels:");
-    lines.push("  #     P0: 0");
-    lines.push("  #     P1: 1");
+  return {
+    source: "disabled",
+  };
+}
+
+function buildStaticFrontMatterComments(
+  input: Pick<GenerateWorkflowInput, "priority" | "includePriorityTemplates">
+): string {
+  if (!input.priority) {
+    return "";
+  }
+
+  const comments =
+    input.priority.source === "disabled"
+      ? [
+          "# Priority dispatch is disabled until an operator chooses one explicit source.",
+        ]
+      : [
+          "# Priority is explicit. Numbers below are editable policy (lower = higher priority).",
+        ];
+  comments.push(
+    "# See docs/adr/2026-05-18_explicit-dispatch-priority-mappings.md"
+  );
+
+  if (input.priority.source === "disabled" && input.includePriorityTemplates) {
+    comments.push(
+      "",
+      "# Optional template: project-field priority source.",
+      "# priority:",
+      "#   source: project-field",
+      "#   field: Priority",
+      "#   values:",
+      "#     Urgent: 0",
+      "#     High: 1",
+      "",
+      "# Optional template: labels priority source.",
+      "# priority:",
+      "#   source: labels",
+      "#   labels:",
+      "#     P0: 0",
+      "#     P1: 1"
+    );
+  }
+
+  return `${comments.join("\n")}\n`;
+}
+
+function stringifyYamlFrontMatter(
+  input: Record<string, YamlFrontMatterNode>
+): string {
+  return `${stringifyYamlObject(input, 0).join("\n")}\n`;
+}
+
+function stringifyYamlObject(
+  input: Record<string, YamlFrontMatterNode>,
+  indent: number
+): string[] {
+  const lines: string[] = [];
+  for (const [key, value] of Object.entries(input)) {
+    const prefix = " ".repeat(indent);
+    if (isYamlNestedValue(value)) {
+      if (Array.isArray(value) && value.length === 0) {
+        lines.push(`${prefix}${formatYamlKey(key)}: []`);
+        continue;
+      }
+      lines.push(`${prefix}${formatYamlKey(key)}:`);
+      lines.push(...stringifyYamlNode(value, indent + 2));
+      continue;
+    }
+    lines.push(`${prefix}${formatYamlKey(key)}: ${formatYamlScalar(value)}`);
   }
   return lines;
 }
 
-function formatYamlScalar(value: string): string {
+function formatYamlKey(value: string): string {
+  if (/^[a-z_][a-z0-9_]*$/.test(value)) {
+    return value;
+  }
   return JSON.stringify(value);
 }
 
-function formatYamlKey(value: string): string {
-  return JSON.stringify(value);
+function stringifyYamlNode(
+  value: YamlFrontMatterNode,
+  indent: number
+): string[] {
+  const prefix = " ".repeat(indent);
+  if (Array.isArray(value)) {
+    if (value.length === 0) {
+      return [`${prefix}[]`];
+    }
+    return value.flatMap((entry) => {
+      if (isYamlNestedValue(entry)) {
+        return [
+          `${prefix}-`,
+          ...stringifyYamlNode(entry, indent + 2),
+        ];
+      }
+      return [`${prefix}- ${formatYamlScalar(entry)}`];
+    });
+  }
+  if (isYamlObject(value)) {
+    return stringifyYamlObject(value, indent);
+  }
+  return [`${prefix}${formatYamlScalar(value)}`];
+}
+
+function isYamlNestedValue(value: YamlFrontMatterNode): boolean {
+  return Array.isArray(value) || isYamlObject(value);
+}
+
+function isYamlObject(
+  value: YamlFrontMatterNode
+): value is Record<string, YamlFrontMatterNode> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    !isYamlQuotedString(value)
+  );
+}
+
+function formatYamlScalar(
+  value: YamlFrontMatterNode
+): string {
+  if (isYamlQuotedString(value)) {
+    return JSON.stringify(value.value);
+  }
+  if (typeof value === "string") {
+    return shouldQuoteYamlScalar(value) ? JSON.stringify(value) : value;
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  if (value === null) {
+    return "null";
+  }
+  throw new Error("Nested YAML values must be serialized by the caller.");
+}
+
+function shouldQuoteYamlScalar(value: string): boolean {
+  const firstChar = value[0] ?? "";
+  return (
+    value.length === 0 ||
+    /^\s|\s$/.test(value) ||
+    /[\n\r]/.test(value) ||
+    /(^|\s)#/.test(value) ||
+    /:\s/.test(value) ||
+    /^(?:null|true|false|-?\d+)$/.test(value) ||
+    "[]{},&*!|>'\"%@`".includes(firstChar)
+  );
+}
+
+function yamlQuotedString(value: string): YamlQuotedString {
+  return {
+    __yamlQuotedString: true,
+    value,
+  };
+}
+
+function isYamlQuotedString(
+  value: YamlFrontMatterNode
+): value is YamlQuotedString {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    "__yamlQuotedString" in value
+  );
 }
 
 function buildPromptBody(input: GenerateWorkflowInput): string {

--- a/packages/cli/src/workflow/generate-workflow-md.ts
+++ b/packages/cli/src/workflow/generate-workflow-md.ts
@@ -68,8 +68,7 @@ type YamlQuotedString = {
 
 function buildFrontMatter(input: GenerateWorkflowInput): string {
   const tracker = buildTrackerFrontMatter(input);
-  const frontMatter: Record<string, YamlFrontMatterNode> = {
-    tracker,
+  const restFrontMatter: Record<string, YamlFrontMatterNode> = {
     polling: {
       interval_ms: input.pollIntervalMs ?? 30000,
     },
@@ -87,7 +86,7 @@ function buildFrontMatter(input: GenerateWorkflowInput): string {
     runtime: buildRuntimeFrontMatterConfig(input.runtime),
   };
 
-  return `${stringifyYamlFrontMatter(frontMatter)}${buildStaticFrontMatterComments(input)}`;
+  return `${stringifyYamlFrontMatter({ tracker })}${buildTrackerFrontMatterComments(input)}${stringifyYamlFrontMatter(restFrontMatter)}`;
 }
 
 function buildTrackerFrontMatter(
@@ -217,7 +216,7 @@ function buildPriorityFrontMatter(
   };
 }
 
-function buildStaticFrontMatterComments(
+function buildTrackerFrontMatterComments(
   input: Pick<GenerateWorkflowInput, "priority" | "includePriorityTemplates">
 ): string {
   if (!input.priority) {
@@ -227,32 +226,32 @@ function buildStaticFrontMatterComments(
   const comments =
     input.priority.source === "disabled"
       ? [
-          "# Priority dispatch is disabled until an operator chooses one explicit source.",
+          "  # Priority dispatch is disabled until an operator chooses one explicit source.",
         ]
       : [
-          "# Priority is explicit. Numbers below are editable policy (lower = higher priority).",
+          "  # Priority is explicit. Numbers below are editable policy (lower = higher priority).",
         ];
   comments.push(
-    "# See docs/adr/2026-05-18_explicit-dispatch-priority-mappings.md"
+    "  # See docs/adr/2026-05-18_explicit-dispatch-priority-mappings.md"
   );
 
   if (input.priority.source === "disabled" && input.includePriorityTemplates) {
     comments.push(
       "",
-      "# Optional template: project-field priority source.",
-      "# priority:",
-      "#   source: project-field",
-      "#   field: Priority",
-      "#   values:",
-      "#     Urgent: 0",
-      "#     High: 1",
+      "  # Optional template: project-field priority source.",
+      "  # priority:",
+      "  #   source: project-field",
+      "  #   field: Priority",
+      "  #   values:",
+      "  #     Urgent: 0",
+      "  #     High: 1",
       "",
-      "# Optional template: labels priority source.",
-      "# priority:",
-      "#   source: labels",
-      "#   labels:",
-      "#     P0: 0",
-      "#     P1: 1"
+      "  # Optional template: labels priority source.",
+      "  # priority:",
+      "  #   source: labels",
+      "  #   labels:",
+      "  #     P0: 0",
+      "  #     P1: 1"
     );
   }
 
@@ -287,7 +286,10 @@ function stringifyYamlObject(
 }
 
 function formatYamlKey(value: string): string {
-  if (/^[a-z_][a-z0-9_]*$/.test(value)) {
+  if (
+    /^[a-z_][a-z0-9_]*$/.test(value) &&
+    !/^(?:true|false|null)$/.test(value)
+  ) {
     return value;
   }
   return JSON.stringify(value);


### PR DESCRIPTION
## TL;DR

- WORKFLOW.md front matter 생성을 문자열 접합에서 객체 기반 YAML-safe serializer 경로로 전환했습니다.
- Linear tracker endpoint/projectSlug/pickup label 주입 페이로드가 runtime 구조를 덮어쓰지 못하도록 round-trip 회귀 TC를 추가했습니다.
- 리뷰 재작업으로 priority 예약어 키 quoting과 disabled priority 템플릿의 `tracker` nesting 회귀를 보강했습니다.

## 변경 지점 다이어그램

`generateWorkflowMarkdown` → `buildFrontMatter` → `buildTrackerFrontMatter` / `buildRuntimeFrontMatterConfig` → `stringifyYamlFrontMatter` → `parseWorkflowMarkdown` round-trip TC

## 여기부터 보세요

- `packages/cli/src/workflow/generate-workflow-md.ts`
- `packages/cli/src/workflow/generate-workflow-md.test.ts`
- `.changeset/safe-workflow-front-matter.md`

## 위험 & 롤백

- 위험: WORKFLOW.md front matter 출력 포맷이 serializer를 통과합니다. Linear 주입 문자열, priority 예약어 키, disabled priority 템플릿 주석 해제 round-trip TC로 구조 안정성을 확인했습니다.
- 롤백: 이 PR의 커밋을 revert하면 기존 문자열 접합 방식으로 돌아갑니다. 다만 원래 H6 YAML 구조 주입 취약점도 함께 되살아납니다.

## 변경 파일

- `packages/cli/src/workflow/generate-workflow-md.ts` — front matter 객체 구성 및 YAML-safe serializer 추가, 예약어 키 quoting, priority 템플릿을 `tracker` 블록 아래에 유지
- `packages/cli/src/workflow/generate-workflow-md.test.ts` — Linear 입력 주입, 예약어 priority key, disabled template uncomment round-trip TC 추가
- `.changeset/safe-workflow-front-matter.md` — CLI patch changeset

## Evidence

- `pnpm --filter @gh-symphony/cli test -- generate-workflow-md.test.ts` — pass (32 tests)
- `pnpm lint` — pass
- `pnpm test` — pass
- `pnpm typecheck` — pass
- `pnpm build` — pass
- `node packages/cli/dist/index.js doctor --smoke --issue hojinzs/github-symphony#445 --json` — partial pass: command exits 1 because local Node.js is v22.22.2 and CLI requires v24.0.0; issue-relevant checks `workflow_file`, `runtime_command`, `smoke_issue`, `workflow_prompt_render`, `workflow_hooks` passed
- GitHub CI `Test` — pass for b92a70d
- GitHub CI `Container Smoke` — pass for b92a70d

## Issues

Closed #445

## 머지 후/사람 확인

- [ ] 생성된 WORKFLOW.md를 실제 repo init 플로우에서 한 번 눈으로 확인
