### PR TITLE
fix(security): validate runtime fetch URLs

### DIFF
--- a/.changeset/secure-runtime-fetch-urls.md
+++ b/.changeset/secure-runtime-fetch-urls.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Reject non-HTTPS, private-network, and non-allowlisted runtime GraphQL URLs before broker or GraphQL fetches for #444.

--- a/.changeset/secure-runtime-fetch-urls.md
+++ b/.changeset/secure-runtime-fetch-urls.md
@@ -2,4 +2,4 @@
 "@gh-symphony/cli": patch
 ---
 
-Reject non-HTTPS, private-network, and non-allowlisted runtime GraphQL URLs before broker or GraphQL fetches for #444.
+Reject non-HTTPS and private-network runtime fetch URLs, and restrict Linear GraphQL hosts, before sending credentials for #444.

--- a/packages/runtime-claude/src/mcp-compose.test.ts
+++ b/packages/runtime-claude/src/mcp-compose.test.ts
@@ -150,7 +150,7 @@ describe("composeClaudeMcpConfig", () => {
     const result = await composeClaudeMcpConfig(workspaceRoot, false, {
       SYMPHONY_TRACKER_KIND: "linear",
       LINEAR_API_KEY: "lin_api_key",
-      LINEAR_GRAPHQL_URL: "https://linear.example/graphql",
+      LINEAR_GRAPHQL_URL: "https://api.linear.app/graphql",
     });
 
     expect(await readJson(result.finalPath)).toEqual({
@@ -166,7 +166,7 @@ describe("composeClaudeMcpConfig", () => {
           command: "node",
           args: [expect.stringContaining("mcp-server.js")],
           env: {
-            LINEAR_GRAPHQL_URL: "https://linear.example/graphql",
+            LINEAR_GRAPHQL_URL: "https://api.linear.app/graphql",
           },
         },
       },

--- a/packages/runtime-codex/src/git-credential-helper.test.ts
+++ b/packages/runtime-codex/src/git-credential-helper.test.ts
@@ -38,7 +38,7 @@ describe("resolveGitCredential", () => {
         host: "github.com",
       },
       {
-        tokenBrokerUrl: "http://127.0.0.1/runtime-token",
+        tokenBrokerUrl: "https://broker.example/runtime-token",
         tokenBrokerSecret: "runtime-secret",
         tokenCachePath: "/tmp/github-token-cache.json",
       },

--- a/packages/runtime-codex/src/runtime.test.ts
+++ b/packages/runtime-codex/src/runtime.test.ts
@@ -34,7 +34,7 @@ describe("createGitHubGraphQLToolDefinition", () => {
   it("builds a runtime tool definition for brokered GitHub GraphQL access", () => {
     const tool = createGitHubGraphQLToolDefinition({
       githubTokenBrokerUrl:
-        "http://host.docker.internal:3000/api/workspaces/workspace-123/runtime-credentials",
+        "https://broker.example/api/workspaces/workspace-123/runtime-credentials",
       githubTokenBrokerSecret: "runtime-secret",
       githubTokenCachePath: "/workspace-runtime/.github-token.json",
       githubProjectId: "project-123",
@@ -46,7 +46,7 @@ describe("createGitHubGraphQLToolDefinition", () => {
     expect(tool.env).toEqual({
       GITHUB_GRAPHQL_API_URL: "https://api.github.com/graphql",
       GITHUB_TOKEN_BROKER_URL:
-        "http://host.docker.internal:3000/api/workspaces/workspace-123/runtime-credentials",
+        "https://broker.example/api/workspaces/workspace-123/runtime-credentials",
       GITHUB_TOKEN_BROKER_SECRET: "runtime-secret",
       GITHUB_TOKEN_CACHE_PATH: "/workspace-runtime/.github-token.json",
       GITHUB_PROJECT_ID: "project-123",
@@ -57,14 +57,14 @@ describe("createGitHubGraphQLToolDefinition", () => {
 describe("createLinearGraphQLToolDefinition", () => {
   it("builds a runtime tool definition for Linear GraphQL access", () => {
     const tool = createLinearGraphQLToolDefinition({
-      linearGraphqlUrl: "https://linear.example/graphql",
+      linearGraphqlUrl: "https://api.linear.app/graphql",
     });
 
     expect(tool.name).toBe("linear_graphql");
     expect(tool.command).toBe("node");
     expect(tool.args[0]).toContain("mcp-server.js");
     expect(tool.env).toEqual({
-      LINEAR_GRAPHQL_URL: "https://linear.example/graphql",
+      LINEAR_GRAPHQL_URL: "https://api.linear.app/graphql",
     });
   });
 });
@@ -75,7 +75,7 @@ describe("buildCodexRuntimePlan", () => {
       projectId: "workspace-123",
       workingDirectory: "/tmp/workspace-123",
       githubTokenBrokerUrl:
-        "http://host.docker.internal:3000/api/workspaces/workspace-123/runtime-credentials",
+        "https://broker.example/api/workspaces/workspace-123/runtime-credentials",
       githubTokenBrokerSecret: "runtime-secret",
       githubTokenCachePath: "/workspace-runtime/.github-token.json",
       githubProjectId: "project-123",
@@ -169,18 +169,20 @@ describe("buildCodexRuntimePlan", () => {
       workingDirectory: "/tmp/workspace-123",
       linearApiKey: "lin_api_key",
       linearAuthorization: "Bearer lin_api_key",
-      linearGraphqlUrl: "https://linear.example/graphql",
+      linearGraphqlUrl: "https://api.linear.app/graphql",
       extraEnv: {
         LINEAR_API_KEY: "global-lin-api-key",
         LINEAR_AUTHORIZATION: "Bearer global-lin-api-key",
-        LINEAR_GRAPHQL_URL: "https://global-linear.example/graphql",
+        LINEAR_GRAPHQL_URL: "https://preview.linear.app/graphql",
       },
       agentEnv: {
         OPENAI_API_KEY: "sk-ready-runtime",
       },
     });
     expect(nonLinearPlanWithLinearSecret.env.LINEAR_GRAPHQL_TOOL_NAME).toBe("");
-    expect(nonLinearPlanWithLinearSecret.env.LINEAR_GRAPHQL_URL).toBeUndefined();
+    expect(
+      nonLinearPlanWithLinearSecret.env.LINEAR_GRAPHQL_URL
+    ).toBeUndefined();
     expect(nonLinearPlanWithLinearSecret.env.LINEAR_API_KEY).toBeUndefined();
     expect(
       nonLinearPlanWithLinearSecret.env.LINEAR_AUTHORIZATION
@@ -191,7 +193,7 @@ describe("buildCodexRuntimePlan", () => {
       workingDirectory: "/tmp/workspace-123",
       enableLinearGraphqlTool: true,
       linearApiKey: "lin_api_key",
-      linearGraphqlUrl: "https://linear.example/graphql",
+      linearGraphqlUrl: "https://api.linear.app/graphql",
       agentEnv: {
         OPENAI_API_KEY: "sk-ready-runtime",
       },
@@ -203,14 +205,14 @@ describe("buildCodexRuntimePlan", () => {
     ]);
     expect(linearPlan.env.LINEAR_GRAPHQL_TOOL_NAME).toBe("linear_graphql");
     expect(linearPlan.env.LINEAR_GRAPHQL_URL).toBe(
-      "https://linear.example/graphql"
+      "https://api.linear.app/graphql"
     );
     expect(linearPlan.env.LINEAR_API_KEY).toBe("lin_api_key");
     const linearTool = linearPlan.tools.find(
       (tool) => tool.name === "linear_graphql"
     );
     expect(linearTool?.env).toEqual({
-      LINEAR_GRAPHQL_URL: "https://linear.example/graphql",
+      LINEAR_GRAPHQL_URL: "https://api.linear.app/graphql",
     });
     expect(JSON.stringify(linearTool)).not.toContain("lin_api_key");
   });
@@ -256,7 +258,7 @@ describe("createGitCredentialHelperEnvironment", () => {
   it("configures git to use a renewable credential helper", () => {
     const env = createGitCredentialHelperEnvironment({
       githubTokenBrokerUrl:
-        "http://host.docker.internal:3000/api/workspaces/workspace-123/runtime-credentials",
+        "https://broker.example/api/workspaces/workspace-123/runtime-credentials",
       githubTokenBrokerSecret: "runtime-secret",
       githubTokenCachePath: "/workspace-runtime/.github-token.json",
     });
@@ -266,6 +268,15 @@ describe("createGitCredentialHelperEnvironment", () => {
     expect(env.GIT_CONFIG_KEY_0).toBe("credential.helper");
     expect(env.GIT_CONFIG_VALUE_0).toContain("git-credential-helper.js");
     expect(env.GITHUB_TOKEN_BROKER_URL).toContain("/runtime-credentials");
+  });
+
+  it("rejects non-https broker URLs before exposing them to git", () => {
+    expect(() =>
+      createGitCredentialHelperEnvironment({
+        githubTokenBrokerUrl: "http://broker.example/runtime-credentials",
+        githubTokenBrokerSecret: "runtime-secret",
+      })
+    ).toThrow(/must use https/);
   });
 });
 
@@ -279,21 +290,17 @@ describe("launchCodexAppServer", () => {
       projectId: "workspace-123",
       workingDirectory: "/tmp/workspace-123",
       githubTokenBrokerUrl:
-        "http://host.docker.internal:3000/api/workspaces/workspace-123/runtime-credentials",
+        "https://broker.example/api/workspaces/workspace-123/runtime-credentials",
       githubTokenBrokerSecret: "runtime-secret",
     });
 
     const child = launchCodexAppServer(plan, spawnImpl);
 
-    expect(spawnImpl).toHaveBeenCalledWith(
-      "codex",
-      ["app-server"],
-      {
-        cwd: "/tmp/workspace-123",
-        env: plan.env,
-        stdio: "pipe",
-      }
-    );
+    expect(spawnImpl).toHaveBeenCalledWith("codex", ["app-server"], {
+      cwd: "/tmp/workspace-123",
+      env: plan.env,
+      stdio: "pipe",
+    });
     expect(child).toEqual({
       pid: 42,
     });
@@ -708,7 +715,7 @@ describe("prepareCodexRuntimePlan", () => {
         projectId: "workspace-123",
         workingDirectory: "/tmp/workspace-123",
         githubTokenBrokerUrl:
-          "http://host.docker.internal:3000/api/workspaces/workspace-123/runtime-credentials",
+          "https://broker.example/api/workspaces/workspace-123/runtime-credentials",
         githubTokenBrokerSecret: "runtime-secret",
         agentCredentialBrokerUrl:
           "http://host.docker.internal:3000/api/workspaces/workspace-123/agent-credentials",

--- a/packages/runtime-codex/src/runtime.ts
+++ b/packages/runtime-codex/src/runtime.ts
@@ -13,7 +13,10 @@ import {
   type AgentEvent,
   type AgentRuntimeEvent,
 } from "@gh-symphony/core";
-import { createGitHubGraphQLMcpServerEntry } from "@gh-symphony/tool-github-graphql";
+import {
+  createGitHubGraphQLMcpServerEntry,
+  validateGitHubTokenBrokerUrl,
+} from "@gh-symphony/tool-github-graphql";
 import { createLinearGraphQLMcpServerEntry } from "@gh-symphony/tool-linear-graphql";
 
 const DEFAULT_GITHUB_GIT_HOST = "github.com";
@@ -723,6 +726,10 @@ export function createGitCredentialHelperEnvironment(
     | "githubTokenCachePath"
   >
 ): Record<string, string> {
+  const githubTokenBrokerUrl = config.githubTokenBrokerUrl
+    ? validateGitHubTokenBrokerUrl(config.githubTokenBrokerUrl)
+    : undefined;
+
   return {
     GITHUB_GIT_HOST: DEFAULT_GITHUB_GIT_HOST,
     GITHUB_GIT_USERNAME: DEFAULT_GITHUB_GIT_USERNAME,
@@ -737,9 +744,9 @@ export function createGitCredentialHelperEnvironment(
           GITHUB_GRAPHQL_TOKEN: config.githubToken,
         }
       : {}),
-    ...(config.githubTokenBrokerUrl
+    ...(githubTokenBrokerUrl
       ? {
-          GITHUB_TOKEN_BROKER_URL: config.githubTokenBrokerUrl,
+          GITHUB_TOKEN_BROKER_URL: githubTokenBrokerUrl,
         }
       : {}),
     ...(config.githubTokenBrokerSecret

--- a/packages/tool-github-graphql/src/index.ts
+++ b/packages/tool-github-graphql/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./tool.js";
 export * from "./mcp-server.js";
 export * from "./mcp-entry.js";
+export * from "./url-policy.js";

--- a/packages/tool-github-graphql/src/mcp-entry.ts
+++ b/packages/tool-github-graphql/src/mcp-entry.ts
@@ -1,4 +1,8 @@
 import { resolveGitHubGraphQLMcpServerEntryPoint } from "./mcp-server.js";
+import {
+  validateGitHubGraphQLApiUrl,
+  validateGitHubTokenBrokerUrl,
+} from "./url-policy.js";
 
 export const DEFAULT_GITHUB_GRAPHQL_API_URL = "https://api.github.com/graphql";
 
@@ -20,20 +24,26 @@ export type GitHubGraphQLMcpServerEntry = {
 export function createGitHubGraphQLMcpServerEntry(
   options: GitHubGraphQLMcpServerEntryOptions = {}
 ): GitHubGraphQLMcpServerEntry {
+  const githubGraphqlApiUrl = validateGitHubGraphQLApiUrl(
+    options.githubGraphqlApiUrl ?? DEFAULT_GITHUB_GRAPHQL_API_URL
+  );
+  const githubTokenBrokerUrl = options.githubTokenBrokerUrl
+    ? validateGitHubTokenBrokerUrl(options.githubTokenBrokerUrl)
+    : undefined;
+
   return {
     command: "node",
     args: [resolveGitHubGraphQLMcpServerEntryPoint()],
     env: {
-      GITHUB_GRAPHQL_API_URL:
-        options.githubGraphqlApiUrl ?? DEFAULT_GITHUB_GRAPHQL_API_URL,
+      GITHUB_GRAPHQL_API_URL: githubGraphqlApiUrl,
       ...(options.githubToken
         ? {
             GITHUB_GRAPHQL_TOKEN: options.githubToken,
           }
         : {}),
-      ...(options.githubTokenBrokerUrl
+      ...(githubTokenBrokerUrl
         ? {
-            GITHUB_TOKEN_BROKER_URL: options.githubTokenBrokerUrl,
+            GITHUB_TOKEN_BROKER_URL: githubTokenBrokerUrl,
           }
         : {}),
       ...(options.githubTokenBrokerSecret

--- a/packages/tool-github-graphql/src/tool.test.ts
+++ b/packages/tool-github-graphql/src/tool.test.ts
@@ -272,10 +272,30 @@ describe("resolveGitHubGraphQLToken", () => {
     ).rejects.toThrow(/private networks/);
     expect(fetchImpl).not.toHaveBeenCalled();
   });
+
+  it.each(["localhost.", "metadata.google.internal."])(
+    "rejects trailing-dot private broker host %s before HTTP",
+    async (hostname) => {
+      const fetchImpl = vi.fn();
+
+      await expect(
+        resolveGitHubGraphQLToken(
+          {
+            tokenBrokerUrl: `https://${hostname}/runtime-token`,
+            tokenBrokerSecret: "runtime-secret",
+          },
+          {
+            fetchImpl: fetchImpl as never,
+          }
+        )
+      ).rejects.toThrow(/private networks/);
+      expect(fetchImpl).not.toHaveBeenCalled();
+    }
+  );
 });
 
 describe("executeGitHubGraphQL", () => {
-  it("posts only to the allowlisted GitHub GraphQL API host", async () => {
+  it("posts to the public GitHub GraphQL API host", async () => {
     const fetchImpl = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({ data: { viewer: { login: "octo" } } }), {
         status: 200,
@@ -303,8 +323,12 @@ describe("executeGitHubGraphQL", () => {
     );
   });
 
-  it("rejects non-allowlisted GitHub GraphQL API URLs before HTTP", async () => {
-    const fetchImpl = vi.fn();
+  it("supports a configured public GHES GraphQL API URL", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ data: { viewer: { login: "octo" } } }), {
+        status: 200,
+      })
+    );
 
     await expect(
       executeGitHubGraphQL(
@@ -317,8 +341,11 @@ describe("executeGitHubGraphQL", () => {
         },
         fetchImpl as typeof fetch
       )
-    ).rejects.toThrow(/host is not allowlisted/);
-    expect(fetchImpl).not.toHaveBeenCalled();
+    ).resolves.toEqual({ data: { viewer: { login: "octo" } } });
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://github.example/api/graphql",
+      expect.objectContaining({ method: "POST" })
+    );
   });
 });
 

--- a/packages/tool-github-graphql/src/tool.test.ts
+++ b/packages/tool-github-graphql/src/tool.test.ts
@@ -6,7 +6,7 @@ import {
   DEFAULT_GITHUB_GRAPHQL_API_URL,
   createGitHubGraphQLMcpServerEntry,
 } from "./mcp-entry.js";
-import { resolveGitHubGraphQLToken } from "./tool.js";
+import { executeGitHubGraphQL, resolveGitHubGraphQLToken } from "./tool.js";
 
 const tempRoots: string[] = [];
 
@@ -36,7 +36,7 @@ describe("resolveGitHubGraphQLToken", () => {
 
     const token = await resolveGitHubGraphQLToken(
       {
-        tokenBrokerUrl: "http://127.0.0.1/runtime-token",
+        tokenBrokerUrl: "https://broker.example/runtime-token",
         tokenBrokerSecret: "runtime-secret",
         tokenCachePath: "/tmp/github-token-cache.json",
       },
@@ -69,7 +69,7 @@ describe("resolveGitHubGraphQLToken", () => {
 
     const token = await resolveGitHubGraphQLToken(
       {
-        tokenBrokerUrl: "http://127.0.0.1/runtime-token",
+        tokenBrokerUrl: "https://broker.example/runtime-token",
         tokenBrokerSecret: "runtime-secret",
         tokenCachePath: "/tmp/github-token-cache.json",
       },
@@ -136,7 +136,7 @@ describe("resolveGitHubGraphQLToken", () => {
     await expect(
       resolveGitHubGraphQLToken(
         {
-          tokenBrokerUrl: "http://127.0.0.1/runtime-token",
+          tokenBrokerUrl: "https://broker.example/runtime-token",
           tokenBrokerSecret: "runtime-secret",
           tokenCachePath: cachePath,
         },
@@ -159,7 +159,7 @@ describe("resolveGitHubGraphQLToken", () => {
     await expect(
       resolveGitHubGraphQLToken(
         {
-          tokenBrokerUrl: "http://127.0.0.1/runtime-token",
+          tokenBrokerUrl: "https://broker.example/runtime-token",
           tokenBrokerSecret: "runtime-secret",
           tokenCachePath: cachePath,
         },
@@ -190,7 +190,7 @@ describe("resolveGitHubGraphQLToken", () => {
     await expect(
       resolveGitHubGraphQLToken(
         {
-          tokenBrokerUrl: "http://127.0.0.1/runtime-token",
+          tokenBrokerUrl: "https://broker.example/runtime-token",
           tokenBrokerSecret: "runtime-secret",
           tokenCachePath: ".github-token-cache.json",
         },
@@ -206,7 +206,9 @@ describe("resolveGitHubGraphQLToken", () => {
             )
           ) as never,
           mkdirImpl: mkdirImpl as never,
-          readFileImpl: vi.fn().mockRejectedValue(new Error("missing")) as never,
+          readFileImpl: vi
+            .fn()
+            .mockRejectedValue(new Error("missing")) as never,
           writeFileImpl: writeFileImpl as never,
         }
       )
@@ -218,6 +220,105 @@ describe("resolveGitHubGraphQLToken", () => {
     });
     expect(chmodImpl).not.toHaveBeenCalledWith(".", 0o700);
     expect(chmodImpl).toHaveBeenCalledWith(".github-token-cache.json", 0o600);
+  });
+
+  it("rejects non-https token broker URLs before HTTP", async () => {
+    const fetchImpl = vi.fn();
+
+    await expect(
+      resolveGitHubGraphQLToken(
+        {
+          tokenBrokerUrl: "http://broker.example/runtime-token",
+          tokenBrokerSecret: "runtime-secret",
+        },
+        {
+          fetchImpl: fetchImpl as never,
+        }
+      )
+    ).rejects.toThrow(/must use https/);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("rejects private token broker URLs before HTTP", async () => {
+    const fetchImpl = vi.fn();
+
+    await expect(
+      resolveGitHubGraphQLToken(
+        {
+          tokenBrokerUrl: "https://169.254.169.254/latest/meta-data",
+          tokenBrokerSecret: "runtime-secret",
+        },
+        {
+          fetchImpl: fetchImpl as never,
+        }
+      )
+    ).rejects.toThrow(/private networks/);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("rejects IPv4-mapped private token broker URLs before HTTP", async () => {
+    const fetchImpl = vi.fn();
+
+    await expect(
+      resolveGitHubGraphQLToken(
+        {
+          tokenBrokerUrl: "https://[::ffff:127.0.0.1]/runtime-token",
+          tokenBrokerSecret: "runtime-secret",
+        },
+        {
+          fetchImpl: fetchImpl as never,
+        }
+      )
+    ).rejects.toThrow(/private networks/);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+});
+
+describe("executeGitHubGraphQL", () => {
+  it("posts only to the allowlisted GitHub GraphQL API host", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ data: { viewer: { login: "octo" } } }), {
+        status: 200,
+      })
+    );
+
+    await expect(
+      executeGitHubGraphQL(
+        {
+          query: "query Viewer { viewer { login } }",
+        },
+        {
+          token: "ghs_static",
+          apiUrl: "https://api.github.com/graphql",
+        },
+        fetchImpl as typeof fetch
+      )
+    ).resolves.toEqual({ data: { viewer: { login: "octo" } } });
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://api.github.com/graphql",
+      expect.objectContaining({
+        method: "POST",
+      })
+    );
+  });
+
+  it("rejects non-allowlisted GitHub GraphQL API URLs before HTTP", async () => {
+    const fetchImpl = vi.fn();
+
+    await expect(
+      executeGitHubGraphQL(
+        {
+          query: "query Viewer { viewer { login } }",
+        },
+        {
+          token: "ghs_static",
+          apiUrl: "https://github.example/api/graphql",
+        },
+        fetchImpl as typeof fetch
+      )
+    ).rejects.toThrow(/host is not allowlisted/);
+    expect(fetchImpl).not.toHaveBeenCalled();
   });
 });
 
@@ -236,19 +337,19 @@ describe("createGitHubGraphQLMcpServerEntry", () => {
     expect(
       createGitHubGraphQLMcpServerEntry({
         githubToken: "ghs_token",
-        githubTokenBrokerUrl: "http://127.0.0.1/runtime-token",
+        githubTokenBrokerUrl: "https://broker.example/runtime-token",
         githubTokenBrokerSecret: "secret",
         githubTokenCachePath: "/tmp/github-token-cache.json",
         githubProjectId: "project-1",
-        githubGraphqlApiUrl: "https://github.example/api/graphql",
+        githubGraphqlApiUrl: "https://api.github.com/graphql",
       })
     ).toEqual({
       command: "node",
       args: [expect.stringContaining("mcp-server.js")],
       env: {
-        GITHUB_GRAPHQL_API_URL: "https://github.example/api/graphql",
+        GITHUB_GRAPHQL_API_URL: "https://api.github.com/graphql",
         GITHUB_GRAPHQL_TOKEN: "ghs_token",
-        GITHUB_TOKEN_BROKER_URL: "http://127.0.0.1/runtime-token",
+        GITHUB_TOKEN_BROKER_URL: "https://broker.example/runtime-token",
         GITHUB_TOKEN_BROKER_SECRET: "secret",
         GITHUB_TOKEN_CACHE_PATH: "/tmp/github-token-cache.json",
         GITHUB_PROJECT_ID: "project-1",

--- a/packages/tool-github-graphql/src/tool.ts
+++ b/packages/tool-github-graphql/src/tool.ts
@@ -1,5 +1,9 @@
 import { chmod, mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
+import {
+  validateGitHubGraphQLApiUrl,
+  validateGitHubTokenBrokerUrl,
+} from "./url-policy.js";
 
 const DEFAULT_GITHUB_GRAPHQL_API_URL = "https://api.github.com/graphql";
 const TOKEN_REUSE_WINDOW_MS = 60 * 1000;
@@ -26,17 +30,17 @@ export async function executeGitHubGraphQL(
   const token = await resolveGitHubGraphQLToken(config, {
     fetchImpl,
   });
-  const response = await fetchImpl(
-    config.apiUrl ?? DEFAULT_GITHUB_GRAPHQL_API_URL,
-    {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-        authorization: `Bearer ${token}`,
-      },
-      body: JSON.stringify(invocation),
-    }
+  const apiUrl = validateGitHubGraphQLApiUrl(
+    config.apiUrl ?? DEFAULT_GITHUB_GRAPHQL_API_URL
   );
+  const response = await fetchImpl(apiUrl, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(invocation),
+  });
 
   const payload = (await response.json()) as {
     errors?: Array<{ message: string }>;
@@ -96,7 +100,8 @@ export async function resolveGitHubGraphQLToken(
   }
 
   const fetchImpl = dependencies.fetchImpl ?? fetch;
-  const response = await fetchImpl(config.tokenBrokerUrl, {
+  const tokenBrokerUrl = validateGitHubTokenBrokerUrl(config.tokenBrokerUrl);
+  const response = await fetchImpl(tokenBrokerUrl, {
     method: "POST",
     headers: {
       accept: "application/json",

--- a/packages/tool-github-graphql/src/url-policy.ts
+++ b/packages/tool-github-graphql/src/url-policy.ts
@@ -1,0 +1,147 @@
+import { isIP } from "node:net";
+
+const GITHUB_GRAPHQL_HOST = "api.github.com";
+const BLOCKED_HOSTS = new Set([
+  "localhost",
+  "metadata.google.internal",
+  "169.254.169.254",
+]);
+const BLOCKED_HOST_SUFFIXES = [".localhost", ".local", ".internal"];
+
+export function validateGitHubGraphQLApiUrl(value: string): string {
+  return validateSecureUrl(
+    value,
+    "GitHub GraphQL API URL",
+    (hostname) => hostname === GITHUB_GRAPHQL_HOST
+  );
+}
+
+export function validateGitHubTokenBrokerUrl(value: string): string {
+  return validateSecureUrl(value, "GitHub token broker URL");
+}
+
+function validateSecureUrl(
+  value: string,
+  label: string,
+  allowHost?: (hostname: string) => boolean
+): string {
+  const url = parseUrl(value, label);
+  const hostname = normalizeHostname(url.hostname);
+
+  if (url.protocol !== "https:") {
+    throw new Error(`${label} must use https.`);
+  }
+
+  if (!hostname || isBlockedHostname(hostname) || isPrivateIp(hostname)) {
+    throw new Error(`${label} must not target localhost or private networks.`);
+  }
+
+  if (allowHost && !allowHost(hostname)) {
+    throw new Error(`${label} host is not allowlisted.`);
+  }
+
+  return url.href;
+}
+
+function parseUrl(value: string, label: string): URL {
+  try {
+    return new URL(value);
+  } catch {
+    throw new Error(`${label} must be a valid URL.`);
+  }
+}
+
+function normalizeHostname(hostname: string): string {
+  return hostname.replace(/^\[|\]$/g, "").toLowerCase();
+}
+
+function isBlockedHostname(hostname: string): boolean {
+  return (
+    BLOCKED_HOSTS.has(hostname) ||
+    BLOCKED_HOST_SUFFIXES.some((suffix) => hostname.endsWith(suffix))
+  );
+}
+
+function isPrivateIp(hostname: string): boolean {
+  const ipVersion = isIP(hostname);
+
+  if (ipVersion === 4) {
+    return isPrivateIpv4(hostname);
+  }
+
+  if (ipVersion === 6) {
+    return isPrivateIpv6(hostname);
+  }
+
+  return false;
+}
+
+function isPrivateIpv4(hostname: string): boolean {
+  const parts = hostname.split(".").map((part) => Number(part));
+
+  if (parts.length !== 4 || parts.some((part) => !Number.isInteger(part))) {
+    return false;
+  }
+
+  const [a, b] = parts as [number, number, number, number];
+  return (
+    a === 0 ||
+    a === 10 ||
+    a === 127 ||
+    (a === 100 && b >= 64 && b <= 127) ||
+    (a === 169 && b === 254) ||
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 192 && b === 168) ||
+    (a === 198 && (b === 18 || b === 19)) ||
+    a >= 224
+  );
+}
+
+function isPrivateIpv6(hostname: string): boolean {
+  const normalized = hostname.toLowerCase();
+  const ipv4MappedPrefix = "::ffff:";
+
+  if (normalized.startsWith(ipv4MappedPrefix)) {
+    const mappedIpv4 = parseIpv4MappedIpv6(
+      normalized.slice(ipv4MappedPrefix.length)
+    );
+    return mappedIpv4 ? isPrivateIpv4(mappedIpv4) : true;
+  }
+
+  return (
+    normalized === "::" ||
+    normalized === "::1" ||
+    normalized.startsWith("fc") ||
+    normalized.startsWith("fd") ||
+    normalized.startsWith("fe80:")
+  );
+}
+
+function parseIpv4MappedIpv6(value: string): string | null {
+  if (value.includes(".")) {
+    return value;
+  }
+
+  const parts = value.split(":");
+  if (parts.length !== 2) {
+    return null;
+  }
+
+  const high = Number.parseInt(parts[0] ?? "", 16);
+  const low = Number.parseInt(parts[1] ?? "", 16);
+
+  if (
+    !Number.isInteger(high) ||
+    !Number.isInteger(low) ||
+    high < 0 ||
+    high > 0xffff ||
+    low < 0 ||
+    low > 0xffff
+  ) {
+    return null;
+  }
+
+  return [(high >> 8) & 0xff, high & 0xff, (low >> 8) & 0xff, low & 0xff].join(
+    "."
+  );
+}

--- a/packages/tool-github-graphql/src/url-policy.ts
+++ b/packages/tool-github-graphql/src/url-policy.ts
@@ -1,6 +1,5 @@
 import { isIP } from "node:net";
 
-const GITHUB_GRAPHQL_HOST = "api.github.com";
 const BLOCKED_HOSTS = new Set([
   "localhost",
   "metadata.google.internal",
@@ -9,11 +8,7 @@ const BLOCKED_HOSTS = new Set([
 const BLOCKED_HOST_SUFFIXES = [".localhost", ".local", ".internal"];
 
 export function validateGitHubGraphQLApiUrl(value: string): string {
-  return validateSecureUrl(
-    value,
-    "GitHub GraphQL API URL",
-    (hostname) => hostname === GITHUB_GRAPHQL_HOST
-  );
+  return validateSecureUrl(value, "GitHub GraphQL API URL");
 }
 
 export function validateGitHubTokenBrokerUrl(value: string): string {
@@ -52,7 +47,10 @@ function parseUrl(value: string, label: string): URL {
 }
 
 function normalizeHostname(hostname: string): string {
-  return hostname.replace(/^\[|\]$/g, "").toLowerCase();
+  return hostname
+    .replace(/^\[|\]$/g, "")
+    .replace(/\.+$/, "")
+    .toLowerCase();
 }
 
 function isBlockedHostname(hostname: string): boolean {

--- a/packages/tool-linear-graphql/src/index.ts
+++ b/packages/tool-linear-graphql/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./tool.js";
 export * from "./mcp-server.js";
 export * from "./mcp-entry.js";
+export * from "./url-policy.js";

--- a/packages/tool-linear-graphql/src/mcp-entry.ts
+++ b/packages/tool-linear-graphql/src/mcp-entry.ts
@@ -1,5 +1,6 @@
 import { resolveLinearGraphQLMcpServerEntryPoint } from "./mcp-server.js";
 import { DEFAULT_LINEAR_GRAPHQL_API_URL } from "./tool.js";
+import { validateLinearGraphQLApiUrl } from "./url-policy.js";
 
 export type LinearGraphQLMcpServerEntryOptions = {
   linearGraphqlUrl?: string;
@@ -14,12 +15,15 @@ export type LinearGraphQLMcpServerEntry = {
 export function createLinearGraphQLMcpServerEntry(
   options: LinearGraphQLMcpServerEntryOptions = {}
 ): LinearGraphQLMcpServerEntry {
+  const linearGraphqlUrl = validateLinearGraphQLApiUrl(
+    options.linearGraphqlUrl ?? DEFAULT_LINEAR_GRAPHQL_API_URL
+  );
+
   return {
     command: "node",
     args: [resolveLinearGraphQLMcpServerEntryPoint()],
     env: {
-      LINEAR_GRAPHQL_URL:
-        options.linearGraphqlUrl ?? DEFAULT_LINEAR_GRAPHQL_API_URL,
+      LINEAR_GRAPHQL_URL: linearGraphqlUrl,
     },
   };
 }

--- a/packages/tool-linear-graphql/src/tool.test.ts
+++ b/packages/tool-linear-graphql/src/tool.test.ts
@@ -162,6 +162,24 @@ describe("executeLinearGraphQL", () => {
     expect(fetchImpl).not.toHaveBeenCalled();
   });
 
+  it("rejects trailing-dot localhost Linear GraphQL URLs before HTTP", async () => {
+    const fetchImpl = vi.fn();
+
+    await expect(
+      executeLinearGraphQL(
+        {
+          query: "query Viewer { viewer { id } }",
+        },
+        {
+          apiKey: "lin_api_key",
+          apiUrl: "https://localhost./graphql",
+        },
+        fetchImpl as typeof fetch
+      )
+    ).rejects.toThrow(/private networks/);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
   it("rejects IPv4-mapped private Linear GraphQL URLs before HTTP", async () => {
     const fetchImpl = vi.fn();
 

--- a/packages/tool-linear-graphql/src/tool.test.ts
+++ b/packages/tool-linear-graphql/src/tool.test.ts
@@ -74,14 +74,14 @@ describe("executeLinearGraphQL", () => {
         },
         {
           authorizationHeader: "Bearer runtime-linear-token",
-          apiUrl: "https://linear.example/graphql",
+          apiUrl: "https://api.linear.app/graphql",
         },
         fetchImpl as typeof fetch
       )
     ).resolves.toEqual({ data: { ok: true } });
 
     expect(fetchImpl).toHaveBeenCalledWith(
-      "https://linear.example/graphql",
+      "https://api.linear.app/graphql",
       expect.objectContaining({
         method: "POST",
         headers: {
@@ -125,6 +125,78 @@ describe("executeLinearGraphQL", () => {
     ).rejects.toThrow(/exactly one GraphQL operation/);
     expect(fetchImpl).not.toHaveBeenCalled();
   });
+
+  it("rejects non-https Linear GraphQL URLs before HTTP", async () => {
+    const fetchImpl = vi.fn();
+
+    await expect(
+      executeLinearGraphQL(
+        {
+          query: "query Viewer { viewer { id } }",
+        },
+        {
+          apiKey: "lin_api_key",
+          apiUrl: "http://api.linear.app/graphql",
+        },
+        fetchImpl as typeof fetch
+      )
+    ).rejects.toThrow(/must use https/);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("rejects private Linear GraphQL URLs before HTTP", async () => {
+    const fetchImpl = vi.fn();
+
+    await expect(
+      executeLinearGraphQL(
+        {
+          query: "query Viewer { viewer { id } }",
+        },
+        {
+          apiKey: "lin_api_key",
+          apiUrl: "https://10.0.0.2/graphql",
+        },
+        fetchImpl as typeof fetch
+      )
+    ).rejects.toThrow(/private networks/);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("rejects IPv4-mapped private Linear GraphQL URLs before HTTP", async () => {
+    const fetchImpl = vi.fn();
+
+    await expect(
+      executeLinearGraphQL(
+        {
+          query: "query Viewer { viewer { id } }",
+        },
+        {
+          apiKey: "lin_api_key",
+          apiUrl: "https://[::ffff:127.0.0.1]/graphql",
+        },
+        fetchImpl as typeof fetch
+      )
+    ).rejects.toThrow(/private networks/);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-allowlisted Linear GraphQL URLs before HTTP", async () => {
+    const fetchImpl = vi.fn();
+
+    await expect(
+      executeLinearGraphQL(
+        {
+          query: "query Viewer { viewer { id } }",
+        },
+        {
+          apiKey: "lin_api_key",
+          apiUrl: "https://linear.example/graphql",
+        },
+        fetchImpl as typeof fetch
+      )
+    ).rejects.toThrow(/host is not allowlisted/);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
 });
 
 describe("resolveLinearAuthorizationHeader", () => {
@@ -158,13 +230,13 @@ describe("createLinearGraphQLMcpServerEntry", () => {
   it("keeps auth out of the MCP server entry environment", () => {
     expect(
       createLinearGraphQLMcpServerEntry({
-        linearGraphqlUrl: "https://linear.example/graphql",
+        linearGraphqlUrl: "https://api.linear.app/graphql",
       })
     ).toEqual({
       command: "node",
       args: [expect.stringContaining("mcp-server.js")],
       env: {
-        LINEAR_GRAPHQL_URL: "https://linear.example/graphql",
+        LINEAR_GRAPHQL_URL: "https://api.linear.app/graphql",
       },
     });
   });

--- a/packages/tool-linear-graphql/src/tool.ts
+++ b/packages/tool-linear-graphql/src/tool.ts
@@ -1,4 +1,5 @@
 import { parse } from "graphql";
+import { validateLinearGraphQLApiUrl } from "./url-policy.js";
 
 export const DEFAULT_LINEAR_GRAPHQL_API_URL = "https://api.linear.app/graphql";
 
@@ -21,17 +22,17 @@ export async function executeLinearGraphQL(
 ): Promise<unknown> {
   validateLinearGraphQLInvocation(invocation);
   const authorization = resolveLinearAuthorizationHeader(config);
-  const response = await fetchImpl(
-    config.apiUrl ?? DEFAULT_LINEAR_GRAPHQL_API_URL,
-    {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-        authorization,
-      },
-      body: JSON.stringify(invocation),
-    }
+  const apiUrl = validateLinearGraphQLApiUrl(
+    config.apiUrl ?? DEFAULT_LINEAR_GRAPHQL_API_URL
   );
+  const response = await fetchImpl(apiUrl, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization,
+    },
+    body: JSON.stringify(invocation),
+  });
 
   const payload = (await response.json()) as {
     errors?: Array<{ message: string }>;

--- a/packages/tool-linear-graphql/src/url-policy.ts
+++ b/packages/tool-linear-graphql/src/url-policy.ts
@@ -42,7 +42,10 @@ function parseUrl(value: string, label: string): URL {
 }
 
 function normalizeHostname(hostname: string): string {
-  return hostname.replace(/^\[|\]$/g, "").toLowerCase();
+  return hostname
+    .replace(/^\[|\]$/g, "")
+    .replace(/\.+$/, "")
+    .toLowerCase();
 }
 
 function isBlockedHostname(hostname: string): boolean {

--- a/packages/tool-linear-graphql/src/url-policy.ts
+++ b/packages/tool-linear-graphql/src/url-policy.ts
@@ -1,0 +1,137 @@
+import { isIP } from "node:net";
+
+const LINEAR_GRAPHQL_HOST = "api.linear.app";
+const LINEAR_GRAPHQL_HOST_SUFFIX = ".linear.app";
+const BLOCKED_HOSTS = new Set([
+  "localhost",
+  "metadata.google.internal",
+  "169.254.169.254",
+]);
+const BLOCKED_HOST_SUFFIXES = [".localhost", ".local", ".internal"];
+
+export function validateLinearGraphQLApiUrl(value: string): string {
+  const url = parseUrl(value, "Linear GraphQL API URL");
+  const hostname = normalizeHostname(url.hostname);
+
+  if (url.protocol !== "https:") {
+    throw new Error("Linear GraphQL API URL must use https.");
+  }
+
+  if (!hostname || isBlockedHostname(hostname) || isPrivateIp(hostname)) {
+    throw new Error(
+      "Linear GraphQL API URL must not target localhost or private networks."
+    );
+  }
+
+  if (
+    hostname !== LINEAR_GRAPHQL_HOST &&
+    !hostname.endsWith(LINEAR_GRAPHQL_HOST_SUFFIX)
+  ) {
+    throw new Error("Linear GraphQL API URL host is not allowlisted.");
+  }
+
+  return url.href;
+}
+
+function parseUrl(value: string, label: string): URL {
+  try {
+    return new URL(value);
+  } catch {
+    throw new Error(`${label} must be a valid URL.`);
+  }
+}
+
+function normalizeHostname(hostname: string): string {
+  return hostname.replace(/^\[|\]$/g, "").toLowerCase();
+}
+
+function isBlockedHostname(hostname: string): boolean {
+  return (
+    BLOCKED_HOSTS.has(hostname) ||
+    BLOCKED_HOST_SUFFIXES.some((suffix) => hostname.endsWith(suffix))
+  );
+}
+
+function isPrivateIp(hostname: string): boolean {
+  const ipVersion = isIP(hostname);
+
+  if (ipVersion === 4) {
+    return isPrivateIpv4(hostname);
+  }
+
+  if (ipVersion === 6) {
+    return isPrivateIpv6(hostname);
+  }
+
+  return false;
+}
+
+function isPrivateIpv4(hostname: string): boolean {
+  const parts = hostname.split(".").map((part) => Number(part));
+
+  if (parts.length !== 4 || parts.some((part) => !Number.isInteger(part))) {
+    return false;
+  }
+
+  const [a, b] = parts as [number, number, number, number];
+  return (
+    a === 0 ||
+    a === 10 ||
+    a === 127 ||
+    (a === 100 && b >= 64 && b <= 127) ||
+    (a === 169 && b === 254) ||
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 192 && b === 168) ||
+    (a === 198 && (b === 18 || b === 19)) ||
+    a >= 224
+  );
+}
+
+function isPrivateIpv6(hostname: string): boolean {
+  const normalized = hostname.toLowerCase();
+  const ipv4MappedPrefix = "::ffff:";
+
+  if (normalized.startsWith(ipv4MappedPrefix)) {
+    const mappedIpv4 = parseIpv4MappedIpv6(
+      normalized.slice(ipv4MappedPrefix.length)
+    );
+    return mappedIpv4 ? isPrivateIpv4(mappedIpv4) : true;
+  }
+
+  return (
+    normalized === "::" ||
+    normalized === "::1" ||
+    normalized.startsWith("fc") ||
+    normalized.startsWith("fd") ||
+    normalized.startsWith("fe80:")
+  );
+}
+
+function parseIpv4MappedIpv6(value: string): string | null {
+  if (value.includes(".")) {
+    return value;
+  }
+
+  const parts = value.split(":");
+  if (parts.length !== 2) {
+    return null;
+  }
+
+  const high = Number.parseInt(parts[0] ?? "", 16);
+  const low = Number.parseInt(parts[1] ?? "", 16);
+
+  if (
+    !Number.isInteger(high) ||
+    !Number.isInteger(low) ||
+    high < 0 ||
+    high > 0xffff ||
+    low < 0 ||
+    low > 0xffff
+  ) {
+    return null;
+  }
+
+  return [(high >> 8) & 0xff, high & 0xff, (low >> 8) & 0xff, low & 0xff].join(
+    "."
+  );
+}


### PR DESCRIPTION
## TL;DR

- `tokenBrokerUrl`, `githubGraphqlApiUrl`, `linearGraphqlUrl`을 credential-bearing fetch 전에 검증합니다.
- HTTPS를 강제하고 localhost·사설 IP·metadata host와 DNS 후행 점 우회를 거부합니다.
- Linear는 `api.linear.app`/`*.linear.app` allowlist를 유지하고, GitHub는 공개 GHES 설정 엔드포인트를 지원합니다.

## 변경 지점 다이어그램

```text
WORKFLOW.md / env URL
  ├─ GitHub GraphQL ─┬─ HTTPS + public-host policy ─→ fetch
  │                  └─ api.github.com 또는 공개 GHES
  ├─ GitHub broker ─── HTTPS + private-host policy ─→ token fetch
  └─ Linear GraphQL ── HTTPS + *.linear.app policy ─→ fetch
                         ↑ trailing DNS dots normalized
```

## 여기부터 보세요

- `packages/tool-github-graphql/src/url-policy.ts` — GitHub API/broker URL 보안 경계와 GHES 호환
- `packages/tool-linear-graphql/src/url-policy.ts` — Linear allowlist와 사설망 차단
- `packages/tool-github-graphql/src/tool.test.ts` — broker FQDN 우회 및 GHES 회귀 TC
- `packages/tool-linear-graphql/src/tool.test.ts` — Linear FQDN 우회 TC

## 위험 & 롤백

- 위험: 기존에 HTTP 또는 localhost/사설망 broker·GraphQL URL을 사용한 설정은 fetch 전에 거부됩니다.
- 호환: 문서화된 공개 GHES GraphQL 엔드포인트는 허용하고, Linear custom host는 기존 보안 allowlist에 따라 거부합니다.
- 롤백: 이 PR의 squash commit을 revert하면 기존 URL 처리로 복귀합니다.

## 변경 파일

- GitHub GraphQL/token broker 및 Linear GraphQL fetch 전에 URL 검증 추가
- DNS trailing-dot, IPv4/IPv6 및 IPv4-mapped IPv6 사설망 우회 차단
- runtime-codex credential helper와 runtime GraphQL MCP 경로에 검증 연결
- non-HTTPS·사설망·allowlist·trailing-dot·GHES 회귀 TC 추가
- `@gh-symphony/cli` patch changeset 추가

## Evidence

- `pnpm exec vitest run packages/tool-github-graphql/src/tool.test.ts packages/tool-linear-graphql/src/tool.test.ts` — 32 passed
- `pnpm lint` — pass
- `pnpm test` — pass
- `pnpm typecheck` — pass
- `pnpm build` — pass
- `PATH="$HOME/.nvm/versions/node/v24.15.0/bin:$PATH" node packages/cli/dist/index.js doctor --smoke --issue hojinzs/github-symphony#444 --json` — pass (`ok=true`)

## Issues — Closed #444

Fixes #444

## 머지 후/사람 확인

- [ ] 필요 시 실제 배포 환경의 broker URL이 public HTTPS host인지 확인
- [ ] 실제 GHES 환경을 사용하는 경우 configured GraphQL endpoint smoke test 확인

## Human Validation

- [ ] 보안 거부 동작이 이슈 요구사항과 일치하는지 확인
- [ ] GHES 호환 회귀가 해소되었는지 확인
- [ ] 인접 broker/Linear 동작에 명백한 회귀가 없는지 확인

