### PR TITLE
fix: 손상 폴백을 fail-loud로 전환

### DIFF
--- a/.changeset/fail-loud-tracker-workflow-errors.md
+++ b/.changeset/fail-loud-tracker-workflow-errors.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Surface corrupt file-tracker data, missing GitHub Project state metadata, and repeated invalid WORKFLOW.md reloads as observable errors instead of silent fallbacks for #441.

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -4189,6 +4189,42 @@ Prefer focused changes.
     );
   });
 
+  it("reports the same invalid WORKFLOW.md on every reconciliation tick", async () => {
+    process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
+    const tempRoot = await mkdtemp(
+      join(tmpdir(), "orchestrator-workflow-invalid-observability-")
+    );
+    const repository = await createRepositoryFixture(
+      tempRoot,
+      "acme",
+      "platform"
+    );
+    const store = new OrchestratorFsStore(tempRoot);
+    const projectConfig = createProjectConfig(tempRoot, repository);
+    await store.saveProjectConfig(projectConfig);
+
+    const stderrWrite = vi.fn(() => true);
+    const service = new OrchestratorService(store, projectConfig, {
+      fetchImpl: vi.fn().mockResolvedValue(createEmptyTrackerResponse()),
+      stderr: { write: stderrWrite },
+      now: () => new Date("2026-03-08T00:00:00.000Z"),
+    });
+
+    await service.runOnce();
+    await commitWorkflowFixture(repository.path, {
+      rawWorkflow: "---\ninvalid: [\n---\n",
+    });
+
+    await service.runOnce();
+    await service.runOnce();
+
+    expect(
+      stderrWrite.mock.calls.filter(([message]) =>
+        String(message).includes("failed to reload WORKFLOW.md")
+      )
+    ).toHaveLength(2);
+  });
+
   it("keeps a readable workflow snapshot when WORKFLOW.md is deleted", async () => {
     process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
     const tempRoot = await mkdtemp(

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -326,7 +326,6 @@ export class OrchestratorService {
     string,
     WorkflowResolution
   >();
-  private readonly lastReportedWorkflowErrors = new Map<string, string>();
   private readonly lastTrackerRateLimitsByProject = new Map<
     string,
     Record<string, unknown>
@@ -1443,8 +1442,7 @@ export class OrchestratorService {
     return this.resolveWorkflowResolution(
       repository,
       cacheRoot,
-      resolution,
-      true
+      resolution
     );
   }
 
@@ -3081,8 +3079,7 @@ export class OrchestratorService {
   private async resolveWorkflowResolution(
     repository: RepositoryRef,
     cacheRoot: string,
-    resolution: WorkflowResolution,
-    changed: boolean
+    resolution: WorkflowResolution
   ): Promise<WorkflowResolution> {
     const cacheKey = this.workflowCacheKey(repository);
 
@@ -3107,20 +3104,15 @@ export class OrchestratorService {
         ...effectiveResolution,
         workflowPath,
       });
-      this.lastReportedWorkflowErrors.delete(cacheKey);
       return effectiveResolution;
     }
 
     const cached = this.lastKnownGoodWorkflows.get(cacheKey);
     const message =
       resolution.validationError ?? "Invalid repository WORKFLOW.md";
-    const previousMessage = this.lastReportedWorkflowErrors.get(cacheKey);
-    if (changed || previousMessage !== message) {
-      process.stderr.write(
-        `[orchestrator] failed to reload WORKFLOW.md for ${repository.owner}/${repository.name}: ${message}\n`
-      );
-      this.lastReportedWorkflowErrors.set(cacheKey, message);
-    }
+    this.writeStderr(
+      `[orchestrator] failed to reload WORKFLOW.md for ${repository.owner}/${repository.name}: ${message}`
+    );
 
     if (!cached) {
       return resolution;

--- a/packages/tracker-file/src/file-tracker-adapter.test.ts
+++ b/packages/tracker-file/src/file-tracker-adapter.test.ts
@@ -102,14 +102,14 @@ describe("fileTrackerAdapter", () => {
       expect(issues[1].id).toBe("issue-1");
     });
 
-    it("returns empty array when file contains truncated JSON", async () => {
+    it("fails loudly when file contains truncated JSON", async () => {
       const issuesPath = join(testDir, "truncated.json");
       await writeFile(issuesPath, '[{"id":');
 
       const project = makeProject(issuesPath);
-      const issues = await fileTrackerAdapter.listIssues(project);
-
-      expect(issues).toEqual([]);
+      await expect(fileTrackerAdapter.listIssues(project)).rejects.toThrow(
+        `[tracker-file] Failed to parse issues JSON at ${issuesPath}`,
+      );
     });
 
     it("throws when file contains non-array JSON", async () => {

--- a/packages/tracker-file/src/file-tracker-adapter.ts
+++ b/packages/tracker-file/src/file-tracker-adapter.ts
@@ -68,9 +68,11 @@ export const fileTrackerAdapter: OrchestratorTrackerAdapter = {
       ) {
         return [];
       }
-      // Gracefully handle truncated/partial JSON from concurrent writes
       if (err instanceof SyntaxError) {
-        return [];
+        throw new Error(
+          `[tracker-file] Failed to parse issues JSON at ${issuesPath}: ${err.message}`,
+          { cause: err },
+        );
       }
       throw err;
     }

--- a/packages/tracker-github/src/adapter.ts
+++ b/packages/tracker-github/src/adapter.ts
@@ -344,7 +344,7 @@ export function normalizeProjectItem(
   }
 
   const fieldValues = extractFieldValues(item.fieldValues?.nodes ?? []);
-  const state = fieldValues[lifecycle.stateFieldName] ?? "Unknown";
+  const state = requireProjectItemState(fieldValues, lifecycle, item.id);
 
   if (item.content.__typename === "PullRequest") {
     return normalizePullRequestProjectItem(
@@ -954,6 +954,31 @@ function extractFieldValues(
   }, {});
 }
 
+function requireProjectItemState(
+  fieldValues: Record<string, string>,
+  lifecycle: WorkflowLifecycleConfig,
+  itemId: string
+): string {
+  const stateFieldName =
+    typeof lifecycle.stateFieldName === "string"
+      ? lifecycle.stateFieldName.trim()
+      : "";
+  if (!stateFieldName) {
+    throw new GitHubTrackerQueryError(
+      `github_project_state_field_unconfigured: Project item ${itemId} cannot be normalized without lifecycle.stateFieldName.`
+    );
+  }
+
+  const state = fieldValues[stateFieldName];
+  if (!state) {
+    throw new GitHubTrackerQueryError(
+      `github_project_state_field_missing: Project item ${itemId} did not include configured state field "${stateFieldName}".`
+    );
+  }
+
+  return state;
+}
+
 function normalizeIssueStateLookupNode(
   projectId: string,
   issue: GraphQLIssueStateLookupNode | null,
@@ -969,7 +994,11 @@ function normalizeIssueStateLookupNode(
   }
 
   const fieldValues = extractFieldValues(projectItem.fieldValues?.nodes ?? []);
-  const state = fieldValues[lifecycle.stateFieldName] ?? "Unknown";
+  const state = requireProjectItemState(
+    fieldValues,
+    lifecycle,
+    projectItem.id
+  );
   const repository = issue.repository;
   const identifier = `${repository.owner.login}/${repository.name}#${issue.number}`;
   const url =

--- a/packages/tracker-github/src/tracker-github.test.ts
+++ b/packages/tracker-github/src/tracker-github.test.ts
@@ -363,6 +363,45 @@ describe("resolveTrackerAdapter", () => {
     expect(issue?.metadata).toEqual({ Status: "Ready" });
   });
 
+  it("fails loudly when a Project item omits the configured state field", () => {
+    const item = makeProjectItem({
+      itemId: "item-missing-state",
+      issueId: "issue-1",
+      number: 1,
+      title: "Missing state metadata",
+      assignees: [],
+    });
+    item.fieldValues = { nodes: [] };
+
+    expect(() =>
+      normalizeGithubProjectItem(
+        "project-123",
+        item,
+        DEFAULT_WORKFLOW_LIFECYCLE
+      )
+    ).toThrow(
+      'github_project_state_field_missing: Project item item-missing-state did not include configured state field "Status".'
+    );
+  });
+
+  it("fails loudly when lifecycle.stateFieldName is empty", () => {
+    expect(() =>
+      normalizeGithubProjectItem(
+        "project-123",
+        makeProjectItem({
+          itemId: "item-unconfigured-state",
+          issueId: "issue-1",
+          number: 1,
+          title: "Unconfigured state metadata",
+          assignees: [],
+        }),
+        { ...DEFAULT_WORKFLOW_LIFECYCLE, stateFieldName: "" }
+      )
+    ).toThrow(
+      "github_project_state_field_unconfigured: Project item item-unconfigured-state cannot be normalized without lifecycle.stateFieldName."
+    );
+  });
+
   it("normalizes PullRequest Project item content instead of dropping it", () => {
     const issue = normalizeGithubProjectItem(
       "project-123",
@@ -3500,6 +3539,38 @@ describe("resolveTrackerAdapter", () => {
     expect(issues[0]?.branchName).toBe("feature/pr-card");
     expect(issues[0]?.url).toBe("https://github.com/acme/platform/pull/42");
     expect(issues[0]?.tracker.itemId).toBe("item-pr-1");
+  });
+
+  it("fails loudly when refreshed Project metadata omits the state field", async () => {
+    const adapter = resolveTrackerAdapter({
+      adapter: "github-project",
+      bindingId: "project-123",
+      settings: {
+        projectId: "project-123",
+      },
+    });
+    const node = makeIssueStateLookupNode({
+      projectId: "project-123",
+      itemId: "item-missing-state",
+      issueId: "issue-1",
+      number: 1,
+      title: "Missing state metadata",
+      state: "Ready",
+    });
+    node.projectItems.nodes[0]!.fieldValues.nodes = [];
+
+    await expect(
+      adapter.fetchIssueStatesByIds(makeProjectConfig(), ["issue-1"], {
+        token: "dependencies-token",
+        fetchImpl: async () =>
+          new Response(JSON.stringify({ data: { nodes: [node] } }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+      })
+    ).rejects.toThrow(
+      'github_project_state_field_missing: Project item item-missing-state did not include configured state field "Status".'
+    );
   });
 
   it("attaches GitHub API rate-limit headers to fetched issue state lookups", async () => {


### PR DESCRIPTION
## TL;DR

- H10: 파일 트래커는 `ENOENT`만 이슈 없음(`[]`)으로 취급하고, 손상 JSON은 파일 경로와 원인을 포함한 오류로 즉시 실패합니다.
- M19: GitHub Project의 state field 설정 누락과 응답 메타데이터 누락을 각각 명시적 `GitHubTrackerQueryError`로 표면화합니다.
- M23: 잘못된 `WORKFLOW.md`에서 last-known-good를 유지하되, 오류를 reconciliation tick마다 계속 stderr에 발행합니다.
- 세 경로 모두 회귀 TC를 추가했고 전체 검증 및 Docker E2E를 통과했습니다.

## 변경 지점 다이어그램

```text
file tracker JSON ── ENOENT ───────────────> []
                  └─ corrupt JSON ─────────> observable Error

GitHub Project ── missing state config/data > GitHubTrackerQueryError

WORKFLOW reload ── invalid snapshot ───────> last-known-good 유지
                                      └────> 매 tick stderr 관측
```

## 여기부터 보세요

1. `packages/tracker-file/src/file-tracker-adapter.ts` — 파일 부재와 손상 JSON의 오류 계약 분리
2. `packages/tracker-github/src/adapter.ts` — state field 설정/응답 메타데이터 검증
3. `packages/orchestrator/src/service.ts` — WORKFLOW reload 오류 dedup 제거
4. 각 인접 `*.test.ts` — H10·M19·M23 회귀 TC

## 위험 & 롤백

- 이전에 숨겨지던 데이터·설정 손상이 호출자와 운영 로그에 오류로 드러나므로 관측되는 실패율은 증가할 수 있습니다. 이는 무신호 디스패치 중단을 제거하기 위한 의도된 동작입니다.
- 잘못된 `WORKFLOW.md`는 upstream Symphony 계약대로 last-known-good를 계속 사용하며, 이번 변경은 오류 관측 빈도만 높입니다.
- 롤백은 세 구현 커밋을 되돌리는 방식이지만, 손상/메타데이터 오류를 빈 결과 또는 `Unknown`으로 오인하는 기존 위험도 함께 복원됩니다.
- `docs/symphony-spec.md`와 의도적 차이는 없습니다.

## 변경 파일

- `.changeset/fail-loud-tracker-workflow-errors.md` — `@gh-symphony/cli` patch changeset
- `packages/tracker-file/src/file-tracker-adapter.ts`
- `packages/tracker-file/src/file-tracker-adapter.test.ts`
- `packages/tracker-github/src/adapter.ts`
- `packages/tracker-github/src/tracker-github.test.ts`
- `packages/orchestrator/src/service.ts`
- `packages/orchestrator/src/service.test.ts`

## Evidence

- `pnpm lint && pnpm test && pnpm typecheck && pnpm build` — pass
- tracker-file TC — 손상 JSON이 빈 배열 대신 명시적 오류로 실패
- tracker-github TC 3건 — state field 미설정, 목록 응답 누락, refresh 응답 누락 오류
- orchestrator TC — 동일한 invalid `WORKFLOW.md`를 연속 두 tick에서 각각 stderr로 관측
- Node.js v24.18.0 `doctor --smoke` — pass
- 격리 file-tracker `repo start --once` — 1 active run 디스패치 후 정상 종료
- `bash e2e/run-e2e.sh happy 40` — PASSED (worker 실행 확인, 최종 health `idle`)

## Issues — Closed #441

Closes #441

## 머지 후/사람 확인

- [ ] 운영 환경에서 새 fail-loud 오류가 로그/알림 파이프라인에 기대한 심각도로 수집되는지 확인
- [ ] 파일 트래커 fixture writer의 tmp+rename/locking 계약은 별도 #440 결과와 함께 확인
