### PR TITLE
fix(runtime): harden state persistence and locking

### DIFF
--- a/.changeset/steady-state-locks.md
+++ b/.changeset/steady-state-locks.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Prevent duplicate orchestration and state loss with durable atomic writes, process-verified leases, and serialized CLI configuration updates for #440.

--- a/packages/cli/src/commands/config-cmd.ts
+++ b/packages/cli/src/commands/config-cmd.ts
@@ -2,9 +2,8 @@ import { spawn } from "node:child_process";
 import type { GlobalOptions } from "../index.js";
 import {
   loadGlobalConfig,
-  saveGlobalConfig,
+  updateGlobalConfig,
   configFilePath,
-  type CliGlobalConfig,
 } from "../config.js";
 
 const handler = async (
@@ -49,7 +48,9 @@ async function configShow(options: GlobalOptions): Promise<void> {
   }
 
   process.stdout.write(`Config: ${configFilePath(options.configDir)}\n\n`);
-  process.stdout.write(`Active project:    ${config.activeProject ?? "none"}\n`);
+  process.stdout.write(
+    `Active project:    ${config.activeProject ?? "none"}\n`
+  );
   process.stdout.write(
     `Projects:         ${config.projects.join(", ") || "none"}\n`
   );
@@ -82,27 +83,26 @@ async function configSet(
     return;
   }
 
-  const config =
-    (await loadGlobalConfig(options.configDir)) ??
-    ({
-      activeProject: null,
-      projects: [],
-    } satisfies CliGlobalConfig);
-
-  switch (key) {
-    case "active-project":
-      if (!config.projects.includes(value)) {
-        process.stderr.write(
-          `Project "${value}" not found. Available: ${config.projects.join(", ")}\n`
-        );
-        process.exitCode = 1;
-        return;
-      }
-      config.activeProject = value;
-      break;
+  let availableProjects: string[] = [];
+  const updated = await updateGlobalConfig(options.configDir, (config) => {
+    availableProjects = config.projects;
+    switch (key) {
+      case "active-project":
+        if (!config.projects.includes(value)) {
+          return null;
+        }
+        return { ...config, activeProject: value };
+      default:
+        return null;
+    }
+  });
+  if (!updated) {
+    process.stderr.write(
+      `Project "${value}" not found. Available: ${availableProjects.join(", ")}\n`
+    );
+    process.exitCode = 1;
+    return;
   }
-
-  await saveGlobalConfig(options.configDir, config);
   process.stdout.write(`Set ${key} = ${value}\n`);
 }
 

--- a/packages/cli/src/commands/lifecycle.test.ts
+++ b/packages/cli/src/commands/lifecycle.test.ts
@@ -1,4 +1,5 @@
 import { mkdtemp, mkdir, readFile, writeFile } from "node:fs/promises";
+import { EventEmitter } from "node:events";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -8,12 +9,14 @@ const orchestratorRunCli = vi.fn();
 const spawnMock = vi.fn();
 const selectMock = vi.fn();
 const cancelMock = vi.fn();
+const getProcessIdentityMock = vi.fn();
 const ghAuthMocks = vi.hoisted(() => ({
   resolveGitHubAuth: vi.fn(),
 }));
 
 vi.mock("@gh-symphony/orchestrator", () => ({
   runCli: orchestratorRunCli,
+  getProcessIdentity: getProcessIdentityMock,
   resolveOrchestratorLogLevel: (value?: string | null) =>
     value === "verbose" ? "verbose" : "normal",
 }));
@@ -54,6 +57,10 @@ const recoverModule = await import("./recover.js");
 const stopModule = await import("./stop.js");
 
 beforeEach(() => {
+  getProcessIdentityMock.mockReset();
+  getProcessIdentityMock.mockImplementation(
+    (pid: number) => `node gh-symphony index.js repo start --pid ${pid}`
+  );
   ghAuthMocks.resolveGitHubAuth.mockReset();
   ghAuthMocks.resolveGitHubAuth.mockResolvedValue({
     source: "gh",
@@ -66,6 +73,7 @@ beforeEach(() => {
 afterEach(() => {
   orchestratorRunCli.mockReset();
   spawnMock.mockReset();
+  getProcessIdentityMock.mockReset();
   selectMock.mockReset();
   cancelMock.mockReset();
   ghAuthMocks.resolveGitHubAuth.mockReset();
@@ -200,11 +208,16 @@ describe("lifecycle command integration", () => {
       projects: [createTenant("tenant-a", "acme", "platform")],
     });
 
-    spawnMock.mockReturnValue({
-      pid: 4321,
-      stdout: { pipe: vi.fn() },
-      stderr: { pipe: vi.fn() },
-      unref: vi.fn(),
+    spawnMock.mockImplementation(() => {
+      const child = Object.assign(new EventEmitter(), {
+        pid: 4321,
+        stdout: { pipe: vi.fn() },
+        stderr: { pipe: vi.fn() },
+        unref: vi.fn(),
+        kill: vi.fn(),
+      });
+      queueMicrotask(() => child.emit("spawn"));
+      return child;
     });
 
     await startModule.default(["--daemon"], baseOptions(configDir));
@@ -322,7 +335,11 @@ describe("lifecycle command integration", () => {
     });
     await writeFile(
       join(configDir, "projects", "tenant-a", "daemon.pid"),
-      "111\n"
+      JSON.stringify({
+        pid: 111,
+        startedAt: "2026-07-15T00:00:00.000Z",
+        processIdentity: "node gh-symphony index.js repo start --pid 111",
+      }) + "\n"
     );
     await writeFile(join(configDir, "projects", "tenant-a", "port"), "41001\n");
 
@@ -346,6 +363,40 @@ describe("lifecycle command integration", () => {
     await expect(
       readFile(join(configDir, "projects", "tenant-a", "daemon.pid"), "utf8")
     ).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("refuses to signal a reused PID with a different process identity", async () => {
+    const configDir = await createConfigFixture({
+      activeProject: "tenant-a",
+      projects: [createTenant("tenant-a", "acme", "platform")],
+    });
+    await writeFile(
+      join(configDir, "projects", "tenant-a", "daemon.pid"),
+      JSON.stringify({
+        pid: 111,
+        startedAt: "2026-07-15T00:00:00.000Z",
+        processIdentity: "node gh-symphony index.js repo start --owner old",
+      }) + "\n"
+    );
+    getProcessIdentityMock.mockReturnValue(
+      "node unrelated-service.js --owner new"
+    );
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+    const stderr = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+
+    await stopModule.default([], baseOptions(configDir));
+
+    expect(killSpy).toHaveBeenCalledWith(111, 0);
+    expect(killSpy).not.toHaveBeenCalledWith(111, "SIGTERM");
+    expect(stderr.mock.calls.map((call) => String(call[0])).join("")).toContain(
+      "process identity does not match"
+    );
+    await expect(
+      readFile(join(configDir, "projects", "tenant-a", "daemon.pid"), "utf8")
+    ).rejects.toMatchObject({ code: "ENOENT" });
+    expect(process.exitCode).toBe(1);
   });
 
   it("rejects unknown project stop flags before touching daemon state", async () => {

--- a/packages/cli/src/commands/start.test.ts
+++ b/packages/cli/src/commands/start.test.ts
@@ -1,4 +1,5 @@
 import { createServer } from "node:http";
+import { EventEmitter } from "node:events";
 import { mkdtemp, mkdir, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -6,14 +7,26 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { CliProjectConfig } from "../config.js";
 import * as configModule from "../config.js";
 
-const acquireProjectLock = vi.fn();
-const releaseProjectLock = vi.fn();
-const run = vi.fn();
-const status = vi.fn();
-const shutdown = vi.fn();
-const requestReconcile = vi.fn();
-const acquireWorkerTurnLease = vi.fn();
-const setWorkerOrchestratorUrl = vi.fn();
+const orchestratorMocks = vi.hoisted(() => ({
+  acquireProjectLock: vi.fn(),
+  releaseProjectLock: vi.fn(),
+  run: vi.fn(),
+  status: vi.fn(),
+  shutdown: vi.fn(),
+  requestReconcile: vi.fn(),
+  acquireWorkerTurnLease: vi.fn(),
+  setWorkerOrchestratorUrl: vi.fn(),
+}));
+const {
+  acquireProjectLock,
+  releaseProjectLock,
+  run,
+  status,
+  shutdown,
+  requestReconcile,
+  acquireWorkerTurnLease,
+  setWorkerOrchestratorUrl,
+} = orchestratorMocks;
 const resolveDashboardResponse = vi.fn();
 const startControlPlaneServer = vi.fn();
 const serviceDependencies: Array<Record<string, unknown>> = [];
@@ -26,10 +39,7 @@ const promptMocks = vi.hoisted(() => ({
   confirm: vi.fn(),
 }));
 const childProcessMocks = vi.hoisted(() => ({
-  spawn: vi.fn(() => ({
-    pid: 2468,
-    unref: vi.fn(),
-  })),
+  spawn: vi.fn(),
 }));
 
 vi.mock("node:child_process", () => ({
@@ -37,9 +47,10 @@ vi.mock("node:child_process", () => ({
 }));
 
 vi.mock("@gh-symphony/orchestrator", () => ({
-  acquireProjectLock,
-  releaseProjectLock,
+  acquireProjectLock: orchestratorMocks.acquireProjectLock,
+  releaseProjectLock: orchestratorMocks.releaseProjectLock,
   createStore: vi.fn(() => ({ kind: "store" })),
+  getProcessIdentity: vi.fn((pid: number) => `process-${pid}`),
   resolveOrchestratorLogLevel: (value?: string | null) =>
     value === "verbose" ? "verbose" : "normal",
   OrchestratorService: class {
@@ -50,12 +61,12 @@ vi.mock("@gh-symphony/orchestrator", () => ({
     ) {
       serviceDependencies.push(dependencies);
     }
-    run = run;
-    status = status;
-    shutdown = shutdown;
-    requestReconcile = requestReconcile;
-    acquireWorkerTurnLease = acquireWorkerTurnLease;
-    setWorkerOrchestratorUrl = setWorkerOrchestratorUrl;
+    run = orchestratorMocks.run;
+    status = orchestratorMocks.status;
+    shutdown = orchestratorMocks.shutdown;
+    requestReconcile = orchestratorMocks.requestReconcile;
+    acquireWorkerTurnLease = orchestratorMocks.acquireWorkerTurnLease;
+    setWorkerOrchestratorUrl = orchestratorMocks.setWorkerOrchestratorUrl;
   },
 }));
 
@@ -135,14 +146,25 @@ beforeEach(() => {
   promptMocks.confirm.mockReset();
   promptMocks.confirm.mockResolvedValue(true);
   childProcessMocks.spawn.mockClear();
-  childProcessMocks.spawn.mockReturnValue({
-    pid: 2468,
-    unref: vi.fn(),
-  });
+  childProcessMocks.spawn.mockImplementation(() => createSpawnedChild(2468));
   process.env.GITHUB_GRAPHQL_TOKEN = originalGithubToken;
   process.env.LINEAR_API_KEY = originalLinearApiKey;
   serviceDependencies.length = 0;
 });
+
+function createSpawnedChild(pid: number): EventEmitter & {
+  pid: number;
+  unref: ReturnType<typeof vi.fn>;
+  kill: ReturnType<typeof vi.fn>;
+} {
+  const child = Object.assign(new EventEmitter(), {
+    pid,
+    unref: vi.fn(),
+    kill: vi.fn(),
+  });
+  queueMicrotask(() => child.emit("spawn"));
+  return child;
+}
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -672,6 +694,54 @@ describe("start command foreground locking", () => {
         "verbose",
       ])
     );
+    const pidRecord = JSON.parse(
+      await readFile(
+        join(configDir, "projects", "tenant-a", "daemon.pid"),
+        "utf8"
+      )
+    ) as { pid: number; processIdentity: string; startedAt: string };
+    expect(pidRecord).toMatchObject({
+      pid: 2468,
+      processIdentity: "process-2468",
+    });
+    expect(Date.parse(pidRecord.startedAt)).not.toBeNaN();
+  });
+
+  it("does not leave a PID file when daemon spawn fails", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "cli-start-spawn-"));
+    await configModule.saveGlobalConfig(configDir, {
+      activeProject: "tenant-a",
+      projects: ["tenant-a"],
+    });
+    await configModule.saveProjectConfig(
+      configDir,
+      "tenant-a",
+      createProject("tenant-a", "acme", "platform")
+    );
+    let child:
+      | (EventEmitter & {
+          pid: undefined;
+          unref: ReturnType<typeof vi.fn>;
+          kill: ReturnType<typeof vi.fn>;
+        })
+      | null = null;
+    childProcessMocks.spawn.mockImplementation(() => {
+      child = Object.assign(new EventEmitter(), {
+        pid: undefined,
+        unref: vi.fn(),
+        kill: vi.fn(),
+      });
+      queueMicrotask(() => child?.emit("error", new Error("spawn failed")));
+      return child;
+    });
+
+    await expect(
+      startModule.default(["--daemon"], baseOptions(configDir))
+    ).rejects.toThrow("spawn failed");
+    await expect(
+      readFile(join(configDir, "projects", "tenant-a", "daemon.pid"), "utf8")
+    ).rejects.toMatchObject({ code: "ENOENT" });
+    expect(child?.unref).not.toHaveBeenCalled();
   });
 
   it("tails completed worker logs from the flat runtime run path", async () => {

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -1,6 +1,6 @@
-import { writeFile, mkdir, readFile, rm } from "node:fs/promises";
+import { mkdir, readFile, rm } from "node:fs/promises";
 import { dirname, join } from "node:path";
-import { spawn } from "node:child_process";
+import { spawn, type ChildProcess } from "node:child_process";
 import {
   createServer,
   type IncomingMessage,
@@ -19,6 +19,7 @@ import {
   OrchestratorService,
   acquireProjectLock,
   createStore,
+  getProcessIdentity,
   releaseProjectLock,
   resolveOrchestratorLogLevel,
   type OrchestratorLogLevel,
@@ -1156,7 +1157,7 @@ async function startDaemon(
   const logPath = orchestratorLogPath(options.configDir, projectId);
   await mkdir(dirname(logPath), { recursive: true });
 
-  const { openSync } = await import("node:fs");
+  const { closeSync, openSync } = await import("node:fs");
   const logFd = openSync(logPath, "a");
 
   const child = spawn(
@@ -1183,17 +1184,54 @@ async function startDaemon(
   );
 
   const pidPath = daemonPidPath(options.configDir, projectId);
-  await mkdir(dirname(pidPath), { recursive: true });
-  await writeFile(pidPath, String(child.pid), "utf8");
+  try {
+    await waitForChildSpawn(child);
+    if (!child.pid) {
+      throw new Error("Daemon process started without a PID.");
+    }
 
-  child.unref();
-
-  const { closeSync } = await import("node:fs");
-  closeSync(logFd);
+    await writeJsonFile(pidPath, {
+      pid: child.pid,
+      startedAt: new Date().toISOString(),
+      processIdentity: getProcessIdentity(child.pid),
+    });
+    child.unref();
+  } catch (error) {
+    await rm(pidPath, { force: true });
+    if (child.pid) {
+      try {
+        child.kill();
+      } catch {
+        // The child may already have exited after a persistence failure.
+      }
+    }
+    throw error;
+  } finally {
+    closeSync(logFd);
+  }
 
   process.stdout.write(
     `Orchestrator started in background (PID: ${child.pid}).\n` +
       `Logs: ${logPath}\n` +
       "Stop with: gh-symphony repo stop\n"
   );
+}
+
+async function waitForChildSpawn(child: ChildProcess): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const cleanup = () => {
+      child.off("spawn", onSpawn);
+      child.off("error", onError);
+    };
+    const onSpawn = () => {
+      cleanup();
+      resolve();
+    };
+    const onError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+    child.once("spawn", onSpawn);
+    child.once("error", onError);
+  });
 }

--- a/packages/cli/src/commands/stop.ts
+++ b/packages/cli/src/commands/stop.ts
@@ -1,6 +1,7 @@
 import { readFile, rm } from "node:fs/promises";
+import { getProcessIdentity } from "@gh-symphony/orchestrator";
 import type { GlobalOptions } from "../index.js";
-import { daemonPidPath } from "../config.js";
+import { daemonPidPath, parseDaemonPidRecord } from "../config.js";
 import {
   handleMissingManagedProjectConfig,
   resolveManagedProjectConfig,
@@ -67,12 +68,13 @@ const handler = async (
     return;
   }
 
-  const pid = Number.parseInt(pidStr.trim(), 10);
-  if (!Number.isFinite(pid)) {
+  const pidRecord = parseDaemonPidRecord(pidStr);
+  if (!pidRecord) {
     process.stderr.write(`Invalid PID in ${pidPath}: ${pidStr}\n`);
     process.exitCode = 1;
     return;
   }
+  const pid = pidRecord.pid;
 
   try {
     // Check if process is running
@@ -85,8 +87,24 @@ const handler = async (
     return;
   }
 
+  const checkedIdentity = getProcessIdentity(pid);
+  const identityMatches = pidRecord.processIdentity
+    ? checkedIdentity === pidRecord.processIdentity
+    : isLegacyOrchestratorIdentity(checkedIdentity);
+  if (!identityMatches) {
+    process.stderr.write(
+      `Refusing to stop PID ${pid}: process identity does not match the recorded orchestrator daemon. Cleaning up stale PID file.\n`
+    );
+    await rm(pidPath, { force: true });
+    process.exitCode = 1;
+    return;
+  }
+
   const signal = resolvedForce ? "SIGKILL" : "SIGTERM";
   try {
+    if (getProcessIdentity(pid) !== checkedIdentity) {
+      throw new Error("process identity changed before signal delivery");
+    }
     process.kill(pid, signal);
     process.stdout.write(`Sent ${signal} to orchestrator (PID ${pid}).\n`);
   } catch (error) {
@@ -100,5 +118,13 @@ const handler = async (
   await rm(pidPath, { force: true });
   process.stdout.write("Daemon stopped.\n");
 };
+
+function isLegacyOrchestratorIdentity(identity: string | null): boolean {
+  return Boolean(
+    identity &&
+    /(?:gh-symphony|(?:^|\s)(?:dist\/)?index\.js)(?:\s|$)/.test(identity) &&
+    /\brepo\s+start\b/.test(identity)
+  );
+}
 
 export default handler;

--- a/packages/cli/src/commands/workflow-init.ts
+++ b/packages/cli/src/commands/workflow-init.ts
@@ -45,10 +45,8 @@ import {
 } from "../mapping/smart-defaults.js";
 import { generateWorkflowMarkdown } from "../workflow/generate-workflow-md.js";
 import {
-  loadGlobalConfig,
-  saveGlobalConfig,
+  updateGlobalConfig,
   saveProjectConfig,
-  type CliGlobalConfig,
   type StateRole,
   type StateMapping,
 } from "../config.js";
@@ -2030,16 +2028,13 @@ export async function writeConfig(
     },
   });
 
-  // Save/update global config
-  const existing = await loadGlobalConfig(configDir);
-  const globalConfig: CliGlobalConfig = {
+  await updateGlobalConfig(configDir, (existing) => ({
     activeProject: input.projectId,
     projects: [
-      ...(existing?.projects ?? []).filter((t) => t !== input.projectId),
+      ...existing.projects.filter((projectId) => projectId !== input.projectId),
       input.projectId,
     ],
-  };
-  await saveGlobalConfig(configDir, globalConfig);
+  }));
 }
 
 export function generateProjectId(

--- a/packages/cli/src/config.test.ts
+++ b/packages/cli/src/config.test.ts
@@ -1,11 +1,15 @@
-import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, readFile, readdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   DEFAULT_CONFIG_DIR,
   REPO_RUNTIME_DIR,
+  loadGlobalConfig,
+  parseDaemonPidRecord,
   resolveConfigDir,
+  saveGlobalConfig,
+  updateGlobalConfig,
 } from "./config.js";
 
 const originalCwd = process.cwd();
@@ -61,5 +65,54 @@ describe("resolveConfigDir", () => {
     delete process.env.GH_SYMPHONY_CONFIG_DIR;
 
     expect(resolveConfigDir()).toBe(DEFAULT_CONFIG_DIR);
+  });
+});
+
+describe("config persistence", () => {
+  it("serializes concurrent load-modify-save updates", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "cli-config-lock-"));
+    await saveGlobalConfig(configDir, {
+      activeProject: null,
+      projects: [],
+    });
+
+    await Promise.all(
+      Array.from({ length: 20 }, (_, index) =>
+        updateGlobalConfig(configDir, (config) => ({
+          ...config,
+          projects: [...config.projects, `project-${index}`],
+        }))
+      )
+    );
+
+    const config = await loadGlobalConfig(configDir);
+    expect(config?.projects).toHaveLength(20);
+    expect(new Set(config?.projects).size).toBe(20);
+    expect(
+      JSON.parse(await readFile(join(configDir, "config.json"), "utf8"))
+    ).toEqual(config);
+    expect(await readdir(configDir)).toEqual(["config.json"]);
+  });
+
+  it("reads structured and legacy daemon PID records", () => {
+    expect(parseDaemonPidRecord("1234\n")).toEqual({
+      pid: 1234,
+      startedAt: "",
+      processIdentity: null,
+    });
+    expect(
+      parseDaemonPidRecord(
+        JSON.stringify({
+          pid: 5678,
+          startedAt: "2026-07-15T00:00:00.000Z",
+          processIdentity: "node gh-symphony repo start",
+        })
+      )
+    ).toEqual({
+      pid: 5678,
+      startedAt: "2026-07-15T00:00:00.000Z",
+      processIdentity: "node gh-symphony repo start",
+    });
+    expect(parseDaemonPidRecord("not-a-pid")).toBeNull();
   });
 });

--- a/packages/cli/src/config.test.ts
+++ b/packages/cli/src/config.test.ts
@@ -77,7 +77,7 @@ describe("config persistence", () => {
     });
 
     await Promise.all(
-      Array.from({ length: 20 }, (_, index) =>
+      Array.from({ length: 8 }, (_, index) =>
         updateGlobalConfig(configDir, (config) => ({
           ...config,
           projects: [...config.projects, `project-${index}`],
@@ -86,13 +86,13 @@ describe("config persistence", () => {
     );
 
     const config = await loadGlobalConfig(configDir);
-    expect(config?.projects).toHaveLength(20);
-    expect(new Set(config?.projects).size).toBe(20);
+    expect(config?.projects).toHaveLength(8);
+    expect(new Set(config?.projects).size).toBe(8);
     expect(
       JSON.parse(await readFile(join(configDir, "config.json"), "utf8"))
     ).toEqual(config);
     expect(await readdir(configDir)).toEqual(["config.json"]);
-  });
+  }, 10_000);
 
   it("reads structured and legacy daemon PID records", () => {
     expect(parseDaemonPidRecord("1234\n")).toEqual({

--- a/packages/cli/src/config.test.ts
+++ b/packages/cli/src/config.test.ts
@@ -1,4 +1,11 @@
-import { mkdtemp, mkdir, readFile, readdir, writeFile } from "node:fs/promises";
+import {
+  mkdtemp,
+  mkdir,
+  readFile,
+  readdir,
+  utimes,
+  writeFile,
+} from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, describe, expect, it } from "vitest";
@@ -93,6 +100,25 @@ describe("config persistence", () => {
     ).toEqual(config);
     expect(await readdir(configDir)).toEqual(["config.json"]);
   }, 10_000);
+
+  it("recovers an expired partial config lock left by a crash", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "cli-config-lock-"));
+    const lockPath = join(configDir, ".config.lock");
+    await writeFile(lockPath, '{"ownerToken":"partial"', "utf8");
+    const expired = new Date(Date.now() - 31_000);
+    await utimes(lockPath, expired, expired);
+
+    await saveGlobalConfig(configDir, {
+      activeProject: "project-1",
+      projects: ["project-1"],
+    });
+
+    await expect(loadGlobalConfig(configDir)).resolves.toEqual({
+      activeProject: "project-1",
+      projects: ["project-1"],
+    });
+    expect(await readdir(configDir)).toEqual(["config.json"]);
+  });
 
   it("reads structured and legacy daemon PID records", () => {
     expect(parseDaemonPidRecord("1234\n")).toEqual({

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1,6 +1,14 @@
 import { randomUUID } from "node:crypto";
 import { existsSync } from "node:fs";
-import { mkdir, open, readFile, rename, rm } from "node:fs/promises";
+import {
+  link,
+  mkdir,
+  open,
+  readFile,
+  rename,
+  rm,
+  stat,
+} from "node:fs/promises";
 import { basename, dirname, join, resolve } from "node:path";
 import { homedir } from "node:os";
 import { setTimeout as delay } from "node:timers/promises";
@@ -20,7 +28,8 @@ export const REPO_RUNTIME_DIR = join(".runtime", "orchestrator");
 const CONFIG_LOCK_FILE = ".config.lock";
 const CONFIG_LOCK_TTL_MS = 30_000;
 const CONFIG_LOCK_RETRY_MS = 20;
-const CONFIG_LOCK_RETRY_LIMIT = 250;
+const CONFIG_LOCK_RETRY_LIMIT =
+  Math.ceil(CONFIG_LOCK_TTL_MS / CONFIG_LOCK_RETRY_MS) + 50;
 
 type ConfigLockRecord = {
   ownerToken: string;
@@ -286,13 +295,7 @@ async function withConfigLock<T>(
 
   for (let attempt = 0; ; attempt += 1) {
     try {
-      const handle = await open(lockPath, "wx", 0o600);
-      try {
-        await handle.writeFile(JSON.stringify(record) + "\n", "utf8");
-        await handle.sync();
-      } finally {
-        await handle.close();
-      }
+      await publishConfigLock(lockPath, record);
       break;
     } catch (error) {
       if (!isAlreadyExists(error)) {
@@ -331,17 +334,40 @@ async function withConfigLock<T>(
   }
 }
 
+async function publishConfigLock(
+  lockPath: string,
+  record: ConfigLockRecord
+): Promise<void> {
+  const temporaryPath = `${lockPath}.${process.pid}.${randomUUID()}.tmp`;
+  try {
+    const handle = await open(temporaryPath, "wx", 0o600);
+    try {
+      await handle.writeFile(JSON.stringify(record) + "\n", "utf8");
+      await handle.sync();
+    } finally {
+      await handle.close();
+    }
+    await link(temporaryPath, lockPath);
+  } finally {
+    await rm(temporaryPath, { force: true });
+  }
+}
+
 async function isStaleConfigLock(path: string): Promise<boolean> {
   try {
-    const record = JSON.parse(
-      await readFile(path, "utf8")
-    ) as Partial<ConfigLockRecord>;
+    const raw = await readFile(path, "utf8");
+    let record: Partial<ConfigLockRecord>;
+    try {
+      record = JSON.parse(raw) as Partial<ConfigLockRecord>;
+    } catch {
+      return isExpiredConfigLockFile(path);
+    }
     if (
       !Number.isInteger(record.pid) ||
       (record.pid ?? 0) <= 0 ||
       typeof record.startedAt !== "string"
     ) {
-      return false;
+      return isExpiredConfigLockFile(path);
     }
     const ageMs = Math.abs(Date.now() - Date.parse(record.startedAt));
     if (!Number.isFinite(ageMs) || ageMs > CONFIG_LOCK_TTL_MS) {
@@ -363,6 +389,18 @@ async function isStaleConfigLock(path: string): Promise<boolean> {
       actualIdentity &&
       record.processIdentity !== actualIdentity
     );
+  } catch (error) {
+    if (isFileMissing(error)) {
+      return false;
+    }
+    throw error;
+  }
+}
+
+async function isExpiredConfigLockFile(path: string): Promise<boolean> {
+  try {
+    const metadata = await stat(path);
+    return Math.abs(Date.now() - metadata.mtimeMs) > CONFIG_LOCK_TTL_MS;
   } catch (error) {
     if (isFileMissing(error)) {
       return false;

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1,7 +1,10 @@
+import { randomUUID } from "node:crypto";
 import { existsSync } from "node:fs";
-import { readFile, writeFile, mkdir } from "node:fs/promises";
-import { dirname, join, resolve } from "node:path";
+import { mkdir, open, readFile, rename, rm } from "node:fs/promises";
+import { basename, dirname, join, resolve } from "node:path";
 import { homedir } from "node:os";
+import { setTimeout as delay } from "node:timers/promises";
+import { getProcessIdentity } from "@gh-symphony/orchestrator";
 import type {
   OrchestratorProjectConfig,
   OrchestratorTrackerSettingValue,
@@ -14,6 +17,23 @@ export const DAEMON_PID_FILE = "daemon.pid";
 export const ORCHESTRATOR_LOG_FILE = "orchestrator.log";
 export const HTTP_STATUS_FILE = "http.json";
 export const REPO_RUNTIME_DIR = join(".runtime", "orchestrator");
+const CONFIG_LOCK_FILE = ".config.lock";
+const CONFIG_LOCK_TTL_MS = 30_000;
+const CONFIG_LOCK_RETRY_MS = 20;
+const CONFIG_LOCK_RETRY_LIMIT = 250;
+
+type ConfigLockRecord = {
+  ownerToken: string;
+  pid: number;
+  startedAt: string;
+  processIdentity: string | null;
+};
+
+export type DaemonPidRecord = {
+  pid: number;
+  startedAt: string;
+  processIdentity: string | null;
+};
 
 export type CliGlobalConfig = {
   activeProject: string | null;
@@ -126,7 +146,26 @@ export async function saveGlobalConfig(
   configDir: string,
   config: CliGlobalConfig
 ): Promise<void> {
-  await writeJsonFile(configFilePath(configDir), config);
+  await withConfigLock(configDir, () =>
+    writeJsonFile(configFilePath(configDir), config)
+  );
+}
+
+export async function updateGlobalConfig(
+  configDir: string,
+  update: (config: CliGlobalConfig) => CliGlobalConfig | null
+): Promise<boolean> {
+  return withConfigLock(configDir, async () => {
+    const current =
+      (await loadGlobalConfig(configDir)) ??
+      ({ activeProject: null, projects: [] } satisfies CliGlobalConfig);
+    const next = update(current);
+    if (!next) {
+      return false;
+    }
+    await writeJsonFile(configFilePath(configDir), next);
+    return true;
+  });
 }
 
 export async function loadProjectConfig(
@@ -143,7 +182,9 @@ export async function saveProjectConfig(
   projectId: string,
   config: CliProjectConfig
 ): Promise<void> {
-  await writeJsonFile(projectConfigPath(configDir, projectId), config);
+  await withConfigLock(configDir, () =>
+    writeJsonFile(projectConfigPath(configDir, projectId), config)
+  );
 }
 
 export async function loadActiveProjectConfig(
@@ -172,11 +213,171 @@ export async function writeJsonFile(
   path: string,
   value: unknown
 ): Promise<void> {
-  await mkdir(dirname(path), { recursive: true });
-  const temporaryPath = `${path}.tmp`;
-  await writeFile(temporaryPath, JSON.stringify(value, null, 2) + "\n", "utf8");
-  const { rename } = await import("node:fs/promises");
-  await rename(temporaryPath, path);
+  await writeFileAtomically(path, JSON.stringify(value, null, 2) + "\n");
+}
+
+async function writeFileAtomically(path: string, data: string): Promise<void> {
+  const directory = dirname(path);
+  await mkdir(directory, { recursive: true });
+  const temporaryPath = join(
+    directory,
+    `.${basename(path)}.${process.pid}.${randomUUID()}.tmp`
+  );
+  let temporaryExists = false;
+  try {
+    const handle = await open(temporaryPath, "wx", 0o600);
+    temporaryExists = true;
+    try {
+      await handle.writeFile(data, "utf8");
+      await handle.sync();
+    } finally {
+      await handle.close();
+    }
+    await rename(temporaryPath, path);
+    temporaryExists = false;
+    const directoryHandle = await open(directory, "r");
+    try {
+      await directoryHandle.sync();
+    } finally {
+      await directoryHandle.close();
+    }
+  } finally {
+    if (temporaryExists) {
+      await rm(temporaryPath, { force: true });
+    }
+  }
+}
+
+export function parseDaemonPidRecord(raw: string): DaemonPidRecord | null {
+  const legacyPid = Number(raw.trim());
+  if (Number.isInteger(legacyPid) && legacyPid > 0) {
+    return { pid: legacyPid, startedAt: "", processIdentity: null };
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as Partial<DaemonPidRecord>;
+    if (
+      !Number.isInteger(parsed.pid) ||
+      (parsed.pid ?? 0) <= 0 ||
+      typeof parsed.startedAt !== "string" ||
+      (parsed.processIdentity !== null &&
+        typeof parsed.processIdentity !== "string")
+    ) {
+      return null;
+    }
+    return parsed as DaemonPidRecord;
+  } catch {
+    return null;
+  }
+}
+
+async function withConfigLock<T>(
+  configDir: string,
+  action: () => Promise<T>
+): Promise<T> {
+  await mkdir(configDir, { recursive: true });
+  const lockPath = join(configDir, CONFIG_LOCK_FILE);
+  const record: ConfigLockRecord = {
+    ownerToken: `${process.pid}:${randomUUID()}`,
+    pid: process.pid,
+    startedAt: new Date().toISOString(),
+    processIdentity: getProcessIdentity(process.pid),
+  };
+
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      const handle = await open(lockPath, "wx", 0o600);
+      try {
+        await handle.writeFile(JSON.stringify(record) + "\n", "utf8");
+        await handle.sync();
+      } finally {
+        await handle.close();
+      }
+      break;
+    } catch (error) {
+      if (!isAlreadyExists(error)) {
+        throw error;
+      }
+      if (await isStaleConfigLock(lockPath)) {
+        await rm(lockPath, { force: true });
+        continue;
+      }
+      if (attempt >= CONFIG_LOCK_RETRY_LIMIT) {
+        throw new Error(`Timed out waiting for config lock at "${lockPath}".`);
+      }
+      await delay(CONFIG_LOCK_RETRY_MS);
+    }
+  }
+
+  try {
+    return await action();
+  } finally {
+    try {
+      const current = JSON.parse(
+        await readFile(lockPath, "utf8")
+      ) as Partial<ConfigLockRecord>;
+      if (current.ownerToken === record.ownerToken) {
+        await rm(lockPath, { force: true });
+      }
+    } catch (error) {
+      if (!isFileMissing(error)) {
+        console.warn(
+          `Failed to release config lock at "${lockPath}": ${
+            error instanceof Error ? error.message : String(error)
+          }`
+        );
+      }
+    }
+  }
+}
+
+async function isStaleConfigLock(path: string): Promise<boolean> {
+  try {
+    const record = JSON.parse(
+      await readFile(path, "utf8")
+    ) as Partial<ConfigLockRecord>;
+    if (
+      !Number.isInteger(record.pid) ||
+      (record.pid ?? 0) <= 0 ||
+      typeof record.startedAt !== "string"
+    ) {
+      return false;
+    }
+    const ageMs = Math.abs(Date.now() - Date.parse(record.startedAt));
+    if (!Number.isFinite(ageMs) || ageMs > CONFIG_LOCK_TTL_MS) {
+      return true;
+    }
+    try {
+      process.kill(record.pid!, 0);
+    } catch (error) {
+      return Boolean(
+        error &&
+        typeof error === "object" &&
+        "code" in error &&
+        error.code === "ESRCH"
+      );
+    }
+    const actualIdentity = getProcessIdentity(record.pid!);
+    return Boolean(
+      record.processIdentity &&
+      actualIdentity &&
+      record.processIdentity !== actualIdentity
+    );
+  } catch (error) {
+    if (isFileMissing(error)) {
+      return false;
+    }
+    throw error;
+  }
+}
+
+function isAlreadyExists(error: unknown): boolean {
+  return Boolean(
+    error &&
+    typeof error === "object" &&
+    "code" in error &&
+    error.code === "EEXIST"
+  );
 }
 
 function isFileMissing(error: unknown): boolean {

--- a/packages/core/src/observability/event-formatter.test.ts
+++ b/packages/core/src/observability/event-formatter.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { createHash } from "node:crypto";
 import {
   formatEventMessage,
   parseRecentEvents,
@@ -176,5 +177,23 @@ describe("event-formatter", () => {
 
   it("returns null when an NDJSON line cannot be parsed", () => {
     expect(parseRunEventLine('{"bad":')).toBeNull();
+  });
+
+  it("accepts valid checksummed events and rejects modified payloads", () => {
+    const event = {
+      at: "2026-03-16T00:00:00.000Z",
+      event: "run-dispatched",
+      projectId: "project-1",
+      issueIdentifier: "acme/repo#1",
+      issueState: "Todo",
+    };
+    const payload = JSON.stringify(event);
+    const integrity = `sha256:${createHash("sha256")
+      .update(payload)
+      .digest("hex")}`;
+    const line = `${payload.slice(0, -1)},"integrity":"${integrity}"}`;
+
+    expect(parseRunEventLine(line)).toEqual(event);
+    expect(parseRunEventLine(line.replace("Todo", "Ready"))).toBeNull();
   });
 });

--- a/packages/core/src/observability/event-formatter.ts
+++ b/packages/core/src/observability/event-formatter.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import type { IssueStatusEvent } from "../contracts/status-surface.js";
 import type { OrchestratorEvent } from "./structured-events.js";
 
@@ -77,7 +78,22 @@ export function parseRecentEvents(
 
 export function parseRunEventLine(line: string): OrchestratorEvent | null {
   try {
-    return JSON.parse(line) as OrchestratorEvent;
+    const parsed = JSON.parse(line) as OrchestratorEvent & {
+      integrity?: unknown;
+    };
+    if (parsed.integrity === undefined) {
+      return parsed;
+    }
+    if (typeof parsed.integrity !== "string") {
+      return null;
+    }
+
+    const integrity = parsed.integrity;
+    delete parsed.integrity;
+    const expected = `sha256:${createHash("sha256")
+      .update(JSON.stringify(parsed))
+      .digest("hex")}`;
+    return integrity === expected ? parsed : null;
   } catch {
     return null;
   }

--- a/packages/orchestrator/src/durable-file.test.ts
+++ b/packages/orchestrator/src/durable-file.test.ts
@@ -2,7 +2,7 @@ import { mkdtemp, readFile, readdir, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { writeFileAtomically } from "./durable-file.js";
+import { appendFileDurably, writeFileAtomically } from "./durable-file.js";
 
 describe("durable file writes", () => {
   it("atomically replaces a file and removes temporary artifacts", async () => {
@@ -35,5 +35,23 @@ describe("durable file writes", () => {
     expect(parsed.index).toBeGreaterThanOrEqual(0);
     expect(parsed.index).toBeLessThan(20);
     await expect(readdir(root)).resolves.toEqual(["state.json"]);
+  });
+
+  it("appends each concurrent record with one durable write", async () => {
+    const root = await mkdtemp(join(tmpdir(), "orchestrator-durable-"));
+    const path = join(root, "events.ndjson");
+
+    await Promise.all(
+      Array.from({ length: 50 }, (_, index) =>
+        appendFileDurably(path, JSON.stringify({ index }) + "\n")
+      )
+    );
+
+    const records = (await readFile(path, "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as { index: number });
+    expect(records).toHaveLength(50);
+    expect(new Set(records.map((record) => record.index)).size).toBe(50);
   });
 });

--- a/packages/orchestrator/src/durable-file.test.ts
+++ b/packages/orchestrator/src/durable-file.test.ts
@@ -1,0 +1,39 @@
+import { mkdtemp, readFile, readdir, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { writeFileAtomically } from "./durable-file.js";
+
+describe("durable file writes", () => {
+  it("atomically replaces a file and removes temporary artifacts", async () => {
+    const root = await mkdtemp(join(tmpdir(), "orchestrator-durable-"));
+    const path = join(root, "nested", "state.json");
+
+    await writeFileAtomically(path, '{"version":1}\n');
+    await writeFileAtomically(path, '{"version":2}\n');
+
+    await expect(readFile(path, "utf8")).resolves.toBe('{"version":2}\n');
+    await expect(readdir(join(root, "nested"))).resolves.toEqual([
+      "state.json",
+    ]);
+    expect((await stat(path)).mode & 0o777).toBe(0o600);
+  });
+
+  it("does not collide when concurrent writers target the same path", async () => {
+    const root = await mkdtemp(join(tmpdir(), "orchestrator-durable-"));
+    const path = join(root, "state.json");
+
+    await Promise.all(
+      Array.from({ length: 20 }, (_, index) =>
+        writeFileAtomically(path, JSON.stringify({ index }) + "\n")
+      )
+    );
+
+    const parsed = JSON.parse(await readFile(path, "utf8")) as {
+      index: number;
+    };
+    expect(parsed.index).toBeGreaterThanOrEqual(0);
+    expect(parsed.index).toBeLessThan(20);
+    await expect(readdir(root)).resolves.toEqual(["state.json"]);
+  });
+});

--- a/packages/orchestrator/src/durable-file.ts
+++ b/packages/orchestrator/src/durable-file.ts
@@ -38,6 +38,26 @@ export async function writeFileAtomically(
   }
 }
 
+export async function appendFileDurably(
+  path: string,
+  data: string | Uint8Array,
+  options: { mode?: number } = {}
+): Promise<void> {
+  const directory = dirname(path);
+  await mkdir(directory, { recursive: true, mode: SECURE_DIRECTORY_MODE });
+  await chmod(directory, SECURE_DIRECTORY_MODE);
+
+  const handle = await open(path, "a", options.mode ?? 0o600);
+  try {
+    const buffer = typeof data === "string" ? Buffer.from(data) : data;
+    await handle.write(buffer);
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+  await syncDirectory(directory);
+}
+
 export async function syncDirectory(path: string): Promise<void> {
   const handle = await open(path, "r");
   try {

--- a/packages/orchestrator/src/durable-file.ts
+++ b/packages/orchestrator/src/durable-file.ts
@@ -1,0 +1,48 @@
+import { randomUUID } from "node:crypto";
+import { chmod, mkdir, open, rename, rm } from "node:fs/promises";
+import { basename, dirname, join } from "node:path";
+
+const SECURE_DIRECTORY_MODE = 0o700;
+
+export async function writeFileAtomically(
+  path: string,
+  data: string | Uint8Array,
+  options: { mode?: number } = {}
+): Promise<void> {
+  const directory = dirname(path);
+  await mkdir(directory, { recursive: true, mode: SECURE_DIRECTORY_MODE });
+  await chmod(directory, SECURE_DIRECTORY_MODE);
+
+  const temporaryPath = join(
+    directory,
+    `.${basename(path)}.${process.pid}.${randomUUID()}.tmp`
+  );
+  let temporaryExists = false;
+  try {
+    const handle = await open(temporaryPath, "wx", options.mode ?? 0o600);
+    temporaryExists = true;
+    try {
+      await handle.writeFile(data);
+      await handle.sync();
+    } finally {
+      await handle.close();
+    }
+
+    await rename(temporaryPath, path);
+    temporaryExists = false;
+    await syncDirectory(directory);
+  } finally {
+    if (temporaryExists) {
+      await rm(temporaryPath, { force: true });
+    }
+  }
+}
+
+export async function syncDirectory(path: string): Promise<void> {
+  const handle = await open(path, "r");
+  try {
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+}

--- a/packages/orchestrator/src/fs-store.ts
+++ b/packages/orchestrator/src/fs-store.ts
@@ -1,5 +1,6 @@
-import { chmod, mkdir, open, rm, stat, appendFile } from "node:fs/promises";
-import { dirname, join, relative, resolve } from "node:path";
+import { createHash } from "node:crypto";
+import { chmod, mkdir, open, rm, stat } from "node:fs/promises";
+import { join, relative, resolve } from "node:path";
 import {
   deriveIssueWorkspaceKeyFromIdentifier,
   isFileMissing,
@@ -16,7 +17,7 @@ import {
   readJsonFile,
   safeReadDir,
 } from "@gh-symphony/core";
-import { writeFileAtomically } from "./durable-file.js";
+import { appendFileDurably, writeFileAtomically } from "./durable-file.js";
 
 const PROJECTS_DIR = "projects";
 const SECURE_DIRECTORY_MODE = 0o700;
@@ -259,17 +260,16 @@ export class OrchestratorFsStore implements OrchestratorStateStore {
 
     const path = join(runDirectory, "events.ndjson");
     const resolvedPath = resolve(path);
-    const serializedEvent = JSON.stringify(redactedEvent) + "\n";
+    const eventPayload = JSON.stringify(redactedEvent);
+    const integrity = `sha256:${createHash("sha256")
+      .update(eventPayload)
+      .digest("hex")}`;
+    const serializedEvent = `${eventPayload.slice(
+      0,
+      -1
+    )},"integrity":"${integrity}"}\n`;
     await this.ensureProjectDirectory(resolvedProjectId);
-    await mkdir(dirname(path), {
-      recursive: true,
-      mode: SECURE_DIRECTORY_MODE,
-    });
-    await chmod(dirname(path), SECURE_DIRECTORY_MODE);
-    await appendFile(path, serializedEvent, {
-      encoding: "utf8",
-      mode: 0o644,
-    });
+    await appendFileDurably(path, serializedEvent, { mode: 0o644 });
 
     const mirrorPath = this.resolveMirroredEventsPath(resolvedPath);
     if (!mirrorPath) {
@@ -277,11 +277,7 @@ export class OrchestratorFsStore implements OrchestratorStateStore {
     }
 
     try {
-      await mkdir(dirname(mirrorPath), { recursive: true });
-      await appendFile(mirrorPath, serializedEvent, {
-        encoding: "utf8",
-        mode: 0o644,
-      });
+      await appendFileDurably(mirrorPath, serializedEvent, { mode: 0o644 });
     } catch (error) {
       console.warn(
         `Failed to mirror orchestrator event log to ${mirrorPath}: ${

--- a/packages/orchestrator/src/fs-store.ts
+++ b/packages/orchestrator/src/fs-store.ts
@@ -1,13 +1,4 @@
-import {
-  chmod,
-  mkdir,
-  open,
-  rename,
-  rm,
-  stat,
-  writeFile,
-  appendFile,
-} from "node:fs/promises";
+import { chmod, mkdir, open, rm, stat, appendFile } from "node:fs/promises";
 import { dirname, join, relative, resolve } from "node:path";
 import {
   deriveIssueWorkspaceKeyFromIdentifier,
@@ -25,6 +16,7 @@ import {
   readJsonFile,
   safeReadDir,
 } from "@gh-symphony/core";
+import { writeFileAtomically } from "./durable-file.js";
 
 const PROJECTS_DIR = "projects";
 const SECURE_DIRECTORY_MODE = 0o700;
@@ -519,14 +511,7 @@ export class OrchestratorFsStore implements OrchestratorStateStore {
 }
 
 async function writeJsonFile(path: string, value: unknown): Promise<void> {
-  await mkdir(dirname(path), {
-    recursive: true,
-    mode: SECURE_DIRECTORY_MODE,
-  });
-  await chmod(dirname(path), SECURE_DIRECTORY_MODE);
-  const temporaryPath = `${path}.tmp`;
-  await writeFile(temporaryPath, JSON.stringify(value, null, 2) + "\n", "utf8");
-  await rename(temporaryPath, path);
+  await writeFileAtomically(path, JSON.stringify(value, null, 2) + "\n");
 }
 
 function encodeProjectId(projectId: string): string {

--- a/packages/orchestrator/src/index.test.ts
+++ b/packages/orchestrator/src/index.test.ts
@@ -334,6 +334,87 @@ describe("orchestrator CLI", () => {
     ).rejects.toMatchObject({ code: "ENOENT" });
   });
 
+  it.each(["run-once", "dispatch", "run-issue", "recover"])(
+    "holds the project lock across the %s mutation",
+    async (command) => {
+      const runtimeRoot = await mkdtemp(join(tmpdir(), "orchestrator-cli-"));
+      const service = createMockService();
+      const acquireLock = vi.fn().mockResolvedValue({
+        lockPath: join(runtimeRoot, ".lock"),
+        ownerToken: "owner-1",
+        pid: 1234,
+        startedAt: "2026-03-16T00:00:00.000Z",
+        heartbeatAt: "2026-03-16T00:00:00.000Z",
+        processIdentity: "test-process",
+      });
+      const releaseLock = vi.fn().mockResolvedValue(undefined);
+
+      await runCli(
+        [
+          command,
+          "--runtime-root",
+          runtimeRoot,
+          "--project-id",
+          "tenant-1",
+          ...(command === "run-issue" ? ["--issue", "acme/repo#1"] : []),
+        ],
+        {
+          createService: () => service,
+          acquireLock,
+          releaseLock,
+        }
+      );
+
+      expect(acquireLock).toHaveBeenCalledOnce();
+      expect(releaseLock).toHaveBeenCalledOnce();
+      expect(
+        command === "recover" ? service.recover : service.runOnce
+      ).toHaveBeenCalledOnce();
+      expect(acquireLock.mock.invocationCallOrder[0]).toBeLessThan(
+        (command === "recover" ? service.recover : service.runOnce).mock
+          .invocationCallOrder[0]
+      );
+      expect(releaseLock.mock.invocationCallOrder[0]).toBeGreaterThan(
+        (command === "recover" ? service.recover : service.runOnce).mock
+          .invocationCallOrder[0]
+      );
+    }
+  );
+
+  it("rejects a concurrent run-once while another mutation owns the lease", async () => {
+    const runtimeRoot = await mkdtemp(join(tmpdir(), "orchestrator-cli-"));
+    const firstService = createMockService();
+    let finishFirst: (() => void) | undefined;
+    (firstService.runOnce as ReturnType<typeof vi.fn>).mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          finishFirst = () => resolve(createMockService().runOnce());
+        })
+    );
+
+    const first = runCli(
+      ["run-once", "--runtime-root", runtimeRoot, "--project-id", "tenant-1"],
+      { createService: () => firstService }
+    );
+    for (let attempt = 0; attempt < 20 && !finishFirst; attempt += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+
+    const secondService = createMockService();
+    await expect(
+      runCli(
+        ["run-once", "--runtime-root", runtimeRoot, "--project-id", "tenant-1"],
+        { createService: () => secondService }
+      )
+    ).rejects.toThrow(
+      `Project "tenant-1" is already running (PID ${process.pid}).`
+    );
+    expect(secondService.runOnce).not.toHaveBeenCalled();
+
+    finishFirst?.();
+    await first;
+  });
+
   it("fails before running the service when the project lock belongs to a live pid", async () => {
     const runtimeRoot = await mkdtemp(join(tmpdir(), "orchestrator-cli-"));
     const service = createMockService();
@@ -345,7 +426,7 @@ describe("orchestrator CLI", () => {
       JSON.stringify({
         ownerToken: "existing-owner",
         pid: process.pid,
-        startedAt: "2026-03-16T00:00:00.000Z",
+        startedAt: new Date().toISOString(),
       }) + "\n",
       "utf8"
     );

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -94,6 +94,23 @@ export async function runCli(
   const stdout = dependencies.stdout ?? process.stdout;
   const exitProcess = dependencies.exitProcess ?? process.exit;
   const signalTarget = dependencies.signalTarget ?? process;
+  const withProjectMutationLock = async <T>(
+    action: () => Promise<T>
+  ): Promise<T> => {
+    if (!parsed.projectId) {
+      return action();
+    }
+
+    const lock = await (dependencies.acquireLock ?? acquireProjectLock)({
+      runtimeRoot,
+      projectId: parsed.projectId,
+    });
+    try {
+      return await action();
+    } finally {
+      await (dependencies.releaseLock ?? releaseProjectLock)(lock);
+    }
+  };
 
   switch (command) {
     case "run": {
@@ -170,9 +187,11 @@ export async function runCli(
     }
     case "run-once":
     case "dispatch": {
-      const result = await service.runOnce({
-        issueIdentifier: parsed.issueIdentifier,
-      });
+      const result = await withProjectMutationLock(() =>
+        service.runOnce({
+          issueIdentifier: parsed.issueIdentifier,
+        })
+      );
       stdout.write(JSON.stringify(result, null, 2) + "\n");
       return;
     }
@@ -181,14 +200,16 @@ export async function runCli(
         throw new Error("run-issue requires --project-id and --issue.");
       }
 
-      const result = await service.runOnce({
-        issueIdentifier: parsed.issueIdentifier,
-      });
+      const result = await withProjectMutationLock(() =>
+        service.runOnce({
+          issueIdentifier: parsed.issueIdentifier,
+        })
+      );
       stdout.write(JSON.stringify(result, null, 2) + "\n");
       return;
     }
     case "recover": {
-      const result = await service.recover();
+      const result = await withProjectMutationLock(() => service.recover());
       stdout.write(JSON.stringify(result, null, 2) + "\n");
       return;
     }

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -9,7 +9,9 @@ import {
 import {
   acquireProjectLock,
   assertValidProjectId,
+  getProcessIdentity,
   releaseProjectLock,
+  renewProjectLock,
   type ProjectLockHandle,
 } from "./lock.js";
 
@@ -25,7 +27,9 @@ export {
 export {
   acquireProjectLock,
   assertValidProjectId,
+  getProcessIdentity,
   releaseProjectLock,
+  renewProjectLock,
   type ProjectLockHandle,
 };
 

--- a/packages/orchestrator/src/lock.test.ts
+++ b/packages/orchestrator/src/lock.test.ts
@@ -9,7 +9,7 @@ import {
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   acquireProjectLock,
   releaseProjectLock,
@@ -175,6 +175,54 @@ describe("project lock", () => {
     await rm(lock.lockPath, { force: true });
     await expect(renewProjectLock(lock)).resolves.toBe(false);
     await releaseProjectLock(lock);
+  });
+
+  it("fails closed when the heartbeat loses lease ownership", async () => {
+    vi.useFakeTimers();
+    const runtimeRoot = await mkdtemp(join(tmpdir(), "orchestrator-lock-"));
+    let confirmLeaseLost: (() => void) | undefined;
+    const leaseLost = new Promise<void>((resolve) => {
+      confirmLeaseLost = resolve;
+    });
+    const onLeaseLost = vi.fn(() => confirmLeaseLost?.());
+    try {
+      const lock = await acquireProjectLock({
+        runtimeRoot,
+        projectId: "project-1",
+        pid: 4321,
+        isProcessRunning: () => false,
+        getProcessIdentity: () => "same-process",
+        leaseTtlMs: 3_000,
+        onLeaseLost,
+      });
+      await writeFile(
+        lock.lockPath,
+        JSON.stringify({
+          ownerToken: "new-owner",
+          pid: 9999,
+          startedAt: new Date().toISOString(),
+          heartbeatAt: new Date().toISOString(),
+          processIdentity: "new-process",
+        }) + "\n",
+        "utf8"
+      );
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      await leaseLost;
+
+      expect(onLeaseLost).toHaveBeenCalledOnce();
+      expect(onLeaseLost).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining("Lost ownership"),
+        })
+      );
+      await releaseProjectLock(lock);
+      expect(JSON.parse(await readFile(lock.lockPath, "utf8")).ownerToken).toBe(
+        "new-owner"
+      );
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("takes over a stale lock when the recorded pid is no longer running", async () => {

--- a/packages/orchestrator/src/lock.test.ts
+++ b/packages/orchestrator/src/lock.test.ts
@@ -10,7 +10,11 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { acquireProjectLock, releaseProjectLock } from "./lock.js";
+import {
+  acquireProjectLock,
+  releaseProjectLock,
+  renewProjectLock,
+} from "./lock.js";
 
 describe("project lock", () => {
   it("creates a project-scoped lock file with pid metadata", async () => {
@@ -22,17 +26,22 @@ describe("project lock", () => {
       pid: 4321,
       now: new Date("2026-03-16T00:00:00.000Z"),
       isProcessRunning: () => false,
+      getProcessIdentity: () => "test-process-4321",
     });
 
     const contents = JSON.parse(await readFile(lock.lockPath, "utf8")) as {
       pid: number;
       startedAt: string;
       ownerToken: string;
+      heartbeatAt: string;
+      processIdentity: string;
     };
 
     expect(contents.pid).toBe(4321);
     expect(contents.startedAt).toBe("2026-03-16T00:00:00.000Z");
     expect(contents.ownerToken).toBe(lock.ownerToken);
+    expect(contents.heartbeatAt).toBe("2026-03-16T00:00:00.000Z");
+    expect(contents.processIdentity).toBe("test-process-4321");
     const projectDirStats = await stat(
       join(runtimeRoot, "projects", "project-1")
     );
@@ -48,6 +57,7 @@ describe("project lock", () => {
       projectId: "project-1",
       pid: 4321,
       isProcessRunning: () => false,
+      getProcessIdentity: () => "same-process",
     });
 
     await expect(
@@ -56,9 +66,81 @@ describe("project lock", () => {
         projectId: "project-1",
         pid: 9999,
         isProcessRunning: (pid) => pid === 4321,
+        getProcessIdentity: () => "same-process",
       })
     ).rejects.toThrow('Project "project-1" is already running (PID 4321).');
 
+    await releaseProjectLock(lock);
+  });
+
+  it("takes over a live reused pid when process identity changed", async () => {
+    const runtimeRoot = await mkdtemp(join(tmpdir(), "orchestrator-lock-"));
+    const first = await acquireProjectLock({
+      runtimeRoot,
+      projectId: "project-1",
+      pid: 4321,
+      isProcessRunning: () => false,
+      getProcessIdentity: () => "original-process",
+    });
+
+    const second = await acquireProjectLock({
+      runtimeRoot,
+      projectId: "project-1",
+      pid: 9999,
+      isProcessRunning: () => true,
+      getProcessIdentity: (pid) =>
+        pid === 4321 ? "reused-process" : "new-owner",
+    });
+
+    expect(second.ownerToken).not.toBe(first.ownerToken);
+    await releaseProjectLock(second);
+  });
+
+  it("takes over an expired lease even when the pid is live", async () => {
+    const runtimeRoot = await mkdtemp(join(tmpdir(), "orchestrator-lock-"));
+    const first = await acquireProjectLock({
+      runtimeRoot,
+      projectId: "project-1",
+      pid: 4321,
+      now: new Date("2026-03-16T00:00:00.000Z"),
+      isProcessRunning: () => false,
+      getProcessIdentity: () => "same-process",
+    });
+
+    const second = await acquireProjectLock({
+      runtimeRoot,
+      projectId: "project-1",
+      pid: 9999,
+      now: new Date("2026-03-16T00:01:01.000Z"),
+      isProcessRunning: () => true,
+      getProcessIdentity: () => "same-process",
+    });
+
+    expect(second.ownerToken).not.toBe(first.ownerToken);
+    await releaseProjectLock(second);
+  });
+
+  it("renews a lease heartbeat only for its current owner", async () => {
+    const runtimeRoot = await mkdtemp(join(tmpdir(), "orchestrator-lock-"));
+    const lock = await acquireProjectLock({
+      runtimeRoot,
+      projectId: "project-1",
+      pid: 4321,
+      now: new Date("2026-03-16T00:00:00.000Z"),
+      isProcessRunning: () => false,
+      getProcessIdentity: () => "same-process",
+    });
+
+    await expect(
+      renewProjectLock(lock, new Date("2026-03-16T00:00:30.000Z"))
+    ).resolves.toBe(true);
+    const renewed = JSON.parse(await readFile(lock.lockPath, "utf8")) as {
+      heartbeatAt: string;
+    };
+    expect(renewed.heartbeatAt).toBe("2026-03-16T00:00:30.000Z");
+
+    await rm(lock.lockPath, { force: true });
+    await expect(renewProjectLock(lock)).resolves.toBe(false);
     await releaseProjectLock(lock);
   });
 

--- a/packages/orchestrator/src/lock.test.ts
+++ b/packages/orchestrator/src/lock.test.ts
@@ -120,6 +120,35 @@ describe("project lock", () => {
     await releaseProjectLock(second);
   });
 
+  it("preserves a live legacy lock without a heartbeat past the lease TTL", async () => {
+    const runtimeRoot = await mkdtemp(join(tmpdir(), "orchestrator-lock-"));
+    const lockPath = join(runtimeRoot, "projects", "project-1", ".lock");
+    await mkdir(join(runtimeRoot, "projects", "project-1"), {
+      recursive: true,
+    });
+    await writeFile(
+      lockPath,
+      JSON.stringify({
+        ownerToken: "legacy-owner",
+        pid: 4321,
+        startedAt: "2026-03-16T00:00:00.000Z",
+        processIdentity: "same-process",
+      }) + "\n",
+      "utf8"
+    );
+
+    await expect(
+      acquireProjectLock({
+        runtimeRoot,
+        projectId: "project-1",
+        pid: 9999,
+        now: new Date("2026-03-16T01:00:00.000Z"),
+        isProcessRunning: (pid) => pid === 4321,
+        getProcessIdentity: () => "same-process",
+      })
+    ).rejects.toThrow('Project "project-1" is already running (PID 4321).');
+  });
+
   it("renews a lease heartbeat only for its current owner", async () => {
     const runtimeRoot = await mkdtemp(join(tmpdir(), "orchestrator-lock-"));
     const lock = await acquireProjectLock({
@@ -131,13 +160,17 @@ describe("project lock", () => {
       getProcessIdentity: () => "same-process",
     });
 
+    const inodeBeforeRenewal = await stat(lock.lockPath);
     await expect(
       renewProjectLock(lock, new Date("2026-03-16T00:00:30.000Z"))
     ).resolves.toBe(true);
+    const inodeAfterRenewal = await stat(lock.lockPath);
     const renewed = JSON.parse(await readFile(lock.lockPath, "utf8")) as {
       heartbeatAt: string;
     };
     expect(renewed.heartbeatAt).toBe("2026-03-16T00:00:30.000Z");
+    expect(inodeAfterRenewal.dev).toBe(inodeBeforeRenewal.dev);
+    expect(inodeAfterRenewal.ino).toBe(inodeBeforeRenewal.ino);
 
     await rm(lock.lockPath, { force: true });
     await expect(renewProjectLock(lock)).resolves.toBe(false);

--- a/packages/orchestrator/src/lock.ts
+++ b/packages/orchestrator/src/lock.ts
@@ -1,16 +1,23 @@
 import { randomUUID } from "node:crypto";
 import { spawnSync } from "node:child_process";
-import { chmod, mkdir, open, readFile, rm } from "node:fs/promises";
+import {
+  chmod,
+  mkdir,
+  open,
+  readFile,
+  rm,
+  type FileHandle,
+} from "node:fs/promises";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import { OrchestratorFsStore } from "./fs-store.js";
-import { syncDirectory, writeFileAtomically } from "./durable-file.js";
+import { syncDirectory } from "./durable-file.js";
 
 type ProjectLockRecord = {
   ownerToken: string;
   pid: number;
   startedAt: string;
-  heartbeatAt: string;
+  heartbeatAt: string | null;
   processIdentity: string | null;
 };
 
@@ -143,21 +150,53 @@ export async function renewProjectLock(
   lock: ProjectLockHandle,
   now = new Date()
 ): Promise<boolean> {
-  const existing = await readProjectLock(lock.lockPath);
-  if (
-    existing.status !== "valid" ||
-    existing.record.ownerToken !== lock.ownerToken
-  ) {
-    return false;
+  let handle;
+  try {
+    handle = await open(lock.lockPath, "r+");
+  } catch (error) {
+    if (isMissingFileError(error)) {
+      return false;
+    }
+    throw error;
   }
 
-  const heartbeatAt = now.toISOString();
-  await writeFileAtomically(
-    lock.lockPath,
-    JSON.stringify({ ...existing.record, heartbeatAt }, null, 2) + "\n"
-  );
-  lock.heartbeatAt = heartbeatAt;
-  return true;
+  try {
+    const existing = parseProjectLock(await handle.readFile("utf8"));
+    if (!existing || existing.ownerToken !== lock.ownerToken) {
+      return false;
+    }
+
+    const heartbeatAt = now.toISOString();
+    const contents =
+      JSON.stringify({ ...existing, heartbeatAt }, null, 2) + "\n";
+    await overwriteOpenFile(handle, contents);
+    lock.heartbeatAt = heartbeatAt;
+    return true;
+  } finally {
+    await handle.close();
+  }
+}
+
+async function overwriteOpenFile(
+  handle: FileHandle,
+  contents: string
+): Promise<void> {
+  const data = Buffer.from(contents);
+  let offset = 0;
+  while (offset < data.length) {
+    const { bytesWritten } = await handle.write(
+      data,
+      offset,
+      data.length - offset,
+      offset
+    );
+    if (bytesWritten === 0) {
+      throw new Error("Failed to make progress while renewing project lock.");
+    }
+    offset += bytesWritten;
+  }
+  await handle.truncate(data.length);
+  await handle.sync();
 }
 
 function isActiveLock(
@@ -173,6 +212,22 @@ function isActiveLock(
     return false;
   }
 
+  const actualIdentity = input.getProcessIdentity(record.pid);
+  const identityMatches =
+    record.processIdentity === null ||
+    actualIdentity === null ||
+    record.processIdentity === actualIdentity;
+  if (!identityMatches) {
+    return false;
+  }
+
+  // Locks written before heartbeat leases were introduced must remain active
+  // while their recorded process is still alive. Otherwise a rolling upgrade
+  // could mistake a long-running legacy daemon for an expired lease.
+  if (record.heartbeatAt === null) {
+    return true;
+  }
+
   const heartbeatAtMs = Date.parse(record.heartbeatAt);
   const leaseAgeMs = input.now.getTime() - heartbeatAtMs;
   if (
@@ -182,12 +237,7 @@ function isActiveLock(
     return false;
   }
 
-  const actualIdentity = input.getProcessIdentity(record.pid);
-  return (
-    record.processIdentity === null ||
-    actualIdentity === null ||
-    record.processIdentity === actualIdentity
-  );
+  return true;
 }
 
 async function ensureSecureDirectory(path: string): Promise<void> {
@@ -305,7 +355,7 @@ function parseProjectLock(raw: string): ProjectLockRecord | null {
       ownerToken: parsed.ownerToken,
       pid: parsed.pid,
       startedAt: parsed.startedAt,
-      heartbeatAt: parsed.heartbeatAt ?? parsed.startedAt,
+      heartbeatAt: parsed.heartbeatAt ?? null,
       processIdentity: parsed.processIdentity ?? null,
     };
   } catch {

--- a/packages/orchestrator/src/lock.ts
+++ b/packages/orchestrator/src/lock.ts
@@ -1,13 +1,17 @@
 import { randomUUID } from "node:crypto";
+import { spawnSync } from "node:child_process";
 import { chmod, mkdir, open, readFile, rm } from "node:fs/promises";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import { OrchestratorFsStore } from "./fs-store.js";
+import { syncDirectory, writeFileAtomically } from "./durable-file.js";
 
 type ProjectLockRecord = {
   ownerToken: string;
   pid: number;
   startedAt: string;
+  heartbeatAt: string;
+  processIdentity: string | null;
 };
 
 export type ProjectLockHandle = {
@@ -15,11 +19,15 @@ export type ProjectLockHandle = {
   ownerToken: string;
   pid: number;
   startedAt: string;
+  heartbeatAt: string;
+  processIdentity: string | null;
 };
 
 const LOCK_READ_RETRY_DELAY_MS = 10;
 const LOCK_READ_RETRY_LIMIT = 20;
 const SECURE_DIRECTORY_MODE = 0o700;
+export const DEFAULT_PROJECT_LOCK_LEASE_TTL_MS = 60_000;
+const heartbeatTimers = new WeakMap<ProjectLockHandle, NodeJS.Timeout>();
 
 export async function acquireProjectLock(input: {
   runtimeRoot: string;
@@ -27,13 +35,23 @@ export async function acquireProjectLock(input: {
   pid?: number;
   now?: Date;
   isProcessRunning?: (pid: number) => boolean;
+  getProcessIdentity?: (pid: number) => string | null;
+  leaseTtlMs?: number;
 }): Promise<ProjectLockHandle> {
   assertValidProjectId(input.projectId);
   const pid = input.pid ?? process.pid;
   const startedAt = (input.now ?? new Date()).toISOString();
+  const heartbeatAt = startedAt;
+  const processIdentity = (input.getProcessIdentity ?? getProcessIdentity)(pid);
   const ownerToken = `${pid}:${randomUUID()}`;
   const lockPath = resolveProjectLockPath(input.runtimeRoot, input.projectId);
-  const record: ProjectLockRecord = { ownerToken, pid, startedAt };
+  const record: ProjectLockRecord = {
+    ownerToken,
+    pid,
+    startedAt,
+    heartbeatAt,
+    processIdentity,
+  };
   let invalidReadAttempts = 0;
 
   for (;;) {
@@ -42,11 +60,25 @@ export async function acquireProjectLock(input: {
       const handle = await open(lockPath, "wx");
       try {
         await handle.writeFile(JSON.stringify(record, null, 2) + "\n", "utf8");
+        await handle.sync();
       } finally {
         await handle.close();
       }
+      await syncDirectory(dirname(lockPath));
 
-      return { lockPath, ownerToken, pid, startedAt };
+      const lock = {
+        lockPath,
+        ownerToken,
+        pid,
+        startedAt,
+        heartbeatAt,
+        processIdentity,
+      };
+      startProjectLockHeartbeat(
+        lock,
+        input.leaseTtlMs ?? DEFAULT_PROJECT_LOCK_LEASE_TTL_MS
+      );
+      return lock;
     } catch (error) {
       if (!isAlreadyExistsError(error)) {
         throw error;
@@ -72,7 +104,14 @@ export async function acquireProjectLock(input: {
     }
 
     invalidReadAttempts = 0;
-    if ((input.isProcessRunning ?? isProcessRunning)(existing.record.pid)) {
+    if (
+      isActiveLock(existing.record, {
+        now: input.now ?? new Date(),
+        leaseTtlMs: input.leaseTtlMs ?? DEFAULT_PROJECT_LOCK_LEASE_TTL_MS,
+        isProcessRunning: input.isProcessRunning ?? isProcessRunning,
+        getProcessIdentity: input.getProcessIdentity ?? getProcessIdentity,
+      })
+    ) {
       throw new Error(
         `Project "${input.projectId}" is already running (PID ${existing.record.pid}).`
       );
@@ -80,6 +119,75 @@ export async function acquireProjectLock(input: {
 
     await rm(lockPath, { force: true });
   }
+}
+
+function startProjectLockHeartbeat(
+  lock: ProjectLockHandle,
+  leaseTtlMs: number
+): void {
+  const intervalMs = Math.max(1_000, Math.floor(leaseTtlMs / 3));
+  const timer = setInterval(() => {
+    void renewProjectLock(lock).catch((error) => {
+      console.error(
+        `Failed to renew project lock at "${lock.lockPath}": ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+    });
+  }, intervalMs);
+  timer.unref();
+  heartbeatTimers.set(lock, timer);
+}
+
+export async function renewProjectLock(
+  lock: ProjectLockHandle,
+  now = new Date()
+): Promise<boolean> {
+  const existing = await readProjectLock(lock.lockPath);
+  if (
+    existing.status !== "valid" ||
+    existing.record.ownerToken !== lock.ownerToken
+  ) {
+    return false;
+  }
+
+  const heartbeatAt = now.toISOString();
+  await writeFileAtomically(
+    lock.lockPath,
+    JSON.stringify({ ...existing.record, heartbeatAt }, null, 2) + "\n"
+  );
+  lock.heartbeatAt = heartbeatAt;
+  return true;
+}
+
+function isActiveLock(
+  record: ProjectLockRecord,
+  input: {
+    now: Date;
+    leaseTtlMs: number;
+    isProcessRunning: (pid: number) => boolean;
+    getProcessIdentity: (pid: number) => string | null;
+  }
+): boolean {
+  if (!input.isProcessRunning(record.pid)) {
+    return false;
+  }
+
+  const heartbeatAtMs = Date.parse(record.heartbeatAt);
+  const leaseAgeMs = input.now.getTime() - heartbeatAtMs;
+  if (
+    !Number.isFinite(heartbeatAtMs) ||
+    Math.abs(leaseAgeMs) > input.leaseTtlMs
+  ) {
+    return false;
+  }
+
+  const actualIdentity = input.getProcessIdentity(record.pid);
+  return (
+    record.processIdentity === null ||
+    actualIdentity === null ||
+    record.processIdentity === actualIdentity
+  );
 }
 
 async function ensureSecureDirectory(path: string): Promise<void> {
@@ -92,6 +200,12 @@ export async function releaseProjectLock(
 ): Promise<void> {
   if (!lock) {
     return;
+  }
+
+  const heartbeatTimer = heartbeatTimers.get(lock);
+  if (heartbeatTimer) {
+    clearInterval(heartbeatTimer);
+    heartbeatTimers.delete(lock);
   }
 
   try {
@@ -177,7 +291,12 @@ function parseProjectLock(raw: string): ProjectLockRecord | null {
       typeof parsed.pid !== "number" ||
       !Number.isInteger(parsed.pid) ||
       parsed.pid <= 0 ||
-      typeof parsed.startedAt !== "string"
+      typeof parsed.startedAt !== "string" ||
+      (parsed.heartbeatAt !== undefined &&
+        typeof parsed.heartbeatAt !== "string") ||
+      (parsed.processIdentity !== undefined &&
+        parsed.processIdentity !== null &&
+        typeof parsed.processIdentity !== "string")
     ) {
       return null;
     }
@@ -186,10 +305,30 @@ function parseProjectLock(raw: string): ProjectLockRecord | null {
       ownerToken: parsed.ownerToken,
       pid: parsed.pid,
       startedAt: parsed.startedAt,
+      heartbeatAt: parsed.heartbeatAt ?? parsed.startedAt,
+      processIdentity: parsed.processIdentity ?? null,
     };
   } catch {
     return null;
   }
+}
+
+export function getProcessIdentity(pid: number): string | null {
+  if (!Number.isInteger(pid) || pid <= 0) {
+    return null;
+  }
+
+  const result = spawnSync(
+    "ps",
+    ["-p", String(pid), "-o", "lstart=", "-o", "command="],
+    { encoding: "utf8" }
+  );
+  if (result.status !== 0) {
+    return null;
+  }
+
+  const identity = result.stdout.trim().replace(/\s+/g, " ");
+  return identity.length > 0 ? identity : null;
 }
 
 function isProcessRunning(pid: number): boolean {

--- a/packages/orchestrator/src/lock.ts
+++ b/packages/orchestrator/src/lock.ts
@@ -30,6 +30,8 @@ export type ProjectLockHandle = {
   processIdentity: string | null;
 };
 
+type LeaseLostHandler = (error: Error) => void | Promise<void>;
+
 const LOCK_READ_RETRY_DELAY_MS = 10;
 const LOCK_READ_RETRY_LIMIT = 20;
 const SECURE_DIRECTORY_MODE = 0o700;
@@ -44,6 +46,7 @@ export async function acquireProjectLock(input: {
   isProcessRunning?: (pid: number) => boolean;
   getProcessIdentity?: (pid: number) => string | null;
   leaseTtlMs?: number;
+  onLeaseLost?: LeaseLostHandler;
 }): Promise<ProjectLockHandle> {
   assertValidProjectId(input.projectId);
   const pid = input.pid ?? process.pid;
@@ -83,7 +86,8 @@ export async function acquireProjectLock(input: {
       };
       startProjectLockHeartbeat(
         lock,
-        input.leaseTtlMs ?? DEFAULT_PROJECT_LOCK_LEASE_TTL_MS
+        input.leaseTtlMs ?? DEFAULT_PROJECT_LOCK_LEASE_TTL_MS,
+        input.onLeaseLost ?? failClosedOnLeaseLoss
       );
       return lock;
     } catch (error) {
@@ -130,20 +134,47 @@ export async function acquireProjectLock(input: {
 
 function startProjectLockHeartbeat(
   lock: ProjectLockHandle,
-  leaseTtlMs: number
+  leaseTtlMs: number,
+  onLeaseLost: LeaseLostHandler
 ): void {
   const intervalMs = Math.max(1_000, Math.floor(leaseTtlMs / 3));
   const timer = setInterval(() => {
-    void renewProjectLock(lock).catch((error) => {
-      console.error(
-        `Failed to renew project lock at "${lock.lockPath}": ${
-          error instanceof Error ? error.message : String(error)
-        }`
-      );
-    });
+    void renewProjectLock(lock)
+      .then(async (renewed) => {
+        if (renewed) {
+          return;
+        }
+
+        stopProjectLockHeartbeat(lock);
+        const error = new Error(
+          `Lost ownership of project lock at "${lock.lockPath}".`
+        );
+        console.error(error.message);
+        await onLeaseLost(error);
+      })
+      .catch((error) => {
+        console.error(
+          `Failed to renew project lock at "${lock.lockPath}": ${
+            error instanceof Error ? error.message : String(error)
+          }`
+        );
+      });
   }, intervalMs);
   timer.unref();
   heartbeatTimers.set(lock, timer);
+}
+
+function stopProjectLockHeartbeat(lock: ProjectLockHandle): void {
+  const heartbeatTimer = heartbeatTimers.get(lock);
+  if (heartbeatTimer) {
+    clearInterval(heartbeatTimer);
+    heartbeatTimers.delete(lock);
+  }
+}
+
+function failClosedOnLeaseLoss(): void {
+  process.exitCode = 1;
+  process.kill(process.pid, "SIGTERM");
 }
 
 export async function renewProjectLock(
@@ -252,11 +283,7 @@ export async function releaseProjectLock(
     return;
   }
 
-  const heartbeatTimer = heartbeatTimers.get(lock);
-  if (heartbeatTimer) {
-    clearInterval(heartbeatTimer);
-    heartbeatTimers.delete(lock);
-  }
+  stopProjectLockHeartbeat(lock);
 
   try {
     const existing = await readProjectLock(lock.lockPath);

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -6722,10 +6722,19 @@ Prefer focused changes.
         join(store.runDir(initialRun!.runId, "tenant-1"), "events.ndjson"),
         "utf8"
       );
-      const turnEvents = raw
+      const persistedEvents = raw
         .trim()
         .split("\n")
-        .map((line) => JSON.parse(line) as Record<string, unknown>)
+        .map((line) => JSON.parse(line) as Record<string, unknown>);
+      expect(persistedEvents).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            integrity: expect.stringMatching(/^sha256:/),
+          }),
+        ])
+      );
+      const turnEvents = persistedEvents
+        .map(({ integrity: _integrity, ...event }) => event)
         .filter((event) => String(event.event).startsWith("turn_"));
 
       expect(turnEvents).toEqual([


### PR DESCRIPTION
## TL;DR

크로스프로세스 상태 변경을 process-verified lease로 직렬화하고, 상태·이벤트·CLI 설정을 내구성 있는 쓰기로 전환했습니다. PID 재사용으로 인한 오탐·무관 프로세스 종료를 차단하며, rework에서 legacy live lock과 heartbeat owner race도 보완했습니다.

## 변경 지점 다이어그램

```text
run / run-once / dispatch / recover
              │
              ▼
 project lease (TTL + heartbeat + PID/cmdline identity)
              │
              ├── snapshot/config ── tmp + fsync + rename + dir fsync
              └── events.ndjson ─── O_APPEND single write + fsync + SHA-256

heartbeat renewal ── same-inode FD write + fsync ── no new-owner clobber
config mutation ──── transaction lease ──────────── no lost update
repo start / stop ── structured PID identity ───── verified signal
```

## 여기부터 보세요

- `packages/orchestrator/src/lock.ts`: lease TTL/heartbeat, PID·cmdline 신원, legacy lock 보호, 동일 inode 갱신
- `packages/orchestrator/src/durable-file.ts`: temp+fsync+rename 및 디렉터리 fsync, durable append
- `packages/orchestrator/src/index.ts`: 상태 mutation 진입점의 프로젝트 lease
- `packages/orchestrator/src/fs-store.ts`: 원자적 snapshot과 단일-write NDJSON integrity
- `packages/cli/src/config.ts`: config transaction lock과 원자적 설정/PID 파일 쓰기
- `packages/cli/src/commands/start.ts`, `stop.ts`: daemon PID 신원 기록·이중 재검증

## 위험 & 롤백

- legacy lock은 heartbeat가 없으므로 기록 PID가 살아 있고 신원이 호환되는 동안 보수적으로 active로 유지합니다. 안전한 rolling upgrade를 우선한 동작입니다.
- heartbeat는 ownership pathname을 rename하지 않고 같은 inode에 갱신합니다. 갱신 중 crash로 line이 손상되면 reader가 fail-loud하여 안전하지 않은 takeover를 차단합니다.
- fsync가 작은 제어면 파일 저장 지연을 늘릴 수 있으나 상태 유실 방지가 우선입니다.
- 롤백은 이 PR 커밋을 revert하면 됩니다. 이벤트 `integrity` 필드는 기존 reader가 무시 가능한 추가 필드입니다.

## 변경 파일

- Orchestrator: lease, atomic writer, mutation serialization, event integrity 및 TC
- CLI: config lock, structured PID lifecycle 및 TC
- Core observability: 이벤트 무결성 생성·검증
- Release: `.changeset/steady-state-locks.md` (`@gh-symphony/cli` patch)

## Evidence

- `pnpm lint` — 통과
- `pnpm test` — 통과 (전체 workspace)
- `pnpm typecheck` — 통과
- `pnpm build` — 통과
- `pnpm --filter @gh-symphony/orchestrator test` — 통과 (214 tests)
- 변경 파일 `pnpm exec prettier --check ...` — 통과
- `bash e2e/run-e2e.sh happy 45` — 통과 (`running → retrying → idle`, 13초)
- Node 24.18.0 `doctor --smoke --issue hojinzs/github-symphony#440 --json` — `ok: true`
- GitHub CI `Test`, `Container Smoke` at `0dd7880` — 통과
- 참고: repo 전체 `pnpm format`은 이 PR 밖의 기존 112개 파일 경고로 실패하며, 이 PR 변경 파일은 모두 통과합니다.

## Issues — Closed #440

Fixes #440

## 머지 후/사람 확인

- [ ] 실제 장기 실행 환경에서 lease heartbeat 및 fsync 지연 추이를 관찰
- [ ] 운영체제별 `ps` 출력 차이가 있는 환경에서 daemon stop 신원 판별을 확인

