### PR TITLE
fix(worker): fail closed between continuation turns

### DIFF
--- a/.changeset/fence-worker-turn-leases.md
+++ b/.changeset/fence-worker-turn-leases.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Fence every worker turn with a short-lived orchestrator lease and fail closed when refresh availability is repeatedly lost for #447.

--- a/packages/cli/src/commands/start.test.ts
+++ b/packages/cli/src/commands/start.test.ts
@@ -12,6 +12,8 @@ const run = vi.fn();
 const status = vi.fn();
 const shutdown = vi.fn();
 const requestReconcile = vi.fn();
+const acquireWorkerTurnLease = vi.fn();
+const setWorkerOrchestratorUrl = vi.fn();
 const resolveDashboardResponse = vi.fn();
 const startControlPlaneServer = vi.fn();
 const serviceDependencies: Array<Record<string, unknown>> = [];
@@ -52,6 +54,8 @@ vi.mock("@gh-symphony/orchestrator", () => ({
     status = status;
     shutdown = shutdown;
     requestReconcile = requestReconcile;
+    acquireWorkerTurnLease = acquireWorkerTurnLease;
+    setWorkerOrchestratorUrl = setWorkerOrchestratorUrl;
   },
 }));
 
@@ -101,6 +105,12 @@ beforeEach(() => {
   shutdown.mockReset();
   shutdown.mockResolvedValue(undefined);
   requestReconcile.mockReset();
+  acquireWorkerTurnLease.mockReset();
+  acquireWorkerTurnLease.mockResolvedValue({
+    acquired: true,
+    expiresAt: "2026-07-15T00:00:15.000Z",
+  });
+  setWorkerOrchestratorUrl.mockReset();
   resolveDashboardResponse.mockReset();
   startControlPlaneServer.mockReset();
   resolveDashboardResponse.mockImplementation(
@@ -1057,6 +1067,23 @@ describe("start command foreground locking", () => {
       expect(refreshResponse.status).toBe(202);
       await expect(refreshResponse.json()).resolves.toEqual({ ok: true });
       expect(requestReconcile).toHaveBeenCalledTimes(1);
+
+      const leaseResponse = await fetch(`${url}/api/v1/worker-turn-lease`, {
+        method: "POST",
+        body: JSON.stringify({ issueId: "issue-1", runId: "run-1", turn: 2 }),
+        headers: { "content-type": "application/json" },
+      });
+      expect(leaseResponse.status).toBe(200);
+      await expect(leaseResponse.json()).resolves.toEqual({
+        acquired: true,
+        expiresAt: "2026-07-15T00:00:15.000Z",
+      });
+      expect(acquireWorkerTurnLease).toHaveBeenCalledWith({
+        issueId: "issue-1",
+        runId: "run-1",
+        turn: 2,
+      });
+      expect(setWorkerOrchestratorUrl).toHaveBeenCalledWith(url);
 
       await expect(
         fetch(`${url}/healthz`).then((response) => response.json())

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -1,7 +1,12 @@
 import { writeFile, mkdir, readFile, rm } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { spawn } from "node:child_process";
-import { createServer, type Server, type ServerResponse } from "node:http";
+import {
+  createServer,
+  type IncomingMessage,
+  type Server,
+  type ServerResponse,
+} from "node:http";
 import * as p from "@clack/prompts";
 import type { GlobalOptions } from "../index.js";
 import {
@@ -264,6 +269,7 @@ type ForegroundShutdownOptions = {
   configDir: string;
   projectId: string;
   httpServer?: Server;
+  workerHttpServer?: Server;
   projectLock?: ProjectLockHandle | null;
   service?: { shutdown(): Promise<void> };
   exit?: (code?: number) => never;
@@ -558,7 +564,18 @@ async function startHttpServer(input: {
   runtimeRoot: string;
   projectId: string;
   initialPort: number;
-  service: { requestReconcile(): void };
+  host: string;
+  service: {
+    requestReconcile(): void;
+    acquireWorkerTurnLease(request: {
+      issueId: string;
+      runId: string;
+      turn: number;
+    }): Promise<
+      | { acquired: true; expiresAt: string }
+      | { acquired: false; reason: string }
+    >;
+  };
 }): Promise<{ server: Server; port: number; url: string }> {
   const reader = new DashboardFsReader(
     join(input.runtimeRoot, "projects", encodeURIComponent(input.projectId))
@@ -573,6 +590,29 @@ async function startHttpServer(input: {
             request.resume();
             input.service.requestReconcile();
             respondJson(response, 202, { ok: true });
+            return;
+          }
+
+          if (
+            request.method === "POST" &&
+            url.pathname === "/api/v1/worker-turn-lease"
+          ) {
+            const body = await readJsonRequest(request);
+            if (
+              !body ||
+              typeof body.issueId !== "string" ||
+              typeof body.runId !== "string" ||
+              typeof body.turn !== "number"
+            ) {
+              respondJson(response, 400, { reason: "invalid_request" });
+              return;
+            }
+            const lease = await input.service.acquireWorkerTurnLease({
+              issueId: body.issueId,
+              runId: body.runId,
+              turn: body.turn,
+            });
+            respondJson(response, lease.acquired ? 200 : 409, lease);
             return;
           }
 
@@ -612,7 +652,7 @@ async function startHttpServer(input: {
 
         server.once("listening", handleListening);
         server.once("error", handleError);
-        server.listen(port, HTTP_HOST);
+        server.listen(port, input.host);
       });
 
       return {
@@ -632,6 +672,29 @@ async function startHttpServer(input: {
   throw new Error(
     `Unable to bind HTTP server starting from port ${input.initialPort}`
   );
+}
+
+async function readJsonRequest(
+  request: IncomingMessage
+): Promise<Record<string, unknown> | null> {
+  const chunks: Buffer[] = [];
+  let size = 0;
+  for await (const chunk of request) {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    size += buffer.length;
+    if (size > 16_384) {
+      return null;
+    }
+    chunks.push(buffer);
+  }
+  try {
+    const parsed = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+    return parsed && typeof parsed === "object"
+      ? (parsed as Record<string, unknown>)
+      : null;
+  } catch {
+    return null;
+  }
 }
 
 // ── Handler ───────────────────────────────────────────────────────────────────
@@ -804,6 +867,8 @@ const handler = async (
       | Awaited<ReturnType<typeof startControlPlaneServer>>
       | Awaited<ReturnType<typeof startHttpServer>>
       | null = null;
+    let workerHttpServer: Awaited<ReturnType<typeof startHttpServer>> | null =
+      null;
     const shutdown = async () => {
       if (shuttingDown) {
         return shutdownPromise;
@@ -817,6 +882,7 @@ const handler = async (
         configDir: options.configDir,
         projectId,
         httpServer: httpServer?.server,
+        workerHttpServer: workerHttpServer?.server,
         projectLock: heldLock,
         service,
       });
@@ -835,6 +901,15 @@ const handler = async (
     process.on("SIGTERM", handleSigterm);
 
     try {
+      workerHttpServer = await startHttpServer({
+        runtimeRoot,
+        projectId,
+        initialPort: parsed.httpPort ?? 0,
+        host: parsed.httpPort !== undefined ? HTTP_HOST : "127.0.0.1",
+        service,
+      });
+      service.setWorkerOrchestratorUrl(workerHttpServer.url);
+
       httpServer =
         parsed.webPort !== undefined
           ? await startControlPlaneServer({
@@ -848,12 +923,7 @@ const handler = async (
               onRefreshRequest: () => service.requestReconcile(),
             })
           : parsed.httpPort !== undefined
-            ? await startHttpServer({
-                runtimeRoot,
-                projectId,
-                initialPort: parsed.httpPort,
-                service,
-              })
+            ? workerHttpServer
             : null;
       if (httpServer) {
         try {
@@ -943,7 +1013,11 @@ const handler = async (
           );
           if (parsed.once) {
             process.exitCode = 1;
-            await closeHttpServer(httpServer?.server).catch((closeError) => {
+            await Promise.all(
+              [...new Set([httpServer?.server, workerHttpServer?.server])]
+                .filter((server): server is Server => Boolean(server))
+                .map((server) => closeHttpServer(server))
+            ).catch((closeError) => {
               logLine(
                 yellow("\u26A0"),
                 `Failed to stop HTTP server: ${
@@ -1002,7 +1076,11 @@ export async function shutdownForegroundOrchestrator(
   }
 
   try {
-    await closeHttpServer(input.httpServer);
+    await Promise.all(
+      [...new Set([input.httpServer, input.workerHttpServer])]
+        .filter((server): server is Server => Boolean(server))
+        .map((server) => closeHttpServer(server))
+    );
   } catch (error) {
     logLine(
       yellow("\u26A0"),

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -66,6 +66,51 @@ describe("OrchestratorService", () => {
     expect(dependencies.assignedOnly).toBe(true);
   });
 
+  it("grants short-lived turn leases only to the current running worker", async () => {
+    const tempRoot = await mkdtemp(join(tmpdir(), "orchestrator-turn-lease-"));
+    const store = new OrchestratorFsStore(tempRoot);
+    const projectConfig = createProjectConfig(tempRoot, {
+      owner: "acme",
+      name: "platform",
+      cloneUrl: "https://github.com/acme/platform.git",
+    });
+    await store.saveProjectConfig(projectConfig);
+    await store.saveProjectIssueOrchestrations("tenant-1", [
+      {
+        issueId: "issue-1",
+        identifier: "acme/platform#1",
+        workspaceKey: "issue-1",
+        completedOnce: false,
+        failureRetryCount: 0,
+        state: "running",
+        currentRunId: "run-current",
+        retryEntry: null,
+        updatedAt: "2026-07-15T00:00:00.000Z",
+      },
+    ]);
+    const service = new OrchestratorService(store, projectConfig, {
+      now: () => new Date("2026-07-15T00:00:00.000Z"),
+    });
+
+    await expect(
+      service.acquireWorkerTurnLease({
+        issueId: "issue-1",
+        runId: "run-current",
+        turn: 2,
+      })
+    ).resolves.toEqual({
+      acquired: true,
+      expiresAt: "2026-07-15T00:00:15.000Z",
+    });
+    await expect(
+      service.acquireWorkerTurnLease({
+        issueId: "issue-1",
+        runId: "run-superseded",
+        turn: 2,
+      })
+    ).resolves.toEqual({ acquired: false, reason: "run_not_current" });
+  });
+
   it("dispatches actionable issues and prevents duplicate issue leases", async () => {
     process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
     const tempRoot = await mkdtemp(join(tmpdir(), "orchestrator-test-"));
@@ -684,6 +729,7 @@ describe("OrchestratorService", () => {
         spawnImpl: spawnImpl as never,
         now: () => new Date("2026-03-08T00:01:00.000Z"),
       });
+      service.setWorkerOrchestratorUrl("http://localhost:4680");
 
       await service.runOnce();
 
@@ -691,6 +737,9 @@ describe("OrchestratorService", () => {
         | NodeJS.ProcessEnv
         | undefined;
       expect(workerEnv?.SYMPHONY_MAX_NONPRODUCTIVE_TURNS).toBe("7");
+      expect(workerEnv?.SYMPHONY_ORCHESTRATOR_URL).toBe(
+        "http://localhost:4680"
+      );
       expect(workerEnv?.SYMPHONY_GLOBAL_MAX_TURNS).toBe("");
       expect(workerEnv?.SYMPHONY_MAX_TOKENS).toBe("");
       expect(workerEnv?.SYMPHONY_SESSION_TIMEOUT_MS).toBe("");
@@ -9300,9 +9349,12 @@ Prefer focused changes.
       execSync(`git -C ${shell(repository.path)} add scripts/before-run.sh`, {
         stdio: "ignore",
       });
-      execSync(`git -C ${shell(repository.path)} commit -m add-before-run-hook`, {
-        stdio: "ignore",
-      });
+      execSync(
+        `git -C ${shell(repository.path)} commit -m add-before-run-hook`,
+        {
+          stdio: "ignore",
+        }
+      );
       const store = new OrchestratorFsStore(tempRoot);
       const projectConfig = createProjectConfig(tempRoot, repository);
       await store.saveProjectConfig(projectConfig);
@@ -9706,9 +9758,12 @@ Prefer focused changes.
     execSync(`git -C ${shell(repository.path)} add scripts/before-run.sh`, {
       stdio: "ignore",
     });
-    execSync(`git -C ${shell(repository.path)} commit -m add-missing-env-hook`, {
-      stdio: "ignore",
-    });
+    execSync(
+      `git -C ${shell(repository.path)} commit -m add-missing-env-hook`,
+      {
+        stdio: "ignore",
+      }
+    );
     const store = new OrchestratorFsStore(tempRoot);
     const projectConfig = createProjectConfig(tempRoot, repository);
     await store.saveProjectConfig(projectConfig);

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -68,6 +68,7 @@ const DEFAULT_RETRY_BACKOFF_MS = 30_000;
 const CONTINUATION_RETRY_DELAY_MS = 1_000;
 const DEFAULT_WORKER_COMMAND = "node packages/worker/dist/index.js";
 const DEFAULT_MAX_NONPRODUCTIVE_TURNS = 3;
+const WORKER_TURN_LEASE_TTL_MS = 15_000;
 const LOW_RATE_LIMIT_WARNING_THRESHOLD = 0.05;
 const ADAPTIVE_RATE_LIMIT_FULL_SPEED_RATIO = 0.5;
 const MAX_ADAPTIVE_POLL_INTERVAL_MULTIPLIER = 10;
@@ -342,6 +343,7 @@ export class OrchestratorService {
   private sleepResolver: (() => void) | null = null;
   private reconcilePromise: Promise<void> = Promise.resolve();
   private reconcileRequested = false;
+  private workerOrchestratorUrl: string | null = null;
 
   constructor(
     readonly store: OrchestratorStateStore,
@@ -368,6 +370,44 @@ export class OrchestratorService {
       assignedOnly?: boolean;
     } = {}
   ) {}
+
+  setWorkerOrchestratorUrl(url: string): void {
+    this.workerOrchestratorUrl = url;
+  }
+
+  async acquireWorkerTurnLease(input: {
+    issueId: string;
+    runId: string;
+    turn: number;
+  }): Promise<
+    { acquired: true; expiresAt: string } | { acquired: false; reason: string }
+  > {
+    return this.runSerialized(async () => {
+      const issueRecords = await this.store.loadProjectIssueOrchestrations(
+        this.projectConfig.projectId
+      );
+      const record = issueRecords.find(
+        (candidate) => candidate.issueId === input.issueId
+      );
+
+      if (!record || record.state !== "running") {
+        return { acquired: false, reason: "issue_not_running" };
+      }
+      if (record.currentRunId !== input.runId) {
+        return { acquired: false, reason: "run_not_current" };
+      }
+      if (!Number.isSafeInteger(input.turn) || input.turn < 1) {
+        return { acquired: false, reason: "invalid_turn" };
+      }
+
+      return {
+        acquired: true,
+        expiresAt: new Date(
+          this.now().getTime() + WORKER_TURN_LEASE_TTL_MS
+        ).toISOString(),
+      };
+    });
+  }
 
   async run(
     options: {
@@ -1655,6 +1695,7 @@ export class OrchestratorService {
           SYMPHONY_TURN_SANDBOX_POLICY:
             workflow.workflow.codex.turnSandboxPolicy ?? "",
           SYMPHONY_MAX_TURNS: String(workflow.workflow.agent.maxTurns),
+          SYMPHONY_ORCHESTRATOR_URL: this.workerOrchestratorUrl ?? "",
           SYMPHONY_MAX_NONPRODUCTIVE_TURNS:
             process.env.SYMPHONY_MAX_NONPRODUCTIVE_TURNS ??
             String(DEFAULT_MAX_NONPRODUCTIVE_TURNS),

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -54,6 +54,12 @@ import {
 } from "./runtime-routing.js";
 import { buildContinuationTurnInput } from "./thread-resume.js";
 import { resolveMaxTurns } from "./turn-limits.js";
+import {
+  acquireTurnLease,
+  refreshTrackerState,
+  resolveRefreshFailureThreshold,
+  updateRefreshFailureCount,
+} from "./turn-lease.js";
 import { persistTokenUsageArtifact, type TokenUsage } from "./token-usage.js";
 
 const launcherEnv = loadLauncherEnvironment(process.env);
@@ -678,6 +684,18 @@ async function runNonCodexRuntimeAdapterLifecycle(
     await (adapter as AgentRuntimeAdapter<{ runId: string }>).prepare({
       runId,
     });
+    const lease = await acquireTurnLease(env, 1);
+    if (lease.status !== "acquired") {
+      const event =
+        lease.status === "denied"
+          ? "worker_lease_lost"
+          : "orchestrator_unavailable";
+      failWorkerTurnGate(event, lease.reason);
+      throw new Error(`${event}: ${lease.reason}`);
+    }
+    process.stderr.write(
+      `[worker] acquired turn lease 1/1 (expires=${lease.expiresAt})\n`
+    );
     runtimeState.status = "running";
     runtimeState.runPhase = "streaming_turn";
     runtimeState.sessionInfo = {
@@ -1027,6 +1045,7 @@ async function runCodexClientProtocol(
   let turnTerminalFailurePhase: TurnTerminalFailurePhase | null = null;
   let activeTurnTelemetry: ActiveTurnTelemetry | null = null;
   let consecutiveNonProductiveTurns = 0;
+  let consecutiveRefreshFailures = 0;
   let convergenceDetected = false;
 
   function resolvePendingTurnCompletion(): void {
@@ -1546,6 +1565,57 @@ async function runCodexClientProtocol(
       runtimeState.sessionInfo.turnCount = turnCount;
       runtimeState.runPhase = "streaming_turn";
       const isFirstTurn = turn === 0;
+
+      if (!isFirstTurn) {
+        const trackerState = await refreshTrackerState(env);
+        process.stderr.write(
+          `[worker] tracker state refresh: ${trackerState}\n`
+        );
+
+        if (trackerState === "non-actionable") {
+          runtimeState.runPhase = "finishing";
+          runtimeState.executionPhase = resolveFinalExecutionPhase({
+            currentPhase: runtimeState.executionPhase,
+            trackerState,
+            userInputRequired: false,
+          });
+          process.stderr.write(
+            "[worker] issue no longer actionable — exiting multi-turn loop\n"
+          );
+          break;
+        }
+
+        const refreshFailureThreshold = resolveRefreshFailureThreshold(
+          env.SYMPHONY_REFRESH_FAILURE_THRESHOLD
+        );
+        const refreshFailures = updateRefreshFailureCount(
+          trackerState,
+          consecutiveRefreshFailures,
+          refreshFailureThreshold
+        );
+        consecutiveRefreshFailures = refreshFailures.count;
+        if (refreshFailures.failClosed) {
+          failWorkerTurnGate(
+            "orchestrator_unavailable",
+            `tracker refresh failed ${consecutiveRefreshFailures} consecutive times`
+          );
+          throw new Error("orchestrator_unavailable");
+        }
+      }
+
+      const lease = await acquireTurnLease(env, turnCount);
+      if (lease.status !== "acquired") {
+        const event =
+          lease.status === "denied"
+            ? "worker_lease_lost"
+            : "orchestrator_unavailable";
+        failWorkerTurnGate(event, lease.reason);
+        throw new Error(`${event}: ${lease.reason}`);
+      }
+      process.stderr.write(
+        `[worker] acquired turn lease ${turnCount}/${maxTurns} (expires=${lease.expiresAt})\n`
+      );
+
       const turnInput = isFirstTurn
         ? renderedPrompt
         : buildContinuationTurnInput({
@@ -1622,23 +1692,6 @@ async function runCodexClientProtocol(
         break;
       }
 
-      // Refresh tracker state to decide whether to continue
-      const trackerState = await refreshTrackerState(env);
-      process.stderr.write(`[worker] tracker state refresh: ${trackerState}\n`);
-
-      if (trackerState === "non-actionable") {
-        runtimeState.runPhase = "finishing";
-        runtimeState.executionPhase = resolveFinalExecutionPhase({
-          currentPhase: runtimeState.executionPhase,
-          trackerState,
-          userInputRequired: false,
-        });
-        process.stderr.write(
-          "[worker] issue no longer actionable — exiting multi-turn loop\n"
-        );
-        break;
-      }
-
       const currentTurnProgressSnapshot = {
         ...captureTurnWorkspaceSnapshot(plan.cwd),
         lastError: runtimeState.run?.lastError ?? null,
@@ -1695,7 +1748,8 @@ async function runCodexClientProtocol(
         break;
       }
 
-      // trackerState is "active" or "unknown" — continue with next turn
+      // The next iteration refreshes state and acquires a fresh lease before
+      // another turn can start.
     }
 
     process.stderr.write(
@@ -1737,7 +1791,14 @@ async function runCodexClientProtocol(
     }
 
     // Map timeout errors to specific categories
-    if (errMsg.startsWith("response_timeout:")) {
+    if (
+      errMsg.startsWith("orchestrator_unavailable") ||
+      errMsg.startsWith("worker_lease_lost")
+    ) {
+      if (runtimeState.run) {
+        runtimeState.run.lastError = errMsg;
+      }
+    } else if (errMsg.startsWith("response_timeout:")) {
       runtimeState.runPhase = "stalled";
       if (runtimeState.run) {
         runtimeState.run.lastError = errMsg;
@@ -1973,35 +2034,15 @@ function parseTokenUsageSnapshot(value: unknown): TokenUsageSnapshot | null {
   };
 }
 
-/**
- * Refresh tracker state by querying the dashboard state API.
- * Returns "active" if the issue run is still tracked, "non-actionable"
- * if the run is no longer listed, or "unknown" on any failure.
- */
-async function refreshTrackerState(
-  env: NodeJS.ProcessEnv
-): Promise<"active" | "non-actionable" | "unknown"> {
-  const orchestratorUrl = env.SYMPHONY_ORCHESTRATOR_URL;
-  const issueIdentifier = env.SYMPHONY_ISSUE_IDENTIFIER;
-
-  if (!orchestratorUrl) {
-    return "unknown";
+function failWorkerTurnGate(event: string, reason: string): void {
+  runtimeState.status = "failed";
+  runtimeState.runPhase = "failed";
+  runtimeState.lastEventAt = new Date().toISOString();
+  if (runtimeState.run) {
+    runtimeState.run.lastError = `${event}: ${reason}`;
   }
-
-  try {
-    const response = await fetch(`${orchestratorUrl}/api/v1/state`);
-    if (!response.ok) return "unknown";
-
-    const status = (await response.json()) as {
-      activeRuns?: Array<{ issueIdentifier: string }>;
-    };
-    const isActive = status.activeRuns?.some(
-      (run) => run.issueIdentifier === issueIdentifier
-    );
-    return isActive ? "active" : "non-actionable";
-  } catch {
-    return "unknown";
-  }
+  process.stderr.write(`[worker] ${event}: ${reason}\n`);
+  emitOrchestratorChannelEvent(event);
 }
 
 /**

--- a/packages/worker/src/turn-lease.test.ts
+++ b/packages/worker/src/turn-lease.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  acquireTurnLease,
+  refreshTrackerState,
+  resolveRefreshFailureThreshold,
+  updateRefreshFailureCount,
+} from "./turn-lease.js";
+
+describe("worker turn lease", () => {
+  it("acquires a lease for the exact issue/run before a turn", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          acquired: true,
+          expiresAt: "2026-07-15T00:00:15.000Z",
+        }),
+        { status: 200 }
+      )
+    );
+
+    await expect(
+      acquireTurnLease(
+        {
+          SYMPHONY_ORCHESTRATOR_URL: "http://localhost:4680",
+          SYMPHONY_ISSUE_ID: "issue-1",
+          SYMPHONY_RUN_ID: "run-1",
+        },
+        2,
+        fetchImpl
+      )
+    ).resolves.toEqual({
+      status: "acquired",
+      expiresAt: "2026-07-15T00:00:15.000Z",
+    });
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "http://localhost:4680/api/v1/worker-turn-lease",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ issueId: "issue-1", runId: "run-1", turn: 2 }),
+      })
+    );
+  });
+
+  it("fails closed when a superseded worker is denied", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ reason: "run_not_current" }), {
+        status: 409,
+      })
+    );
+
+    await expect(
+      acquireTurnLease(
+        {
+          SYMPHONY_ORCHESTRATOR_URL: "http://localhost:4680",
+          SYMPHONY_ISSUE_ID: "issue-1",
+          SYMPHONY_RUN_ID: "old-run",
+        },
+        1,
+        fetchImpl
+      )
+    ).resolves.toEqual({ status: "denied", reason: "run_not_current" });
+  });
+
+  it("classifies an unreachable orchestrator as unavailable", async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new Error("ECONNREFUSED"));
+
+    await expect(
+      acquireTurnLease(
+        {
+          SYMPHONY_ORCHESTRATOR_URL: "http://localhost:4680",
+          SYMPHONY_ISSUE_ID: "issue-1",
+          SYMPHONY_RUN_ID: "run-1",
+        },
+        1,
+        fetchImpl
+      )
+    ).resolves.toEqual({
+      status: "unavailable",
+      reason: "ECONNREFUSED",
+    });
+  });
+});
+
+describe("tracker refresh fail-closed threshold", () => {
+  it("returns unknown on transport failure for threshold accounting", async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new Error("network error"));
+    await expect(
+      refreshTrackerState(
+        {
+          SYMPHONY_ORCHESTRATOR_URL: "http://localhost:4680",
+          SYMPHONY_ISSUE_IDENTIFIER: "acme/repo#1",
+        },
+        fetchImpl
+      )
+    ).resolves.toBe("unknown");
+  });
+
+  it("uses a positive configured threshold and rejects unsafe values", () => {
+    expect(resolveRefreshFailureThreshold("2")).toBe(2);
+    expect(resolveRefreshFailureThreshold("0")).toBe(3);
+    expect(resolveRefreshFailureThreshold("invalid")).toBe(3);
+  });
+
+  it("fails closed on the configured consecutive refresh failure", () => {
+    const first = updateRefreshFailureCount("unknown", 0, 2);
+    const second = updateRefreshFailureCount("unknown", first.count, 2);
+    const recovered = updateRefreshFailureCount("active", second.count, 2);
+
+    expect(first).toEqual({ count: 1, failClosed: false });
+    expect(second).toEqual({ count: 2, failClosed: true });
+    expect(recovered).toEqual({ count: 0, failClosed: false });
+  });
+});

--- a/packages/worker/src/turn-lease.ts
+++ b/packages/worker/src/turn-lease.ts
@@ -1,0 +1,119 @@
+export const DEFAULT_REFRESH_FAILURE_THRESHOLD = 3;
+const ORCHESTRATOR_REQUEST_TIMEOUT_MS = 5_000;
+
+export type TrackerRefreshState = "active" | "non-actionable" | "unknown";
+
+export type TurnLeaseResult =
+  | { status: "acquired"; expiresAt: string }
+  | { status: "denied"; reason: string }
+  | { status: "unavailable"; reason: string };
+
+export function resolveRefreshFailureThreshold(
+  value: string | undefined
+): number {
+  if (!value?.trim()) {
+    return DEFAULT_REFRESH_FAILURE_THRESHOLD;
+  }
+
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed > 0
+    ? parsed
+    : DEFAULT_REFRESH_FAILURE_THRESHOLD;
+}
+
+export function updateRefreshFailureCount(
+  state: TrackerRefreshState,
+  currentCount: number,
+  threshold: number
+): { count: number; failClosed: boolean } {
+  const count = state === "unknown" ? currentCount + 1 : 0;
+  return { count, failClosed: count >= threshold };
+}
+
+export async function refreshTrackerState(
+  env: NodeJS.ProcessEnv,
+  fetchImpl: typeof fetch = fetch
+): Promise<TrackerRefreshState> {
+  const orchestratorUrl = env.SYMPHONY_ORCHESTRATOR_URL;
+  const issueIdentifier = env.SYMPHONY_ISSUE_IDENTIFIER;
+
+  if (!orchestratorUrl) {
+    return "unknown";
+  }
+
+  try {
+    const response = await fetchImpl(`${orchestratorUrl}/api/v1/state`, {
+      signal: AbortSignal.timeout(ORCHESTRATOR_REQUEST_TIMEOUT_MS),
+    });
+    if (!response.ok) return "unknown";
+
+    const status = (await response.json()) as {
+      activeRuns?: Array<{ issueIdentifier: string }>;
+    };
+    const isActive = status.activeRuns?.some(
+      (run) => run.issueIdentifier === issueIdentifier
+    );
+    return isActive ? "active" : "non-actionable";
+  } catch {
+    return "unknown";
+  }
+}
+
+export async function acquireTurnLease(
+  env: NodeJS.ProcessEnv,
+  turn: number,
+  fetchImpl: typeof fetch = fetch
+): Promise<TurnLeaseResult> {
+  const orchestratorUrl = env.SYMPHONY_ORCHESTRATOR_URL;
+  const issueId = env.SYMPHONY_ISSUE_ID;
+  const runId = env.SYMPHONY_RUN_ID;
+
+  if (!orchestratorUrl || !issueId || !runId) {
+    return {
+      status: "unavailable",
+      reason: "missing orchestrator URL or worker run identity",
+    };
+  }
+
+  try {
+    const response = await fetchImpl(
+      `${orchestratorUrl}/api/v1/worker-turn-lease`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ issueId, runId, turn }),
+        signal: AbortSignal.timeout(ORCHESTRATOR_REQUEST_TIMEOUT_MS),
+      }
+    );
+    const payload = (await response.json().catch(() => null)) as {
+      acquired?: boolean;
+      expiresAt?: string;
+      reason?: string;
+    } | null;
+
+    if (!response.ok) {
+      if (response.status === 409 || response.status === 403) {
+        return {
+          status: "denied",
+          reason:
+            payload?.reason ?? `lease request rejected (${response.status})`,
+        };
+      }
+      return {
+        status: "unavailable",
+        reason: payload?.reason ?? `lease endpoint returned ${response.status}`,
+      };
+    }
+
+    if (payload?.acquired !== true || !payload.expiresAt) {
+      return { status: "unavailable", reason: "invalid lease response" };
+    }
+
+    return { status: "acquired", expiresAt: payload.expiresAt };
+  } catch (error) {
+    return {
+      status: "unavailable",
+      reason: error instanceof Error ? error.message : String(error),
+    };
+  }
+}


### PR DESCRIPTION
## Issues

- Closed #447

## TL;DR

- 모든 Codex·non-Codex agent turn 직전에 15초 orchestrator lease를 획득하여 현재 run만 side effect를 시작할 수 있게 했습니다.
- tracker refresh가 기본 3회 연속 실패하면 `orchestrator_unavailable` 이벤트를 남기고 worker가 비정상 종료합니다.
- 공개 HTTP 옵션이 없어도 loopback 전용 내부 endpoint를 자동 기동해 기본 `repo start` 경로를 보존합니다.

## 변경 지점 다이어그램

```text
repo start
  └─ loopback worker endpoint 주입
       ├─ GET  /api/v1/state
       └─ POST /api/v1/worker-turn-lease
                    │
worker turn N 직전 ─┴─ current issue/run 검증 → 15초 lease → turn/start
                    ├─ superseded run → worker_lease_lost + exit 1
                    └─ endpoint 불가 → orchestrator_unavailable + exit 1

turn N 완료 → tracker refresh
                    └─ unknown 3회 연속 → orchestrator_unavailable + exit 1
```

## 여기부터 보세요

- `packages/worker/src/turn-lease.ts` — lease 요청, refresh 상태, 연속 실패 임계 로직
- `packages/worker/src/index.ts` — Codex·non-Codex turn 직전 fail-closed gate
- `packages/orchestrator/src/service.ts` — serialized current-run lease authority와 worker endpoint 주입
- `packages/cli/src/commands/start.ts` — loopback endpoint 및 lease HTTP route

## 변경 사항

- 현재 `running` orchestration record의 `issueId`·`runId`와 일치할 때만 15초 turn lease를 발급합니다.
- superseded worker의 lease 요청은 `409 run_not_current`로 거부합니다.
- lease/refresh 요청에 5초 timeout을 적용하고, lease endpoint 장애는 즉시 fail-closed합니다.
- refresh `unknown`은 기본 임계 3회까지 계수하고 정상 응답 시 초기화합니다.
- fail-closed 원인을 worker channel의 `orchestrator_unavailable` 또는 `worker_lease_lost` 이벤트로 노출합니다.
- `changeset:patch` 정책에 따라 `@gh-symphony/cli` changeset을 추가했습니다.

## Evidence

- `pnpm lint` — pass
- `pnpm test` — pass (worker 133, orchestrator 201, CLI 487 포함)
- `pnpm typecheck` — pass
- `pnpm build` — pass
- `pnpm --filter @gh-symphony/worker test -- --run src/turn-lease.test.ts` — pass (6 TC)
- `pnpm --filter @gh-symphony/orchestrator test -- --run src/service.test.ts` — pass (117 TC)
- `pnpm --filter @gh-symphony/cli test -- --run src/commands/start.test.ts` — pass (33 TC)
- `pnpm exec changeset status --since=origin/main` — `@gh-symphony/cli` patch only
- `docker compose -f docker-compose.e2e.yml -f docker-compose.e2e.events.yml up -d --build` + happy-path fixture — completed 후 continuation retry 관찰, `lastError: null`

## 위험 & 롤백

- Upstream spec 8.5/11.4는 refresh 실패 시 worker keep-running을 권고합니다. 이 변경은 토큰 낭비와 HA 중복 side effect를 막기 위해 worker turn 경계에서 fail-closed하는 명시적 repository-level 안전성 divergence입니다.
- 단일 orchestration authority, claim/current-run 확인, 동일 thread continuation, structured event 경계는 upstream spec을 유지합니다.
- 회귀 시 이 PR을 revert하면 기존 refresh/continuation 동작으로 복구됩니다.

## 변경 파일

- `.changeset/fence-worker-turn-leases.md`
- `packages/worker/src/index.ts`
- `packages/worker/src/turn-lease.ts`
- `packages/worker/src/turn-lease.test.ts`
- `packages/orchestrator/src/service.ts`
- `packages/orchestrator/src/service.test.ts`
- `packages/cli/src/commands/start.ts`
- `packages/cli/src/commands/start.test.ts`

## 머지 후/사람 확인

- [ ] 실제 HA 전환 시 superseded worker의 `worker_lease_lost`와 중복 PR/comment 부재를 운영 로그에서 확인

## Human Validation

- [ ] 턴별 lease 거부 시 다음 agent turn이 시작되지 않는지 확인
- [ ] orchestrator 연속 도달 실패가 `orchestrator_unavailable`과 비정상 종료로 노출되는지 확인
- [ ] `repo start`의 공개 HTTP 미사용 경로가 loopback endpoint와 함께 정상 dispatch되는지 확인
