### PR TITLE
feat(tracker-github): GraphQL rate limit 비용 계측

### DIFF
--- a/.changeset/measure-github-graphql-costs.md
+++ b/.changeset/measure-github-graphql-costs.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Record GitHub GraphQL cost, remaining points, per-query breakdowns, and per-cycle totals in runtime tracker events for #472.

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -8614,6 +8614,17 @@ Handle Linear issue.`,
         limit: 1500,
         remaining: 1499,
         resource: "graphql",
+        cycleCost: 13,
+        queryCosts: {
+          ProjectFields: {
+            requestCount: 1,
+            cost: 2,
+          },
+          ProjectItems: {
+            requestCount: 1,
+            cost: 11,
+          },
+        },
       },
     };
     vi.spyOn(trackerAdapters, "resolveTrackerAdapter").mockReturnValue({
@@ -8669,6 +8680,17 @@ Handle Linear issue.`,
           rateLimits: expect.objectContaining({
             source: "linear",
             remaining: 1499,
+            cycleCost: 13,
+            queryCosts: {
+              ProjectFields: {
+                requestCount: 1,
+                cost: 2,
+              },
+              ProjectItems: {
+                requestCount: 1,
+                cost: 11,
+              },
+            },
           }),
         }),
         expect.objectContaining({

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -8757,6 +8757,31 @@ Handle Linear issue.`,
       lastError: null,
       nextRetryAt: null,
     });
+    await store.saveRun({
+      runId: "run-2",
+      projectId: "tenant-1",
+      projectSlug: "tenant-1",
+      issueId: "linear-issue-2",
+      issueSubjectId: "linear-issue-2",
+      issueIdentifier: "ENG-2",
+      issueState: "Todo",
+      repository,
+      status: "running",
+      attempt: 1,
+      processId: null,
+      port: 4604,
+      workingDirectory: join(tempRoot, "active-run-2"),
+      issueWorkspaceKey: null,
+      workspaceRuntimeDir: join(tempRoot, "active-run-2", "workspace-runtime"),
+      workflowPath: null,
+      retryKind: null,
+      createdAt: "2026-03-08T00:00:00.000Z",
+      updatedAt: "2026-03-08T00:00:00.000Z",
+      startedAt: "2026-03-08T00:00:00.000Z",
+      completedAt: null,
+      lastError: null,
+      nextRetryAt: null,
+    });
 
     const issue = {
       id: "linear-issue-1",
@@ -8788,10 +8813,35 @@ Handle Linear issue.`,
         resource: "graphql",
       },
     };
+    const secondIssue = {
+      ...issue,
+      id: "linear-issue-2",
+      identifier: "ENG-2",
+      number: 2,
+      title: "Second Linear issue",
+      tracker: {
+        ...issue.tracker,
+        itemId: "linear-issue-2",
+      },
+    };
+    const refreshedIssues = [issue, secondIssue] as TrackedIssueList;
+    refreshedIssues.rateLimits = {
+      source: "linear",
+      limit: 1500,
+      remaining: 1497,
+      resource: "graphql",
+      cycleCost: 5,
+      queryCosts: {
+        IssuesByIds: {
+          requestCount: 1,
+          cost: 5,
+        },
+      },
+    };
     vi.spyOn(trackerAdapters, "resolveTrackerAdapter").mockReturnValue({
       listIssues: vi.fn().mockResolvedValue([]),
       listIssuesByStates: vi.fn().mockResolvedValue([]),
-      fetchIssueStatesByIds: vi.fn().mockResolvedValue([issue]),
+      fetchIssueStatesByIds: vi.fn().mockResolvedValue(refreshedIssues),
       buildWorkerEnvironment: vi.fn().mockReturnValue({
         LINEAR_ISSUE_ID: "linear-issue-1",
       }),
@@ -8805,14 +8855,20 @@ Handle Linear issue.`,
     await service.runOnce();
 
     const rawEvents = (
-      await readFile(
-        join(store.runDir("run-1", projectConfig.projectId), "events.ndjson"),
-        "utf8"
+      await Promise.all(
+        ["run-1", "run-2"].map((runId) =>
+          readFile(
+            join(store.runDir(runId, projectConfig.projectId), "events.ndjson"),
+            "utf8"
+          )
+        )
       )
-    )
-      .trim()
-      .split("\n")
-      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    ).flatMap((contents) =>
+      contents
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line) as Record<string, unknown>)
+    );
     expect(rawEvents).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -8825,13 +8881,22 @@ Handle Linear issue.`,
             identifier: "ENG-1",
             id: "linear-issue-1",
           },
-          rateLimits: expect.objectContaining({
-            source: "linear",
-            remaining: 1498,
-          }),
         }),
       ])
     );
+    const fetchEvents = rawEvents.filter(
+      (event) => event.event === "tracker.fetchByIds"
+    );
+    expect(fetchEvents).toHaveLength(2);
+    expect(
+      fetchEvents.filter(
+        (event) =>
+          (event.rateLimits as Record<string, unknown> | null)?.cycleCost === 5
+      )
+    ).toHaveLength(1);
+    expect(
+      fetchEvents.filter((event) => event.rateLimits === null)
+    ).toHaveLength(1);
   });
 
   it("uses empty tracker list rate limits in project snapshots", async () => {

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -8899,6 +8899,142 @@ Handle Linear issue.`,
     ).toHaveLength(1);
   });
 
+  it("records tracker.list cost on an active run when no issue is dispatched", async () => {
+    const tempRoot = await mkdtemp(
+      join(tmpdir(), "orchestrator-no-dispatch-list-cost-")
+    );
+    const repository = await createRepositoryFixture(
+      tempRoot,
+      "acme",
+      "platform"
+    );
+    const store = new OrchestratorFsStore(tempRoot);
+    const projectConfig = createProjectConfig(tempRoot, repository);
+    await store.saveProjectConfig(projectConfig);
+    await store.saveProjectIssueOrchestrations(projectConfig.projectId, [
+      {
+        issueId: "issue-1",
+        identifier: "acme/platform#1",
+        workspaceKey: "acme_platform_1",
+        completedOnce: false,
+        failureRetryCount: 0,
+        state: "running",
+        currentRunId: "run-1",
+        retryEntry: null,
+        updatedAt: "2026-03-08T00:00:00.000Z",
+      },
+    ]);
+    await store.saveRun({
+      runId: "run-1",
+      projectId: projectConfig.projectId,
+      projectSlug: projectConfig.slug,
+      issueId: "issue-1",
+      issueSubjectId: "issue-1",
+      issueIdentifier: "acme/platform#1",
+      issueState: "In progress",
+      repository,
+      status: "running",
+      attempt: 1,
+      processId: null,
+      port: 4603,
+      workingDirectory: join(tempRoot, "active-run"),
+      issueWorkspaceKey: "acme_platform_1",
+      workspaceRuntimeDir: join(tempRoot, "active-run", "workspace-runtime"),
+      workflowPath: null,
+      retryKind: null,
+      createdAt: "2026-03-08T00:00:00.000Z",
+      updatedAt: "2026-03-08T00:00:00.000Z",
+      startedAt: "2026-03-08T00:00:00.000Z",
+      completedAt: null,
+      lastError: null,
+      nextRetryAt: null,
+    });
+
+    const issue = {
+      id: "issue-1",
+      identifier: "acme/platform#1",
+      number: 1,
+      title: "Active issue",
+      description: null,
+      priority: null,
+      state: "In progress",
+      branchName: null,
+      url: "https://github.com/acme/platform/issues/1",
+      labels: [],
+      blockedBy: [],
+      createdAt: "2026-03-08T00:00:00.000Z",
+      updatedAt: "2026-03-08T00:05:00.000Z",
+      repository,
+      tracker: {
+        adapter: "github-project" as const,
+        bindingId: projectConfig.tracker.bindingId,
+        itemId: "issue-1",
+      },
+      metadata: {},
+      rateLimits: null,
+    };
+    const listedIssues = [issue] as TrackedIssueList;
+    listedIssues.rateLimits = {
+      source: "github",
+      limit: 5000,
+      remaining: 4989,
+      resource: "graphql",
+      cycleCost: 11,
+      queryCosts: {
+        ProjectItems: {
+          requestCount: 1,
+          cost: 11,
+        },
+      },
+    };
+    vi.spyOn(trackerAdapters, "resolveTrackerAdapter").mockReturnValue({
+      listIssues: vi.fn().mockResolvedValue(listedIssues),
+      listIssuesByStates: vi.fn().mockResolvedValue([]),
+      fetchIssueStatesByIds: vi.fn().mockResolvedValue([issue]),
+      buildWorkerEnvironment: vi.fn().mockReturnValue({}),
+      reviveIssue: vi.fn(),
+    });
+
+    const service = new OrchestratorService(store, projectConfig, {
+      now: () => new Date("2026-03-08T00:05:00.000Z"),
+    });
+
+    const snapshot = await service.runOnce();
+    const events = (
+      await readFile(
+        join(
+          store.runDir("run-1", projectConfig.projectId),
+          "events.ndjson"
+        ),
+        "utf8"
+      )
+    )
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    const listEvents = events.filter((event) => event.event === "tracker.list");
+
+    expect(snapshot.summary.dispatched).toBe(0);
+    expect(listEvents).toEqual([
+      expect.objectContaining({
+        event: "tracker.list",
+        issue: {
+          identifier: "acme/platform#1",
+          id: "issue-1",
+        },
+        rateLimits: expect.objectContaining({
+          cycleCost: 11,
+          queryCosts: {
+            ProjectItems: {
+              requestCount: 1,
+              cost: 11,
+            },
+          },
+        }),
+      }),
+    ]);
+  });
+
   it("uses empty tracker list rate limits in project snapshots", async () => {
     process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
     const tempRoot = await mkdtemp(

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -899,6 +899,23 @@ export class OrchestratorService {
         );
       }
 
+      if (listRateLimits && !listRateLimitsRecorded) {
+        const activeRun = syncedActiveRuns[0];
+        const activeIssue = activeRun
+          ? trackedIssuesByIdentifier.get(activeRun.issueIdentifier)
+          : null;
+        if (activeRun && activeIssue) {
+          await this.store.appendRunEvent(activeRun.runId, {
+            at: now.toISOString(),
+            event: "tracker.list",
+            projectId: tenant.projectId,
+            ...buildStructuredTrackerEventMetadata(tenant, activeIssue),
+            rateLimits: listRateLimits,
+          });
+          listRateLimitsRecorded = true;
+        }
+      }
+
       for (const issueRecord of issueRecords) {
         if (!isIssueOrchestrationClaimedState(issueRecord.state)) {
           continue;

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -783,6 +783,8 @@ export class OrchestratorService {
 
       // Sort candidates by priority (asc, null last) → createdAt (oldest) → identifier (lexicographic)
       const sortedCandidates = sortCandidatesForDispatch(unscheduledCandidates);
+      const listRateLimits = getTrackedIssueListRateLimits(issues);
+      let listRateLimitsRecorded = false;
 
       // Count active runs by state for per-state concurrency limits
       const activeByState = new Map<string, number>();
@@ -863,12 +865,19 @@ export class OrchestratorService {
           updatedAt: now.toISOString(),
         });
         await this.store.saveRun(run);
+        const eventRateLimits =
+          listRateLimits && !listRateLimitsRecorded
+            ? listRateLimits
+            : listRateLimits
+              ? null
+              : (issue.rateLimits ?? null);
+        listRateLimitsRecorded ||= listRateLimits !== null;
         await this.store.appendRunEvent(run.runId, {
           at: now.toISOString(),
           event: "tracker.list",
           projectId: tenant.projectId,
           ...buildStructuredTrackerEventMetadata(tenant, issue),
-          rateLimits: issue.rateLimits ?? null,
+          rateLimits: eventRateLimits,
         });
         await this.store.appendRunEvent(run.runId, {
           at: now.toISOString(),
@@ -1892,17 +1901,26 @@ export class OrchestratorService {
     const issueStateByIdentifier = new Map<string, TrackedIssue["state"]>(
       issues.map((issue) => [issue.identifier, issue.state])
     );
+    const fetchRateLimits = getTrackedIssueListRateLimits(issues);
+    let fetchRateLimitsRecorded = false;
 
     const syncedRuns: OrchestratorRunRecord[] = [];
     for (const run of activeRuns) {
       const currentIssue = issuesByIdentifier.get(run.issueIdentifier);
       if (currentIssue) {
+        const eventRateLimits =
+          fetchRateLimits && !fetchRateLimitsRecorded
+            ? fetchRateLimits
+            : fetchRateLimits
+              ? null
+              : (currentIssue.rateLimits ?? null);
+        fetchRateLimitsRecorded ||= fetchRateLimits !== null;
         await this.store.appendRunEvent(run.runId, {
           at: now.toISOString(),
           event: "tracker.fetchByIds",
           projectId: tenant.projectId,
           ...buildStructuredTrackerEventMetadata(tenant, currentIssue),
-          rateLimits: currentIssue.rateLimits ?? null,
+          rateLimits: eventRateLimits,
         });
       }
       const currentTrackerState = issueStateByIdentifier.get(

--- a/packages/tracker-github/src/adapter.ts
+++ b/packages/tracker-github/src/adapter.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import {
   DEFAULT_WORKFLOW_LIFECYCLE,
   type TrackedIssue,
+  type TrackedIssueList,
   type WorkflowPriorityConfig,
   type WorkflowLifecycleConfig,
 } from "@gh-symphony/core";
@@ -24,6 +25,8 @@ export type GitHubTrackerConfig = {
   timeoutMs?: number;
   priority?: WorkflowPriorityConfig | null;
   priorityFieldName?: string;
+  /** @internal Collects per-operation GraphQL cost within one tracker call. */
+  rateLimitCollector?: GitHubRateLimitCollector;
 };
 
 export type GitHubRepositoryRef = {
@@ -270,7 +273,9 @@ type GraphQLRepositoryIssueLookupResponse = {
 };
 
 type GraphQLResponse<TData> = {
-  data?: TData;
+  data?: TData & {
+    rateLimit?: GraphQLRateLimitField | null;
+  };
   errors?: Array<{ message: string }>;
 };
 
@@ -322,6 +327,38 @@ type GitHubRateLimitPayload = {
   reset: number | null;
   resetAt: string | null;
   resource: string | null;
+  cost?: number;
+  cycleCost?: number;
+  queryCosts?: Record<
+    string,
+    {
+      requestCount: number;
+      cost: number;
+    }
+  >;
+  fieldRateLimits?: GraphQLRateLimitField;
+  headerRateLimits?: GitHubRateLimitHeaderPayload | null;
+};
+
+type GitHubRateLimitHeaderPayload = Omit<
+  GitHubRateLimitPayload,
+  "cost" | "cycleCost" | "queryCosts" | "fieldRateLimits" | "headerRateLimits"
+>;
+
+type GraphQLRateLimitField = {
+  cost: number;
+  remaining: number;
+  resetAt: string;
+};
+
+type GitHubRateLimitObservation = {
+  operationName: string;
+  rateLimit: GraphQLRateLimitField;
+  payload: GitHubRateLimitPayload;
+};
+
+type GitHubRateLimitCollector = {
+  observations: GitHubRateLimitObservation[];
 };
 
 const cachedGitHubGraphQLRateLimits = new Map<
@@ -468,7 +505,8 @@ function normalizePullRequestProjectItem(
 export async function fetchProjectIssues(
   config: GitHubTrackerConfig,
   fetchImpl: FetchLike = fetch
-): Promise<GitHubTrackedIssue[]> {
+): Promise<GitHubTrackedIssue[] & TrackedIssueList> {
+  const cycleConfig = beginGraphQLRateLimitCycle(config);
   // GitHub Project V2 does not expose query-time item filtering by workflow
   // state, so callers must fetch the project items and filter in memory.
   const issues: GitHubTrackedIssue[] = [];
@@ -476,7 +514,7 @@ export async function fetchProjectIssues(
   const priorityOptionIds =
     !config.priority && config.priorityFieldName
       ? await fetchPriorityOptionOrder(
-          config,
+          cycleConfig,
           config.priorityFieldName,
           fetchImpl
         )
@@ -486,10 +524,14 @@ export async function fetchProjectIssues(
     : null;
   let excludedCount = 0;
   let repositoryExcludedCount = 0;
-  let latestRateLimits: Record<string, unknown> | null = null;
+  let latestRateLimits: GitHubRateLimitPayload | null = null;
 
   do {
-    const pageResult = await fetchProjectItemsPage(config, cursor, fetchImpl);
+    const pageResult = await fetchProjectItemsPage(
+      cycleConfig,
+      cursor,
+      fetchImpl
+    );
     const page = pageResult.page;
     latestRateLimits = pageResult.rateLimits ?? latestRateLimits;
     const pageIssues = (page.nodes ?? []).flatMap((item) => {
@@ -559,13 +601,18 @@ export async function fetchProjectIssues(
     });
   }
 
+  latestRateLimits = finalizeGraphQLRateLimitCycle(
+    latestRateLimits,
+    cycleConfig.rateLimitCollector
+  );
   if (latestRateLimits) {
     for (const issue of issues) {
       issue.rateLimits = latestRateLimits;
     }
   }
+  (issues as TrackedIssueList).rateLimits = latestRateLimits;
 
-  return issues;
+  return issues as GitHubTrackedIssue[] & TrackedIssueList;
 }
 
 export async function fetchActionableIssues(
@@ -586,17 +633,19 @@ export async function fetchIssueStatesByIds(
   config: GitHubTrackerConfig,
   issueIds: readonly string[],
   fetchImpl: FetchLike = fetch
-): Promise<GitHubTrackedIssue[]> {
+): Promise<GitHubTrackedIssue[] & TrackedIssueList> {
   if (issueIds.length === 0) {
     return [];
   }
 
   const issues: GitHubTrackedIssue[] = [];
+  const cycleConfig = beginGraphQLRateLimitCycle(config);
+  let latestRateLimits: GitHubRateLimitPayload | null = null;
 
   for (const issueIdBatch of chunkValues([...new Set(issueIds)], 100)) {
     const result =
       await executeGraphQLQueryWithMetadata<GraphQLIssueStatesByIdsResponse>(
-        config,
+        cycleConfig,
         ISSUE_STATES_BY_IDS_QUERY,
         {
           issueIds: issueIdBatch,
@@ -605,10 +654,11 @@ export async function fetchIssueStatesByIds(
       );
     const data = result.data;
     const rateLimits = result.rateLimits;
+    latestRateLimits = rateLimits ?? latestRateLimits;
 
     for (const node of data.nodes ?? []) {
       const projectItem = await resolveIssueProjectItemForStateLookup(
-        config,
+        cycleConfig,
         node,
         fetchImpl
       );
@@ -625,7 +675,16 @@ export async function fetchIssueStatesByIds(
     }
   }
 
-  return issues;
+  const rateLimits = finalizeGraphQLRateLimitCycle(
+    latestRateLimits,
+    cycleConfig.rateLimitCollector
+  );
+  for (const issue of issues) {
+    issue.rateLimits = rateLimits;
+  }
+  (issues as TrackedIssueList).rateLimits = rateLimits;
+
+  return issues as GitHubTrackedIssue[] & TrackedIssueList;
 }
 
 export async function fetchProjectIssueByRepositoryAndNumber(
@@ -637,17 +696,18 @@ export async function fetchProjectIssueByRepositoryAndNumber(
   issueNumber: number,
   fetchImpl: FetchLike = fetch
 ): Promise<GitHubTrackedIssue | null> {
+  const cycleConfig = beginGraphQLRateLimitCycle(config);
   const priorityOptionIds =
     !config.priority && config.priorityFieldName
       ? await fetchPriorityOptionOrder(
-          config,
+          cycleConfig,
           config.priorityFieldName,
           fetchImpl
         )
       : undefined;
   const result =
     await executeGraphQLQueryWithMetadata<GraphQLRepositoryIssueLookupResponse>(
-      config,
+      cycleConfig,
       REPOSITORY_ISSUE_QUERY,
       {
         owner: repository.owner,
@@ -663,7 +723,7 @@ export async function fetchProjectIssueByRepositoryAndNumber(
   }
 
   const projectItem = await resolveIssueProjectItemForStateLookup(
-    config,
+    cycleConfig,
     issue,
     fetchImpl
   );
@@ -684,7 +744,10 @@ export async function fetchProjectIssueByRepositoryAndNumber(
         optionIds: priorityOptionIds,
       },
     },
-    result.rateLimits
+    finalizeGraphQLRateLimitCycle(
+      result.rateLimits,
+      cycleConfig.rateLimitCollector
+    )
   );
 }
 
@@ -694,7 +757,7 @@ async function fetchProjectItemsPage(
   fetchImpl: FetchLike
 ): Promise<{
   page: GraphQLProjectItemsPage;
-  rateLimits: Record<string, unknown> | null;
+  rateLimits: GitHubRateLimitPayload | null;
 }> {
   const result =
     await executeGraphQLQueryWithMetadata<GraphQLProjectItemsResponse>(
@@ -994,11 +1057,7 @@ function normalizeIssueStateLookupNode(
   }
 
   const fieldValues = extractFieldValues(projectItem.fieldValues?.nodes ?? []);
-  const state = requireProjectItemState(
-    fieldValues,
-    lifecycle,
-    projectItem.id
-  );
+  const state = requireProjectItemState(fieldValues, lifecycle, projectItem.id);
   const repository = issue.repository;
   const identifier = `${repository.owner.login}/${repository.name}#${issue.number}`;
   const url =
@@ -1581,7 +1640,15 @@ async function executeGraphQLQueryWithMetadata<TData>(
   }
 
   const data = payload.data as TData;
-  const rateLimits = extractGitHubRateLimits(response.headers);
+  const fieldRateLimits = extractGraphQLRateLimitField(payload.data.rateLimit);
+  const rateLimits = extractGitHubRateLimits(response.headers, fieldRateLimits);
+  if (fieldRateLimits && rateLimits) {
+    config.rateLimitCollector?.observations.push({
+      operationName: extractGraphQLOperationName(query),
+      rateLimit: fieldRateLimits,
+      payload: rateLimits,
+    });
+  }
   cachedGitHubGraphQLRateLimits.set(tokenFingerprint, rateLimits);
   return {
     data,
@@ -1627,8 +1694,31 @@ function fingerprintToken(token: string): string {
 }
 
 function extractGitHubRateLimits(
-  headers: Pick<Headers, "get"> | null | undefined
+  headers: Pick<Headers, "get"> | null | undefined,
+  fieldRateLimits: GraphQLRateLimitField | null = null
 ): GitHubRateLimitPayload | null {
+  const headerRateLimits = extractGitHubRateLimitHeaders(headers);
+  if (!fieldRateLimits) {
+    return headerRateLimits;
+  }
+
+  return {
+    source: "github",
+    limit: headerRateLimits?.limit ?? null,
+    remaining: fieldRateLimits.remaining,
+    used: headerRateLimits?.used ?? null,
+    reset: headerRateLimits?.reset ?? null,
+    resetAt: fieldRateLimits.resetAt,
+    resource: headerRateLimits?.resource ?? "graphql",
+    cost: fieldRateLimits.cost,
+    fieldRateLimits,
+    headerRateLimits,
+  };
+}
+
+function extractGitHubRateLimitHeaders(
+  headers: Pick<Headers, "get"> | null | undefined
+): GitHubRateLimitHeaderPayload | null {
   if (!headers || typeof headers.get !== "function") {
     return null;
   }
@@ -1657,6 +1747,84 @@ function extractGitHubRateLimits(
     reset,
     resetAt: reset === null ? null : new Date(reset * 1000).toISOString(),
     resource,
+  };
+}
+
+function extractGraphQLRateLimitField(
+  value: GraphQLRateLimitField | null | undefined
+): GraphQLRateLimitField | null {
+  if (
+    !value ||
+    !Number.isFinite(value.cost) ||
+    !Number.isFinite(value.remaining) ||
+    typeof value.resetAt !== "string" ||
+    parseTimestampMs(value.resetAt) === null
+  ) {
+    return null;
+  }
+
+  return {
+    cost: value.cost,
+    remaining: value.remaining,
+    resetAt: value.resetAt,
+  };
+}
+
+function extractGraphQLOperationName(query: string): string {
+  return (
+    /\b(?:query|mutation)\s+([_A-Za-z][_0-9A-Za-z]*)/.exec(query)?.[1] ??
+    "Anonymous"
+  );
+}
+
+function beginGraphQLRateLimitCycle(
+  config: GitHubTrackerConfig
+): GitHubTrackerConfig {
+  return {
+    ...config,
+    rateLimitCollector: {
+      observations: [],
+    },
+  };
+}
+
+function finalizeGraphQLRateLimitCycle(
+  latestRateLimits: GitHubRateLimitPayload | null,
+  collector: GitHubRateLimitCollector | undefined
+): GitHubRateLimitPayload | null {
+  const observations = collector?.observations ?? [];
+  if (observations.length === 0) {
+    return latestRateLimits;
+  }
+
+  const queryCosts: NonNullable<GitHubRateLimitPayload["queryCosts"]> = {};
+  let cycleCost = 0;
+  for (const observation of observations) {
+    const previous = queryCosts[observation.operationName] ?? {
+      requestCount: 0,
+      cost: 0,
+    };
+    queryCosts[observation.operationName] = {
+      requestCount: previous.requestCount + 1,
+      cost: previous.cost + observation.rateLimit.cost,
+    };
+    cycleCost += observation.rateLimit.cost;
+  }
+
+  const latestObservation = observations.at(-1);
+  return {
+    ...(latestObservation?.payload ??
+      latestRateLimits ?? {
+        source: "github",
+        limit: null,
+        remaining: latestObservation?.rateLimit.remaining ?? null,
+        used: null,
+        reset: null,
+        resetAt: latestObservation?.rateLimit.resetAt ?? null,
+        resource: "graphql",
+      }),
+    cycleCost,
+    queryCosts,
   };
 }
 
@@ -1690,6 +1858,11 @@ export function resetGitHubRateLimitCacheForTests(): void {
 
 const PROJECT_ITEMS_QUERY = `
   query ProjectItems($projectId: ID!, $cursor: String, $pageSize: Int!) {
+    rateLimit {
+      cost
+      remaining
+      resetAt
+    }
     node(id: $projectId) {
       __typename
       ... on ProjectV2 {
@@ -1824,6 +1997,11 @@ const PROJECT_ITEMS_QUERY = `
 
 const PROJECT_FIELDS_QUERY = `
   query ProjectFields($projectId: ID!) {
+    rateLimit {
+      cost
+      remaining
+      resetAt
+    }
     node(id: $projectId) {
       __typename
       ... on ProjectV2 {
@@ -1846,6 +2024,11 @@ const PROJECT_FIELDS_QUERY = `
 
 const ISSUE_STATES_BY_IDS_QUERY = `
   query IssueStatesByIds($issueIds: [ID!]!) {
+    rateLimit {
+      cost
+      remaining
+      resetAt
+    }
     nodes(ids: $issueIds) {
       __typename
       ... on Issue {
@@ -1951,6 +2134,11 @@ const ISSUE_STATES_BY_IDS_QUERY = `
 
 const ISSUE_PROJECT_ITEMS_PAGE_QUERY = `
   query IssueProjectItemsPage($issueId: ID!, $cursor: String) {
+    rateLimit {
+      cost
+      remaining
+      resetAt
+    }
     node(id: $issueId) {
       __typename
       ... on Issue {
@@ -2056,6 +2244,11 @@ const ISSUE_PROJECT_ITEMS_PAGE_QUERY = `
 
 const ISSUE_COMMENTS_BY_ID_QUERY = `
   query IssueCommentsById($issueId: ID!, $cursor: String) {
+    rateLimit {
+      cost
+      remaining
+      resetAt
+    }
     node(id: $issueId) {
       __typename
       ... on Issue {
@@ -2104,6 +2297,11 @@ const REPOSITORY_ISSUE_QUERY = `
     $name: String!
     $issueNumber: Int!
   ) {
+    rateLimit {
+      cost
+      remaining
+      resetAt
+    }
     repository(owner: $owner, name: $name) {
       issue(number: $issueNumber) {
         __typename

--- a/packages/tracker-github/src/adapter.ts
+++ b/packages/tracker-github/src/adapter.ts
@@ -2261,6 +2261,11 @@ const ISSUE_COMMENTS_BY_ID_QUERY = `
 
 const ADD_ISSUE_COMMENT_MUTATION = `
   mutation AddIssueComment($subjectId: ID!, $body: String!) {
+    rateLimit {
+      cost
+      remaining
+      resetAt
+    }
     addComment(input: { subjectId: $subjectId, body: $body }) {
       commentEdge {
         node {
@@ -2274,6 +2279,11 @@ const ADD_ISSUE_COMMENT_MUTATION = `
 
 const UPDATE_ISSUE_COMMENT_MUTATION = `
   mutation UpdateIssueComment($commentId: ID!, $body: String!) {
+    rateLimit {
+      cost
+      remaining
+      resetAt
+    }
     updateIssueComment(input: { id: $commentId, body: $body }) {
       issueComment {
         id

--- a/packages/tracker-github/src/adapter.ts
+++ b/packages/tracker-github/src/adapter.ts
@@ -605,11 +605,6 @@ export async function fetchProjectIssues(
     latestRateLimits,
     cycleConfig.rateLimitCollector
   );
-  if (latestRateLimits) {
-    for (const issue of issues) {
-      issue.rateLimits = latestRateLimits;
-    }
-  }
   (issues as TrackedIssueList).rateLimits = latestRateLimits;
 
   return issues as GitHubTrackedIssue[] & TrackedIssueList;
@@ -679,9 +674,6 @@ export async function fetchIssueStatesByIds(
     latestRateLimits,
     cycleConfig.rateLimitCollector
   );
-  for (const issue of issues) {
-    issue.rateLimits = rateLimits;
-  }
   (issues as TrackedIssueList).rateLimits = rateLimits;
 
   return issues as GitHubTrackedIssue[] & TrackedIssueList;

--- a/packages/tracker-github/src/orchestrator-adapter.ts
+++ b/packages/tracker-github/src/orchestrator-adapter.ts
@@ -3,6 +3,7 @@ import type {
   OrchestratorTrackerAdapter,
   OrchestratorTrackerDependencies,
   OrchestratorTrackerConfig,
+  TrackedIssueList,
 } from "@gh-symphony/core";
 import {
   fetchGithubIssueStatesByIds,
@@ -27,9 +28,11 @@ export const githubProjectTrackerAdapter: OrchestratorTrackerAdapter = {
     const normalizedStates = new Set(
       states.map((state) => state.trim().toLowerCase())
     );
-    return issues.filter((issue) =>
+    const filtered = issues.filter((issue) =>
       normalizedStates.has(issue.state.trim().toLowerCase())
-    );
+    ) as TrackedIssueList;
+    filtered.rateLimits = (issues as TrackedIssueList).rateLimits;
+    return filtered;
   },
 
   async fetchIssueStatesByIds(project, issueIds, dependencies = {}) {

--- a/packages/tracker-github/src/tracker-github.test.ts
+++ b/packages/tracker-github/src/tracker-github.test.ts
@@ -1854,7 +1854,7 @@ describe("resolveTrackerAdapter", () => {
     );
 
     expect(issues).toHaveLength(1);
-    expect(issues[0]?.rateLimits).toEqual({
+    expect(issues.rateLimits).toEqual({
       source: "github",
       limit: 5000,
       remaining: 4988,
@@ -1885,7 +1885,12 @@ describe("resolveTrackerAdapter", () => {
         resource: "graphql",
       },
     });
-    expect(issues.rateLimits).toEqual(issues[0]?.rateLimits);
+    expect(issues[0]?.rateLimits).toEqual(
+      expect.objectContaining({
+        cost: 11,
+      })
+    );
+    expect(issues[0]?.rateLimits).not.toHaveProperty("cycleCost");
   });
 
   it("waits for the cached GraphQL rate limit reset when exhausted", async () => {
@@ -2434,70 +2439,24 @@ describe("resolveTrackerAdapter", () => {
     );
 
     expect(issues).toHaveLength(2);
+    expect(issues.rateLimits).toEqual(
+      expect.objectContaining({
+        cost: 4,
+        cycleCost: 11,
+        queryCosts: {
+          ProjectItems: {
+            requestCount: 2,
+            cost: 11,
+          },
+        },
+      })
+    );
     expect(issues.map((issue) => issue.rateLimits)).toEqual([
-      {
-        source: "github",
-        limit: 5000,
-        remaining: 4997,
-        used: 3,
-        reset: 1773892860,
-        resetAt: "2026-03-19T04:01:00.000Z",
-        resource: "graphql",
-        cost: 4,
-        cycleCost: 11,
-        queryCosts: {
-          ProjectItems: {
-            requestCount: 2,
-            cost: 11,
-          },
-        },
-        fieldRateLimits: {
-          cost: 4,
-          remaining: 4997,
-          resetAt: "2026-03-19T04:01:00.000Z",
-        },
-        headerRateLimits: {
-          source: "github",
-          limit: 5000,
-          remaining: 4997,
-          used: 3,
-          reset: 1773892860,
-          resetAt: "2026-03-19T04:01:00.000Z",
-          resource: "graphql",
-        },
-      },
-      {
-        source: "github",
-        limit: 5000,
-        remaining: 4997,
-        used: 3,
-        reset: 1773892860,
-        resetAt: "2026-03-19T04:01:00.000Z",
-        resource: "graphql",
-        cost: 4,
-        cycleCost: 11,
-        queryCosts: {
-          ProjectItems: {
-            requestCount: 2,
-            cost: 11,
-          },
-        },
-        fieldRateLimits: {
-          cost: 4,
-          remaining: 4997,
-          resetAt: "2026-03-19T04:01:00.000Z",
-        },
-        headerRateLimits: {
-          source: "github",
-          limit: 5000,
-          remaining: 4997,
-          used: 3,
-          reset: 1773892860,
-          resetAt: "2026-03-19T04:01:00.000Z",
-          resource: "graphql",
-        },
-      },
+      expect.objectContaining({ cost: 7 }),
+      expect.objectContaining({ cost: 4 }),
     ]);
+    expect(issues[0]?.rateLimits).not.toHaveProperty("cycleCost");
+    expect(issues[1]?.rateLimits).not.toHaveProperty("cycleCost");
   });
 
   it("applies the default network timeout to GitHub API requests", async () => {
@@ -2864,7 +2823,7 @@ describe("resolveTrackerAdapter", () => {
 
     expect(issues).toHaveLength(1);
     expect(issues[0]?.priority).toBe(1);
-    expect(issues[0]?.rateLimits).toEqual(
+    expect(issues.rateLimits).toEqual(
       expect.objectContaining({
         cycleCost: 13,
         queryCosts: {
@@ -3907,7 +3866,7 @@ describe("resolveTrackerAdapter", () => {
     expect(issues).toHaveLength(1);
     expect(issues[0]?.tracker.itemId).toBe("item-1");
     expect(issues[0]?.state).toBe("Done");
-    expect(issues[0]?.rateLimits).toEqual(
+    expect(issues.rateLimits).toEqual(
       expect.objectContaining({
         cycleCost: 5,
         queryCosts: {

--- a/packages/tracker-github/src/tracker-github.test.ts
+++ b/packages/tracker-github/src/tracker-github.test.ts
@@ -1039,6 +1039,9 @@ describe("resolveTrackerAdapter", () => {
       String(fetchImpl.mock.calls[1]?.[1]?.body)
     ) as { query: string; variables: Record<string, string> };
     expect(mutationBody.query).toContain("mutation AddIssueComment");
+    expect(mutationBody.query).toMatch(
+      /rateLimit\s*\{\s*cost\s+remaining\s+resetAt\s*\}/s
+    );
     expect(mutationBody.variables.subjectId).toBe("issue-1");
   });
 
@@ -1135,6 +1138,9 @@ describe("resolveTrackerAdapter", () => {
       String(fetchImpl.mock.calls[1]?.[1]?.body)
     ) as { query: string; variables: Record<string, string> };
     expect(mutationBody.query).toContain("mutation UpdateIssueComment");
+    expect(mutationBody.query).toMatch(
+      /rateLimit\s*\{\s*cost\s+remaining\s+resetAt\s*\}/s
+    );
     expect(mutationBody.variables.commentId).toBe("comment-1");
   });
 

--- a/packages/tracker-github/src/tracker-github.test.ts
+++ b/packages/tracker-github/src/tracker-github.test.ts
@@ -827,6 +827,9 @@ describe("resolveTrackerAdapter", () => {
           ? (JSON.parse(init.body) as { query?: string })
           : {};
       expect(body.query).toContain("RepositoryIssue");
+      expect(body.query).toMatch(
+        /rateLimit\s*\{\s*cost\s+remaining\s+resetAt\s*\}/s
+      );
       return new Response(
         JSON.stringify({
           data: {
@@ -1025,6 +1028,13 @@ describe("resolveTrackerAdapter", () => {
 
     expect(result).toBe("created");
     expect(fetchImpl).toHaveBeenCalledTimes(2);
+    const queryBody = JSON.parse(
+      String(fetchImpl.mock.calls[0]?.[1]?.body)
+    ) as { query: string };
+    expect(queryBody.query).toContain("query IssueCommentsById");
+    expect(queryBody.query).toMatch(
+      /rateLimit\s*\{\s*cost\s+remaining\s+resetAt\s*\}/s
+    );
     const mutationBody = JSON.parse(
       String(fetchImpl.mock.calls[1]?.[1]?.body)
     ) as { query: string; variables: Record<string, string> };
@@ -1773,7 +1783,7 @@ describe("resolveTrackerAdapter", () => {
     }
   });
 
-  it("attaches GitHub API rate-limit headers to listed issues", async () => {
+  it("records field-based GraphQL cost while retaining rate-limit headers", async () => {
     const adapter = resolveTrackerAdapter({
       adapter: "github-project",
       bindingId: "project-123",
@@ -1806,6 +1816,11 @@ describe("resolveTrackerAdapter", () => {
           new Response(
             JSON.stringify({
               data: {
+                rateLimit: {
+                  cost: 11,
+                  remaining: 4988,
+                  resetAt: "2026-03-19T04:02:00.000Z",
+                },
                 node: {
                   __typename: "ProjectV2",
                   items: {
@@ -1828,8 +1843,8 @@ describe("resolveTrackerAdapter", () => {
               headers: {
                 "content-type": "application/json",
                 "x-ratelimit-limit": "5000",
-                "x-ratelimit-remaining": "4999",
-                "x-ratelimit-used": "1",
+                "x-ratelimit-remaining": "4987",
+                "x-ratelimit-used": "13",
                 "x-ratelimit-reset": "1773892800",
                 "x-ratelimit-resource": "graphql",
               },
@@ -1842,12 +1857,35 @@ describe("resolveTrackerAdapter", () => {
     expect(issues[0]?.rateLimits).toEqual({
       source: "github",
       limit: 5000,
-      remaining: 4999,
-      used: 1,
+      remaining: 4988,
+      used: 13,
       reset: 1773892800,
-      resetAt: "2026-03-19T04:00:00.000Z",
+      resetAt: "2026-03-19T04:02:00.000Z",
       resource: "graphql",
+      cost: 11,
+      cycleCost: 11,
+      queryCosts: {
+        ProjectItems: {
+          requestCount: 1,
+          cost: 11,
+        },
+      },
+      fieldRateLimits: {
+        cost: 11,
+        remaining: 4988,
+        resetAt: "2026-03-19T04:02:00.000Z",
+      },
+      headerRateLimits: {
+        source: "github",
+        limit: 5000,
+        remaining: 4987,
+        used: 13,
+        reset: 1773892800,
+        resetAt: "2026-03-19T04:00:00.000Z",
+        resource: "graphql",
+      },
     });
+    expect(issues.rateLimits).toEqual(issues[0]?.rateLimits);
   });
 
   it("waits for the cached GraphQL rate limit reset when exhausted", async () => {
@@ -2281,7 +2319,7 @@ describe("resolveTrackerAdapter", () => {
           fetchImpl,
         }
       )
-    ).resolves.toEqual([]);
+    ).resolves.toHaveLength(0);
 
     expect(fetchImpl).toHaveBeenCalledTimes(2);
   });
@@ -2333,6 +2371,11 @@ describe("resolveTrackerAdapter", () => {
                     }),
                   ],
                   pageInfo: { endCursor: "cursor-1", hasNextPage: true },
+                  rateLimit: {
+                    cost: 7,
+                    remaining: 4999,
+                    resetAt: "2026-03-19T04:00:00.000Z",
+                  },
                   headers: {
                     "content-type": "application/json",
                     "x-ratelimit-limit": "5000",
@@ -2353,6 +2396,11 @@ describe("resolveTrackerAdapter", () => {
                     }),
                   ],
                   pageInfo: { endCursor: null, hasNextPage: false },
+                  rateLimit: {
+                    cost: 4,
+                    remaining: 4997,
+                    resetAt: "2026-03-19T04:01:00.000Z",
+                  },
                   headers: {
                     "content-type": "application/json",
                     "x-ratelimit-limit": "5000",
@@ -2366,6 +2414,7 @@ describe("resolveTrackerAdapter", () => {
           return new Response(
             JSON.stringify({
               data: {
+                rateLimit: page.rateLimit,
                 node: {
                   __typename: "ProjectV2",
                   items: {
@@ -2394,6 +2443,28 @@ describe("resolveTrackerAdapter", () => {
         reset: 1773892860,
         resetAt: "2026-03-19T04:01:00.000Z",
         resource: "graphql",
+        cost: 4,
+        cycleCost: 11,
+        queryCosts: {
+          ProjectItems: {
+            requestCount: 2,
+            cost: 11,
+          },
+        },
+        fieldRateLimits: {
+          cost: 4,
+          remaining: 4997,
+          resetAt: "2026-03-19T04:01:00.000Z",
+        },
+        headerRateLimits: {
+          source: "github",
+          limit: 5000,
+          remaining: 4997,
+          used: 3,
+          reset: 1773892860,
+          resetAt: "2026-03-19T04:01:00.000Z",
+          resource: "graphql",
+        },
       },
       {
         source: "github",
@@ -2403,6 +2474,28 @@ describe("resolveTrackerAdapter", () => {
         reset: 1773892860,
         resetAt: "2026-03-19T04:01:00.000Z",
         resource: "graphql",
+        cost: 4,
+        cycleCost: 11,
+        queryCosts: {
+          ProjectItems: {
+            requestCount: 2,
+            cost: 11,
+          },
+        },
+        fieldRateLimits: {
+          cost: 4,
+          remaining: 4997,
+          resetAt: "2026-03-19T04:01:00.000Z",
+        },
+        headerRateLimits: {
+          source: "github",
+          limit: 5000,
+          remaining: 4997,
+          used: 3,
+          reset: 1773892860,
+          resetAt: "2026-03-19T04:01:00.000Z",
+          resource: "graphql",
+        },
       },
     ]);
   });
@@ -2693,12 +2786,20 @@ describe("resolveTrackerAdapter", () => {
         token: "dependencies-token",
         fetchImpl: async (_url, init) => {
           const body = JSON.parse(String(init?.body)) as { query: string };
+          expect(body.query).toMatch(
+            /rateLimit\s*\{\s*cost\s+remaining\s+resetAt\s*\}/s
+          );
 
           if (body.query.includes("query ProjectFields")) {
             expect(body.query).toContain("fields(first: 100)");
             return new Response(
               JSON.stringify({
                 data: {
+                  rateLimit: {
+                    cost: 2,
+                    remaining: 4998,
+                    resetAt: "2026-03-19T04:00:00.000Z",
+                  },
                   node: {
                     __typename: "ProjectV2",
                     fields: {
@@ -2729,6 +2830,11 @@ describe("resolveTrackerAdapter", () => {
           return new Response(
             JSON.stringify({
               data: {
+                rateLimit: {
+                  cost: 11,
+                  remaining: 4987,
+                  resetAt: "2026-03-19T04:00:00.000Z",
+                },
                 node: {
                   __typename: "ProjectV2",
                   items: {
@@ -2758,6 +2864,21 @@ describe("resolveTrackerAdapter", () => {
 
     expect(issues).toHaveLength(1);
     expect(issues[0]?.priority).toBe(1);
+    expect(issues[0]?.rateLimits).toEqual(
+      expect.objectContaining({
+        cycleCost: 13,
+        queryCosts: {
+          ProjectFields: {
+            requestCount: 1,
+            cost: 2,
+          },
+          ProjectItems: {
+            requestCount: 1,
+            cost: 11,
+          },
+        },
+      })
+    );
   });
 
   it("maps priority using only non-null option entries and fetches field metadata once", async () => {
@@ -3664,11 +3785,19 @@ describe("resolveTrackerAdapter", () => {
           cursor?: string | null;
         };
       };
+      expect(body.query).toMatch(
+        /rateLimit\s*\{\s*cost\s+remaining\s+resetAt\s*\}/s
+      );
 
       if (body.query.includes("query IssueStatesByIds")) {
         return new Response(
           JSON.stringify({
             data: {
+              rateLimit: {
+                cost: 3,
+                remaining: 4997,
+                resetAt: "2026-03-19T04:00:00.000Z",
+              },
               nodes: [
                 makeIssueStateLookupNode({
                   projectId: "project-999",
@@ -3702,6 +3831,11 @@ describe("resolveTrackerAdapter", () => {
       return new Response(
         JSON.stringify({
           data: {
+            rateLimit: {
+              cost: 2,
+              remaining: 4995,
+              resetAt: "2026-03-19T04:00:00.000Z",
+            },
             node: {
               __typename: "Issue",
               id: "issue-1",
@@ -3773,6 +3907,21 @@ describe("resolveTrackerAdapter", () => {
     expect(issues).toHaveLength(1);
     expect(issues[0]?.tracker.itemId).toBe("item-1");
     expect(issues[0]?.state).toBe("Done");
+    expect(issues[0]?.rateLimits).toEqual(
+      expect.objectContaining({
+        cycleCost: 5,
+        queryCosts: {
+          IssueStatesByIds: {
+            requestCount: 1,
+            cost: 3,
+          },
+          IssueProjectItemsPage: {
+            requestCount: 1,
+            cost: 2,
+          },
+        },
+      })
+    );
   });
 
   it("paginates pull request projectItems until the configured project item is found", async () => {


### PR DESCRIPTION
## TL;DR

- GitHub GraphQL의 6개 query와 2개 comment mutation 모두 `rateLimit { cost remaining resetAt }`를 요청합니다.
- tracker 호출 단위 총 소비량(`cycleCost`)과 operation별 요청 횟수·cost(`queryCosts`)를 기존 `tracker.list`/`tracker.fetchByIds` run event에 기록합니다.
- 신규 dispatch가 없는 active-run polling cycle도 `ProjectItems` 비용을 active run 한 건의 `tracker.list` 이벤트로 남깁니다.
- 전체 호출 집계는 호출당 이벤트 한 건에만 기록해 active run 수에 따른 비용 중복 합산을 방지합니다.
- GraphQL 필드 값을 주 계측값으로 사용하되 기존 `x-ratelimit-*` 헤더 원본도 함께 보존해 상호 검증할 수 있습니다.

## 변경 지점 다이어그램

```text
GitHub GraphQL response
  ├─ rateLimit { cost remaining resetAt } ──┐
  └─ x-ratelimit-* headers ─────────────────┤
                                            ▼
                                tracker-github adapter
                                  ├─ fieldRateLimits
                                  ├─ headerRateLimits
                                  └─ TrackedIssueList
                                       ├─ cycleCost
                                       └─ queryCosts[operation]
                                            │
                  ┌─────────────────────────┴──────────────────────────┐
                  ▼                                                    ▼
          dispatch/fetch refresh                              no-dispatch poll
     tracker.list/fetchByIds event                       active run 1건의 tracker.list
                  └─────────────────────────┬──────────────────────────┘
                                            ▼
                                   events.ndjson / logs
```

## 여기부터 보세요

- `packages/tracker-github/src/adapter.ts`
  - 모든 GraphQL query/mutation의 `rateLimit` selection
  - 필드 우선·헤더 보존 파싱
  - 호출 단위 `cycleCost`와 operation별 `queryCosts` 집계
- `packages/orchestrator/src/service.ts`
  - 전체 호출 집계를 `tracker.list`/`tracker.fetchByIds` 이벤트 한 건에만 기록
  - 신규 dispatch가 없는 polling cycle의 list aggregate 보존
- `packages/tracker-github/src/tracker-github.test.ts`
  - 필드/헤더 불일치 상호 검증, 페이지 합산, query 종류별 분해, mutation selection TC
- `packages/orchestrator/src/service.test.ts`
  - 집계 정보의 `events.ndjson` 보존, 다중 active run 중복 방지, no-dispatch cycle TC

## 위험 & 롤백

- 위험: 필드와 헤더의 `remaining`/`resetAt` 관측 시점이 다르면 값이 일시적으로 다를 수 있습니다.
- 완화: 의사결정에는 GraphQL 필드 값을 사용하고, 헤더 값은 `headerRateLimits`에 독립 보존해 비교 가능하게 했습니다.
- 완화: 호출 집계는 해당 호출에서 생성된 이벤트 중 한 건에만 저장해 이벤트 합산 시 과대 계측되지 않게 했습니다.
- 완화: active run이 없는 comment advisory의 project-cycle mutation 합산은 run 이벤트에 억지로 기록하지 않고 #492에서 project-scoped 관측 계약으로 다룹니다.
- 롤백: adapter와 observability 계측 커밋을 revert하면 기존 헤더 기반 rate-limit 가드 동작으로 복귀합니다.

## 변경 파일

- `.changeset/measure-github-graphql-costs.md`
- `packages/tracker-github/src/adapter.ts`
- `packages/tracker-github/src/orchestrator-adapter.ts`
- `packages/tracker-github/src/tracker-github.test.ts`
- `packages/orchestrator/src/service.ts`
- `packages/orchestrator/src/service.test.ts`

## Evidence

- `pnpm --filter @gh-symphony/tracker-github test -- tracker-github.test.ts` — 68 tests passed
- `pnpm --filter @gh-symphony/orchestrator test -- service.test.ts` — 119 tests passed
- `pnpm lint` — pass
- `pnpm test` — pass (`@gh-symphony/orchestrator` 216 tests 포함)
- `pnpm typecheck` — pass
- `pnpm build` — pass
- `bash e2e/run-e2e.sh happy 45` — pass; worker dispatched/running, continuation retry, final health idle (12s)
- GitHub CI `Container Smoke`, `Test` — pass at head `bed1a44`
- `pnpm exec changeset status` — `@gh-symphony/cli` patch only

## Issues — Closed #472

- Closed #472

## 머지 후/사람 확인

- [ ] 운영 `tracker.list`/`tracker.fetchByIds` 이벤트에서 `cycleCost`가 한 tracker 호출의 실제 소비량과 일치하는지 확인
- [ ] 운영 이벤트의 `queryCosts`로 `ProjectItems`, `ProjectFields`, `IssueStatesByIds` 비용을 분리할 수 있는지 확인
- [ ] 신규 dispatch가 없는 active-run polling cycle에서 `tracker.list` 비용이 한 번 기록되는지 확인
- [ ] 다중 active run 갱신 시 같은 `cycleCost`가 여러 이벤트에서 중복 합산되지 않는지 확인
- [ ] `fieldRateLimits`와 `headerRateLimits` 차이가 예상 범위인지 확인
- [ ] comment mutation의 project-cycle aggregate 후속 #492 검토
