### PR TITLE
refactor: 어드바이저리 코멘트 조회에 ETag 캐시 적용

### DIFF
--- a/.changeset/cache-advisory-comment-etags.md
+++ b/.changeset/cache-advisory-comment-etags.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Persist advisory comment identifiers and ETags for #476 so steady-state GitHub polling uses conditional REST requests instead of repeatedly paging issue comments.

--- a/packages/core/src/contracts/tracker-adapter.ts
+++ b/packages/core/src/contracts/tracker-adapter.ts
@@ -95,10 +95,23 @@ export type ProjectItemsCache = {
   ): Promise<TrackedIssue[]>;
 };
 
+export type IssueCommentCacheEntry = {
+  commentId: number;
+  etag: string | null;
+  body: string;
+};
+
+export type IssueCommentCache = {
+  get(key: string): Promise<IssueCommentCacheEntry | null>;
+  set(key: string, entry: IssueCommentCacheEntry): Promise<void>;
+  delete(key: string): Promise<void>;
+};
+
 export type OrchestratorTrackerDependencies = {
   fetchImpl?: typeof fetch;
   token?: string;
   projectItemsCache?: ProjectItemsCache;
+  issueCommentCache?: IssueCommentCache;
   assignedOnly?: boolean;
 };
 

--- a/packages/orchestrator/src/issue-comment-cache.test.ts
+++ b/packages/orchestrator/src/issue-comment-cache.test.ts
@@ -1,0 +1,37 @@
+import { mkdtemp, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { PersistentIssueCommentCache } from "./issue-comment-cache.js";
+
+describe("PersistentIssueCommentCache", () => {
+  it("persists comment ids and ETags in the project cache directory", async () => {
+    const projectDirectory = await mkdtemp(
+      join(tmpdir(), "orchestrator-comment-cache-")
+    );
+    const cacheKey = "github:acme:platform:issue-1:marker";
+    const firstInstance = new PersistentIssueCommentCache(projectDirectory);
+
+    await firstInstance.set(cacheKey, {
+      commentId: 42,
+      etag: '"comment-v1"',
+      body: "marker body",
+    });
+
+    const secondInstance = new PersistentIssueCommentCache(projectDirectory);
+    expect(await secondInstance.get(cacheKey)).toEqual({
+      commentId: 42,
+      etag: '"comment-v1"',
+      body: "marker body",
+    });
+
+    const persisted = JSON.parse(
+      await readFile(
+        join(projectDirectory, "cache", "issue-comments.json"),
+        "utf8"
+      )
+    ) as { version: number; entries: Record<string, unknown> };
+    expect(persisted.version).toBe(1);
+    expect(persisted.entries[cacheKey]).toBeDefined();
+  });
+});

--- a/packages/orchestrator/src/issue-comment-cache.ts
+++ b/packages/orchestrator/src/issue-comment-cache.ts
@@ -1,0 +1,66 @@
+import { join } from "node:path";
+import {
+  readJsonFile,
+  type IssueCommentCache,
+  type IssueCommentCacheEntry,
+} from "@gh-symphony/core";
+import { writeFileAtomically } from "./durable-file.js";
+
+type PersistedIssueCommentCache = {
+  version: 1;
+  entries: Record<string, IssueCommentCacheEntry>;
+};
+
+const EMPTY_CACHE: PersistedIssueCommentCache = {
+  version: 1,
+  entries: {},
+};
+
+export class PersistentIssueCommentCache implements IssueCommentCache {
+  private statePromise: Promise<PersistedIssueCommentCache> | null = null;
+
+  constructor(projectDirectory: string) {
+    this.path = join(projectDirectory, "cache", "issue-comments.json");
+  }
+
+  private readonly path: string;
+
+  async get(key: string): Promise<IssueCommentCacheEntry | null> {
+    const state = await this.load();
+    return state.entries[key] ?? null;
+  }
+
+  async set(key: string, entry: IssueCommentCacheEntry): Promise<void> {
+    const state = await this.load();
+    state.entries[key] = entry;
+    await this.persist(state);
+  }
+
+  async delete(key: string): Promise<void> {
+    const state = await this.load();
+    if (!(key in state.entries)) {
+      return;
+    }
+
+    delete state.entries[key];
+    await this.persist(state);
+  }
+
+  private async load(): Promise<PersistedIssueCommentCache> {
+    this.statePromise ??= this.loadFromDisk();
+    return this.statePromise;
+  }
+
+  private async loadFromDisk(): Promise<PersistedIssueCommentCache> {
+    const persisted = await readJsonFile<PersistedIssueCommentCache>(this.path);
+    if (!persisted || persisted.version !== 1 || !persisted.entries) {
+      return structuredClone(EMPTY_CACHE);
+    }
+
+    return persisted;
+  }
+
+  private async persist(state: PersistedIssueCommentCache): Promise<void> {
+    await writeFileAtomically(this.path, `${JSON.stringify(state, null, 2)}\n`);
+  }
+}

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -46,7 +46,9 @@ describe("OrchestratorService", () => {
 
   it("passes runtime assignedOnly into tracker dependencies", () => {
     const service = new OrchestratorService(
-      {} as never,
+      {
+        projectDir: () => "/tmp/orchestrator/projects/tenant-1",
+      } as never,
       createProjectConfig("/tmp/orchestrator", {
         owner: "acme",
         name: "platform",

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -37,6 +37,7 @@ import {
   type OrchestratorProjectConfig,
   type OrchestratorTrackerDependencies,
   type OrchestratorTrackerAdapter,
+  type IssueCommentCache,
   type ProjectItemsCache,
   type ProjectStatusSnapshot,
   type RepositoryRef,
@@ -53,6 +54,7 @@ import {
   loadRepositoryWorkflow,
 } from "./git.js";
 import { OrchestratorFsStore } from "./fs-store.js";
+import { PersistentIssueCommentCache } from "./issue-comment-cache.js";
 import { resolveTrackerAdapter } from "./tracker-adapters.js";
 import {
   hasConvergenceLockedRunForIssue,
@@ -331,6 +333,7 @@ export class OrchestratorService {
     string,
     Record<string, unknown>
   >();
+  private readonly issueCommentCaches = new Map<string, IssueCommentCache>();
   private workflowResolutionCache: Map<
     string,
     Promise<WorkflowResolution>
@@ -1324,7 +1327,23 @@ export class OrchestratorService {
       assignedOnly: this.dependencies.assignedOnly,
       fetchImpl: this.dependencies.fetchImpl,
       projectItemsCache: createProjectItemsCache(),
+      issueCommentCache: this.resolveIssueCommentCache(
+        this.projectConfig.projectId
+      ),
     };
+  }
+
+  private resolveIssueCommentCache(projectId: string): IssueCommentCache {
+    const cached = this.issueCommentCaches.get(projectId);
+    if (cached) {
+      return cached;
+    }
+
+    const commentCache = new PersistentIssueCommentCache(
+      this.store.projectDir(projectId)
+    );
+    this.issueCommentCaches.set(projectId, commentCache);
+    return commentCache;
   }
 
   private async findLatestRunForIssue(

--- a/packages/tracker-github/src/adapter.ts
+++ b/packages/tracker-github/src/adapter.ts
@@ -1,6 +1,8 @@
 import { createHash } from "node:crypto";
 import {
   DEFAULT_WORKFLOW_LIFECYCLE,
+  type IssueCommentCache,
+  type IssueCommentCacheEntry,
   type TrackedIssue,
   type TrackedIssueList,
   type WorkflowPriorityConfig,
@@ -176,6 +178,7 @@ type GraphQLIssueProjectItemsConnection = {
 
 type GraphQLIssueCommentNode = {
   id: string;
+  databaseId: number;
   body: string;
 };
 
@@ -782,16 +785,21 @@ export const upsertGithubIssueComment = upsertIssueComment;
 
 async function upsertIssueComment(
   config: GitHubTrackerConfig,
-  issueId: string,
+  issue: Pick<TrackedIssue, "id" | "number" | "repository">,
   input: {
     marker: string;
     body: string;
   },
-  fetchImpl: FetchLike = fetch
+  fetchImpl: FetchLike = fetch,
+  cache?: IssueCommentCache
 ): Promise<"created" | "updated" | "unchanged"> {
+  if (cache) {
+    return upsertIssueCommentWithCache(config, issue, input, fetchImpl, cache);
+  }
+
   const existingComment = await findIssueCommentByMarker(
     config,
-    issueId,
+    issue.id,
     input.marker,
     fetchImpl
   );
@@ -801,7 +809,7 @@ async function upsertIssueComment(
       config,
       ADD_ISSUE_COMMENT_MUTATION,
       {
-        subjectId: issueId,
+        subjectId: issue.id,
         body: input.body,
       },
       fetchImpl
@@ -823,6 +831,266 @@ async function upsertIssueComment(
     fetchImpl
   );
   return "updated";
+}
+
+async function upsertIssueCommentWithCache(
+  config: GitHubTrackerConfig,
+  issue: Pick<TrackedIssue, "id" | "number" | "repository">,
+  input: {
+    marker: string;
+    body: string;
+  },
+  fetchImpl: FetchLike,
+  cache: IssueCommentCache
+): Promise<"created" | "updated" | "unchanged"> {
+  const cacheKey = buildIssueCommentCacheKey(issue, input.marker);
+  const cached = await cache.get(cacheKey);
+
+  if (cached) {
+    const current = await fetchRestIssueComment(
+      config,
+      issue,
+      cached.commentId,
+      cached.etag,
+      fetchImpl
+    );
+    if (current.status === "not-modified") {
+      if (cached.body === input.body) {
+        return "unchanged";
+      }
+
+      const updated = await updateRestIssueComment(
+        config,
+        issue,
+        cached.commentId,
+        input.body,
+        fetchImpl
+      );
+      await cache.set(cacheKey, updated);
+      return "updated";
+    }
+    if (current.status === "found") {
+      await cache.set(cacheKey, current.entry);
+      if (current.entry.body === input.body) {
+        return "unchanged";
+      }
+
+      const updated = await updateRestIssueComment(
+        config,
+        issue,
+        current.entry.commentId,
+        input.body,
+        fetchImpl
+      );
+      await cache.set(cacheKey, updated);
+      return "updated";
+    }
+
+    await cache.delete(cacheKey);
+  }
+
+  const discovered = await findIssueCommentByMarker(
+    config,
+    issue.id,
+    input.marker,
+    fetchImpl
+  );
+  if (!discovered) {
+    const created = await createRestIssueComment(
+      config,
+      issue,
+      input.body,
+      fetchImpl
+    );
+    await cache.set(cacheKey, created);
+    return "created";
+  }
+
+  const current = await fetchRestIssueComment(
+    config,
+    issue,
+    discovered.databaseId,
+    null,
+    fetchImpl
+  );
+  if (current.status === "missing") {
+    const created = await createRestIssueComment(
+      config,
+      issue,
+      input.body,
+      fetchImpl
+    );
+    await cache.set(cacheKey, created);
+    return "created";
+  }
+  if (current.status === "not-modified") {
+    throw new GitHubTrackerQueryError(
+      "GitHub returned 304 for an unconditional issue comment request."
+    );
+  }
+
+  await cache.set(cacheKey, current.entry);
+  if (current.entry.body === input.body) {
+    return "unchanged";
+  }
+
+  const updated = await updateRestIssueComment(
+    config,
+    issue,
+    current.entry.commentId,
+    input.body,
+    fetchImpl
+  );
+  await cache.set(cacheKey, updated);
+  return "updated";
+}
+
+function buildIssueCommentCacheKey(
+  issue: Pick<TrackedIssue, "number" | "repository">,
+  marker: string
+): string {
+  const markerHash = createHash("sha256").update(marker).digest("hex");
+  return [
+    "github",
+    issue.repository.owner.toLowerCase(),
+    issue.repository.name.toLowerCase(),
+    `issue-${issue.number}`,
+    markerHash,
+  ].join(":");
+}
+
+async function fetchRestIssueComment(
+  config: GitHubTrackerConfig,
+  issue: Pick<TrackedIssue, "repository">,
+  commentId: number,
+  etag: string | null,
+  fetchImpl: FetchLike
+): Promise<
+  | { status: "not-modified" }
+  | { status: "missing" }
+  | { status: "found"; entry: IssueCommentCacheEntry }
+> {
+  const response = await fetchImpl(
+    resolveRestApiUrl(
+      config.apiUrl,
+      `/repos/${encodeURIComponent(issue.repository.owner)}/${encodeURIComponent(issue.repository.name)}/issues/comments/${commentId}`
+    ),
+    {
+      method: "GET",
+      headers: buildRestHeaders(config, etag),
+      signal: buildRequestSignal(config.timeoutMs),
+    }
+  );
+
+  if (response.status === 304) {
+    return { status: "not-modified" };
+  }
+  if (response.status === 404) {
+    return { status: "missing" };
+  }
+  if (!response.ok) {
+    throw await buildRestHttpError(response);
+  }
+
+  return {
+    status: "found",
+    entry: await parseRestIssueComment(response),
+  };
+}
+
+async function createRestIssueComment(
+  config: GitHubTrackerConfig,
+  issue: Pick<TrackedIssue, "number" | "repository">,
+  body: string,
+  fetchImpl: FetchLike
+): Promise<IssueCommentCacheEntry> {
+  const response = await fetchImpl(
+    resolveRestApiUrl(
+      config.apiUrl,
+      `/repos/${encodeURIComponent(issue.repository.owner)}/${encodeURIComponent(issue.repository.name)}/issues/${issue.number}/comments`
+    ),
+    {
+      method: "POST",
+      headers: buildRestHeaders(config),
+      body: JSON.stringify({ body }),
+      signal: buildRequestSignal(config.timeoutMs),
+    }
+  );
+  if (!response.ok) {
+    throw await buildRestHttpError(response);
+  }
+
+  return parseRestIssueComment(response);
+}
+
+async function updateRestIssueComment(
+  config: GitHubTrackerConfig,
+  issue: Pick<TrackedIssue, "repository">,
+  commentId: number,
+  body: string,
+  fetchImpl: FetchLike
+): Promise<IssueCommentCacheEntry> {
+  const response = await fetchImpl(
+    resolveRestApiUrl(
+      config.apiUrl,
+      `/repos/${encodeURIComponent(issue.repository.owner)}/${encodeURIComponent(issue.repository.name)}/issues/comments/${commentId}`
+    ),
+    {
+      method: "PATCH",
+      headers: buildRestHeaders(config),
+      body: JSON.stringify({ body }),
+      signal: buildRequestSignal(config.timeoutMs),
+    }
+  );
+  if (!response.ok) {
+    throw await buildRestHttpError(response);
+  }
+
+  return parseRestIssueComment(response);
+}
+
+function buildRestHeaders(
+  config: GitHubTrackerConfig,
+  etag?: string | null
+): Record<string, string> {
+  return {
+    authorization: `Bearer ${config.token}`,
+    "user-agent": "gh-symphony",
+    accept: "application/vnd.github+json",
+    "content-type": "application/json",
+    ...(etag ? { "if-none-match": etag } : {}),
+  };
+}
+
+async function parseRestIssueComment(
+  response: Response
+): Promise<IssueCommentCacheEntry> {
+  const payload = (await response.json()) as {
+    id?: number;
+    body?: string;
+  };
+  if (typeof payload.id !== "number" || typeof payload.body !== "string") {
+    throw new GitHubTrackerQueryError(
+      "GitHub REST response did not include a valid issue comment."
+    );
+  }
+
+  return {
+    commentId: payload.id,
+    etag: response.headers.get("etag"),
+    body: payload.body,
+  };
+}
+
+async function buildRestHttpError(
+  response: Response
+): Promise<GitHubTrackerHttpError> {
+  const details = await response.text();
+  return new GitHubTrackerHttpError(
+    `GitHub REST request failed with status ${response.status}`,
+    response.status,
+    details
+  );
 }
 
 async function findIssueCommentByMarker(
@@ -1515,6 +1783,10 @@ function normalizeBlockerState(
 }
 
 function resolveRestUserApiUrl(apiUrl?: string): string {
+  return resolveRestApiUrl(apiUrl, "/user");
+}
+
+function resolveRestApiUrl(apiUrl: string | undefined, path: string): string {
   const parsed = new URL(apiUrl ?? DEFAULT_API_URL);
   const pathSegments = parsed.pathname.split("/").filter(Boolean);
 
@@ -1522,7 +1794,11 @@ function resolveRestUserApiUrl(apiUrl?: string): string {
     pathSegments.pop();
   }
 
-  parsed.pathname = `/${pathSegments.join("/")}/user`.replace(/\/{2,}/g, "/");
+  parsed.pathname =
+    `/${pathSegments.join("/")}/${path.replace(/^\/+/, "")}`.replace(
+      /\/{2,}/g,
+      "/"
+    );
   parsed.search = "";
   parsed.hash = "";
   return parsed.toString();
@@ -2219,6 +2495,7 @@ const ISSUE_COMMENTS_BY_ID_QUERY = `
         comments(first: 100, after: $cursor) {
           nodes {
             id
+            databaseId
             body
           }
           pageInfo {

--- a/packages/tracker-github/src/orchestrator-adapter.ts
+++ b/packages/tracker-github/src/orchestrator-adapter.ts
@@ -81,9 +81,10 @@ export const githubProjectTrackerAdapter: OrchestratorTrackerAdapter = {
     const trackerConfig = resolveGitHubTrackerConfig(project, dependencies);
     return upsertGithubIssueComment(
       trackerConfig,
-      issue.id,
+      issue,
       input,
-      dependencies.fetchImpl
+      dependencies.fetchImpl,
+      dependencies.issueCommentCache
     );
   },
 };

--- a/packages/tracker-github/src/tracker-github.test.ts
+++ b/packages/tracker-github/src/tracker-github.test.ts
@@ -2,6 +2,8 @@ import { createHash } from "node:crypto";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   DEFAULT_WORKFLOW_LIFECYCLE,
+  type IssueCommentCache,
+  type IssueCommentCacheEntry,
   type ProjectItemsCache,
   type TrackedIssue,
 } from "@gh-symphony/core";
@@ -1146,6 +1148,172 @@ describe("resolveTrackerAdapter", () => {
       /rateLimit\s*\{\s*cost\s+remaining\s+resetAt\s*\}/s
     );
     expect(mutationBody.variables.commentId).toBe("comment-1");
+  });
+
+  it("discovers an advisory comment once and reuses its persisted ETag", async () => {
+    const adapter = resolveTrackerAdapter({
+      adapter: "github-project",
+      bindingId: "project-123",
+      settings: {
+        projectId: "project-123",
+      },
+    });
+    const marker =
+      "<!-- gh-symphony:linked-pr-active-while-issue-inactive issue=issue-1 pr=pr-2 -->";
+    const body = `${marker}\n\nLinked PR card status alone does not trigger dispatch.`;
+    const entries = new Map<string, IssueCommentCacheEntry>();
+    const cache: IssueCommentCache = {
+      get: vi.fn(async (key) => entries.get(key) ?? null),
+      set: vi.fn(async (key, entry) => {
+        entries.set(key, entry);
+      }),
+      delete: vi.fn(async (key) => {
+        entries.delete(key);
+      }),
+    };
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              node: {
+                __typename: "Issue",
+                comments: {
+                  nodes: [
+                    {
+                      id: "comment-node-1",
+                      databaseId: 42,
+                      body,
+                    },
+                  ],
+                  pageInfo: { endCursor: null, hasNextPage: false },
+                },
+              },
+            },
+          })
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ id: 42, body }), {
+          headers: { etag: '"comment-v1"' },
+        })
+      )
+      .mockResolvedValueOnce(new Response(null, { status: 304 }));
+
+    const dependencies = {
+      token: "test-token",
+      fetchImpl,
+      issueCommentCache: cache,
+    };
+    const first = await adapter.upsertIssueComment?.(
+      makeProjectConfig(),
+      makeTrackedIssue(),
+      { marker, body },
+      dependencies
+    );
+    const second = await adapter.upsertIssueComment?.(
+      makeProjectConfig(),
+      makeTrackedIssue(),
+      { marker, body },
+      dependencies
+    );
+
+    expect(first).toBe("unchanged");
+    expect(second).toBe("unchanged");
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+    expect(String(fetchImpl.mock.calls[0]?.[0])).toBe(
+      "https://api.github.com/graphql"
+    );
+    expect(String(fetchImpl.mock.calls[1]?.[0])).toBe(
+      "https://api.github.com/repos/acme/platform/issues/comments/42"
+    );
+    expect(String(fetchImpl.mock.calls[2]?.[0])).toBe(
+      "https://api.github.com/repos/acme/platform/issues/comments/42"
+    );
+    expect(fetchImpl.mock.calls[2]?.[1]?.headers).toMatchObject({
+      "if-none-match": '"comment-v1"',
+    });
+    expect(cache.set).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        commentId: 42,
+        etag: '"comment-v1"',
+        body,
+      })
+    );
+  });
+
+  it("re-discovers an advisory comment when the cached REST id is stale", async () => {
+    const adapter = resolveTrackerAdapter({
+      adapter: "github-project",
+      bindingId: "project-123",
+      settings: {
+        projectId: "project-123",
+      },
+    });
+    const marker =
+      "<!-- gh-symphony:linked-pr-active-while-issue-inactive issue=issue-1 pr=pr-2 -->";
+    const body = `${marker}\nnew body`;
+    const staleEntry: IssueCommentCacheEntry = {
+      commentId: 41,
+      etag: '"stale"',
+      body,
+    };
+    let entry: IssueCommentCacheEntry | null = staleEntry;
+    const cache: IssueCommentCache = {
+      get: vi.fn(async () => entry),
+      set: vi.fn(async (_key, value) => {
+        entry = value;
+      }),
+      delete: vi.fn(async () => {
+        entry = null;
+      }),
+    };
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(null, { status: 404 }))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              node: {
+                __typename: "Issue",
+                comments: {
+                  nodes: [
+                    {
+                      id: "comment-node-2",
+                      databaseId: 42,
+                      body,
+                    },
+                  ],
+                  pageInfo: { endCursor: null, hasNextPage: false },
+                },
+              },
+            },
+          })
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ id: 42, body }), {
+          headers: { etag: '"comment-v2"' },
+        })
+      );
+
+    const result = await adapter.upsertIssueComment?.(
+      makeProjectConfig(),
+      makeTrackedIssue(),
+      { marker, body },
+      { token: "test-token", fetchImpl, issueCommentCache: cache }
+    );
+
+    expect(result).toBe("unchanged");
+    expect(cache.delete).toHaveBeenCalledTimes(1);
+    expect(entry).toEqual({
+      commentId: 42,
+      etag: '"comment-v2"',
+      body,
+    });
   });
 
   it("throws for unsupported tracker adapters", () => {


### PR DESCRIPTION
## TL;DR

- 어드바이저리 코멘트의 REST ID·ETag를 프로젝트 상태 디렉터리에 영속화해 매 폴링의 무제한 GraphQL 코멘트 페이징을 제거합니다.
- 최초 마커 탐색 뒤에는 `GET /repos/{owner}/{repo}/issues/comments/{id}`와 `If-None-Match`를 사용하며, 304는 즉시 `unchanged`로 처리합니다.
- Land-return rework에서 최신 `main` rebase와 `@gh-symphony/cli` patch Changeset을 반영했고, 최종 승인·전체 검증을 통과했습니다.

## 변경 지점 다이어그램

```text
Orchestrator reconciliation
  -> projects/<project>/cache/issue-comments.json
  -> GitHub tracker adapter
       ├─ cache miss: GraphQL marker discovery (최초 1회)
       │    └─ REST GET으로 comment id/body/ETag 저장
       ├─ cache hit: REST GET + If-None-Match
       │    ├─ 304: unchanged
       │    └─ 200: body 비교 후 필요 시 REST PATCH
       └─ stale id(404): 캐시 삭제 후 마커 재탐색
```

## 여기부터 보세요

- `packages/core/src/contracts/tracker-adapter.ts` — 코멘트 캐시 계약
- `packages/orchestrator/src/issue-comment-cache.ts` — 프로젝트 단위 원자적 JSON 영속화
- `packages/orchestrator/src/service.ts` — reconciliation 전반에 영속 캐시 주입
- `packages/tracker-github/src/adapter.ts` — 최초 탐색, 조건부 REST 조회, 304·404·갱신 처리
- `packages/tracker-github/src/tracker-github.test.ts` — ETag 재사용 및 stale ID 재탐색 TC
- `.changeset/cache-advisory-comment-etags.md` — `@gh-symphony/cli` patch 릴리스 기록

## 위험 & 롤백

- 캐시 파일이 삭제되면 다음 사이클에서 GraphQL 마커 탐색을 한 번 다시 수행합니다.
- GitHub에서 코멘트가 삭제되어 REST 404가 반환되면 캐시를 폐기하고 재탐색합니다.
- 손상 캐시 복원력과 GHES REST base 매핑은 비차단 후속 #496, #497로 분리했습니다.
- 롤백은 `IssueCommentCache` 주입과 조건부 REST 경로를 제거해 기존 GraphQL upsert 경로로 복귀할 수 있습니다.

## 변경 파일

- `.changeset/cache-advisory-comment-etags.md`
- `packages/core/src/contracts/tracker-adapter.ts`
- `packages/orchestrator/src/issue-comment-cache.ts`
- `packages/orchestrator/src/issue-comment-cache.test.ts`
- `packages/orchestrator/src/service.ts`
- `packages/orchestrator/src/service.test.ts`
- `packages/tracker-github/src/adapter.ts`
- `packages/tracker-github/src/orchestrator-adapter.ts`
- `packages/tracker-github/src/tracker-github.test.ts`

## Evidence

- `pnpm lint` — pass, Cycle 4에서 head `ff070fb` 재실행
- `pnpm test` — pass, Cycle 4에서 전체 워크스페이스 재실행
- `pnpm typecheck` — pass, Cycle 4에서 재실행
- `pnpm build` — pass, Cycle 4에서 재실행
- Docker E2E — pass: 같은 head에서 `/healthz`, happy stub `running → completed`, continuation retry, `lastError=null`
- GitHub CI — pass: `Test`, `Container Smoke`
- Human review — `hojinzs` 최종 APPROVED at head `ff070fb`

## Issues — Closed #476

Closed #476

## 머지 후/사람 확인

- [ ] 운영 GitHub API 메트릭에서 변경 없는 폴링이 REST 304로 수렴하는지 확인
- [ ] 캐시 파일 삭제 후 최초 탐색이 한 번만 재실행되는지 운영 로그로 확인
