### PR TITLE
fix(orchestrator): isolate targeted suppression scope

### DIFF
--- a/.changeset/targeted-suppression-scope.md
+++ b/.changeset/targeted-suppression-scope.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Keep unrelated active workers running when targeted reconciliation narrows dispatch candidates for #477.

--- a/packages/orchestrator/src/dispatch.test.ts
+++ b/packages/orchestrator/src/dispatch.test.ts
@@ -1,5 +1,5 @@
 import { execSync } from "node:child_process";
-import { mkdtemp, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -12,6 +12,10 @@ import type {
   TrackedIssue,
   TrackedPullRequestContext,
   IssueWorkspaceRecord,
+} from "@gh-symphony/core";
+import {
+  deriveIssueWorkspaceKey,
+  resolveIssueWorkspaceDirectory,
 } from "@gh-symphony/core";
 import { OrchestratorFsStore } from "./fs-store.js";
 import * as trackerAdapters from "./tracker-adapters.js";
@@ -985,6 +989,126 @@ describe("targeted canonical subject dispatch", () => {
     );
   });
 
+  it("uses each repository lifecycle for targeted terminal reconciliation", async () => {
+    const tempRoot = await mkdtemp(
+      join(tmpdir(), "orchestrator-targeted-terminal-lifecycle-")
+    );
+    const defaultRepository = await createRepositoryFixture(
+      tempRoot,
+      "acme",
+      "platform"
+    );
+    const alternateRepository = await createRepositoryFixture(
+      tempRoot,
+      "other",
+      "service",
+      { activeStates: ["Doing"], terminalStates: ["Closed"] }
+    );
+    const store = new OrchestratorFsStore(tempRoot);
+    const projectConfig = createProjectConfig(
+      tempRoot,
+      defaultRepository.cloneUrl,
+      defaultRepository.owner,
+      defaultRepository.name
+    );
+    await store.saveProjectConfig(projectConfig);
+
+    const defaultIssue = makeIssue({
+      id: "issue-default",
+      identifier: "acme/platform#9",
+      number: 9,
+      state: "Done",
+      repository: defaultRepository,
+    });
+    const targetIssue = makeIssue({
+      id: "issue-target",
+      identifier: "other/service#10",
+      number: 10,
+      state: "Closed",
+      repository: alternateRepository,
+    });
+    const workspaceKey = deriveIssueWorkspaceKey(
+      {
+        adapter: "github-project",
+        issueSubjectId: targetIssue.id,
+      },
+      targetIssue.identifier
+    );
+    const workspacePath = resolveIssueWorkspaceDirectory(
+      store.projectDir(projectConfig.projectId),
+      workspaceKey
+    );
+    const repositoryPath = join(workspacePath, "repository");
+    const sentinelPath = join(workspacePath, "sentinel.txt");
+    await mkdir(repositoryPath, { recursive: true });
+    await writeFile(sentinelPath, "cleanup me", "utf8");
+    await store.saveIssueWorkspace(
+      makeIssueWorkspace({
+        workspaceKey,
+        issueSubjectId: targetIssue.id,
+        issueIdentifier: targetIssue.identifier,
+        workspacePath,
+        repositoryPath,
+      })
+    );
+    await store.saveProjectIssueOrchestrations(projectConfig.projectId, [
+      {
+        issueId: targetIssue.id,
+        identifier: targetIssue.identifier,
+        workspaceKey,
+        completedOnce: false,
+        failureRetryCount: 0,
+        state: "running",
+        currentRunId: "run-target-10",
+        retryEntry: null,
+        updatedAt: "2026-03-08T00:00:00.000Z",
+      },
+    ]);
+    await store.saveRun(
+      makeRun({
+        runId: "run-target-10",
+        issueId: targetIssue.id,
+        issueSubjectId: targetIssue.id,
+        issueIdentifier: targetIssue.identifier,
+        issueState: "Doing",
+        repository: alternateRepository,
+        processId: 5401,
+        issueWorkspaceKey: workspaceKey,
+      })
+    );
+
+    vi.spyOn(trackerAdapters, "resolveTrackerAdapter").mockReturnValue(
+      createDispatchAdapter(defaultRepository, [defaultIssue, targetIssue])
+    );
+    const killImpl = vi.fn();
+    const service = new OrchestratorService(store, projectConfig, {
+      now: () => new Date("2026-03-08T00:05:00.000Z"),
+      killImpl,
+      isProcessRunning: vi.fn().mockReturnValue(true),
+      spawnImpl: vi.fn() as never,
+    });
+
+    const result = await service.runOnce({
+      issueIdentifier: targetIssue.identifier,
+    });
+
+    expect(result.summary.suppressed).toBe(1);
+    expect(killImpl).toHaveBeenCalledWith(5401, "SIGTERM");
+    expect(
+      await store.loadRun("run-target-10", projectConfig.projectId)
+    ).toEqual(
+      expect.objectContaining({
+        status: "suppressed",
+        lastError:
+          "Run suppressed because the tracker issue moved to a terminal state.",
+      })
+    );
+    await expect(readFile(sentinelPath, "utf8")).rejects.toThrow();
+    expect(
+      await store.loadIssueWorkspace(projectConfig.projectId, workspaceKey)
+    ).toEqual(expect.objectContaining({ status: "removed" }));
+  });
+
   it("dispatches the canonical Issue when targeting a linked PR identifier", async () => {
     const tempRoot = await mkdtemp(join(tmpdir(), "orchestrator-targeted-pr-"));
     const repository = await createRepositoryFixture(
@@ -1613,6 +1737,7 @@ async function createRepositoryFixture(
   name: string,
   options: {
     activeStates?: string[];
+    terminalStates?: string[];
     maxConcurrentByState?: Record<string, number>;
     codex?: {
       approvalPolicy?: string;
@@ -1662,7 +1787,11 @@ async function writeWorkflowFixture(
   } = {}
 ): Promise<void> {
   const activeStates = options.activeStates ?? ["Todo", "In Progress"];
+  const terminalStates = options.terminalStates ?? ["Done"];
   const activeStateLines = activeStates
+    .map((state) => `    - ${state}`)
+    .join("\n");
+  const terminalStateLines = terminalStates
     .map((state) => `    - ${state}`)
     .join("\n");
   const maxConcurrentByState = options.maxConcurrentByState
@@ -1703,7 +1832,7 @@ tracker:
   active_states:
 ${activeStateLines}
   terminal_states:
-    - Done
+${terminalStateLines}
   blocker_check_states:
     - Todo
 hooks:

--- a/packages/orchestrator/src/dispatch.test.ts
+++ b/packages/orchestrator/src/dispatch.test.ts
@@ -889,6 +889,102 @@ describe("targeted canonical subject dispatch", () => {
     vi.restoreAllMocks();
   });
 
+  it("does not suppress an unrelated active run during targeted reconciliation", async () => {
+    const tempRoot = await mkdtemp(
+      join(tmpdir(), "orchestrator-targeted-active-run-")
+    );
+    const repository = await createRepositoryFixture(
+      tempRoot,
+      "acme",
+      "platform"
+    );
+    const store = new OrchestratorFsStore(tempRoot);
+    const projectConfig = createProjectConfig(
+      tempRoot,
+      repository.cloneUrl,
+      repository.owner,
+      repository.name
+    );
+    await store.saveProjectConfig(projectConfig);
+
+    const targetIssue = makeIssue({
+      id: "issue-7",
+      identifier: "acme/platform#7",
+      number: 7,
+      state: "In review",
+      repository,
+    });
+    const activeIssue = makeIssue({
+      id: "issue-8",
+      identifier: "acme/platform#8",
+      number: 8,
+      state: "Todo",
+      repository,
+    });
+    await store.saveProjectIssueOrchestrations(projectConfig.projectId, [
+      {
+        issueId: activeIssue.id,
+        identifier: activeIssue.identifier,
+        workspaceKey: "acme-platform-8",
+        completedOnce: false,
+        failureRetryCount: 0,
+        state: "running",
+        currentRunId: "run-active-8",
+        retryEntry: null,
+        updatedAt: "2026-03-08T00:00:00.000Z",
+      },
+    ]);
+    await store.saveRun(
+      makeRun({
+        runId: "run-active-8",
+        issueId: activeIssue.id,
+        issueSubjectId: activeIssue.id,
+        issueIdentifier: activeIssue.identifier,
+        issueState: activeIssue.state,
+        repository,
+        processId: 5400,
+        issueWorkspaceKey: "acme-platform-8",
+      })
+    );
+
+    vi.spyOn(trackerAdapters, "resolveTrackerAdapter").mockReturnValue(
+      createDispatchAdapter(repository, [targetIssue, activeIssue])
+    );
+    const killImpl = vi.fn();
+    const service = new OrchestratorService(store, projectConfig, {
+      now: () => new Date("2026-03-08T00:05:00.000Z"),
+      killImpl,
+      isProcessRunning: vi.fn().mockReturnValue(true),
+      spawnImpl: vi.fn() as never,
+    });
+
+    const result = await service.runOnce({
+      issueIdentifier: targetIssue.identifier,
+    });
+
+    expect(result.summary.suppressed).toBe(0);
+    expect(killImpl).not.toHaveBeenCalled();
+    expect(
+      await store.loadRun("run-active-8", projectConfig.projectId)
+    ).toEqual(
+      expect.objectContaining({
+        status: "running",
+        processId: 5400,
+      })
+    );
+    expect(
+      await store.loadProjectIssueOrchestrations(projectConfig.projectId)
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          issueId: activeIssue.id,
+          state: "running",
+          currentRunId: "run-active-8",
+        }),
+      ])
+    );
+  });
+
   it("dispatches the canonical Issue when targeting a linked PR identifier", async () => {
     const tempRoot = await mkdtemp(join(tmpdir(), "orchestrator-targeted-pr-"));
     const repository = await createRepositoryFixture(

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -1723,7 +1723,11 @@ export class OrchestratorService {
       repositoryDirectory,
       repository
     );
-    return this.resolveWorkflowResolution(repository, cacheRoot, resolution);
+    return this.resolveWorkflowResolution(
+      repository,
+      cacheRoot,
+      resolution
+    );
   }
 
   private async startRun(
@@ -3759,7 +3763,8 @@ function shouldInheritProcessEnvKey(key: string): boolean {
 
 function isWorkflowHookExecutionAllowed(env: Record<string, string>): boolean {
   const value =
-    env[WORKFLOW_HOOK_APPROVAL_ENV] ?? process.env[WORKFLOW_HOOK_APPROVAL_ENV];
+    env[WORKFLOW_HOOK_APPROVAL_ENV] ??
+    process.env[WORKFLOW_HOOK_APPROVAL_ENV];
   return value === "1" || value?.toLowerCase() === "true";
 }
 

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -892,8 +892,23 @@ export class OrchestratorService {
         trackerDependencies
       );
       const canonicalIssues = resolveCanonicalSubjectIssues(issues);
-      const { candidates: trackedActionableIssues, lifecycle } =
-        await this.resolveActionableCandidates(tenant, canonicalIssues);
+      const {
+        candidates: trackedActionableIssues,
+        lifecyclesByIssueIdentifier,
+      } = await this.resolveActionableCandidates(tenant, canonicalIssues);
+      const resolveTrackedIssueLifecycle = async (
+        issue: TrackedIssue
+      ): Promise<WorkflowLifecycleConfig | null> => {
+        const cached = lifecyclesByIssueIdentifier.get(issue.identifier);
+        if (cached) {
+          return cached;
+        }
+        const resolved = await this.resolveIssueLifecycle(tenant, issue);
+        if (resolved) {
+          lifecyclesByIssueIdentifier.set(issue.identifier, resolved);
+        }
+        return resolved;
+      };
       const actionableCandidates = issueIdentifier
         ? trackedActionableIssues.filter((issue: TrackedIssue) =>
             matchesTargetIssueIdentifier(issue, issueIdentifier)
@@ -1184,9 +1199,11 @@ export class OrchestratorService {
           this.retireWorkerPid(activeRun.processId);
         }
         if (activeRun) {
+          const issueLifecycle = await resolveTrackedIssueLifecycle(issue);
           const terminalState =
             !isArchivedProjectItem(issue) &&
-            isStateTerminal(issue.state, lifecycle);
+            issueLifecycle !== null &&
+            isStateTerminal(issue.state, issueLifecycle);
           const recovery = terminalState
             ? null
             : await this.classifyIncompleteTurnDirtyWorkspace(
@@ -1236,9 +1253,11 @@ export class OrchestratorService {
 
       const terminalIssuesByIdentifier = new Map<string, TrackedIssue>();
       for (const issue of trackedIssuesByIdentifier.values()) {
+        const issueLifecycle = await resolveTrackedIssueLifecycle(issue);
         if (
           isArchivedProjectItem(issue) ||
-          !isStateTerminal(issue.state, lifecycle)
+          issueLifecycle === null ||
+          !isStateTerminal(issue.state, issueLifecycle)
         ) {
           continue;
         }
@@ -1562,51 +1581,40 @@ export class OrchestratorService {
     issues: TrackedIssue[]
   ): Promise<{
     candidates: TrackedIssue[];
-    lifecycle: WorkflowLifecycleConfig;
+    lifecyclesByIssueIdentifier: Map<string, WorkflowLifecycleConfig>;
   }> {
     const candidates: TrackedIssue[] = [];
-    let lifecycle: WorkflowLifecycleConfig | null = null;
+    const lifecyclesByIssueIdentifier = new Map<
+      string,
+      WorkflowLifecycleConfig
+    >();
 
     for (const issue of issues) {
-      const resolution = await this.loadProjectWorkflow(
-        tenant,
-        issue.repository
-      );
-      if (!isUsableWorkflowResolution(resolution)) {
+      const lifecycle = await this.resolveIssueLifecycle(tenant, issue);
+      if (!lifecycle) {
         continue;
       }
-      if (!lifecycle) {
-        lifecycle = resolution.lifecycle;
-      }
+      lifecyclesByIssueIdentifier.set(issue.identifier, lifecycle);
 
-      if (!this.isIssueCandidateEligible(issue, resolution.lifecycle, issues)) {
+      if (!this.isIssueCandidateEligible(issue, lifecycle, issues)) {
         continue;
       }
 
       candidates.push(issue);
     }
 
-    // If no issues were processed, load lifecycle from the configured repo.
-    if (!lifecycle) {
-      const resolution = await this.loadProjectWorkflow(
-        tenant,
-        tenant.repository
-      );
-      if (isUsableWorkflowResolution(resolution)) {
-        lifecycle = resolution.lifecycle;
-      }
-    }
-
     return {
       candidates,
-      lifecycle: lifecycle ?? {
-        stateFieldName: "Status",
-        activeStates: ["Todo", "In Progress"],
-        terminalStates: ["Done"],
-        blockerCheckStates: ["Todo"],
-        planningStates: ["Todo"],
-      },
+      lifecyclesByIssueIdentifier,
     };
+  }
+
+  private async resolveIssueLifecycle(
+    tenant: OrchestratorProjectConfig,
+    issue: TrackedIssue
+  ): Promise<WorkflowLifecycleConfig | null> {
+    const resolution = await this.loadProjectWorkflow(tenant, issue.repository);
+    return isUsableWorkflowResolution(resolution) ? resolution.lifecycle : null;
   }
 
   private isIssueCandidateEligible(

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -892,23 +892,28 @@ export class OrchestratorService {
         trackerDependencies
       );
       const canonicalIssues = resolveCanonicalSubjectIssues(issues);
-      const filteredIssues = issueIdentifier
+      const { candidates: trackedActionableIssues, lifecycle } =
+        await this.resolveActionableCandidates(tenant, canonicalIssues);
+      const actionableCandidates = issueIdentifier
+        ? trackedActionableIssues.filter((issue: TrackedIssue) =>
+            matchesTargetIssueIdentifier(issue, issueIdentifier)
+          )
+        : trackedActionableIssues;
+      const targetedIssues = issueIdentifier
         ? canonicalIssues.filter((issue: TrackedIssue) =>
             matchesTargetIssueIdentifier(issue, issueIdentifier)
           )
         : canonicalIssues;
-      const { candidates: actionableCandidates, lifecycle } =
-        await this.resolveActionableCandidates(tenant, filteredIssues);
       await this.publishLinkedPullRequestActiveAdvisories(
         tenant,
         trackerAdapter,
-        filteredIssues,
+        targetedIssues,
         trackerDependencies
       );
       const trackedIssuesByIdentifier = new Map<string, TrackedIssue>(
         syncedIssuesByIdentifier
       );
-      for (const issue of filteredIssues) {
+      for (const issue of canonicalIssues) {
         const existing = trackedIssuesByIdentifier.get(issue.identifier);
         trackedIssuesByIdentifier.set(issue.identifier, {
           ...(existing ?? issue),
@@ -1167,7 +1172,7 @@ export class OrchestratorService {
           suppressed += 1;
           continue;
         }
-        const resolvedIssue = actionableCandidates.find(
+        const resolvedIssue = trackedActionableIssues.find(
           (candidate) => candidate.identifier === issue.identifier
         );
         if (resolvedIssue) {


### PR DESCRIPTION
## TL;DR

- targeted `reconcileProject`의 `issueIdentifier` narrowing을 dispatch 후보에만 적용합니다.
- suppression은 전체 tracked/actionable issue 집합을 사용해 무관한 active worker를 보존합니다.
- multi-repository Project에서는 각 issue repository의 workflow lifecycle로 suppression 사유와 terminal workspace cleanup을 판정합니다.

## 변경 지점 다이어그램

```text
tracker listIssues
  ├─ 전체 canonical issues
  │    ├─ repository별 workflow lifecycle
  │    └─ 전체 actionable issues ──→ active run suppression / terminal cleanup
  └─ issueIdentifier narrowing ──→ dispatch candidates only
```

## 여기부터 보세요

1. `packages/orchestrator/src/service.ts` — 전체 actionable issue 집합, targeted dispatch 후보, repository별 lifecycle cache의 경계
2. `packages/orchestrator/src/dispatch.test.ts` — 무관한 active run 보존 및 repository별 terminal state/cleanup 회귀 TC
3. `.changeset/targeted-suppression-scope.md` — `@gh-symphony/cli` patch 릴리스 기록

## 위험 & 롤백

- suppression과 cleanup의 tracker 판단 입력만 분리하며 일반 reconcile, dispatch 정렬, linked-PR advisory 범위는 유지합니다.
- workflow를 읽을 수 없는 repository는 기존처럼 dispatch 후보에서 제외되고 terminal 판정도 수행하지 않습니다.
- 문제가 있으면 이 PR의 squash commit을 revert할 수 있습니다.

## 변경 파일

- 구현: `packages/orchestrator/src/service.ts`
- 테스트: `packages/orchestrator/src/dispatch.test.ts`
- 릴리스: `.changeset/targeted-suppression-scope.md`

## Evidence

- `pnpm lint && pnpm test && pnpm typecheck && pnpm build` — pass
- `pnpm exec vitest run packages/orchestrator/src/dispatch.test.ts --reporter=dot` — 31 tests pass
- `bash e2e/run-e2e.sh happy 60` — pass; running → continuation retry → idle (11s)
- GitHub CI `Test`, `Container Smoke` for `0879752` — success
- Upstream spec §§7.4, 8.1, 8.5 — reconciliation-before-dispatch 및 active-run state refresh/terminal cleanup 계약과 일치, 의도적 divergence 없음
- Changeset: `.changeset/targeted-suppression-scope.md`

## Issues — Closed #477

Closed #477

## 머지 후/사람 확인

- [ ] 실제 GitHub Project targeted event에서 무관한 active worker가 계속 실행되는지 확인
- [ ] 서로 다른 terminal state를 사용하는 multi-repository Project에서 대상 workspace cleanup을 확인
- [ ] 인접한 일반 polling dispatch/suppression 동작에 회귀가 없는지 확인
