### PR TITLE
refactor(tracker-github): remove nested PR metadata queries

### DIFF
--- a/.changeset/lean-project-pr-metadata.md
+++ b/.changeset/lean-project-pr-metadata.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Reduce GitHub Project polling cost for #473 by omitting unused nested pull request label and assignee connections while retaining linked pull request identity and branch metadata.

--- a/packages/tracker-github/src/adapter.ts
+++ b/packages/tracker-github/src/adapter.ts
@@ -50,8 +50,6 @@ export type GitHubPullRequestMetadata = {
   baseRefName: string | null;
   headRepository: GitHubRepositoryRef | null;
   repository: GitHubRepositoryRef;
-  labels: string[];
-  assignees: string[];
   createdAt: string | null;
   updatedAt: string | null;
 };
@@ -150,8 +148,6 @@ type GraphQLPullRequestNode = {
     url: string;
     owner: { login: string };
   };
-  labels: { nodes: Array<{ name: string | null } | null> | null } | null;
-  assignees: { nodes: Array<{ login: string | null } | null> | null } | null;
   createdAt: string | null;
   updatedAt: string | null;
 };
@@ -483,7 +479,7 @@ function normalizePullRequestProjectItem(
     state,
     branchName: content.headRefName,
     url: content.url,
-    labels: pullRequest.labels,
+    labels: [],
     blockedBy: [],
     createdAt: content.createdAt,
     updatedAt: trackedUpdatedAt,
@@ -912,10 +908,7 @@ function isIssueAssignedToLogin(
   item: GraphQLProjectItem,
   login: string
 ): boolean {
-  if (
-    item.content?.__typename !== "Issue" &&
-    item.content?.__typename !== "PullRequest"
-  ) {
+  if (item.content?.__typename !== "Issue") {
     return false;
   }
 
@@ -1145,8 +1138,6 @@ function normalizePullRequestNode(
       ? normalizeRepositoryRef(node.headRepository)
       : null,
     repository,
-    labels: normalizeLabelNames(node.labels?.nodes ?? []),
-    assignees: normalizeAssigneeLogins(node.assignees?.nodes ?? []),
     createdAt: node.createdAt,
     updatedAt: node.updatedAt,
   };
@@ -1171,12 +1162,6 @@ function normalizeLabelNames(
   return nodes
     .flatMap((label) => (label?.name ? [label.name.toLowerCase()] : []))
     .sort();
-}
-
-function normalizeAssigneeLogins(
-  nodes: Array<{ login: string | null } | null>
-): string[] {
-  return nodes.flatMap((assignee) => (assignee?.login ? [assignee.login] : []));
 }
 
 function withGitHubMetadata(
@@ -1358,10 +1343,7 @@ function resolveLabelPriority(
   item: GraphQLProjectItem,
   priority: Extract<WorkflowPriorityConfig, { source: "labels" }>
 ): number | null {
-  if (
-    item.content?.__typename !== "Issue" &&
-    item.content?.__typename !== "PullRequest"
-  ) {
+  if (item.content?.__typename !== "Issue") {
     return null;
   }
 
@@ -1969,16 +1951,6 @@ const PROJECT_ITEMS_QUERY = `
       name
       url
       owner {
-        login
-      }
-    }
-    labels(first: 20) {
-      nodes {
-        name
-      }
-    }
-    assignees(first: 20) {
-      nodes {
         login
       }
     }

--- a/packages/tracker-github/src/tracker-github.test.ts
+++ b/packages/tracker-github/src/tracker-github.test.ts
@@ -424,7 +424,7 @@ describe("resolveTrackerAdapter", () => {
       state: "Ready",
       branchName: "feature/pr-metadata",
       url: "https://github.com/acme/platform/pull/7",
-      labels: ["enhancement", "tracker"],
+      labels: [],
       blockedBy: [],
       repository: {
         owner: "acme",
@@ -461,12 +461,12 @@ describe("resolveTrackerAdapter", () => {
           url: "https://github.com/acme/platform",
           cloneUrl: "https://github.com/acme/platform.git",
         },
-        labels: ["enhancement", "tracker"],
-        assignees: ["octocat"],
         createdAt: "2026-03-13T00:00:00.000Z",
         updatedAt: "2026-03-14T00:00:00.000Z",
       },
     });
+    expect(issue?.metadata.pullRequest).not.toHaveProperty("labels");
+    expect(issue?.metadata.pullRequest).not.toHaveProperty("assignees");
   });
 
   it("preserves fork head repository metadata when normalizing PullRequest Project items", () => {
@@ -541,7 +541,9 @@ describe("resolveTrackerAdapter", () => {
 
     const metadata = issue?.metadata as Record<string, unknown> | undefined;
 
-    expect(metadata?.linkedPullRequests).toEqual([
+    const linkedPullRequests = metadata?.linkedPullRequests as unknown[];
+
+    expect(linkedPullRequests).toEqual([
       expect.objectContaining({
         id: "pr-7",
         number: 7,
@@ -557,6 +559,8 @@ describe("resolveTrackerAdapter", () => {
         },
       }),
     ]);
+    expect(linkedPullRequests[0]).not.toHaveProperty("labels");
+    expect(linkedPullRequests[0]).not.toHaveProperty("assignees");
     expect(metadata?.linkedPullRequestsTruncated).toBe(false);
   });
 
@@ -1223,6 +1227,72 @@ describe("resolveTrackerAdapter", () => {
         process.env.GITHUB_GRAPHQL_TOKEN = originalToken;
       }
     }
+  });
+
+  it("omits nested PR labels and assignees from the project items query", async () => {
+    const adapter = resolveTrackerAdapter({
+      adapter: "github-project",
+      bindingId: "project-123",
+      settings: {
+        projectId: "project-123",
+      },
+    });
+
+    await adapter.listIssues(
+      {
+        projectId: "workspace-1",
+        slug: "workspace-1",
+        workspaceDir: "/tmp/workspace-1",
+        repository: {
+          owner: "acme",
+          name: "platform",
+          cloneUrl: "https://github.com/acme/platform.git",
+        },
+        tracker: {
+          adapter: "github-project",
+          bindingId: "project-123",
+          settings: {
+            projectId: "project-123",
+          },
+        },
+      },
+      {
+        token: "dependencies-token",
+        fetchImpl: async (_url, init) => {
+          const body = JSON.parse(String(init?.body)) as { query: string };
+          expect(body.query.match(/labels\(first: 20\)/g)).toHaveLength(1);
+          expect(body.query.match(/assignees\(first: 20\)/g)).toHaveLength(1);
+          expect(body.query).toContain("blockedBy(first: 100)");
+          expect(body.query).toContain(
+            "closedByPullRequestsReferences(first: 20)"
+          );
+          const pullRequestFragment = body.query.match(
+            /fragment PullRequestMetadata on PullRequest \{[\s\S]*?\n {2}\}/
+          )?.[0];
+          expect(pullRequestFragment).toBeDefined();
+          expect(pullRequestFragment).not.toContain("labels(");
+          expect(pullRequestFragment).not.toContain("assignees(");
+
+          return new Response(
+            JSON.stringify({
+              data: {
+                node: {
+                  __typename: "ProjectV2",
+                  items: {
+                    nodes: [],
+                    pageInfo: { endCursor: null, hasNextPage: false },
+                  },
+                },
+              },
+            }),
+            {
+              status: 200,
+              headers: { "content-type": "application/json" },
+            }
+          );
+        },
+      }
+    );
   });
 
   it("falls back to legacy assignedOnly tracker setting with a deprecation warning", async () => {
@@ -4293,12 +4363,6 @@ function makePullRequestProjectItem(input: {
         name: "platform",
         url: "https://github.com/acme/platform",
         owner: { login: "acme" },
-      },
-      labels: {
-        nodes: [{ name: "tracker" }, { name: "enhancement" }],
-      },
-      assignees: {
-        nodes: [{ login: "octocat" }],
       },
       createdAt: "2026-03-13T00:00:00.000Z",
       updatedAt: "2026-03-14T00:00:00.000Z",


### PR DESCRIPTION
## TL;DR

- GitHub Project polling의 `PullRequestMetadata`에서 중첩 `labels(first: 20)` / `assignees(first: 20)` 연결을 제거했습니다.
- 이슈 본체의 labels/assignees와 `blockedBy(first: 100)`, `closedByPullRequestsReferences(first: 20)`, PR 식별·브랜치·저장소 메타데이터는 유지합니다.
- 쿼리 구조·정규화 회귀 TC와 전체 workspace 검증, Docker blackbox를 통과했습니다.

## 변경 지점 다이어그램

```text
PROJECT_ITEMS_QUERY
  ├─ Issue labels / assignees ── 유지
  ├─ blockedBy(first: 100) ───── 유지
  └─ PullRequestMetadata
       ├─ identity / branch / repository ── 유지
       └─ labels / assignees connections ── 제거
```

## 여기부터 보세요

1. `packages/tracker-github/src/adapter.ts` — 경량화한 fragment, GraphQL 타입, `normalizePullRequestNode`
2. `packages/tracker-github/src/tracker-github.test.ts` — 쿼리 연결 개수·보호 필드·정규화 결과 회귀 TC
3. `.changeset/lean-project-pr-metadata.md` — `@gh-symphony/cli` patch 릴리스 기록

## 위험 & 롤백

- PullRequest Project item의 tracked labels는 빈 배열이 되고, PR item은 `assignedOnly`/label-priority 입력으로 사용되지 않습니다. 중첩 연결을 다시 조회하지 않고는 이 값을 신뢰할 수 없기 때문입니다.
- PR 식별·head/base branch·head repository·repository 메타데이터는 유지되어 checkout과 이슈/PR dedup 경로는 바뀌지 않습니다.
- `blockedBy(first: 100)`와 `closedByPullRequestsReferences` 본체는 그대로 유지합니다.
- 문제가 있으면 이 PR의 squash commit을 revert할 수 있습니다.

## 변경 파일

- 구현: `packages/tracker-github/src/adapter.ts`
- 테스트: `packages/tracker-github/src/tracker-github.test.ts`
- 릴리스: `.changeset/lean-project-pr-metadata.md`

## Evidence

- `pnpm --filter @gh-symphony/tracker-github test` — 69 tests pass
- `pnpm lint` — pass
- `pnpm test` — pass
- `pnpm typecheck` — pass
- `pnpm build` — pass
- `bash e2e/run-e2e.sh happy 60` — pass; running → continuation retry → idle (11s)
- Upstream spec — Integration Layer의 tracker API/normalization 경계와 일치, 의도적 divergence 없음
- Changeset: `.changeset/lean-project-pr-metadata.md`

## Issues — Closed #473

Closed #473

## 머지 후/사람 확인

- [ ] 운영 GitHub Project에서 다음 polling cycle의 `PROJECT_ITEMS_QUERY` cost가 1인지 확인
