### PR TITLE
fix(orchestrator): handle archived project items

### DIFF
--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -8542,6 +8542,156 @@ Prefer focused changes.
     expect(snapshot.activeRuns).toHaveLength(0);
   });
 
+  it("suppresses an active run when its project item is archived", async () => {
+    process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
+    const tempRoot = await mkdtemp(
+      join(tmpdir(), "orchestrator-archived-reconciliation-")
+    );
+    const repository = await createRepositoryFixture(
+      tempRoot,
+      "acme",
+      "platform",
+      {
+        rawWorkflow: `---
+tracker:
+  kind: github-project
+  project_id: project-123
+  state_field: Status
+  active_states:
+    - In Progress
+    - Archived
+  terminal_states:
+    - Done
+  blocker_check_states:
+    - In Progress
+hooks:
+  after_create: ""
+  before_remove: ""
+polling:
+  interval_ms: 30000
+workspace:
+  root: .runtime/symphony-workspaces
+agent:
+  max_concurrent_agents: 10
+  max_retry_backoff_ms: 30000
+  retry_base_delay_ms: 1000
+codex:
+  command: node ${join(tempRoot, "worker.js")}
+  read_timeout_ms: 5000
+  stall_timeout_ms: 300000
+  turn_timeout_ms: 3600000
+---
+Handle archived item reconciliation.`,
+      }
+    );
+    const store = new OrchestratorFsStore(tempRoot);
+    const projectConfig = createProjectConfig(tempRoot, repository);
+    await store.saveProjectConfig(projectConfig);
+    await store.saveProjectIssueOrchestrations("tenant-1", [
+      {
+        issueId: "issue-1",
+        identifier: "acme/platform#1",
+        workspaceKey: "acme_platform_1",
+        completedOnce: false,
+        failureRetryCount: 0,
+        state: "running",
+        currentRunId: "run-1",
+        retryEntry: null,
+        updatedAt: "2026-03-08T00:00:00.000Z",
+      },
+    ]);
+    await store.saveRun({
+      runId: "run-1",
+      projectId: "tenant-1",
+      projectSlug: "tenant-1",
+      issueId: "issue-1",
+      issueSubjectId: "issue-1",
+      issueIdentifier: "acme/platform#1",
+      issueState: "In Progress",
+      repository,
+      status: "running",
+      attempt: 1,
+      processId: 4209,
+      port: 4604,
+      workingDirectory: join(tempRoot, "active-run"),
+      issueWorkspaceKey: null,
+      workspaceRuntimeDir: join(tempRoot, "active-run", "workspace-runtime"),
+      workflowPath: null,
+      retryKind: null,
+      createdAt: "2026-03-08T00:00:00.000Z",
+      updatedAt: "2026-03-08T00:00:00.000Z",
+      startedAt: "2026-03-08T00:00:00.000Z",
+      completedAt: null,
+      lastError: null,
+      nextRetryAt: null,
+    });
+
+    const archivedIssue = {
+      id: "issue-1",
+      identifier: "acme/platform#1",
+      number: 1,
+      title: "Archived issue",
+      description: null,
+      priority: null,
+      state: "Archived",
+      branchName: null,
+      url: "https://github.com/acme/platform/issues/1",
+      labels: [],
+      blockedBy: [],
+      createdAt: "2026-03-08T00:00:00.000Z",
+      updatedAt: "2026-03-08T00:05:00.000Z",
+      repository,
+      tracker: {
+        adapter: "github-project" as const,
+        bindingId: "project-123",
+        itemId: "item-1",
+      },
+      metadata: {
+        isArchived: true,
+      },
+    };
+    const listIssues = vi.fn().mockResolvedValue([archivedIssue]);
+    const fetchIssueStatesByIds = vi
+      .fn()
+      .mockResolvedValue([archivedIssue]);
+    const killImpl = vi.fn();
+    vi.spyOn(trackerAdapters, "resolveTrackerAdapter").mockReturnValue({
+      listIssues,
+      listIssuesByStates: vi.fn().mockResolvedValue([]),
+      fetchIssueStatesByIds,
+      buildWorkerEnvironment: vi.fn().mockReturnValue({
+        GITHUB_PROJECT_ID: "project-123",
+      }),
+      reviveIssue: vi.fn(),
+    });
+
+    const service = new OrchestratorService(store, projectConfig, {
+      fetchImpl: vi
+        .fn()
+        .mockResolvedValue(createEmptyTrackerResponse()) as never,
+      now: () => new Date("2026-03-08T00:05:00.000Z"),
+      killImpl,
+      isProcessRunning: vi.fn().mockReturnValue(true),
+    });
+
+    const snapshot = await service.runOnce();
+    const updatedRun = await store.loadRun("run-1");
+    const issueRecords = await store.loadProjectIssueOrchestrations("tenant-1");
+
+    expect(fetchIssueStatesByIds).toHaveBeenCalledTimes(1);
+    expect(killImpl).toHaveBeenCalledWith(4209, "SIGTERM");
+    expect(updatedRun).toMatchObject({
+      status: "suppressed",
+      issueState: "Archived",
+      processId: null,
+      runPhase: "canceled_by_reconciliation",
+      lastError:
+        "Run suppressed because the tracker state is no longer actionable.",
+    });
+    expect(issueRecords[0]?.state).toBe("released");
+    expect(snapshot.activeRuns).toHaveLength(0);
+  });
+
   it("records Linear tracker and issue metadata on structured tracker events", async () => {
     const tempRoot = await mkdtemp(
       join(tmpdir(), "orchestrator-linear-events-")

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -997,7 +997,9 @@ export class OrchestratorService {
           this.retireWorkerPid(activeRun.processId);
         }
         if (activeRun) {
-          const terminalState = isStateTerminal(issue.state, lifecycle);
+          const terminalState =
+            !isArchivedProjectItem(issue) &&
+            isStateTerminal(issue.state, lifecycle);
           const recovery = terminalState
             ? null
             : await this.classifyIncompleteTurnDirtyWorkspace(
@@ -1047,7 +1049,10 @@ export class OrchestratorService {
 
       const terminalIssuesByIdentifier = new Map<string, TrackedIssue>();
       for (const issue of trackedIssuesByIdentifier.values()) {
-        if (!isStateTerminal(issue.state, lifecycle)) {
+        if (
+          isArchivedProjectItem(issue) ||
+          !isStateTerminal(issue.state, lifecycle)
+        ) {
           continue;
         }
         terminalIssuesByIdentifier.set(issue.identifier, issue);
@@ -1422,6 +1427,10 @@ export class OrchestratorService {
     lifecycle: WorkflowLifecycleConfig,
     issues: readonly TrackedIssue[]
   ): boolean {
+    if (isArchivedProjectItem(issue)) {
+      return false;
+    }
+
     return isIssueCandidateEligibleWithReason(issue, lifecycle, issues)
       .eligible;
   }
@@ -1437,7 +1446,10 @@ export class OrchestratorService {
     }
 
     for (const issue of issues) {
-      if (issue.metadata.contentType === "PullRequest") {
+      if (
+        isArchivedProjectItem(issue) ||
+        issue.metadata.contentType === "PullRequest"
+      ) {
         continue;
       }
 
@@ -3345,6 +3357,10 @@ export class OrchestratorService {
     now: Date,
     workflowResolution?: ProjectWorkflowResolution
   ): Promise<void> {
+    if (isArchivedProjectItem(issue)) {
+      return;
+    }
+
     const issueSubjectId = issue.id;
     const identity: IssueSubjectIdentity = {
       adapter: issue.tracker.adapter,
@@ -4031,4 +4047,8 @@ function releaseIssueOrchestration(
         }
       : record
   );
+}
+
+function isArchivedProjectItem(issue: TrackedIssue): boolean {
+  return issue.metadata.isArchived === true;
 }

--- a/packages/tracker-github/src/adapter.ts
+++ b/packages/tracker-github/src/adapter.ts
@@ -2139,14 +2139,9 @@ const PROJECT_ITEMS_QUERY = `
     node(id: $projectId) {
       __typename
       ... on ProjectV2 {
-        items(
-          first: $pageSize
-          after: $cursor
-          archivedStates: [ARCHIVED, NOT_ARCHIVED]
-        ) {
+        items(first: $pageSize, after: $cursor) {
           nodes {
             id
-            isArchived
             updatedAt
             fieldValues(first: 20) {
               nodes {

--- a/packages/tracker-github/src/adapter.ts
+++ b/packages/tracker-github/src/adapter.ts
@@ -156,6 +156,7 @@ type GraphQLPullRequestNode = {
 
 type GraphQLProjectItem = {
   id: string;
+  isArchived?: boolean;
   updatedAt: string | null;
   fieldValues: { nodes: Array<GraphQLFieldValue | null> | null } | null;
   content: GraphQLIssueNode | GraphQLPullRequestNode | null;
@@ -163,6 +164,7 @@ type GraphQLProjectItem = {
 
 type GraphQLIssueProjectItemNode = {
   id: string;
+  isArchived?: boolean;
   updatedAt: string | null;
   project: { id: string } | null;
   fieldValues: { nodes: Array<GraphQLFieldValue | null> | null } | null;
@@ -364,6 +366,7 @@ const cachedGitHubGraphQLRateLimits = new Map<
   string,
   GitHubRateLimitPayload | null
 >();
+const ARCHIVED_PROJECT_ITEM_STATE = "Archived";
 
 export function normalizeProjectItem(
   projectId: string,
@@ -380,7 +383,10 @@ export function normalizeProjectItem(
   }
 
   const fieldValues = extractFieldValues(item.fieldValues?.nodes ?? []);
-  const state = requireProjectItemState(fieldValues, lifecycle, item.id);
+  const isArchived = item.isArchived === true;
+  const state = isArchived
+    ? ARCHIVED_PROJECT_ITEM_STATE
+    : requireProjectItemState(fieldValues, lifecycle, item.id);
 
   if (item.content.__typename === "PullRequest") {
     return normalizePullRequestProjectItem(
@@ -447,7 +453,8 @@ export function normalizeProjectItem(
     metadata: withIssueMetadata(
       fieldValues,
       linkedPullRequests,
-      linkedPullRequestsTruncated
+      linkedPullRequestsTruncated,
+      isArchived
     ),
     rateLimits,
   };
@@ -496,6 +503,7 @@ function normalizePullRequestProjectItem(
       contentType: "PullRequest",
       pullRequest,
       linkedPullRequests: [],
+      isArchived: item.isArchived === true,
     }),
     rateLimits,
   };
@@ -1310,7 +1318,10 @@ function normalizeIssueStateLookupNode(
   }
 
   const fieldValues = extractFieldValues(projectItem.fieldValues?.nodes ?? []);
-  const state = requireProjectItemState(fieldValues, lifecycle, projectItem.id);
+  const isArchived = projectItem.isArchived === true;
+  const state = isArchived
+    ? ARCHIVED_PROJECT_ITEM_STATE
+    : requireProjectItemState(fieldValues, lifecycle, projectItem.id);
   const repository = issue.repository;
   const identifier = `${repository.owner.login}/${repository.name}#${issue.number}`;
   const url =
@@ -1345,8 +1356,13 @@ function normalizeIssueStateLookupNode(
     },
     metadata:
       issue.__typename === "PullRequest"
-        ? withGitHubMetadata(fieldValues, { contentType: "PullRequest" })
-        : fieldValues,
+        ? withGitHubMetadata(fieldValues, {
+            contentType: "PullRequest",
+            isArchived,
+          })
+        : withGitHubMetadata(fieldValues, {
+            isArchived,
+          }),
     rateLimits,
   };
 }
@@ -1367,6 +1383,7 @@ function normalizeRepositoryIssueLookup(
     projectId,
     {
       id: projectItem.id,
+      isArchived: projectItem.isArchived,
       updatedAt: projectItem.updatedAt,
       fieldValues: projectItem.fieldValues,
       content: issue,
@@ -1445,15 +1462,21 @@ function withGitHubMetadata(
 function withIssueMetadata(
   fieldValues: Record<string, string>,
   linkedPullRequests: GitHubPullRequestMetadata[],
-  linkedPullRequestsTruncated = false
+  linkedPullRequestsTruncated = false,
+  isArchived = false
 ): TrackedIssue["metadata"] {
-  if (linkedPullRequests.length === 0 && !linkedPullRequestsTruncated) {
+  if (
+    linkedPullRequests.length === 0 &&
+    !linkedPullRequestsTruncated &&
+    !isArchived
+  ) {
     return fieldValues;
   }
 
   return withGitHubMetadata(fieldValues, {
     linkedPullRequests,
     linkedPullRequestsTruncated,
+    isArchived,
   });
 }
 
@@ -2116,9 +2139,14 @@ const PROJECT_ITEMS_QUERY = `
     node(id: $projectId) {
       __typename
       ... on ProjectV2 {
-        items(first: $pageSize, after: $cursor) {
+        items(
+          first: $pageSize
+          after: $cursor
+          archivedStates: [ARCHIVED, NOT_ARCHIVED]
+        ) {
           nodes {
             id
+            isArchived
             updatedAt
             fieldValues(first: 20) {
               nodes {
@@ -2283,9 +2311,10 @@ const ISSUE_STATES_BY_IDS_QUERY = `
             login
           }
         }
-        projectItems(first: 100, includeArchived: false) {
+        projectItems(first: 100, includeArchived: true) {
           nodes {
             id
+            isArchived
             updatedAt
             project {
               id
@@ -2332,9 +2361,10 @@ const ISSUE_STATES_BY_IDS_QUERY = `
             login
           }
         }
-        projectItems(first: 100, includeArchived: false) {
+        projectItems(first: 100, includeArchived: true) {
           nodes {
             id
+            isArchived
             updatedAt
             project {
               id
@@ -2393,9 +2423,10 @@ const ISSUE_PROJECT_ITEMS_PAGE_QUERY = `
             login
           }
         }
-        projectItems(first: 100, after: $cursor, includeArchived: false) {
+        projectItems(first: 100, after: $cursor, includeArchived: true) {
           nodes {
             id
+            isArchived
             updatedAt
             project {
               id
@@ -2442,9 +2473,10 @@ const ISSUE_PROJECT_ITEMS_PAGE_QUERY = `
             login
           }
         }
-        projectItems(first: 100, after: $cursor, includeArchived: false) {
+        projectItems(first: 100, after: $cursor, includeArchived: true) {
           nodes {
             id
+            isArchived
             updatedAt
             project {
               id
@@ -2601,9 +2633,10 @@ const REPOSITORY_ISSUE_QUERY = `
             hasNextPage
           }
         }
-        projectItems(first: 20, includeArchived: false) {
+        projectItems(first: 20, includeArchived: true) {
           nodes {
             id
+            isArchived
             updatedAt
             project {
               id

--- a/packages/tracker-github/src/tracker-github.test.ts
+++ b/packages/tracker-github/src/tracker-github.test.ts
@@ -28,6 +28,29 @@ afterEach(() => {
 });
 
 describe("resolveTrackerAdapter", () => {
+  it("normalizes archived project items to an explicit non-terminal state", () => {
+    const projectItem = makeProjectItem({
+      itemId: "item-archived",
+      issueId: "issue-1",
+      number: 1,
+      title: "Archived issue",
+      assignees: [],
+      isArchived: true,
+    });
+    projectItem.fieldValues.nodes = [];
+
+    const issue = normalizeGithubProjectItem(
+      "project-123",
+      projectItem,
+      DEFAULT_WORKFLOW_LIFECYCLE
+    );
+
+    expect(issue?.state).toBe("Archived");
+    expect(issue?.metadata).toMatchObject({
+      isArchived: true,
+    });
+  });
+
   it("normalizes blocker refs into the workflow lifecycle state domain", () => {
     const issue = normalizeGithubProjectItem(
       "project-123",
@@ -1434,6 +1457,10 @@ describe("resolveTrackerAdapter", () => {
           expect(body.query).toContain(
             "closedByPullRequestsReferences(first: 20)"
           );
+          expect(body.query).toContain(
+            "archivedStates: [ARCHIVED, NOT_ARCHIVED]"
+          );
+          expect(body.query).toContain("isArchived");
           const pullRequestFragment = body.query.match(
             /fragment PullRequestMetadata on PullRequest \{[\s\S]*?\n {2}\}/
           )?.[0];
@@ -3743,8 +3770,9 @@ describe("resolveTrackerAdapter", () => {
           );
           expect(body.query).toContain("nodes(ids: $issueIds)");
           expect(body.query).toContain(
-            "projectItems(first: 100, includeArchived: false)"
+            "projectItems(first: 100, includeArchived: true)"
           );
+          expect(body.query).toContain("isArchived");
           expect(body.query).toContain("... on Issue");
           expect(body.query).toContain("... on PullRequest");
           expect(body.query).not.toContain("blockedBy(");
@@ -3790,6 +3818,47 @@ describe("resolveTrackerAdapter", () => {
       "acme/platform#2",
     ]);
     expect(issues.map((issue) => issue.state)).toEqual(["In Progress", "Done"]);
+  });
+
+  it("returns archived issue states explicitly from the by-id lookup", async () => {
+    const adapter = resolveTrackerAdapter({
+      adapter: "github-project",
+      bindingId: "project-123",
+      settings: {
+        projectId: "project-123",
+      },
+    });
+    const node = makeIssueStateLookupNode({
+      projectId: "project-123",
+      itemId: "item-archived",
+      issueId: "issue-1",
+      number: 1,
+      title: "Archived issue",
+      state: "In progress",
+      isArchived: true,
+    });
+    node.projectItems.nodes[0]!.fieldValues.nodes = [];
+
+    const issues = await adapter.fetchIssueStatesByIds(
+      makeProjectConfig(),
+      ["issue-1"],
+      {
+        token: "dependencies-token",
+        fetchImpl: async () =>
+          new Response(JSON.stringify({ data: { nodes: [node] } }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+      }
+    );
+
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toMatchObject({
+      state: "Archived",
+      metadata: {
+        isArchived: true,
+      },
+    });
   });
 
   it("fetches pull request states by GraphQL pull request ids", async () => {
@@ -4408,6 +4477,7 @@ function makeProjectItem(input: {
   labels?: string[];
   priorityName?: string;
   priorityOptionId?: string;
+  isArchived?: boolean;
   repository?: {
     owner: string;
     name: string;
@@ -4417,6 +4487,7 @@ function makeProjectItem(input: {
 
   return {
     id: input.itemId,
+    isArchived: input.isArchived ?? false,
     updatedAt: "2026-03-14T00:00:00.000Z",
     fieldValues: {
       nodes: [
@@ -4545,6 +4616,7 @@ function makeIssueStateLookupNode(input: {
   number: number;
   title: string;
   state: string;
+  isArchived?: boolean;
   pageInfo?: {
     endCursor: string | null;
     hasNextPage: boolean;
@@ -4564,6 +4636,7 @@ function makeIssueStateLookupNode(input: {
       nodes: [
         {
           id: input.itemId,
+          isArchived: input.isArchived ?? false,
           updatedAt: "2026-03-14T00:00:00.000Z",
           project: { id: input.projectId },
           fieldValues: {
@@ -4591,6 +4664,7 @@ function makePullRequestStateLookupNode(input: {
   pullRequestId: string;
   number: number;
   state: string;
+  isArchived?: boolean;
   headRefName?: string | null;
   pageInfo?: {
     endCursor: string | null;
@@ -4613,6 +4687,7 @@ function makePullRequestStateLookupNode(input: {
       nodes: [
         {
           id: input.itemId,
+          isArchived: input.isArchived ?? false,
           updatedAt: "2026-03-14T00:00:00.000Z",
           project: { id: input.projectId },
           fieldValues: {

--- a/packages/tracker-github/src/tracker-github.test.ts
+++ b/packages/tracker-github/src/tracker-github.test.ts
@@ -1457,10 +1457,8 @@ describe("resolveTrackerAdapter", () => {
           expect(body.query).toContain(
             "closedByPullRequestsReferences(first: 20)"
           );
-          expect(body.query).toContain(
-            "archivedStates: [ARCHIVED, NOT_ARCHIVED]"
-          );
-          expect(body.query).toContain("isArchived");
+          expect(body.query).not.toContain("archivedStates:");
+          expect(body.query).not.toContain("isArchived");
           const pullRequestFragment = body.query.match(
             /fragment PullRequestMetadata on PullRequest \{[\s\S]*?\n {2}\}/
           )?.[0];


### PR DESCRIPTION
## Issues — Closed #482

## TL;DR

- 아카이브된 GitHub Project item을 active run 전용 by-id 조회에서 명시적인 `Archived` state와 `metadata.isArchived`로 정규화합니다.
- 해당 run은 terminal 완료로 오인하지 않고 suppress/release하여 stale state와 실행 프로세스를 남기지 않습니다.
- 전체 프로젝트 폴링은 비아카이브 item만 유지해 누적 아카이브에 따른 GraphQL 페이지네이션 비용을 만들지 않습니다.

## 변경 지점 다이어그램

```text
전체 폴링: items() ── 기본 NOT_ARCHIVED 범위 ──→ dispatch 후보

active run reconciliation
  └─ fetchIssueStatesByIds
       └─ projectItems(includeArchived: true)
            ↓ isArchived
       state: "Archived" + metadata.isArchived: true
            ↓
       worker SIGTERM → run suppressed → orchestration released
                      └─ terminal workspace cleanup 제외
```

## 여기부터 보세요

1. `packages/tracker-github/src/adapter.ts` — by-id 아카이브 조회·정규화와 비아카이브 전체 폴링 범위
2. `packages/orchestrator/src/service.ts` — archived item의 dispatch·continuation·terminal 처리 정책
3. `packages/tracker-github/src/tracker-github.test.ts` — by-id 아카이브 조회와 전체 폴링 범위 회귀 TC
4. `packages/orchestrator/src/service.test.ts` — active run suppress/release 회귀 TC

## 위험 & 롤백

- `Archived`는 워크플로 terminal state가 아니라 GitHub Project item의 별도 비활성 상태입니다. 이슈 자체를 완료하거나 workspace를 terminal cleanup하지 않습니다.
- 아카이브 해제 후에는 실제 Status 필드가 다시 정규화되어 기존 eligibility 규칙을 따릅니다.
- 롤백은 이 PR의 squash commit을 revert하면 됩니다. 롤백 시 아카이브된 active run의 state가 다시 stale해질 수 있습니다.

## 변경 파일

- `packages/tracker-github/src/adapter.ts`
- `packages/tracker-github/src/tracker-github.test.ts`
- `packages/orchestrator/src/service.ts`
- `packages/orchestrator/src/service.test.ts`

## Evidence

- `pnpm --filter @gh-symphony/tracker-github exec vitest run src/tracker-github.test.ts` — pass (71 tests)
- `pnpm lint && pnpm test && pnpm typecheck && pnpm build` — pass
- `./e2e/run-e2e.sh happy 45` — pass (12초, worker 실행 → continuation retry → idle)
- upstream spec §8.5 — 비active·비terminal tracker 상태의 worker 종료 및 workspace 보존 규칙 준수, 의도적 divergence 없음
- Changeset — N/A (`changeset:*` label 없음)

## 머지 후/사람 확인

- [ ] 실제 GitHub Project에서 active run item을 아카이브했을 때 run이 suppress되고 재dispatch되지 않는지 확인
- [ ] 아카이브 해제 후 Status 필드 기준으로 다시 eligibility가 평가되는지 확인
- [ ] 아카이브가 issue 완료나 terminal workspace cleanup으로 오인되지 않는지 확인
