### PR TITLE
perf(tracker-github): filter terminal project items

### DIFF
--- a/.changeset/tidy-project-filter.md
+++ b/.changeset/tidy-project-filter.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Filter terminal GitHub Project items server-side during candidate polling to reduce pagination work.

--- a/packages/core/src/contracts/tracker-adapter.ts
+++ b/packages/core/src/contracts/tracker-adapter.ts
@@ -3,6 +3,7 @@ import type {
   OrchestratorRunRecord,
   OrchestratorProjectConfig,
 } from "./status-surface.js";
+import type { WorkflowLifecycleConfig } from "../workflow/lifecycle.js";
 
 export type TrackerAdapterKind = "github-project" | (string & {});
 
@@ -113,6 +114,7 @@ export type OrchestratorTrackerDependencies = {
   projectItemsCache?: ProjectItemsCache;
   issueCommentCache?: IssueCommentCache;
   assignedOnly?: boolean;
+  workflowLifecycle?: WorkflowLifecycleConfig;
 };
 
 export type TrackerStateRequest =

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -8818,6 +8818,15 @@ Prefer focused changes.
       listIssues.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY
     );
     expect(listIssues).toHaveBeenCalledTimes(1);
+    expect(listIssues).toHaveBeenCalledWith(
+      projectConfig,
+      expect.objectContaining({
+        workflowLifecycle: expect.objectContaining({
+          activeStates: ["Todo", "In Progress"],
+          terminalStates: ["Done"],
+        }),
+      })
+    );
     expect(snapshot.activeRuns[0]?.issueState).toBe("In Progress");
     expect(updatedRun?.issueState).toBe("In Progress");
   });

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -887,9 +887,14 @@ export class OrchestratorService {
       );
       this.rememberTrackerRateLimits(tenant.projectId, trackerRateLimits);
       rateLimits = rateLimits ?? trackerRateLimits;
+      const candidateTrackerDependencies =
+        await this.resolveCandidateTrackerDependencies(
+          tenant,
+          trackerDependencies
+        );
       const issues = await trackerAdapter.listIssues(
         tenant,
-        trackerDependencies
+        candidateTrackerDependencies
       );
       const canonicalIssues = resolveCanonicalSubjectIssues(issues);
       const {
@@ -1555,6 +1560,24 @@ export class OrchestratorService {
     );
     this.issueCommentCaches.set(projectId, commentCache);
     return commentCache;
+  }
+
+  private async resolveCandidateTrackerDependencies(
+    tenant: OrchestratorProjectConfig,
+    trackerDependencies: OrchestratorTrackerDependencies
+  ): Promise<OrchestratorTrackerDependencies> {
+    const resolution = await this.loadProjectWorkflow(
+      tenant,
+      tenant.repository
+    );
+    if (!isUsableWorkflowResolution(resolution)) {
+      return trackerDependencies;
+    }
+
+    return {
+      ...trackerDependencies,
+      workflowLifecycle: resolution.lifecycle,
+    };
   }
 
   private async findLatestRunForIssue(

--- a/packages/tracker-github/src/adapter.ts
+++ b/packages/tracker-github/src/adapter.ts
@@ -1684,6 +1684,10 @@ function buildTerminalStatesQuery(
     return null;
   }
 
+  if (lifecycle.stateFieldName.trim().toLowerCase() !== "status") {
+    return null;
+  }
+
   const activeStates = new Set(
     lifecycle.activeStates.map((state) => state.trim().toLowerCase())
   );

--- a/packages/tracker-github/src/adapter.ts
+++ b/packages/tracker-github/src/adapter.ts
@@ -223,6 +223,7 @@ type GraphQLUpdateIssueCommentResponse = {
 };
 
 type GraphQLProjectItemsPage = {
+  totalCount?: number;
   nodes: Array<GraphQLProjectItem | null> | null;
   pageInfo: {
     endCursor: string | null;
@@ -234,6 +235,9 @@ type GraphQLProjectItemsResponse = {
   node?: {
     __typename?: string;
     items?: GraphQLProjectItemsPage;
+    unfilteredItems?: {
+      totalCount?: number;
+    };
   } | null;
 };
 
@@ -542,10 +546,12 @@ export async function fetchProjectIssues(
   fetchImpl: FetchLike = fetch
 ): Promise<GitHubTrackedIssue[] & TrackedIssueList> {
   const cycleConfig = beginGraphQLRateLimitCycle(config);
-  // GitHub Project V2 does not expose query-time item filtering by workflow
-  // state, so callers must fetch the project items and filter in memory.
+  const stateFilterQuery = buildTerminalStatesQuery(config.lifecycle);
   const issues: GitHubTrackedIssue[] = [];
   let cursor: string | null = null;
+  let pageCount = 0;
+  let unfilteredCount: number | null = null;
+  let filteredCount: number | null = null;
   const priorityOptionIds =
     !config.priority && config.priorityFieldName
       ? await fetchPriorityOptionOrder(
@@ -565,9 +571,13 @@ export async function fetchProjectIssues(
     const pageResult = await fetchProjectItemsPage(
       cycleConfig,
       cursor,
+      stateFilterQuery,
       fetchImpl
     );
+    pageCount += 1;
     const page = pageResult.page;
+    unfilteredCount = pageResult.unfilteredCount ?? unfilteredCount;
+    filteredCount = page.totalCount ?? filteredCount;
     latestRateLimits = pageResult.rateLimits ?? latestRateLimits;
     const pageIssues = (page.nodes ?? []).flatMap((item) => {
       if (!item) {
@@ -617,6 +627,16 @@ export async function fetchProjectIssues(
     issues.push(...pageIssues);
     cursor = page.pageInfo.hasNextPage ? page.pageInfo.endCursor : null;
   } while (cursor);
+
+  if (stateFilterQuery && unfilteredCount !== null && filteredCount !== null) {
+    emitProjectItemsStateFilterEvent({
+      projectId: config.projectId,
+      query: stateFilterQuery,
+      unfilteredCount,
+      filteredCount,
+      pageCount,
+    });
+  }
 
   if (currentUserLogin) {
     emitAssignedOnlyFilterEvent({
@@ -1132,10 +1152,12 @@ export async function fetchProjectIssueByRepositoryAndNumber(
 async function fetchProjectItemsPage(
   config: GitHubTrackerConfig,
   cursor: string | null,
+  query: string | null,
   fetchImpl: FetchLike
 ): Promise<{
   page: GraphQLProjectItemsPage;
   rateLimits: GitHubRateLimitPayload | null;
+  unfilteredCount: number | null;
 }> {
   const result =
     await executeGraphQLQueryWithMetadata<GraphQLProjectItemsResponse>(
@@ -1145,6 +1167,8 @@ async function fetchProjectItemsPage(
         projectId: config.projectId,
         cursor,
         pageSize: config.pageSize ?? DEFAULT_PAGE_SIZE,
+        query,
+        includeUnfilteredCount: cursor === null && query !== null,
       },
       fetchImpl
     );
@@ -1160,6 +1184,7 @@ async function fetchProjectItemsPage(
   return {
     page: items,
     rateLimits: result.rateLimits,
+    unfilteredCount: data.node?.unfilteredItems?.totalCount ?? null,
   };
 }
 
@@ -1630,6 +1655,71 @@ function emitRepositoryFilterEvent(input: {
       excludedCount: input.excludedCount,
     })
   );
+}
+
+function emitProjectItemsStateFilterEvent(input: {
+  projectId: string;
+  query: string;
+  unfilteredCount: number;
+  filteredCount: number;
+  pageCount: number;
+}): void {
+  console.info(
+    JSON.stringify({
+      event: "tracker-project-items-state-filtered",
+      projectId: input.projectId,
+      query: input.query,
+      unfilteredCount: input.unfilteredCount,
+      filteredCount: input.filteredCount,
+      excludedCount: input.unfilteredCount - input.filteredCount,
+      pageCount: input.pageCount,
+    })
+  );
+}
+
+function buildTerminalStatesQuery(
+  lifecycle: WorkflowLifecycleConfig | undefined
+): string | null {
+  if (!lifecycle) {
+    return null;
+  }
+
+  const activeStates = new Set(
+    lifecycle.activeStates.map((state) => state.trim().toLowerCase())
+  );
+  const terminalStates = new Map<string, string>();
+  for (const state of lifecycle.terminalStates) {
+    const trimmedState = state.trim();
+    if (!trimmedState) {
+      continue;
+    }
+
+    const normalizedState = trimmedState.toLowerCase();
+    if (activeStates.has(normalizedState)) {
+      throw new GitHubTrackerQueryError(
+        `Workflow state "${trimmedState}" cannot be both active and terminal.`
+      );
+    }
+    if (!terminalStates.has(normalizedState)) {
+      terminalStates.set(normalizedState, trimmedState);
+    }
+  }
+
+  if (terminalStates.size === 0) {
+    return null;
+  }
+
+  return `-status:${[...terminalStates.values()]
+    .map(formatProjectQueryValue)
+    .join(",")}`;
+}
+
+function formatProjectQueryValue(value: string): string {
+  if (/^[A-Za-z0-9_-]+$/.test(value)) {
+    return value;
+  }
+
+  return `"${value.replaceAll("\\", "\\\\").replaceAll('"', '\\"')}"`;
 }
 
 function extractFieldValues(
@@ -2231,7 +2321,7 @@ function resolveNetworkTimeoutMs(timeoutMs?: number): number {
 async function executeGraphQLQuery<TData>(
   config: GitHubTrackerConfig,
   query: string,
-  variables: Record<string, string | number | string[] | null>,
+  variables: Record<string, string | number | boolean | string[] | null>,
   fetchImpl: FetchLike
 ): Promise<TData> {
   const result = await executeGraphQLQueryWithMetadata<TData>(
@@ -2246,7 +2336,7 @@ async function executeGraphQLQuery<TData>(
 async function executeGraphQLQueryWithMetadata<TData>(
   config: GitHubTrackerConfig,
   query: string,
-  variables: Record<string, string | number | string[] | null>,
+  variables: Record<string, string | number | boolean | string[] | null>,
   fetchImpl: FetchLike
 ): Promise<{
   data: TData;
@@ -2529,7 +2619,13 @@ export function resetGitHubRateLimitCacheForTests(): void {
 }
 
 const PROJECT_ITEMS_QUERY = `
-  query ProjectItems($projectId: ID!, $cursor: String, $pageSize: Int!) {
+  query ProjectItems(
+    $projectId: ID!
+    $cursor: String
+    $pageSize: Int!
+    $query: String
+    $includeUnfilteredCount: Boolean!
+  ) {
     rateLimit {
       cost
       remaining
@@ -2538,7 +2634,11 @@ const PROJECT_ITEMS_QUERY = `
     node(id: $projectId) {
       __typename
       ... on ProjectV2 {
-        items(first: $pageSize, after: $cursor) {
+        unfilteredItems: items(first: 1) @include(if: $includeUnfilteredCount) {
+          totalCount
+        }
+        items(first: $pageSize, after: $cursor, query: $query) {
+          totalCount
           nodes {
             id
             updatedAt

--- a/packages/tracker-github/src/orchestrator-adapter.ts
+++ b/packages/tracker-github/src/orchestrator-adapter.ts
@@ -23,9 +23,12 @@ export const githubProjectTrackerAdapter: OrchestratorTrackerAdapter = {
       return [];
     }
 
-    // GitHub Project V2 cannot filter project items by state at query time,
-    // so we reuse the full project fetch and apply state filtering locally.
-    const issues = await listProjectIssues(project, dependencies);
+    // Terminal-state exclusion is only safe for candidate listing. State
+    // lookups (including startup cleanup for Done items) stay unfiltered.
+    const issues = await listProjectIssues(project, {
+      ...dependencies,
+      workflowLifecycle: undefined,
+    });
     const normalizedStates = new Set(
       states.map((state) => state.trim().toLowerCase())
     );
@@ -178,6 +181,7 @@ function resolveGitHubTrackerConfig(
       "priorityFieldName"
     ),
     timeoutMs: readNumberTrackerSetting(project.tracker, "timeoutMs"),
+    lifecycle: dependencies.workflowLifecycle,
   };
 }
 
@@ -257,6 +261,7 @@ function buildProjectItemsCacheKey(
     priority: config.priority ?? null,
     priorityFieldName: config.priorityFieldName ?? null,
     projectId: config.projectId,
+    workflowLifecycle: config.lifecycle ?? null,
     repositoryFilter: config.repositoryFilter
       ? `${config.repositoryFilter.owner}/${config.repositoryFilter.name}`
       : null,

--- a/packages/tracker-github/src/tracker-github.test.ts
+++ b/packages/tracker-github/src/tracker-github.test.ts
@@ -1582,6 +1582,53 @@ describe("resolveTrackerAdapter", () => {
     }
   });
 
+  it("falls back to unfiltered project items for a custom lifecycle state field", async () => {
+    const adapter = resolveTrackerAdapter({
+      adapter: "github-project",
+      bindingId: "project-123",
+      settings: {
+        projectId: "project-123",
+      },
+    });
+
+    const issues = await adapter.listIssues(makeProjectConfig(), {
+      token: "dependencies-token",
+      workflowLifecycle: {
+        stateFieldName: "Stage",
+        activeStates: ["Ready", "In progress"],
+        terminalStates: ["Done"],
+        blockerCheckStates: ["Ready"],
+        planningStates: ["Ready"],
+      },
+      fetchImpl: async (_url, init) => {
+        const body = JSON.parse(String(init?.body)) as {
+          variables: {
+            query: string | null;
+            includeUnfilteredCount: boolean;
+          };
+        };
+        expect(body.variables.query).toBeNull();
+        expect(body.variables.includeUnfilteredCount).toBe(false);
+
+        return makeJsonResponse(
+          makeProjectItemsPayload([
+            makeProjectItem({
+              itemId: "item-ready",
+              issueId: "issue-ready",
+              number: 1,
+              title: "Ready issue with custom state field",
+              assignees: [],
+              state: "Ready",
+              stateFieldName: "Stage",
+            }),
+          ])
+        );
+      },
+    });
+
+    expect(issues.map((issue) => issue.state)).toEqual(["Ready"]);
+  });
+
   it("fails loudly instead of excluding a state configured as active and terminal", async () => {
     const adapter = resolveTrackerAdapter({
       adapter: "github-project",
@@ -4641,6 +4688,7 @@ function makeProjectItem(input: {
   title: string;
   assignees: string[];
   state?: string;
+  stateFieldName?: string;
   labels?: string[];
   priorityName?: string;
   priorityOptionId?: string;
@@ -4661,7 +4709,7 @@ function makeProjectItem(input: {
         {
           __typename: "ProjectV2ItemFieldSingleSelectValue" as const,
           name: input.state ?? "Todo",
-          field: { name: "Status" },
+          field: { name: input.stateFieldName ?? "Status" },
         },
         ...(input.priorityOptionId
           ? [

--- a/packages/tracker-github/src/tracker-github.test.ts
+++ b/packages/tracker-github/src/tracker-github.test.ts
@@ -1489,6 +1489,174 @@ describe("resolveTrackerAdapter", () => {
     );
   });
 
+  it("excludes terminal states with a negative Project V2 query and logs before/after counts", async () => {
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+    const adapter = resolveTrackerAdapter({
+      adapter: "github-project",
+      bindingId: "project-123",
+      settings: {
+        projectId: "project-123",
+      },
+    });
+
+    try {
+      const issues = await adapter.listIssues(makeProjectConfig(), {
+        token: "dependencies-token",
+        workflowLifecycle: {
+          stateFieldName: "Status",
+          activeStates: ["Ready", "In progress", "Land"],
+          terminalStates: ["Done", "Won't Do"],
+          blockerCheckStates: ["Ready"],
+          planningStates: ["Ready"],
+        },
+        fetchImpl: async (_url, init) => {
+          const body = JSON.parse(String(init?.body)) as {
+            query: string;
+            variables: {
+              query: string | null;
+              includeUnfilteredCount: boolean;
+            };
+          };
+          expect(body.query).toContain("$query: String");
+          expect(body.query).toContain(
+            "items(first: $pageSize, after: $cursor, query: $query)"
+          );
+          expect(body.variables.query).toBe(`-status:Done,"Won't Do"`);
+          expect(body.variables.includeUnfilteredCount).toBe(true);
+
+          return makeJsonResponse({
+            data: {
+              node: {
+                __typename: "ProjectV2",
+                unfilteredItems: {
+                  totalCount: 90,
+                },
+                items: {
+                  totalCount: 2,
+                  nodes: [
+                    makeProjectItem({
+                      itemId: "item-ready",
+                      issueId: "issue-ready",
+                      number: 1,
+                      title: "Ready issue",
+                      assignees: [],
+                      state: "Ready",
+                    }),
+                    makeProjectItem({
+                      itemId: "item-progress",
+                      issueId: "issue-progress",
+                      number: 2,
+                      title: "Active run issue",
+                      assignees: [],
+                      state: "In progress",
+                    }),
+                  ],
+                  pageInfo: { endCursor: null, hasNextPage: false },
+                },
+              },
+            },
+          });
+        },
+      });
+
+      expect(issues.map((issue) => issue.state)).toEqual([
+        "Ready",
+        "In progress",
+      ]);
+      expect(infoSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          '"event":"tracker-project-items-state-filtered"'
+        )
+      );
+      expect(infoSpy).toHaveBeenCalledWith(
+        expect.stringContaining('"unfilteredCount":90')
+      );
+      expect(infoSpy).toHaveBeenCalledWith(
+        expect.stringContaining('"filteredCount":2')
+      );
+      expect(infoSpy).toHaveBeenCalledWith(
+        expect.stringContaining('"excludedCount":88')
+      );
+    } finally {
+      infoSpy.mockRestore();
+    }
+  });
+
+  it("fails loudly instead of excluding a state configured as active and terminal", async () => {
+    const adapter = resolveTrackerAdapter({
+      adapter: "github-project",
+      bindingId: "project-123",
+      settings: {
+        projectId: "project-123",
+      },
+    });
+    const fetchImpl = vi.fn();
+
+    await expect(
+      adapter.listIssues(makeProjectConfig(), {
+        token: "dependencies-token",
+        workflowLifecycle: {
+          stateFieldName: "Status",
+          activeStates: ["Ready", "In progress"],
+          terminalStates: ["Done", "ready"],
+          blockerCheckStates: ["Ready"],
+          planningStates: ["Ready"],
+        },
+        fetchImpl,
+      })
+    ).rejects.toThrow('state "ready" cannot be both active and terminal');
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("keeps explicit state lookups unfiltered when candidate lifecycle filtering is enabled", async () => {
+    const adapter = resolveTrackerAdapter({
+      adapter: "github-project",
+      bindingId: "project-123",
+      settings: {
+        projectId: "project-123",
+      },
+    });
+
+    const issues = await adapter.listIssuesByStates(
+      makeProjectConfig(),
+      ["Done"],
+      {
+        token: "dependencies-token",
+        workflowLifecycle: {
+          stateFieldName: "Status",
+          activeStates: ["Ready", "In progress"],
+          terminalStates: ["Done"],
+          blockerCheckStates: ["Ready"],
+          planningStates: ["Ready"],
+        },
+        fetchImpl: async (_url, init) => {
+          const body = JSON.parse(String(init?.body)) as {
+            variables: {
+              query: string | null;
+              includeUnfilteredCount: boolean;
+            };
+          };
+          expect(body.variables.query).toBeNull();
+          expect(body.variables.includeUnfilteredCount).toBe(false);
+          return makeJsonResponse(
+            makeProjectItemsPayload([
+              makeProjectItem({
+                itemId: "item-done",
+                issueId: "issue-done",
+                number: 3,
+                title: "Done issue",
+                assignees: [],
+                state: "Done",
+              }),
+            ])
+          );
+        },
+      }
+    );
+
+    expect(issues.map((issue) => issue.state)).toEqual(["Done"]);
+  });
+
   it("falls back to legacy assignedOnly tracker setting with a deprecation warning", async () => {
     const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});


### PR DESCRIPTION
## TL;DR

- GitHub ProjectV2 candidate 조회에 `WORKFLOW.md`의 `terminal_states`를 `-status:` 부정 query로 전달해 terminal 카드가 pagination에 들어오기 전에 제외됩니다.
- 필터 적용 전/후 `totalCount`, 제외 건수, 실제 page 수를 구조화 로그로 남깁니다.
- 커스텀 `tracker.state_field` 보드는 내장 `Status`와 의미가 다를 수 있으므로 서버 필터를 끄고 기존 무필터 조회·로컬 판별로 안전하게 폴백합니다.
- 최신 `main`의 targeted suppression 변경과 #474 candidate lifecycle 전달을 함께 보존해 rebase 충돌을 해소했습니다.

## 변경 지점 다이어그램

```text
WORKFLOW.md lifecycle
  │
  ├─ state_field == Status
  │    └─ terminal_states → -status:Done,"Won't Do"
  │                         └─ ProjectV2.items(query:) pagination 절감
  │
  └─ custom state_field
       └─ query: null → 전량 조회 → 설정 필드로 로컬 상태 판별

candidate polling                 explicit/active state lookup
  └─ lifecycle filter 전달          └─ 항상 query: null
                                      └─ worker suppression 안전성 유지
```

## 여기부터 보세요

1. `packages/tracker-github/src/adapter.ts` — terminal query 조립, custom field 폴백, GraphQL 변수 전달, 전후 건수 로그
2. `packages/tracker-github/src/orchestrator-adapter.ts` — candidate와 explicit state lookup의 필터 경계
3. `packages/orchestrator/src/service.ts` — repository workflow lifecycle을 candidate 조회 dependency로 전달
4. `packages/tracker-github/src/tracker-github.test.ts` — 부정 query, active run, custom field 폴백, terminal lookup 회귀 TC

## 위험 & 롤백

- 상태 이름에 공백·특수문자가 있으면 quoting이 필요하며 `"Won't Do"` TC로 표현식을 고정했습니다.
- active/terminal 목록이 겹치면 정상 worker 누락 위험이 있으므로 GraphQL 호출 전에 fail-loud합니다.
- 커스텀 상태 필드는 GitHub 내장 `Status` query qualifier로 안전하게 표현할 수 없어 최적화하지 않고 과다 조회로 폴백합니다.
- active run 동기화와 explicit state lookup은 서버 필터 없이 유지해 terminal/active 상태 누락을 방지합니다.
- 롤백은 이 PR의 squash commit을 revert하면 기존 전량 조회로 복원됩니다.

## 변경 파일

- `packages/core/src/contracts/tracker-adapter.ts` — 해석된 workflow lifecycle 전달 계약
- `packages/orchestrator/src/service.ts` / `service.test.ts` — candidate 조회 연결과 lifecycle 전달 TC
- `packages/tracker-github/src/adapter.ts` — `items(query:)`, 부정식 조립, 관측 로그, 안전 guard
- `packages/tracker-github/src/orchestrator-adapter.ts` — candidate/explicit lookup 분리
- `packages/tracker-github/src/tracker-github.test.ts` — 서버 query 및 active-run/custom-field/terminal 회귀 TC
- `.changeset/tidy-project-filter.md` — `@gh-symphony/cli` patch changeset

## Validation

- `pnpm lint` — pass
- `pnpm test` — pass, 전 workspace
- `pnpm typecheck` — pass
- `pnpm build` — pass
- `pnpm --filter @gh-symphony/tracker-github test` — pass, 83 tests
- `pnpm --filter @gh-symphony/orchestrator test -- service.test.ts` — pass, 123 tests
- `./e2e/run-e2e.sh happy 60` — pass; running/implementation 및 continuation retry 관측 후 idle 복귀
- `git diff --check origin/main...HEAD` — pass
- GitHub Actions run `30691118330` — `Test`, `Container Smoke` success
- Branch freshness — 최신 `origin/main` 대비 0 behind / 4 ahead, PR `MERGEABLE/CLEAN`
- Upstream spec — candidate fetch와 active-state refresh 경계를 유지한 GitHub Integration/Coordination/Observability 확장으로 정합; 의도적 divergence 없음; `docs/symphony-spec.md` 미변경
- Changeset — `.changeset/tidy-project-filter.md` (`@gh-symphony/cli`: patch)

## Issues — Closed #474

## 머지 후/사람 확인

- [ ] 운영 보드 로그에서 `tracker-project-items-state-filtered`의 unfiltered/filtered 건수와 page 수 확인
- [ ] 실제 polling에서 기존 4페이지가 1페이지 수준으로 감소하는지 확인
- [ ] 커스텀 `tracker.state_field` 보드가 무필터 폴백을 유지하는지 확인
- [ ] 최신 main 충돌 해소 결과가 기존 승인된 #474 동작을 유지하는지 확인
