### PR TITLE
fix(runtime): enforce run-owned issue identity

### DIFF
--- a/.changeset/issue-identity-isolation.md
+++ b/.changeset/issue-identity-isolation.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": minor
+---
+
+Fail closed when issue #507 runtime identity, workspace, repository, branch, or agent event boundaries do not match the run-owned issue, and quarantine unattributed dirty recovery workspaces before continuing.

--- a/docs/adr/2026-07-31_issue-runtime-identity-isolation.md
+++ b/docs/adr/2026-07-31_issue-runtime-identity-isolation.md
@@ -1,0 +1,21 @@
+# Issue runtime identity isolation
+
+## Context
+
+A worker run owns one canonical issue, but the rendered workflow prompt previously did not have to name that issue. Continuation and dirty-workspace recovery guidance were also issue-anonymous. A coding agent could therefore discover and adopt a different actionable issue while remaining inside the original issue workspace.
+
+## Decision
+
+The coordination layer prepends an engine-owned issue identity envelope to every rendered initial or recovery prompt. The execution layer applies the same envelope to continuation turns and rejects startup when the workspace key, workspace/repository boundary, Git origin, or expected linked-PR branch does not match the orchestrator-owned values.
+
+Codex command and file-change item events are checked against the repository boundary. A boundary violation interrupts the turn and fails the worker. The worker also rejects a branch that explicitly identifies a different issue. Event logs emit cwd values in a separate complete field rather than relying only on a truncated parameter preview.
+
+An incomplete-turn dirty workspace is reusable only when its current branch can be attributed to the run issue (the linked PR head branch or an issue-number-bearing branch). Otherwise the orchestrator renames the issue workspace to a quarantine path, records a structured quarantine event, creates a clean workspace, and omits the commit-and-push recovery instruction.
+
+## Specification alignment
+
+Workspace and event boundary validation implements Symphony specification §9.5 invariants 1 and 2. The issue identity envelope intentionally extends §10.2's rendered prompt input, and quarantine is the repository's explicit §9.3 reset policy. These are repository-level safety choices; `docs/symphony-spec.md` remains unchanged.
+
+## Consequences
+
+Unattributed dirty work is preserved under a quarantine path for operator inspection but is never offered to an agent for automatic commit or push. Branch attribution is deliberately fail-closed during recovery; repositories that use issue-number-free branches must expose the linked PR head branch through tracker metadata for recovery reuse.


### PR DESCRIPTION
## TL;DR

- run이 소유한 issue identity를 initial·continuation·recovery turn에 엔진 레벨로 고정합니다.
- workspace/repository/branch/event 경계를 fail-closed로 검증하고 귀속 불명 recovery workspace는 quarantine합니다.

## 변경 지점 다이어그램

```text
canonical issue
  ├─ identity envelope ──→ initial / continuation / recovery prompt
  ├─ startup preflight ──→ workspace key · path · origin · expected branch
  └─ runtime guard ──────→ command cwd · file path · conflicting branch
                              │ violation
                              └─ interrupt + fail closed

dirty recovery ── attribution? ── no ──→ quarantine + clean clone
```

## 여기부터 보세요

1. `docs/adr/2026-07-31_issue-runtime-identity-isolation.md` — 안전 정책과 upstream spec 정합성
2. `.changeset/issue-identity-isolation.md` — `@gh-symphony/cli` minor 릴리스 기록
3. 구현·TC 파일 — 작업 중, PR ready 전 갱신 예정

## 위험 & 롤백

- fail-closed recovery는 issue-number-free branch가 linked PR metadata로 귀속되지 않으면 기존 dirty workspace를 quarantine합니다.
- quarantine 원본은 삭제하지 않아 수동 조사·복구가 가능합니다.
- 문제가 있으면 이 PR의 squash commit을 revert할 수 있습니다.

## 변경 파일

- 설계: `docs/adr/2026-07-31_issue-runtime-identity-isolation.md`
- 릴리스: `.changeset/issue-identity-isolation.md`
- 구현·테스트: 작업 중

## Evidence

- `pnpm exec prettier --check .changeset/issue-identity-isolation.md docs/adr/2026-07-31_issue-runtime-identity-isolation.md` — pass
- 전체 Completion Bar와 Docker E2E — 작업 완료 전 갱신 예정

## Issues — Closed #507

Closed #507

## 머지 후/사람 확인

- [ ] 실제 GitHub Project에서 두 이슈가 동시에 actionable한 운영 시나리오 확인

