### PR TITLE
fix(runtime): forward run-scoped env to agent + enforce issue identity at runtime

### DIFF
--- a/.changeset/forward-run-scoped-env-to-agent.md
+++ b/.changeset/forward-run-scoped-env-to-agent.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Forward run-scoped orchestrator context (`SYMPHONY_ORCHESTRATOR_URL`, `SYMPHONY_RUN_ID`, `SYMPHONY_ORCHESTRATOR_TOKEN`) through the Codex runtime plan so the agent-side `/gh-project` skill can authenticate tracker state reads and transition requests. The orchestrator injected these into the worker process since #502, but the codex app-server environment allowlist stripped them, so every run fail-closed on its first Project transition.

--- a/.changeset/issue-runtime-identity-enforcement.md
+++ b/.changeset/issue-runtime-identity-enforcement.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": minor
+---
+
+Enforce issue identity at runtime (#507). The engine now prepends an identity header binding every initial, continuation, and recovery turn to the run's issue regardless of the WORKFLOW.md template; workers fail closed at startup when the workspace origin, workspace key, or checked-out branch does not belong to the run's issue; codex events whose command cwd escapes the workspace boundary terminate the turn; dirty recovery workspaces whose branch or workpads belong to a different issue are quarantined (preserved under a `.quarantine-*` directory with a `recovery-quarantined` event) instead of being committed and pushed; and worker event logs append the untruncated event cwd so truncation can no longer fake a project-root working directory.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -12,6 +12,7 @@ export * from "./workflow/parser.js";
 export * from "./workflow/loader.js";
 export * from "./workflow/render.js";
 export * from "./workflow/exit-classification.js";
+export * from "./workflow/issue-identity.js";
 export * from "./orchestration/index.js";
 export * from "./runtime/index.js";
 export * from "./workspace/index.js";

--- a/packages/core/src/observability/event-formatter.ts
+++ b/packages/core/src/observability/event-formatter.ts
@@ -24,6 +24,8 @@ export function formatEventMessage(event: OrchestratorEvent): string | null {
       return event.lastError;
     case "run-suppressed":
       return event.reason;
+    case "recovery-quarantined":
+      return `Workspace quarantined before recovery: ${event.reason}`;
     case "hook-executed":
       return `${event.hook}: ${event.outcome}`;
     case "hook-failed":

--- a/packages/core/src/observability/structured-events.ts
+++ b/packages/core/src/observability/structured-events.ts
@@ -105,6 +105,19 @@ export type RunSuppressedEvent = {
   reason: string;
 };
 
+export type RecoveryQuarantinedEvent = {
+  at: string;
+  event: "recovery-quarantined";
+  projectId?: string;
+  issueIdentifier: string;
+  issueId?: string;
+  workspaceKey: string;
+  reason: string;
+  currentBranch: string | null;
+  quarantinePath: string | null;
+  dirtyFiles: string[];
+};
+
 export type HookExecutedEvent = {
   at: string;
   event: "hook-executed";
@@ -239,6 +252,7 @@ export type OrchestratorEvent =
   | RunRetriedEvent
   | RunFailedEvent
   | RunSuppressedEvent
+  | RecoveryQuarantinedEvent
   | HookExecutedEvent
   | HookFailedEvent
   | WorkspaceCleanupEvent

--- a/packages/core/src/workflow/issue-identity.test.ts
+++ b/packages/core/src/workflow/issue-identity.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest";
+import {
+  attributeDirtyWorkToIssue,
+  buildIssueIdentityHeader,
+  extractIssueNumberFromIdentifier,
+  extractIssueNumbersFromBranch,
+  extractIssueNumbersFromWorkpadFiles,
+} from "./issue-identity.js";
+
+describe("buildIssueIdentityHeader", () => {
+  it("binds the run to a single issue with exclusivity constraints", () => {
+    const header = buildIssueIdentityHeader({
+      issueIdentifier: "acme/platform#507",
+      issueTitle: "Fix identity isolation",
+      repositorySlug: "acme/platform",
+    });
+
+    expect(header).toContain("## Engine-Enforced Run Identity");
+    expect(header).toContain(
+      "bound exclusively to issue acme/platform#507 — Fix identity isolation in acme/platform"
+    );
+    expect(header).toContain("Never adopt another issue as the active task");
+    expect(header).toContain("report a blocker instead of switching issues");
+  });
+
+  it("renders without optional title and repository", () => {
+    const header = buildIssueIdentityHeader({
+      issueIdentifier: "#173",
+    });
+
+    expect(header).toContain("bound exclusively to issue #173.");
+  });
+});
+
+describe("extractIssueNumberFromIdentifier", () => {
+  it("parses canonical identifier shapes", () => {
+    expect(extractIssueNumberFromIdentifier("acme/platform#507")).toBe(507);
+    expect(extractIssueNumberFromIdentifier("#173")).toBe(173);
+    expect(extractIssueNumberFromIdentifier("173")).toBe(173);
+    expect(extractIssueNumberFromIdentifier("ACME-42")).toBeNull();
+    expect(extractIssueNumberFromIdentifier("no-number")).toBeNull();
+  });
+});
+
+describe("extractIssueNumbersFromBranch", () => {
+  it("finds issue numbers at conventional segment starts", () => {
+    expect(extractIssueNumbersFromBranch("feat/507-identity")).toEqual([507]);
+    expect(extractIssueNumbersFromBranch("fix/172-decode-nonascii")).toEqual([
+      172,
+    ]);
+    expect(extractIssueNumbersFromBranch("507-quickfix")).toEqual([507]);
+  });
+
+  it("ignores version-like fragments inside segments", () => {
+    expect(extractIssueNumbersFromBranch("chore/upgrade-node-24")).toEqual([]);
+    expect(extractIssueNumbersFromBranch("main")).toEqual([]);
+    expect(extractIssueNumbersFromBranch("release/v2")).toEqual([]);
+  });
+});
+
+describe("extractIssueNumbersFromWorkpadFiles", () => {
+  it("reads issue numbers from workpad paths only", () => {
+    expect(
+      extractIssueNumbersFromWorkpadFiles([
+        ".gh-symphony/workpads/172.md",
+        "src/index.ts",
+        "docs/172-notes.md",
+      ])
+    ).toEqual([172]);
+  });
+});
+
+describe("attributeDirtyWorkToIssue", () => {
+  it("denies attribution when the branch belongs to another issue", () => {
+    const result = attributeDirtyWorkToIssue({
+      issueIdentifier: "acme/platform#173",
+      currentBranch: "fix/172-decode-nonascii-handles",
+      dirtyFiles: ["src/handles.ts"],
+    });
+
+    expect(result.attributed).toBe(false);
+    expect(result.reason).toContain("#172");
+  });
+
+  it("denies attribution when a dirty workpad belongs to another issue", () => {
+    const result = attributeDirtyWorkToIssue({
+      issueIdentifier: "acme/platform#173",
+      currentBranch: "main",
+      dirtyFiles: [".gh-symphony/workpads/172.md"],
+    });
+
+    expect(result.attributed).toBe(false);
+    expect(result.reason).toContain("#172");
+  });
+
+  it("attributes work on the issue's own branch", () => {
+    const result = attributeDirtyWorkToIssue({
+      issueIdentifier: "acme/platform#507",
+      currentBranch: "feat/507-issue-identity-isolation",
+      dirtyFiles: ["packages/core/src/index.ts"],
+    });
+
+    expect(result.attributed).toBe(true);
+  });
+
+  it("attributes work on a tracker-linked branch without an issue number", () => {
+    const result = attributeDirtyWorkToIssue({
+      issueIdentifier: "acme/platform#507",
+      currentBranch: "identity-hardening",
+      dirtyFiles: ["packages/core/src/index.ts"],
+      expectedBranches: ["identity-hardening"],
+    });
+
+    expect(result.attributed).toBe(true);
+  });
+
+  it("fails closed when no artifact carries attribution evidence", () => {
+    const result = attributeDirtyWorkToIssue({
+      issueIdentifier: "acme/platform#507",
+      currentBranch: "main",
+      dirtyFiles: ["partial.txt"],
+    });
+
+    expect(result.attributed).toBe(false);
+    expect(result.reason).toContain("no dirty artifact");
+  });
+
+  it("prefers foreign evidence over positive evidence", () => {
+    const result = attributeDirtyWorkToIssue({
+      issueIdentifier: "acme/platform#173",
+      currentBranch: "feat/173-own-work",
+      dirtyFiles: [".gh-symphony/workpads/172.md"],
+    });
+
+    expect(result.attributed).toBe(false);
+  });
+});

--- a/packages/core/src/workflow/issue-identity.ts
+++ b/packages/core/src/workflow/issue-identity.ts
@@ -1,0 +1,172 @@
+/**
+ * Engine-owned issue identity enforcement (#507).
+ *
+ * The Symphony engine — not the repository WORKFLOW.md template — is
+ * responsible for telling the agent which issue a run is bound to, and for
+ * deciding whether dirty workspace artifacts belong to that issue before any
+ * recovery flow is allowed to commit and push them.
+ */
+
+export type IssueIdentityContext = {
+  issueIdentifier: string;
+  issueTitle?: string | null;
+  repositorySlug?: string | null;
+};
+
+/**
+ * Build the identity header the engine prepends to every turn input
+ * (initial, continuation, and recovery), independent of the workflow
+ * prompt template.
+ */
+export function buildIssueIdentityHeader(
+  context: IssueIdentityContext
+): string {
+  const subject = context.issueTitle?.trim()
+    ? `${context.issueIdentifier} — ${context.issueTitle.trim()}`
+    : context.issueIdentifier;
+  const location = context.repositorySlug?.trim()
+    ? ` in ${context.repositorySlug.trim()}`
+    : "";
+
+  return [
+    "## Engine-Enforced Run Identity",
+    "",
+    `This run is bound exclusively to issue ${subject}${location}.`,
+    "",
+    `- Work only on ${context.issueIdentifier}. Never adopt another issue as the active task, even if the tracker or project board shows a different issue as active or in progress.`,
+    "- Never create or switch to branches, workpads, commits, or pull requests that belong to a different issue.",
+    `- If tracker state appears to conflict with this assignment, keep working on ${context.issueIdentifier} and report a blocker instead of switching issues.`,
+  ].join("\n");
+}
+
+/**
+ * Extract the numeric issue number from a canonical issue identifier such as
+ * `owner/repo#507`, `#507`, or `507`. Returns null when the identifier does
+ * not end in a numeric fragment.
+ */
+export function extractIssueNumberFromIdentifier(
+  identifier: string
+): number | null {
+  const match = identifier.trim().match(/(?:^|#|\/)(\d{1,9})$/);
+  if (!match) {
+    return null;
+  }
+
+  return Number.parseInt(match[1]!, 10);
+}
+
+/**
+ * Extract issue numbers encoded in a branch name using the conventional
+ * `<prefix>/<issue-number>-<slug>` shape (for example `feat/507-identity`).
+ * Only numbers at the start of a slash-delimited segment and followed by a
+ * separator are considered, so version-like fragments such as `node-24`
+ * are ignored.
+ */
+export function extractIssueNumbersFromBranch(branch: string): number[] {
+  const numbers = new Set<number>();
+  for (const match of branch.matchAll(/(?:^|\/)(\d{1,9})(?=[-_/]|$)/g)) {
+    numbers.add(Number.parseInt(match[1]!, 10));
+  }
+
+  return [...numbers];
+}
+
+const WORKPAD_FILE_PATTERN = /(?:^|\/)\.gh-symphony\/workpads\/([^/]+)\.md$/;
+
+/**
+ * Extract issue numbers referenced by dirty workpad files
+ * (`.gh-symphony/workpads/<n>.md`).
+ */
+export function extractIssueNumbersFromWorkpadFiles(
+  dirtyFiles: string[]
+): number[] {
+  const numbers = new Set<number>();
+  for (const file of dirtyFiles) {
+    const match = file.match(WORKPAD_FILE_PATTERN);
+    if (!match) {
+      continue;
+    }
+    const numeric = match[1]!.match(/(\d{1,9})/);
+    if (numeric) {
+      numbers.add(Number.parseInt(numeric[1]!, 10));
+    }
+  }
+
+  return [...numbers];
+}
+
+export type DirtyWorkAttributionInput = {
+  issueIdentifier: string;
+  /** Current checked-out branch of the dirty workspace, when readable. */
+  currentBranch?: string | null;
+  dirtyFiles: string[];
+  /** Branches known to belong to this issue (for example the tracker-linked PR head). */
+  expectedBranches?: string[];
+};
+
+export type DirtyWorkAttribution = {
+  attributed: boolean;
+  reason: string;
+};
+
+/**
+ * Decide whether dirty workspace state can be attributed to the run's issue.
+ *
+ * Fail-closed: attribution requires positive evidence (the issue's own
+ * branch, a tracker-linked branch, or the issue's own workpad) and is
+ * always denied when any artifact references a different issue.
+ */
+export function attributeDirtyWorkToIssue(
+  input: DirtyWorkAttributionInput
+): DirtyWorkAttribution {
+  const issueNumber = extractIssueNumberFromIdentifier(input.issueIdentifier);
+  const branch = input.currentBranch?.trim() || null;
+  const branchNumbers = branch ? extractIssueNumbersFromBranch(branch) : [];
+  const workpadNumbers = extractIssueNumbersFromWorkpadFiles(input.dirtyFiles);
+
+  const foreignBranchNumbers = branchNumbers.filter(
+    (number) => number !== issueNumber
+  );
+  if (foreignBranchNumbers.length > 0) {
+    return {
+      attributed: false,
+      reason: `current branch '${branch}' references issue #${foreignBranchNumbers[0]} instead of ${input.issueIdentifier}`,
+    };
+  }
+
+  const foreignWorkpadNumbers = workpadNumbers.filter(
+    (number) => number !== issueNumber
+  );
+  if (foreignWorkpadNumbers.length > 0) {
+    return {
+      attributed: false,
+      reason: `dirty workpad references issue #${foreignWorkpadNumbers[0]} instead of ${input.issueIdentifier}`,
+    };
+  }
+
+  if (branch && input.expectedBranches?.includes(branch)) {
+    return {
+      attributed: true,
+      reason: `current branch '${branch}' is tracker-linked to ${input.issueIdentifier}`,
+    };
+  }
+
+  if (issueNumber !== null && branchNumbers.includes(issueNumber)) {
+    return {
+      attributed: true,
+      reason: `current branch '${branch}' references ${input.issueIdentifier}`,
+    };
+  }
+
+  if (issueNumber !== null && workpadNumbers.includes(issueNumber)) {
+    return {
+      attributed: true,
+      reason: `dirty workpad belongs to ${input.issueIdentifier}`,
+    };
+  }
+
+  return {
+    attributed: false,
+    reason: `no dirty artifact could be attributed to ${input.issueIdentifier}`,
+  };
+}

--- a/packages/orchestrator/src/git.ts
+++ b/packages/orchestrator/src/git.ts
@@ -166,6 +166,47 @@ export async function inspectIssueWorkspaceDirtyStatus(input: {
   };
 }
 
+export async function readGitCurrentBranch(
+  repositoryDirectory: string
+): Promise<string | null> {
+  try {
+    const branch = await runCommandCapture("git", [
+      "-C",
+      repositoryDirectory,
+      "rev-parse",
+      "--abbrev-ref",
+      "HEAD",
+    ]);
+    const trimmed = branch.trim();
+    return trimmed && trimmed !== "HEAD" ? trimmed : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Preserve a workspace whose dirty state cannot be attributed to the run's
+ * issue by renaming it out of the active workspace path. Returns the
+ * quarantine directory, or null when the workspace no longer exists.
+ */
+export async function quarantineIssueWorkspace(
+  issueWorkspacePath: string,
+  now: Date = new Date()
+): Promise<string | null> {
+  const timestamp = now.toISOString().replace(/[:.]/g, "-");
+  const quarantinePath = `${issueWorkspacePath}.quarantine-${timestamp}`;
+  try {
+    await rename(issueWorkspacePath, quarantinePath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return null;
+    }
+    throw error;
+  }
+
+  return quarantinePath;
+}
+
 export async function loadRepositoryWorkflow(
   repositoryDirectory: string,
   _repository: RepositoryRef

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -5,6 +5,7 @@ import {
   mkdir,
   mkdtemp,
   readFile,
+  readdir,
   rm,
   writeFile,
 } from "node:fs/promises";
@@ -516,6 +517,9 @@ describe("OrchestratorService", () => {
       issueWorkspacePath,
       existingWorkspace: false,
     });
+    execSync(`git -C ${shell(repositoryDirectory)} switch -c feat/1-partial`, {
+      encoding: "utf8",
+    });
     await store.saveIssueWorkspace({
       workspaceKey,
       projectId: projectConfig.projectId,
@@ -699,6 +703,198 @@ describe("OrchestratorService", () => {
     ).toContain("?? partial.txt");
   });
 
+  it("quarantines dirty recovery workspaces whose work belongs to another issue", async () => {
+    process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
+    const tempRoot = await mkdtemp(
+      join(tmpdir(), "orchestrator-quarantine-foreign-dirty-")
+    );
+    const repository = await createRepositoryFixture(
+      tempRoot,
+      "acme",
+      "platform"
+    );
+    const store = new OrchestratorFsStore(tempRoot);
+    const projectConfig = createProjectConfig(tempRoot, repository);
+    await store.saveProjectConfig(projectConfig);
+
+    const workspaceKey = deriveIssueWorkspaceKey(
+      {
+        adapter: "github-project",
+        issueSubjectId: "issue-1",
+      },
+      "acme/platform#1"
+    );
+    const issueWorkspacePath = resolveIssueWorkspaceDirectory(
+      store.projectDir(projectConfig.projectId),
+      workspaceKey
+    );
+    const repositoryDirectory = await gitModule.ensureIssueWorkspaceRepository({
+      repository,
+      issueWorkspacePath,
+      existingWorkspace: false,
+    });
+    // Cross-issue contamination: the previous worker adopted issue #2 inside
+    // issue #1's workspace (#507 incident shape).
+    execSync(`git -C ${shell(repositoryDirectory)} switch -c fix/2-foreign`, {
+      encoding: "utf8",
+    });
+    await store.saveIssueWorkspace({
+      workspaceKey,
+      projectId: projectConfig.projectId,
+      adapter: "github-project",
+      issueSubjectId: "issue-1",
+      issueIdentifier: "acme/platform#1",
+      workspacePath: issueWorkspacePath,
+      repositoryPath: repositoryDirectory,
+      status: "active",
+      createdAt: "2026-03-08T00:00:00.000Z",
+      updatedAt: "2026-03-08T00:00:00.000Z",
+      lastError: null,
+    });
+    await mkdir(join(repositoryDirectory, ".gh-symphony", "workpads"), {
+      recursive: true,
+    });
+    await writeFile(
+      join(repositoryDirectory, ".gh-symphony", "workpads", "2.md"),
+      "# workpad for issue 2\n",
+      "utf8"
+    );
+    await store.saveProjectIssueOrchestrations("tenant-1", [
+      {
+        issueId: "issue-1",
+        identifier: "acme/platform#1",
+        workspaceKey,
+        completedOnce: false,
+        failureRetryCount: 0,
+        state: "running",
+        currentRunId: "run-contaminated",
+        retryEntry: null,
+        updatedAt: "2026-03-08T00:04:00.000Z",
+      },
+    ]);
+    await store.saveRun({
+      runId: "run-contaminated",
+      projectId: "tenant-1",
+      projectSlug: "tenant-1",
+      issueId: "issue-1",
+      issueSubjectId: "issue-1",
+      issueIdentifier: "acme/platform#1",
+      issueState: "In Review",
+      repository,
+      status: "running",
+      attempt: 1,
+      processId: 4410,
+      port: 4601,
+      workingDirectory: repositoryDirectory,
+      issueWorkspaceKey: workspaceKey,
+      workspaceRuntimeDir: join(tempRoot, "run-contaminated", "workspace"),
+      workflowPath: null,
+      retryKind: null,
+      createdAt: "2026-03-08T00:00:00.000Z",
+      updatedAt: "2026-03-08T00:04:30.000Z",
+      startedAt: "2026-03-08T00:00:00.000Z",
+      completedAt: null,
+      lastError: null,
+      nextRetryAt: null,
+      threadId: "thread-1",
+      cumulativeTurnCount: 7,
+      turnCount: 7,
+      lastEvent: "heartbeat",
+      lastEventAt: "2026-03-08T00:04:30.000Z",
+      runtimeSession: {
+        sessionId: "thread-1-turn-7",
+        threadId: "thread-1",
+        status: "active",
+        startedAt: "2026-03-08T00:00:00.000Z",
+        updatedAt: "2026-03-08T00:04:30.000Z",
+        exitClassification: null,
+      },
+    });
+
+    const spawnImpl = vi.fn().mockReturnValue({
+      pid: 4411,
+      unref: vi.fn(),
+    });
+    let currentTime = new Date("2026-03-08T00:05:00.000Z");
+    const service = new OrchestratorService(store, projectConfig, {
+      fetchImpl: vi
+        .fn()
+        .mockResolvedValueOnce(
+          createTrackerResponseWithState(repository, "In Review")
+        )
+        .mockResolvedValueOnce(
+          createTrackerResponseWithState(repository, "In Review")
+        )
+        .mockResolvedValue(createTrackerResponseWithState(repository, "Todo")),
+      spawnImpl: spawnImpl as never,
+      isProcessRunning: (pid) => pid === 4410,
+      sendSignal: vi.fn(),
+      now: () => currentTime,
+    });
+
+    const suppressed = await service.runOnce();
+    expect(suppressed.summary.suppressed).toBe(1);
+
+    currentTime = new Date("2026-03-08T00:06:00.000Z");
+    const redispatched = await service.runOnce();
+    const runs = await store.loadAllRuns();
+    const freshRun = runs.find((run) => run.runId !== "run-contaminated");
+    const spawnEnv = spawnImpl.mock.calls[0]?.[2]?.env;
+
+    expect(redispatched.summary.dispatched).toBe(1);
+    expect(freshRun).toMatchObject({
+      status: "running",
+      retryKind: null,
+      recovery: null,
+    });
+    expect(spawnEnv?.SYMPHONY_RECOVERY_KIND).toBe("");
+    expect(spawnEnv?.SYMPHONY_RENDERED_PROMPT).toContain(
+      "## Engine-Enforced Run Identity"
+    );
+    expect(spawnEnv?.SYMPHONY_RENDERED_PROMPT).not.toContain(
+      "## Recovery Context — Incomplete Turn Dirty Workspace"
+    );
+
+    // The contaminated workspace is preserved under a quarantine directory
+    // and the active workspace is a fresh, clean clone.
+    const workspaceParent = join(issueWorkspacePath, "..");
+    const quarantined = (await readdir(workspaceParent)).filter((entry) =>
+      entry.startsWith(`${workspaceKey}.quarantine-`)
+    );
+    expect(quarantined).toHaveLength(1);
+    expect(
+      await readFile(
+        join(
+          workspaceParent,
+          quarantined[0]!,
+          "repository",
+          ".gh-symphony",
+          "workpads",
+          "2.md"
+        ),
+        "utf8"
+      )
+    ).toBe("# workpad for issue 2\n");
+    expect(
+      execSync(`git -C ${shell(repositoryDirectory)} status --porcelain`, {
+        encoding: "utf8",
+      }).trim()
+    ).toBe("");
+    expect(
+      execSync(
+        `git -C ${shell(repositoryDirectory)} rev-parse --abbrev-ref HEAD`,
+        { encoding: "utf8" }
+      ).trim()
+    ).not.toBe("fix/2-foreign");
+
+    const eventsRaw = await readFile(
+      join(store.runDir(freshRun!.runId, "tenant-1"), "events.ndjson"),
+      "utf8"
+    );
+    expect(eventsRaw).toContain('"event":"recovery-quarantined"');
+    expect(eventsRaw).toContain("fix/2-foreign");
+  });
+
   it("recovers a dirty workspace after a crash even when session metadata is stale", async () => {
     process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
     const tempRoot = await mkdtemp(
@@ -728,6 +924,9 @@ describe("OrchestratorService", () => {
       repository,
       issueWorkspacePath,
       existingWorkspace: false,
+    });
+    execSync(`git -C ${shell(repositoryDirectory)} switch -c feat/1-partial`, {
+      encoding: "utf8",
     });
     await store.saveIssueWorkspace({
       workspaceKey,
@@ -8881,9 +9080,7 @@ Handle archived item reconciliation.`,
       },
     };
     const listIssues = vi.fn().mockResolvedValue([archivedIssue]);
-    const fetchIssueStatesByIds = vi
-      .fn()
-      .mockResolvedValue([archivedIssue]);
+    const fetchIssueStatesByIds = vi.fn().mockResolvedValue([archivedIssue]);
     const killImpl = vi.fn();
     vi.spyOn(trackerAdapters, "resolveTrackerAdapter").mockReturnValue({
       listIssues,

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -8,7 +8,9 @@ import { fileURLToPath } from "node:url";
 import {
   DEFAULT_MAX_FAILURE_RETRIES,
   DEFAULT_WORKFLOW_LIFECYCLE,
+  attributeDirtyWorkToIssue,
   buildHookEnv,
+  buildIssueIdentityHeader,
   buildPromptVariables,
   buildProjectSnapshot,
   deriveIssueWorkspaceKey,
@@ -54,6 +56,8 @@ import {
   ensureIssueWorkspaceRepository,
   inspectIssueWorkspaceDirtyStatus,
   loadRepositoryWorkflow,
+  quarantineIssueWorkspace,
+  readGitCurrentBranch,
 } from "./git.js";
 import { OrchestratorFsStore } from "./fs-store.js";
 import { PersistentIssueCommentCache } from "./issue-comment-cache.js";
@@ -1769,16 +1773,64 @@ export class OrchestratorService {
     );
     const pullRequestBranch = resolvePullRequestBranchCheckoutTarget(issue);
 
+    // #507: dirty recovery may only reuse the workspace when the dirty state
+    // is attributable to this run's issue. Otherwise quarantine the workspace
+    // (preserving the foreign work for operators) and start from a fresh clone.
+    let recovery = options.recovery ?? null;
+    let workspaceQuarantined = false;
+    if (
+      recovery?.kind === "incomplete-turn-dirty-workspace" &&
+      existingWorkspaceRecord
+    ) {
+      const currentBranch = await readGitCurrentBranch(
+        join(issueWorkspacePath, "repository")
+      );
+      const attribution = attributeDirtyWorkToIssue({
+        issueIdentifier: issue.identifier,
+        currentBranch,
+        dirtyFiles: recovery.dirtyFiles,
+        expectedBranches: pullRequestBranch
+          ? [pullRequestBranch.headRefName]
+          : [],
+      });
+      if (!attribution.attributed) {
+        const quarantinePath = await quarantineIssueWorkspace(
+          issueWorkspacePath,
+          now
+        );
+        workspaceQuarantined = true;
+        recovery = null;
+        this.writeStderr(
+          `[orchestrator] quarantined dirty workspace for ${issue.identifier}: ${attribution.reason}`
+        );
+        await this.store.appendRunEvent(runId, {
+          at: now.toISOString(),
+          event: "recovery-quarantined",
+          projectId: tenant.projectId,
+          issueId: issue.id,
+          issueIdentifier: issue.identifier,
+          workspaceKey,
+          reason: attribution.reason,
+          currentBranch,
+          quarantinePath,
+          dirtyFiles: formatRecoveryDirtyFiles(
+            options.recovery?.dirtyFiles ?? []
+          ),
+        });
+      }
+    }
+
     const repositoryDirectory = await ensureIssueWorkspaceRepository({
       repository: issue.repository,
       issueWorkspacePath,
-      existingWorkspace: Boolean(existingWorkspaceRecord),
+      existingWorkspace:
+        Boolean(existingWorkspaceRecord) && !workspaceQuarantined,
       pullRequestBranch,
       allowDirtyExistingWorkspace:
-        options.recovery?.kind === "incomplete-turn-dirty-workspace",
+        recovery?.kind === "incomplete-turn-dirty-workspace",
     });
 
-    if (!existingWorkspaceRecord) {
+    if (!existingWorkspaceRecord || workspaceQuarantined) {
       const workspaceRecord: IssueWorkspaceRecord = {
         workspaceKey,
         projectId: tenant.projectId,
@@ -1834,10 +1886,11 @@ export class OrchestratorService {
     const promptVariables = buildPromptVariables(issue, {
       attempt: null, // first execution
     });
-    const renderedPrompt = appendIncompleteTurnRecoveryPrompt(
+    const renderedPrompt = composeWorkerRunPrompt(
+      issue,
       workflow.promptTemplate,
       promptVariables,
-      options.recovery ?? null
+      recovery
     );
 
     // Run before_run hook before spawning the worker
@@ -1940,12 +1993,11 @@ export class OrchestratorService {
           SYMPHONY_CUMULATIVE_OUTPUT_TOKENS: "0",
           SYMPHONY_CUMULATIVE_TOTAL_TOKENS: "0",
           SYMPHONY_LAST_TURN_SUMMARY: "",
-          SYMPHONY_RECOVERY_KIND: options.recovery?.kind ?? "",
-          SYMPHONY_RECOVERY_DIRTY_FILES: options.recovery
-            ? formatRecoveryDirtyFilesForContext(options.recovery.dirtyFiles)
+          SYMPHONY_RECOVERY_KIND: recovery?.kind ?? "",
+          SYMPHONY_RECOVERY_DIRTY_FILES: recovery
+            ? formatRecoveryDirtyFilesForContext(recovery.dirtyFiles)
             : "",
-          SYMPHONY_RECOVERY_SUGGESTED_COMMAND:
-            options.recovery?.suggestedCommand ?? "",
+          SYMPHONY_RECOVERY_SUGGESTED_COMMAND: recovery?.suggestedCommand ?? "",
           SYMPHONY_SESSION_STARTED_AT: "",
           SYMPHONY_READ_TIMEOUT_MS: String(runtimeTimeouts.readTimeoutMs),
           SYMPHONY_TURN_TIMEOUT_MS: String(runtimeTimeouts.turnTimeoutMs),
@@ -2079,7 +2131,7 @@ export class OrchestratorService {
       issueWorkspaceKey: workspaceKey,
       workspaceRuntimeDir,
       workflowPath: workflow.workflowPath,
-      retryKind: options.recovery ? "recovery" : null,
+      retryKind: recovery ? "recovery" : null,
       threadId: null,
       cumulativeTurnCount: 0,
       lastTurnSummary: null,
@@ -2091,7 +2143,7 @@ export class OrchestratorService {
       nextRetryAt: null,
       runPhase: "preparing_workspace",
       rateLimits: issue.rateLimits ?? null,
-      recovery: options.recovery ?? null,
+      recovery,
     };
   }
 
@@ -3967,17 +4019,25 @@ function buildRuntimeSession(
   };
 }
 
-function appendIncompleteTurnRecoveryPrompt(
+function composeWorkerRunPrompt(
+  issue: TrackedIssue,
   promptTemplate: string,
   promptVariables: ReturnType<typeof buildPromptVariables>,
   recovery: IncompleteTurnRecoveryContext | null
 ): string {
+  const identityHeader = buildIssueIdentityHeader({
+    issueIdentifier: issue.identifier,
+    issueTitle: issue.title,
+    repositorySlug: `${issue.repository.owner}/${issue.repository.name}`,
+  });
   const renderedPrompt = renderPrompt(promptTemplate, promptVariables);
   if (!recovery) {
-    return renderedPrompt;
+    return [identityHeader, "", renderedPrompt].join("\n");
   }
 
   return [
+    identityHeader,
+    "",
     renderedPrompt,
     "",
     "## Recovery Context — Incomplete Turn Dirty Workspace",
@@ -3992,7 +4052,7 @@ function appendIncompleteTurnRecoveryPrompt(
     "Dirty files:",
     ...formatRecoveryDirtyFileLinesForPrompt(recovery.dirtyFiles),
     "",
-    "Inspect the dirty diff before editing. If the partial work is correct, validate it, commit it, and push it. If it is invalid, revert it explicitly and record a blocker/comment with the reason. Do not discard uncommitted work without making an intentional recovery decision.",
+    `Inspect the dirty diff before editing. This dirty state was attributed to ${issue.identifier}; if any artifact turns out to belong to a different issue, stop and record a blocker instead of committing it. If the partial work is correct, validate it, commit it, and push it to this issue's branch only. If it is invalid, revert it explicitly and record a blocker/comment with the reason. Do not discard uncommitted work without making an intentional recovery decision.`,
     `Suggested operator command: ${recovery.suggestedCommand}`,
   ].join("\n");
 }

--- a/packages/runtime-codex/src/launcher.test.ts
+++ b/packages/runtime-codex/src/launcher.test.ts
@@ -55,6 +55,22 @@ describe("resolveLocalRuntimeLaunchConfig", () => {
     });
   });
 
+  it("carries run-scoped orchestrator context from the environment", () => {
+    const config = resolveLocalRuntimeLaunchConfig({
+      PROJECT_ID: "workspace-local",
+      WORKING_DIRECTORY: "/tmp/workspace-local",
+      SYMPHONY_ORCHESTRATOR_URL: "http://127.0.0.1:4680",
+      SYMPHONY_RUN_ID: "run-abc",
+      SYMPHONY_ORCHESTRATOR_TOKEN: "token-secret",
+    });
+
+    expect(config).toMatchObject({
+      orchestratorUrl: "http://127.0.0.1:4680",
+      orchestratorRunId: "run-abc",
+      orchestratorToken: "token-secret",
+    });
+  });
+
   it("fails when the working directory is missing", () => {
     expect(() =>
       resolveLocalRuntimeLaunchConfig({

--- a/packages/runtime-codex/src/launcher.ts
+++ b/packages/runtime-codex/src/launcher.ts
@@ -44,6 +44,9 @@ export function resolveLocalRuntimeLaunchConfig(
     linearAuthorization: env.LINEAR_AUTHORIZATION,
     linearGraphqlUrl: env.LINEAR_GRAPHQL_URL,
     agentCommand: env.SYMPHONY_AGENT_COMMAND,
+    orchestratorUrl: env.SYMPHONY_ORCHESTRATOR_URL,
+    orchestratorRunId: env.SYMPHONY_RUN_ID,
+    orchestratorToken: env.SYMPHONY_ORCHESTRATOR_TOKEN,
   };
 }
 

--- a/packages/runtime-codex/src/runtime.test.ts
+++ b/packages/runtime-codex/src/runtime.test.ts
@@ -148,6 +148,46 @@ describe("buildCodexRuntimePlan", () => {
     }
   });
 
+  it("forwards run-scoped orchestrator context to the agent environment", () => {
+    const plan = buildCodexRuntimePlan({
+      projectId: "workspace-123",
+      workingDirectory: "/tmp/workspace-123",
+      orchestratorUrl: "http://127.0.0.1:4680",
+      orchestratorRunId: "run-abc",
+      orchestratorToken: "token-secret",
+      agentEnv: {
+        OPENAI_API_KEY: "sk-ready-runtime",
+      },
+    });
+
+    expect(plan.env.SYMPHONY_ORCHESTRATOR_URL).toBe("http://127.0.0.1:4680");
+    expect(plan.env.SYMPHONY_RUN_ID).toBe("run-abc");
+    expect(plan.env.SYMPHONY_ORCHESTRATOR_TOKEN).toBe("token-secret");
+  });
+
+  it("omits run-scoped orchestrator context when it is absent or empty", () => {
+    process.env.SYMPHONY_ORCHESTRATOR_TOKEN = "process-secret";
+
+    try {
+      const plan = buildCodexRuntimePlan({
+        projectId: "workspace-123",
+        workingDirectory: "/tmp/workspace-123",
+        orchestratorUrl: "",
+        orchestratorRunId: "",
+        orchestratorToken: "",
+        agentEnv: {
+          OPENAI_API_KEY: "sk-ready-runtime",
+        },
+      });
+
+      expect(plan.env.SYMPHONY_ORCHESTRATOR_URL).toBeUndefined();
+      expect(plan.env.SYMPHONY_RUN_ID).toBeUndefined();
+      expect(plan.env.SYMPHONY_ORCHESTRATOR_TOKEN).toBeUndefined();
+    } finally {
+      delete process.env.SYMPHONY_ORCHESTRATOR_TOKEN;
+    }
+  });
+
   it("exposes linear_graphql only when enabled for Linear tracker sessions", () => {
     const nonLinearPlan = buildCodexRuntimePlan({
       projectId: "workspace-123",

--- a/packages/runtime-codex/src/runtime.ts
+++ b/packages/runtime-codex/src/runtime.ts
@@ -62,6 +62,10 @@ export type CodexRuntimeConfig = {
   extraEnv?: NodeJS.ProcessEnv;
   /** Command line to launch codex app-server. Parsed into argv and spawned without a shell. */
   agentCommand?: string;
+  /** Run-scoped orchestrator context required by worker skills such as /gh-project. */
+  orchestratorUrl?: string;
+  orchestratorRunId?: string;
+  orchestratorToken?: string;
 };
 
 export type CodexRuntimePlan = {
@@ -543,6 +547,17 @@ export function buildCodexRuntimePlan(
     config.agentCommand ?? "codex app-server"
   );
   const agentEnv = resolvePreparedAgentEnvironment(config.agentEnv);
+  const orchestratorRunEnv = {
+    ...(config.orchestratorUrl
+      ? { SYMPHONY_ORCHESTRATOR_URL: config.orchestratorUrl }
+      : {}),
+    ...(config.orchestratorRunId
+      ? { SYMPHONY_RUN_ID: config.orchestratorRunId }
+      : {}),
+    ...(config.orchestratorToken
+      ? { SYMPHONY_ORCHESTRATOR_TOKEN: config.orchestratorToken }
+      : {}),
+  };
   const linearGraphqlEnv = config.enableLinearGraphqlTool
     ? {
         LINEAR_GRAPHQL_TOOL_NAME: "linear_graphql",
@@ -582,6 +597,7 @@ export function buildCodexRuntimePlan(
         ...githubTool.args,
       ].join(" "),
       ...linearGraphqlEnv,
+      ...orchestratorRunEnv,
       ...agentEnv,
       ...gitCredentialHelper,
       ...Object.assign({}, ...tools.map((tool) => tool.env)),

--- a/packages/worker/src/identity-preflight.test.ts
+++ b/packages/worker/src/identity-preflight.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import { deriveIssueWorkspaceKey } from "@gh-symphony/core";
+import {
+  evaluateWorkerIdentityPreflight,
+  normalizeRepositoryUrl,
+} from "./identity-preflight.js";
+
+const baseEnv = {
+  SYMPHONY_ISSUE_IDENTIFIER: "acme/platform#507",
+  SYMPHONY_ISSUE_SUBJECT_ID: "issue-507",
+  SYMPHONY_TRACKER_ADAPTER: "github-project",
+  TARGET_REPOSITORY_CLONE_URL: "https://github.com/acme/platform.git",
+  TARGET_REPOSITORY_URL: "https://github.com/acme/platform",
+};
+
+describe("normalizeRepositoryUrl", () => {
+  it("normalizes https, ssh, and credentialed remotes to the same slug", () => {
+    expect(normalizeRepositoryUrl("https://github.com/acme/platform.git")).toBe(
+      "github.com/acme/platform"
+    );
+    expect(normalizeRepositoryUrl("git@github.com:acme/platform.git")).toBe(
+      "github.com/acme/platform"
+    );
+    expect(
+      normalizeRepositoryUrl("https://x-token@github.com/acme/platform")
+    ).toBe("github.com/acme/platform");
+  });
+});
+
+describe("evaluateWorkerIdentityPreflight", () => {
+  const workspaceKey = deriveIssueWorkspaceKey(
+    { adapter: "github-project", issueSubjectId: "issue-507" },
+    "acme/platform#507"
+  );
+
+  it("passes for a workspace matching origin, key, and branch", () => {
+    const result = evaluateWorkerIdentityPreflight({
+      env: { ...baseEnv, SYMPHONY_ISSUE_WORKSPACE_KEY: workspaceKey },
+      originUrl: "git@github.com:acme/platform.git",
+      currentBranch: "feat/507-identity",
+    });
+
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("fails closed when the origin points at a different repository", () => {
+    const result = evaluateWorkerIdentityPreflight({
+      env: { ...baseEnv, SYMPHONY_ISSUE_WORKSPACE_KEY: workspaceKey },
+      originUrl: "https://github.com/acme/other-repo.git",
+      currentBranch: "main",
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toContain("does not match the target repository");
+    }
+  });
+
+  it("fails closed when the workspace key cannot be derived from the issue", () => {
+    const result = evaluateWorkerIdentityPreflight({
+      env: { ...baseEnv, SYMPHONY_ISSUE_WORKSPACE_KEY: "acme_platform_9999" },
+      originUrl: "https://github.com/acme/platform.git",
+      currentBranch: "main",
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toContain("cannot be derived");
+    }
+  });
+
+  it("fails closed when the checked-out branch belongs to another issue", () => {
+    const result = evaluateWorkerIdentityPreflight({
+      env: { ...baseEnv, SYMPHONY_ISSUE_WORKSPACE_KEY: workspaceKey },
+      originUrl: "https://github.com/acme/platform.git",
+      currentBranch: "fix/172-decode-nonascii-handles",
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toContain("#172");
+    }
+  });
+
+  it("accepts neutral branches and missing git metadata", () => {
+    expect(
+      evaluateWorkerIdentityPreflight({
+        env: { ...baseEnv, SYMPHONY_ISSUE_WORKSPACE_KEY: workspaceKey },
+        originUrl: null,
+        currentBranch: "main",
+      })
+    ).toEqual({ ok: true });
+    expect(
+      evaluateWorkerIdentityPreflight({
+        env: { ...baseEnv, SYMPHONY_ISSUE_WORKSPACE_KEY: workspaceKey },
+        originUrl: "https://github.com/acme/platform.git",
+        currentBranch: null,
+      })
+    ).toEqual({ ok: true });
+  });
+});

--- a/packages/worker/src/identity-preflight.ts
+++ b/packages/worker/src/identity-preflight.ts
@@ -1,0 +1,148 @@
+import { spawn } from "node:child_process";
+import {
+  deriveIssueWorkspaceKey,
+  deriveLegacyIssueWorkspaceKey,
+  extractIssueNumberFromIdentifier,
+  extractIssueNumbersFromBranch,
+} from "@gh-symphony/core";
+
+/**
+ * Startup identity preflight (#507): before launching the agent, verify that
+ * the workspace this worker was pointed at actually belongs to the issue the
+ * run claims to own. Any mismatch is a fail-closed startup failure.
+ */
+
+export type IdentityPreflightEnv = {
+  SYMPHONY_ISSUE_IDENTIFIER?: string;
+  SYMPHONY_ISSUE_SUBJECT_ID?: string;
+  SYMPHONY_ISSUE_WORKSPACE_KEY?: string;
+  SYMPHONY_TRACKER_ADAPTER?: string;
+  TARGET_REPOSITORY_CLONE_URL?: string;
+  TARGET_REPOSITORY_URL?: string;
+  PROJECT_ID?: string;
+  CODEX_PROJECT_ID?: string;
+};
+
+export type IdentityPreflightResult =
+  | { ok: true }
+  | { ok: false; reason: string };
+
+/**
+ * Normalize a git remote URL for comparison: strips protocol, credentials,
+ * `git@host:` prefixes, and trailing `.git`.
+ */
+export function normalizeRepositoryUrl(url: string): string {
+  let normalized = url.trim().toLowerCase();
+  normalized = normalized.replace(/^[a-z+]+:\/\//, "");
+  normalized = normalized.replace(/^[^@/]+@/, "");
+  normalized = normalized.replace(":", "/");
+  normalized = normalized.replace(/\.git$/, "");
+  normalized = normalized.replace(/\/+$/, "");
+  return normalized;
+}
+
+export function evaluateWorkerIdentityPreflight(input: {
+  env: IdentityPreflightEnv;
+  originUrl: string | null;
+  currentBranch: string | null;
+}): IdentityPreflightResult {
+  const { env, originUrl, currentBranch } = input;
+  const issueIdentifier = env.SYMPHONY_ISSUE_IDENTIFIER?.trim() ?? "";
+
+  const expectedUrls = [
+    env.TARGET_REPOSITORY_CLONE_URL,
+    env.TARGET_REPOSITORY_URL,
+  ]
+    .map((url) => url?.trim())
+    .filter((url): url is string => Boolean(url))
+    .map(normalizeRepositoryUrl);
+  if (expectedUrls.length > 0 && originUrl) {
+    const normalizedOrigin = normalizeRepositoryUrl(originUrl);
+    if (!expectedUrls.includes(normalizedOrigin)) {
+      return {
+        ok: false,
+        reason: `workspace git origin '${originUrl}' does not match the target repository '${expectedUrls[0]}'`,
+      };
+    }
+  }
+
+  const workspaceKey = env.SYMPHONY_ISSUE_WORKSPACE_KEY?.trim() ?? "";
+  if (workspaceKey && issueIdentifier) {
+    const identity = {
+      adapter: env.SYMPHONY_TRACKER_ADAPTER?.trim() ?? "",
+      issueSubjectId: env.SYMPHONY_ISSUE_SUBJECT_ID?.trim() ?? "",
+    };
+    const acceptableKeys = new Set(
+      [
+        deriveIssueWorkspaceKey(identity, issueIdentifier),
+        deriveIssueWorkspaceKey(issueIdentifier),
+        identity.issueSubjectId
+          ? deriveLegacyIssueWorkspaceKey(identity)
+          : null,
+        identity.issueSubjectId
+          ? deriveLegacyIssueWorkspaceKey(
+              identity,
+              env.PROJECT_ID ?? env.CODEX_PROJECT_ID
+            )
+          : null,
+      ].filter((key): key is string => Boolean(key))
+    );
+    if (!acceptableKeys.has(workspaceKey)) {
+      return {
+        ok: false,
+        reason: `issue workspace key '${workspaceKey}' cannot be derived from issue '${issueIdentifier}'`,
+      };
+    }
+  }
+
+  if (currentBranch && issueIdentifier) {
+    const issueNumber = extractIssueNumberFromIdentifier(issueIdentifier);
+    const branchNumbers = extractIssueNumbersFromBranch(currentBranch);
+    const foreign = branchNumbers.filter((number) => number !== issueNumber);
+    if (foreign.length > 0) {
+      return {
+        ok: false,
+        reason: `workspace branch '${currentBranch}' belongs to issue #${foreign[0]} instead of '${issueIdentifier}'`,
+      };
+    }
+  }
+
+  return { ok: true };
+}
+
+export async function runWorkerIdentityPreflight(
+  env: IdentityPreflightEnv & { WORKING_DIRECTORY?: string }
+): Promise<IdentityPreflightResult> {
+  const workingDirectory = env.WORKING_DIRECTORY?.trim();
+  if (!workingDirectory) {
+    return { ok: false, reason: "WORKING_DIRECTORY is not set" };
+  }
+
+  const [originUrl, currentBranch] = await Promise.all([
+    captureGitOutput(workingDirectory, ["remote", "get-url", "origin"]),
+    captureGitOutput(workingDirectory, ["rev-parse", "--abbrev-ref", "HEAD"]),
+  ]);
+
+  return evaluateWorkerIdentityPreflight({
+    env,
+    originUrl,
+    currentBranch: currentBranch === "HEAD" ? null : currentBranch,
+  });
+}
+
+function captureGitOutput(cwd: string, args: string[]): Promise<string | null> {
+  return new Promise((resolve) => {
+    const child = spawn("git", ["-C", cwd, ...args], { stdio: "pipe" });
+    const stdout: Buffer[] = [];
+    child.stdout?.on("data", (chunk: Buffer) => stdout.push(chunk));
+    child.once("error", () => resolve(null));
+    child.once("exit", (code) => {
+      if (code !== 0) {
+        resolve(null);
+        return;
+      }
+      const output = Buffer.concat(stdout).toString("utf8").trim();
+      resolve(output || null);
+    });
+  });
+}

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -2,6 +2,7 @@ import { spawn, type ChildProcess } from "node:child_process";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import {
+  buildIssueIdentityHeader,
   classifySessionExit,
   DEFAULT_AGENT_INPUT_REQUIRED_REASON,
   parseWorkflowMarkdown,
@@ -53,6 +54,11 @@ import {
   resolveWorkerRuntimeRoute,
 } from "./runtime-routing.js";
 import { buildContinuationTurnInput } from "./thread-resume.js";
+import { runWorkerIdentityPreflight } from "./identity-preflight.js";
+import {
+  findCwdBoundaryViolation,
+  formatEventCwdSuffix,
+} from "./workspace-boundary.js";
 import { resolveMaxTurns } from "./turn-limits.js";
 import {
   acquireTurnLease,
@@ -490,6 +496,16 @@ function emitTurnFailedEvent(
 
 async function startAssignedRun() {
   try {
+    // #507: fail closed before launching any agent when the workspace does
+    // not belong to this run's issue (origin, workspace key, or branch).
+    const identityPreflight = await runWorkerIdentityPreflight(launcherEnv);
+    if (!identityPreflight.ok) {
+      await exitWorkerStartupFailure(
+        `Issue identity preflight failed: ${identityPreflight.reason}`
+      );
+      return;
+    }
+
     const workflowPath =
       launcherEnv.SYMPHONY_WORKFLOW_PATH ||
       join(launcherEnv.WORKING_DIRECTORY!, "WORKFLOW.md");
@@ -1438,6 +1454,24 @@ async function runCodexClientProtocol(
     // Track the timestamp of every server-initiated notification/event.
     // This powers stall detection in the orchestrator (§4.1.6 last_codex_timestamp).
     runtimeState.lastEventAt = new Date().toISOString();
+
+    // #507 / spec §9.5: any command cwd escaping the workspace boundary is an
+    // identity violation — fail the turn closed instead of letting the agent
+    // keep operating outside this issue's workspace.
+    const boundaryViolation = findCwdBoundaryViolation(msg.params, plan.cwd);
+    if (boundaryViolation) {
+      const reason = `identity_violation: event cwd '${boundaryViolation}' escapes workspace '${plan.cwd}'`;
+      process.stderr.write(`[worker] ${reason}\n`);
+      emitOrchestratorChannelEvent("worker_identity_violation");
+      markTurnTerminalFailure("failed", reason);
+      try {
+        child.kill("SIGTERM");
+      } catch {
+        // The codex process may already be gone.
+      }
+      return;
+    }
+
     const agentEvents = normalizeCodexRuntimeEvents(msg);
     let handledAgentEvent = false;
     for (const event of agentEvents) {
@@ -1452,12 +1486,14 @@ async function runCodexClientProtocol(
       applyRateLimitUpdate(msg.method, rateLimits);
     }
 
-    // Log all other server notifications for observability
+    // Log all other server notifications for observability. The payload is
+    // truncated, but any event cwd is appended in full (#507): truncated
+    // workspace paths previously masqueraded as project-root cwds.
     if (typeof msg.method === "string") {
       flushDeltaBuffer();
       emitOrchestratorChannelEvent(msg.method);
       process.stderr.write(
-        `[worker] codex → ${msg.method} ${JSON.stringify(msg.params ?? {}).slice(0, 300)}\n`
+        `[worker] codex → ${msg.method} ${JSON.stringify(msg.params ?? {}).slice(0, 300)}${formatEventCwdSuffix(msg.params)}\n`
       );
     }
   }
@@ -1616,12 +1652,21 @@ async function runCodexClientProtocol(
         `[worker] acquired turn lease ${turnCount}/${maxTurns} (expires=${lease.expiresAt})\n`
       );
 
+      // #507: continuation turns carry the engine-owned identity header so
+      // the agent never loses its issue binding after the initial prompt.
       const turnInput = isFirstTurn
         ? renderedPrompt
-        : buildContinuationTurnInput({
-            continuationGuidance,
-            cumulativeTurnCount: turn,
-          });
+        : [
+            buildIssueIdentityHeader({
+              issueIdentifier: issueIdentifier || "the assigned issue",
+              issueTitle: env.SYMPHONY_ISSUE_TITLE ?? null,
+            }),
+            "",
+            buildContinuationTurnInput({
+              continuationGuidance,
+              cumulativeTurnCount: turn,
+            }),
+          ].join("\n");
 
       process.stderr.write(
         `[worker] starting codex turn ${turnCount}/${maxTurns}${isFirstTurn ? " (initial)" : " (continuation)"}\n`

--- a/packages/worker/src/workspace-boundary.test.ts
+++ b/packages/worker/src/workspace-boundary.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import {
+  findCwdBoundaryViolation,
+  formatEventCwdSuffix,
+} from "./workspace-boundary.js";
+
+const boundary = "/runtime/workspaces/acme_platform_507/repository";
+
+describe("findCwdBoundaryViolation", () => {
+  it("allows cwds inside the workspace boundary", () => {
+    expect(findCwdBoundaryViolation({ cwd: boundary }, boundary)).toBeNull();
+    expect(
+      findCwdBoundaryViolation({ cwd: `${boundary}/packages/core` }, boundary)
+    ).toBeNull();
+    expect(
+      findCwdBoundaryViolation({ item: { cwd: boundary } }, boundary)
+    ).toBeNull();
+  });
+
+  it("flags cwds outside the boundary", () => {
+    expect(
+      findCwdBoundaryViolation({ cwd: "/Users/steve/other-project" }, boundary)
+    ).toBe("/Users/steve/other-project");
+    expect(
+      findCwdBoundaryViolation(
+        { item: { cwd: "/runtime/workspaces/acme_platform_172/repository" } },
+        boundary
+      )
+    ).toBe("/runtime/workspaces/acme_platform_172/repository");
+  });
+
+  it("is not fooled by sibling directories sharing a prefix", () => {
+    expect(
+      findCwdBoundaryViolation({ cwd: `${boundary}-other` }, boundary)
+    ).toBe(`${boundary}-other`);
+  });
+
+  it("resolves relative cwds against the boundary", () => {
+    expect(
+      findCwdBoundaryViolation({ cwd: "packages/core" }, boundary)
+    ).toBeNull();
+    expect(findCwdBoundaryViolation({ cwd: "../../escape" }, boundary)).toBe(
+      "../../escape"
+    );
+  });
+
+  it("ignores events without a cwd", () => {
+    expect(findCwdBoundaryViolation({}, boundary)).toBeNull();
+    expect(findCwdBoundaryViolation(null, boundary)).toBeNull();
+    expect(findCwdBoundaryViolation("text", boundary)).toBeNull();
+  });
+});
+
+describe("formatEventCwdSuffix", () => {
+  it("appends the untruncated cwd when present", () => {
+    expect(formatEventCwdSuffix({ cwd: boundary })).toBe(` cwd=${boundary}`);
+    expect(formatEventCwdSuffix({ item: { cwd: boundary } })).toBe(
+      ` cwd=${boundary}`
+    );
+  });
+
+  it("returns an empty suffix without a cwd", () => {
+    expect(formatEventCwdSuffix({})).toBe("");
+    expect(formatEventCwdSuffix(undefined)).toBe("");
+  });
+});

--- a/packages/worker/src/workspace-boundary.ts
+++ b/packages/worker/src/workspace-boundary.ts
@@ -1,0 +1,66 @@
+import { isAbsolute, resolve, sep } from "node:path";
+
+/**
+ * Workspace boundary enforcement for codex runtime events (#507, upstream
+ * spec §9.5 Safety Invariants): every reported command `cwd` must stay inside
+ * the run's workspace path.
+ */
+
+function collectEventCwds(params: unknown): string[] {
+  if (!params || typeof params !== "object") {
+    return [];
+  }
+
+  const record = params as Record<string, unknown>;
+  const cwds: string[] = [];
+  if (typeof record.cwd === "string" && record.cwd.trim()) {
+    cwds.push(record.cwd);
+  }
+
+  const item = record.item;
+  if (item && typeof item === "object") {
+    const itemCwd = (item as Record<string, unknown>).cwd;
+    if (typeof itemCwd === "string" && itemCwd.trim()) {
+      cwds.push(itemCwd);
+    }
+  }
+
+  return cwds;
+}
+
+function isWithinBoundary(cwd: string, boundary: string): boolean {
+  const resolvedBoundary = resolve(boundary);
+  // Relative cwds are interpreted against the workspace by the runtime.
+  const resolvedCwd = isAbsolute(cwd) ? resolve(cwd) : resolve(boundary, cwd);
+  return (
+    resolvedCwd === resolvedBoundary ||
+    resolvedCwd.startsWith(`${resolvedBoundary}${sep}`)
+  );
+}
+
+/**
+ * Return the first `cwd` reported by a codex event that escapes the
+ * workspace boundary, or null when every reported cwd is inside it.
+ */
+export function findCwdBoundaryViolation(
+  params: unknown,
+  boundary: string
+): string | null {
+  for (const cwd of collectEventCwds(params)) {
+    if (!isWithinBoundary(cwd, boundary)) {
+      return cwd;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Untruncated cwd suffix for worker event logs. The 300-char JSON truncation
+ * previously cut workspace paths mid-prefix, which made commands look like
+ * they ran from the project root during the #507 incident investigation.
+ */
+export function formatEventCwdSuffix(params: unknown): string {
+  const cwds = collectEventCwds(params);
+  return cwds.length > 0 ? ` cwd=${cwds[0]}` : "";
+}


### PR DESCRIPTION
## TL;DR

두 가지를 함께 해결합니다:

1. **릴리스 블로커** — v0.6.5(#502 포함)의 모든 run이 첫 Project 전이에서 fail-closed로 멈추는 env 전파 버그
2. **#507 본체** — issue identity가 런타임에서 강제되지 않아 다른 이슈의 branch에 commit/push되는 cross-issue contamination

Closes #507

---

## Part 1 — run-scoped env가 agent에 전달되지 않던 버그

### 원인

#502는 `/gh-project`를 run-scoped orchestrator API 인증 방식으로 바꾸면서, agent 쉘이 `$SYMPHONY_ORCHESTRATOR_URL` / `$SYMPHONY_RUN_ID` / `$SYMPHONY_ORCHESTRATOR_TOKEN`으로 curl하도록 했습니다. orchestrator는 이 세 변수를 worker 프로세스에 정상 주입하지만(`packages/orchestrator/src/service.ts`), worker가 codex app-server를 spawn할 때 `buildCodexRuntimePlan`이 `SAFE_RUNTIME_ENV_KEYS` allowlist로 환경을 재구성하면서 세 변수가 모두 제거됩니다. agent는 run context가 없다고 판단하여 fail-closed — #507 workpad의 blocker가 정확히 이 증상입니다.

### 수정

- `CodexRuntimeConfig`에 `orchestratorUrl` / `orchestratorRunId` / `orchestratorToken` 필드 추가, launcher가 worker env에서 읽어 전달
- `buildCodexRuntimePlan`이 비어 있지 않은 값만 agent env에 명시적으로 주입 (allowlist 상속이 아닌 명시 전달)

## Part 2 — #507 issue identity 런타임 강제 (fail-closed)

이슈의 제안 ①–⑤를 모두 구현했습니다:

**① 엔진 소유 identity 헤더** — `core`의 `buildIssueIdentityHeader`가 issue identifier·전용 제약을 생성. orchestrator가 initial/recovery 프롬프트에(`composeWorkerRunPrompt`), worker가 모든 continuation turn에 template과 무관하게 강제 prepend. board-discovery 스타일 WORKFLOW.md여도 agent가 자기 이슈를 모르는 상태가 불가능해집니다.

**② 시작 preflight (worker)** — agent 실행 전 `runWorkerIdentityPreflight`가 검증: workspace git origin ↔ `TARGET_REPOSITORY_*`, `SYMPHONY_ISSUE_WORKSPACE_KEY` ↔ 재계산값(preferred + legacy 형태 모두 수용), 현재 branch가 다른 이슈 번호를 인코딩하면 거부. 불일치 시 startup failure.

**③ event.cwd 검증 (worker)** — codex 이벤트의 command cwd가 `plan.cwd` 경계를 벗어나면 `identity_violation`으로 turn을 종료하고 agent 프로세스를 kill (spec §9.5 Safety Invariants 구현).

**④ Recovery quarantine (orchestrator)** — dirty workspace 재사용 전 `attributeDirtyWorkToIssue`로 귀속 판정: 이슈 자신의 branch(번호 매칭)·tracker-linked branch·자신의 workpad만 positive evidence로 인정, 다른 이슈의 branch/workpad는 즉시 거부, 증거가 전혀 없으면 fail-closed 거부. 미귀속 시 workspace를 `<key>.quarantine-<ts>`로 rename 보존 → `recovery-quarantined` 이벤트 기록 → fresh clone으로 진행하며 "commit & push" recovery 지시를 제거. 귀속 확인된 경우에도 recovery 프롬프트가 "이 이슈의 branch에만 push"로 identity-scoped 됩니다.

**⑤ 관측성** — worker.log의 300자 JSON 절단 뒤에 이벤트 cwd를 절단 없이 `cwd=` suffix로 병기. #507 조사에서 발생한 "root repo에서 실행된 것처럼 보이는" 오진이 재발하지 않습니다.

### Spec compliance

- ②③은 upstream spec §9.5 Safety Invariants(Invariant 1·2)가 요구하는 검증의 구현
- ①은 §10.2 "input = rendered prompt"에 대한 명시적 엔진 확장
- ④는 spec에 없는 자체 recovery 확장의 fail-closed 강화이므로 spec 제약 없음

## 검증

- `pnpm lint` / `pnpm typecheck` / `pnpm test` / `pnpm build` — 전부 pass
  - core 12개 신규 TC (identity header, 번호 추출, attribution 매트릭스)
  - orchestrator 221개 pass — **#507 사고 재현 TC 추가**: 다른 이슈 branch + workpad로 오염된 dirty workspace가 quarantine되고, fresh clone으로 재시작하며, recovery-quarantined 이벤트가 기록됨
  - worker 146개 pass — preflight 매트릭스, cwd 경계(형제 디렉터리 prefix 함정 포함) TC 추가
- 변경 파일 Prettier pass (repo 전체 110개 경고는 main에 기존재)

## 위험 & 롤백

- 위험: 귀속 증거가 전혀 없는 dirty workspace(예: branch 생성 전 default branch 위의 작업)도 quarantine됩니다. 작업물은 quarantine 디렉터리에 보존되므로 파괴적이지 않지만, 해당 케이스는 fresh clone으로 재시작합니다.
- 위험: 구버전에서 생성된 비표준 workspace key는 preflight에서 startup failure가 됩니다(명시적 메시지 포함). preferred/legacy 두 파생 형태는 모두 수용합니다.
- 롤백: 이 PR과 두 changeset을 되돌리면 이전 동작으로 복원됩니다.

## 머지 후

- [ ] patch+minor 릴리스 후 **운영 데몬(github-symphony, anxhome) 업그레이드 + 재시작** — 재시작 전까지 구버전 코드가 계속 동작
- [ ] anxhome에서 두 이슈 동시 actionable 상태로 identity 격리 실증
- [ ] Draft PR #508(ADR + changeset only)은 이 PR로 대체 — close 처리

🤖 Generated with [Claude Code](https://claude.com/claude-code)