### PR TITLE
fix(tracker-github): remove invalid rateLimit selection from mutation documents

### DIFF
--- a/.changeset/remove-ratelimit-from-mutations.md
+++ b/.changeset/remove-ratelimit-from-mutations.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Remove the invalid `rateLimit` selection from GitHub GraphQL mutation documents (project item state transition, add/update issue comment). GitHub only defines `rateLimit` on the Query type, so every orchestrator-owned `Ready → In progress` transition failed schema validation with `Field 'rateLimit' doesn't exist on type 'Mutation'`. Mutation rate-limit telemetry now relies on the `x-ratelimit-*` response headers instead of an in-body field, and per-cycle GraphQL cost no longer counts a field-reported mutation cost.

--- a/packages/tracker-github/src/adapter.ts
+++ b/packages/tracker-github/src/adapter.ts
@@ -2753,11 +2753,6 @@ const UPDATE_PROJECT_ITEM_STATE_MUTATION = `
         id
       }
     }
-    rateLimit {
-      cost
-      remaining
-      resetAt
-    }
   }
 `;
 
@@ -3013,11 +3008,6 @@ const ISSUE_COMMENTS_BY_ID_QUERY = `
 
 const ADD_ISSUE_COMMENT_MUTATION = `
   mutation AddIssueComment($subjectId: ID!, $body: String!) {
-    rateLimit {
-      cost
-      remaining
-      resetAt
-    }
     addComment(input: { subjectId: $subjectId, body: $body }) {
       commentEdge {
         node {
@@ -3031,11 +3021,6 @@ const ADD_ISSUE_COMMENT_MUTATION = `
 
 const UPDATE_ISSUE_COMMENT_MUTATION = `
   mutation UpdateIssueComment($commentId: ID!, $body: String!) {
-    rateLimit {
-      cost
-      remaining
-      resetAt
-    }
     updateIssueComment(input: { id: $commentId, body: $body }) {
       issueComment {
         id

--- a/packages/tracker-github/src/tracker-github.test.ts
+++ b/packages/tracker-github/src/tracker-github.test.ts
@@ -1069,9 +1069,9 @@ describe("resolveTrackerAdapter", () => {
       String(fetchImpl.mock.calls[1]?.[1]?.body)
     ) as { query: string; variables: Record<string, string> };
     expect(mutationBody.query).toContain("mutation AddIssueComment");
-    expect(mutationBody.query).toMatch(
-      /rateLimit\s*\{\s*cost\s+remaining\s+resetAt\s*\}/s
-    );
+    // rateLimit only exists on the Query type; selecting it in a mutation
+    // fails GitHub schema validation.
+    expect(mutationBody.query).not.toContain("rateLimit");
     expect(mutationBody.variables.subjectId).toBe("issue-1");
   });
 
@@ -1168,9 +1168,9 @@ describe("resolveTrackerAdapter", () => {
       String(fetchImpl.mock.calls[1]?.[1]?.body)
     ) as { query: string; variables: Record<string, string> };
     expect(mutationBody.query).toContain("mutation UpdateIssueComment");
-    expect(mutationBody.query).toMatch(
-      /rateLimit\s*\{\s*cost\s+remaining\s+resetAt\s*\}/s
-    );
+    // rateLimit only exists on the Query type; selecting it in a mutation
+    // fails GitHub schema validation.
+    expect(mutationBody.query).not.toContain("rateLimit");
     expect(mutationBody.variables.commentId).toBe("comment-1");
   });
 

--- a/packages/tracker-github/src/tracker-state.test.ts
+++ b/packages/tracker-github/src/tracker-state.test.ts
@@ -68,7 +68,7 @@ describe("requestGithubProjectItemState", () => {
     expect(results).toHaveLength(5);
     expect(results.every((result) => result.ok)).toBe(true);
     expect(results.every((result) => result.state === "In review")).toBe(true);
-    expect(results.every((result) => result.rateLimits?.cycleCost === 4)).toBe(
+    expect(results.every((result) => result.rateLimits?.cycleCost === 3)).toBe(
       true
     );
     expect(maxInFlight).toBe(1);
@@ -333,10 +333,19 @@ function graphqlResponse(
     });
   }
   if (query.includes("mutation UpdateProjectItemState")) {
+    // GitHub's schema only defines rateLimit on Query; selecting it inside a
+    // mutation fails validation in production (see the v0.6.6 transition
+    // outage), so the mock enforces the same rule.
+    if (query.includes("rateLimit")) {
+      return jsonResponse({
+        errors: [
+          { message: "Field 'rateLimit' doesn't exist on type 'Mutation'" },
+        ],
+      });
+    }
     states.set(variables.itemId, "In review");
     return jsonResponse({
       data: {
-        rateLimit: rateLimit(),
         updateProjectV2ItemFieldValue: {
           projectV2Item: { id: variables.itemId },
         },


### PR DESCRIPTION
## TL;DR

릴리스 후에도 모든 worker가 `Ready → In progress` 전이에서 막히는 원인 수정입니다. #479 / #474의 blocker 댓글이 보고한 `Field 'rateLimit' doesn't exist on type 'Mutation'` 이 바로 이것입니다.

## 원인

GitHub GraphQL 스키마에서 `rateLimit` 필드는 **Query 타입에만** 존재합니다. #502에서 도입된 세 mutation(`UpdateProjectItemState`, `AddIssueComment`, `UpdateIssueComment`)이 mutation 루트에 `rateLimit { cost remaining resetAt }`를 선택해, GitHub이 요청 자체를 스키마 검증 단계에서 거부합니다. state **read**는 Query라서 성공하고 transition **mutation**만 실패하는, 운영에서 관측된 증상과 정확히 일치합니다.

#502의 테스트가 이를 못 잡은 이유: fetch mock이 mutation 응답에 `data.rateLimit`을 그대로 돌려줘 실제 스키마 검증이 재현되지 않았습니다.

## 수정

- 세 mutation 문서에서 `rateLimit` 셀렉션 제거
- mutation의 rate-limit telemetry는 `x-ratelimit-*` 응답 헤더 경로로 유지 (`executeGraphQLQueryWithMetadata`에 이미 있던 fallback — 코드 변경 불필요)
- retry/backoff는 기존대로 `Retry-After` 헤더 + 헤더 기반 reset 사용

## 재발 방지

- 공유 테스트 mock(`graphqlResponse`)이 이제 GitHub과 동일하게 `rateLimit`을 포함한 mutation을 에러로 거부 — transition 경로의 모든 테스트가 회귀 가드가 됩니다
- comment mutation 테스트의 단언을 `rateLimit` 포함 → **불포함**으로 반전
- cycleCost 기대값 4 → 3 (mutation은 더 이상 field-reported cost를 내지 않음; 헤더 기반 remaining 추적은 유지)

## 검증

- `pnpm lint` / `pnpm typecheck` / `pnpm test`(tracker-github 79 포함 전체) / `pnpm build` — 전부 pass
- 변경 파일 Prettier — pass

## 머지 후

- [ ] patch 릴리스 → **운영 데몬 업그레이드 + 재시작** (재시작 전까지 mutation은 계속 실패)
- [ ] #479 / #474 worker가 `Ready` 재dispatch에서 `Ready → In progress` 전이 성공하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)