### PR TITLE
refactor(orchestrator): consolidate active state sync

### DIFF
--- a/.changeset/quiet-active-state-sync.md
+++ b/.changeset/quiet-active-state-sync.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Reuse each reconciliation cycle's project item snapshot for active-run state synchronization, removing the duplicate by-ID tracker lookup for #478.

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -609,9 +609,6 @@ describe("OrchestratorService", () => {
         .mockResolvedValueOnce(
           createTrackerResponseWithState(repository, "In Review")
         )
-        .mockResolvedValueOnce(
-          createTrackerResponseWithState(repository, "In Review")
-        )
         .mockResolvedValue(createTrackerResponseWithState(repository, "Todo")),
       spawnImpl: spawnImpl as never,
       isProcessRunning: (pid) => pid === 4410,
@@ -819,9 +816,6 @@ describe("OrchestratorService", () => {
     const service = new OrchestratorService(store, projectConfig, {
       fetchImpl: vi
         .fn()
-        .mockResolvedValueOnce(
-          createTrackerResponseWithState(repository, "In Review")
-        )
         .mockResolvedValueOnce(
           createTrackerResponseWithState(repository, "In Review")
         )
@@ -3393,7 +3387,7 @@ Prefer focused changes.
     expect(result.summary.recovered).toBe(1);
     expect(spawnImpl).toHaveBeenCalledTimes(1);
     expect(listIssues).toHaveBeenCalled();
-    expect(fetchIssueStatesByIds).toHaveBeenCalled();
+    expect(fetchIssueStatesByIds).not.toHaveBeenCalled();
   });
 
   it("builds issue-specific debug status for a tracked issue", async () => {
@@ -3829,9 +3823,11 @@ Prefer focused changes.
           rateLimits,
         },
       ]),
-      listIssues: vi
-        .fn()
-        .mockRejectedValue(new Error("Rate limit near exhaustion")),
+      listIssues: vi.fn().mockRejectedValue(
+        Object.assign(new Error("Rate limit near exhaustion"), {
+          rateLimits,
+        })
+      ),
       listIssuesByStates: vi.fn().mockResolvedValue([]),
       buildWorkerEnvironment: vi.fn().mockReturnValue({}),
       reviveIssue: vi.fn(),
@@ -4549,9 +4545,8 @@ Prefer focused changes.
         createTrackerResponseWithPullRequestOnly(repository, "Todo")
       )
       .mockResolvedValueOnce(
-        createPullRequestStateLookupResponse(repository, "In Progress")
-      )
-      .mockResolvedValueOnce(createEmptyTrackerResponse());
+        createTrackerResponseWithPullRequestOnly(repository, "In Progress")
+      );
     const service = new OrchestratorService(store, projectConfig, {
       fetchImpl,
       spawnImpl: vi.fn().mockReturnValue({
@@ -6745,7 +6740,7 @@ Prefer focused changes.
         nextRetryAt: null,
       });
 
-      const fetchIssueStatesByIds = vi.fn().mockImplementation(async () => {
+      const listIssues = vi.fn().mockImplementation(async () => {
         (
           service as unknown as {
             consumeWorkerStderrLine(runId: string, line: string): void;
@@ -6800,32 +6795,9 @@ Prefer focused changes.
         ];
       });
       vi.spyOn(trackerAdapters, "resolveTrackerAdapter").mockReturnValue({
-        listIssues: vi.fn().mockResolvedValue([
-          {
-            id: "issue-1",
-            identifier: "acme/platform#1",
-            number: 1,
-            title: "Test issue",
-            description: null,
-            priority: null,
-            state: "Todo",
-            branchName: null,
-            url: "https://github.com/acme/platform/issues/1",
-            labels: [],
-            blockedBy: [],
-            createdAt: "2026-03-08T00:00:00.000Z",
-            updatedAt: "2026-03-08T00:05:00.000Z",
-            repository,
-            tracker: {
-              adapter: "github-project" as const,
-              bindingId: "project-123",
-              itemId: "item-1",
-            },
-            metadata: {},
-          },
-        ]),
+        listIssues,
         listIssuesByStates: vi.fn().mockResolvedValue([]),
-        fetchIssueStatesByIds,
+        fetchIssueStatesByIds: vi.fn(),
         buildWorkerEnvironment: vi.fn().mockReturnValue({
           GITHUB_PROJECT_ID: "project-123",
         }),
@@ -8685,7 +8657,7 @@ Prefer focused changes.
     expect(updatedRun?.runtimeSession?.sessionId).toBeNull();
   });
 
-  it("reuses listIssues results to synchronize active run issueState", async () => {
+  it("reuses the full listIssues snapshot during targeted active run synchronization", async () => {
     const tempRoot = await mkdtemp(join(tmpdir(), "orchestrator-live-state-"));
     const repository = await createRepositoryFixture(
       tempRoot,
@@ -8803,20 +8775,12 @@ Prefer focused changes.
       now: () => new Date("2026-03-08T00:05:00.000Z"),
     });
 
-    const snapshot = await service.runOnce();
+    const snapshot = await service.runOnce({
+      issueIdentifier: "acme/platform#999",
+    });
     const updatedRun = await store.loadRun("run-1");
 
-    expect(fetchIssueStatesByIds).toHaveBeenCalledTimes(1);
-    expect(fetchIssueStatesByIds).toHaveBeenCalledWith(
-      projectConfig,
-      ["issue-1"],
-      expect.objectContaining({
-        fetchImpl: expect.any(Function),
-      })
-    );
-    expect(fetchIssueStatesByIds.mock.invocationCallOrder[0]).toBeLessThan(
-      listIssues.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY
-    );
+    expect(fetchIssueStatesByIds).not.toHaveBeenCalled();
     expect(listIssues).toHaveBeenCalledTimes(1);
     expect(listIssues).toHaveBeenCalledWith(
       projectConfig,
@@ -8843,6 +8807,14 @@ Prefer focused changes.
     );
     const store = new OrchestratorFsStore(tempRoot);
     const projectConfig = createProjectConfig(tempRoot, repository);
+    projectConfig.tracker = {
+      adapter: "linear",
+      bindingId: "symphony-0c79b11b75ea",
+      settings: {
+        projectSlug: "symphony-0c79b11b75ea",
+        activeStates: ["Todo", "In Progress"],
+      },
+    };
     await store.saveProjectConfig(projectConfig);
     await store.saveProjectIssueOrchestrations("tenant-1", [
       {
@@ -8884,7 +8856,7 @@ Prefer focused changes.
     });
     const workspaceKey = deriveIssueWorkspaceKey(
       {
-        adapter: "github-project",
+        adapter: "linear",
         issueSubjectId: "issue-1",
       },
       "acme/platform#1"
@@ -8900,7 +8872,7 @@ Prefer focused changes.
     await store.saveIssueWorkspace({
       workspaceKey,
       projectId: "tenant-1",
-      adapter: "github-project",
+      adapter: "linear",
       issueSubjectId: "issue-1",
       issueIdentifier: "acme/platform#1",
       workspacePath,
@@ -8911,38 +8883,37 @@ Prefer focused changes.
       lastError: null,
     });
 
-    const listIssues = vi.fn().mockResolvedValue([]);
-    const fetchIssueStatesByIds = vi.fn().mockResolvedValue([
-      {
-        id: "issue-1",
-        identifier: "acme/platform#1",
-        number: 1,
-        title: "Test issue",
-        description: null,
-        priority: null,
-        state: "Done",
-        branchName: null,
-        url: "https://github.com/acme/platform/issues/1",
-        labels: [],
-        blockedBy: [],
-        createdAt: "2026-03-08T00:00:00.000Z",
-        updatedAt: "2026-03-08T00:05:00.000Z",
-        repository,
-        tracker: {
-          adapter: "github-project" as const,
-          bindingId: "project-123",
-          itemId: "item-1",
-        },
-        metadata: {},
+    const terminalIssue = {
+      id: "issue-1",
+      identifier: "acme/platform#1",
+      number: 1,
+      title: "Test issue",
+      description: null,
+      priority: null,
+      state: "Done",
+      branchName: null,
+      url: "https://github.com/acme/platform/issues/1",
+      labels: [],
+      blockedBy: [],
+      createdAt: "2026-03-08T00:00:00.000Z",
+      updatedAt: "2026-03-08T00:05:00.000Z",
+      repository,
+      tracker: {
+        adapter: "linear" as const,
+        bindingId: "symphony-0c79b11b75ea",
+        itemId: "issue-1",
       },
-    ]);
+      metadata: {},
+    };
+    const listIssues = vi.fn().mockResolvedValue([]);
+    const fetchIssueStatesByIds = vi.fn().mockResolvedValue([terminalIssue]);
     const killImpl = vi.fn();
     vi.spyOn(trackerAdapters, "resolveTrackerAdapter").mockReturnValue({
       listIssues,
       listIssuesByStates: vi.fn().mockResolvedValue([]),
       fetchIssueStatesByIds,
       buildWorkerEnvironment: vi.fn().mockReturnValue({
-        GITHUB_PROJECT_ID: "project-123",
+        LINEAR_ISSUE_ID: "issue-1",
       }),
       reviveIssue: vi.fn(),
     });
@@ -8965,9 +8936,12 @@ Prefer focused changes.
     );
 
     expect(fetchIssueStatesByIds).toHaveBeenCalledTimes(1);
-    expect(fetchIssueStatesByIds.mock.invocationCallOrder[0]).toBeLessThan(
-      listIssues.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY
+    expect(fetchIssueStatesByIds).toHaveBeenCalledWith(
+      projectConfig,
+      ["issue-1"],
+      expect.objectContaining({ fetchImpl: expect.any(Function) })
     );
+    expect(listIssues).toHaveBeenCalledTimes(1);
     expect(killImpl).toHaveBeenCalledWith(4205, "SIGTERM");
     expect(updatedRun?.status).toBe("suppressed");
     expect(updatedRun?.issueState).toBe("Done");
@@ -8980,7 +8954,7 @@ Prefer focused changes.
     expect(snapshot.activeRuns).toHaveLength(0);
   });
 
-  it("suppresses an active run when its project item is archived", async () => {
+  it("suppresses an active run when its issue is removed from the project snapshot", async () => {
     process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
     const tempRoot = await mkdtemp(
       join(tmpdir(), "orchestrator-archived-reconciliation-")
@@ -9088,7 +9062,7 @@ Handle archived item reconciliation.`,
         isArchived: true,
       },
     };
-    const listIssues = vi.fn().mockResolvedValue([archivedIssue]);
+    const listIssues = vi.fn().mockResolvedValue([]);
     const fetchIssueStatesByIds = vi.fn().mockResolvedValue([archivedIssue]);
     const killImpl = vi.fn();
     vi.spyOn(trackerAdapters, "resolveTrackerAdapter").mockReturnValue({
@@ -9114,15 +9088,15 @@ Handle archived item reconciliation.`,
     const updatedRun = await store.loadRun("run-1");
     const issueRecords = await store.loadProjectIssueOrchestrations("tenant-1");
 
-    expect(fetchIssueStatesByIds).toHaveBeenCalledTimes(1);
+    expect(fetchIssueStatesByIds).not.toHaveBeenCalled();
     expect(killImpl).toHaveBeenCalledWith(4209, "SIGTERM");
     expect(updatedRun).toMatchObject({
       status: "suppressed",
-      issueState: "Archived",
+      issueState: "In Progress",
       processId: null,
       runPhase: "canceled_by_reconciliation",
       lastError:
-        "Run suppressed because the tracker state is no longer actionable.",
+        "Run suppressed because the tracker issue is no longer tracked.",
     });
     expect(issueRecords[0]?.state).toBe("released");
     expect(snapshot.activeRuns).toHaveLength(0);
@@ -9298,7 +9272,7 @@ Handle Linear issue.`,
     );
   });
 
-  it("records tracker.fetchByIds metadata when active Linear runs are refreshed", async () => {
+  it("records tracker.list metadata when active Linear runs are refreshed", async () => {
     const tempRoot = await mkdtemp(
       join(tmpdir(), "orchestrator-linear-fetch-events-")
     );
@@ -9427,9 +9401,9 @@ Handle Linear issue.`,
       },
     };
     vi.spyOn(trackerAdapters, "resolveTrackerAdapter").mockReturnValue({
-      listIssues: vi.fn().mockResolvedValue([]),
+      listIssues: vi.fn().mockResolvedValue(refreshedIssues),
       listIssuesByStates: vi.fn().mockResolvedValue([]),
-      fetchIssueStatesByIds: vi.fn().mockResolvedValue(refreshedIssues),
+      fetchIssueStatesByIds: vi.fn(),
       buildWorkerEnvironment: vi.fn().mockReturnValue({
         LINEAR_ISSUE_ID: "linear-issue-1",
       }),
@@ -9443,24 +9417,18 @@ Handle Linear issue.`,
     await service.runOnce();
 
     const rawEvents = (
-      await Promise.all(
-        ["run-1", "run-2"].map((runId) =>
-          readFile(
-            join(store.runDir(runId, projectConfig.projectId), "events.ndjson"),
-            "utf8"
-          )
-        )
+      await readFile(
+        join(store.runDir("run-1", projectConfig.projectId), "events.ndjson"),
+        "utf8"
       )
-    ).flatMap((contents) =>
-      contents
-        .trim()
-        .split("\n")
-        .map((line) => JSON.parse(line) as Record<string, unknown>)
-    );
+    )
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
     expect(rawEvents).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          event: "tracker.fetchByIds",
+          event: "tracker.list",
           tracker: {
             adapter: "linear",
             projectSlug: "symphony-0c79b11b75ea",
@@ -9472,18 +9440,15 @@ Handle Linear issue.`,
         }),
       ])
     );
-    const fetchEvents = rawEvents.filter(
-      (event) => event.event === "tracker.fetchByIds"
+    const listEvents = rawEvents.filter(
+      (event) => event.event === "tracker.list"
     );
-    expect(fetchEvents).toHaveLength(2);
+    expect(listEvents).toHaveLength(1);
     expect(
-      fetchEvents.filter(
+      listEvents.filter(
         (event) =>
           (event.rateLimits as Record<string, unknown> | null)?.cycleCost === 5
       )
-    ).toHaveLength(1);
-    expect(
-      fetchEvents.filter((event) => event.rateLimits === null)
     ).toHaveLength(1);
   });
 
@@ -9741,13 +9706,8 @@ Handle Linear issue.`,
     const updatedRun = await store.loadRun("run-1");
     const issueRecords = await store.loadProjectIssueOrchestrations("tenant-1");
 
-    expect(fetchIssueStatesByIds).toHaveBeenCalledWith(
-      projectConfig,
-      ["issue-1"],
-      expect.objectContaining({
-        fetchImpl: expect.any(Function),
-      })
-    );
+    expect(fetchIssueStatesByIds).not.toHaveBeenCalled();
+    expect(listIssues).toHaveBeenCalledTimes(1);
     expect(killImpl).toHaveBeenCalledWith(4208, "SIGTERM");
     expect(updatedRun).toMatchObject({
       status: "suppressed",
@@ -11147,66 +11107,6 @@ function createTrackerResponseWithPullRequestOnly(
   return createTrackerResponseFromProjectItems([
     makeTrackerProjectPullRequest(repository, state),
   ]);
-}
-
-function createPullRequestStateLookupResponse(
-  repository: {
-    owner: string;
-    name: string;
-    cloneUrl: string;
-  },
-  state: string
-) {
-  return {
-    ok: true,
-    json: async () => ({
-      data: {
-        nodes: [
-          {
-            __typename: "PullRequest",
-            id: "pr-2",
-            number: 2,
-            url: `https://example.test/${repository.owner}/${repository.name}/pull/2`,
-            updatedAt: "2026-03-08T00:00:00.000Z",
-            headRefName: "feature/canonical-pr",
-            repository: {
-              name: repository.name,
-              url: `file://${repository.cloneUrl}`,
-              owner: {
-                login: repository.owner,
-              },
-            },
-            projectItems: {
-              nodes: [
-                {
-                  id: "item-pr-2",
-                  updatedAt: "2026-03-08T00:01:00.000Z",
-                  project: {
-                    id: "project-123",
-                  },
-                  fieldValues: {
-                    nodes: [
-                      {
-                        __typename: "ProjectV2ItemFieldSingleSelectValue",
-                        name: state,
-                        field: {
-                          name: "Status",
-                        },
-                      },
-                    ],
-                  },
-                },
-              ],
-              pageInfo: {
-                endCursor: null,
-                hasNextPage: false,
-              },
-            },
-          },
-        ],
-      },
-    }),
-  };
 }
 
 function createTrackerResponseFromProjectItems(items: unknown[]) {

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -873,20 +873,6 @@ export class OrchestratorService {
           run.projectId === tenant.projectId &&
           isActiveRunRecordStatus(run.status)
       );
-      const {
-        runs: syncedActiveRuns,
-        issuesByIdentifier: syncedIssuesByIdentifier,
-      } = await this.syncActiveRunIssueStates(
-        tenant,
-        trackerAdapter,
-        currentActiveRuns,
-        now
-      );
-      trackerRateLimits = resolveTrackerRateLimits(
-        syncedIssuesByIdentifier.values()
-      );
-      this.rememberTrackerRateLimits(tenant.projectId, trackerRateLimits);
-      rateLimits = rateLimits ?? trackerRateLimits;
       const candidateTrackerDependencies =
         await this.resolveCandidateTrackerDependencies(
           tenant,
@@ -897,6 +883,79 @@ export class OrchestratorService {
         candidateTrackerDependencies
       );
       const canonicalIssues = resolveCanonicalSubjectIssues(issues);
+      // `canonicalIssues`로 맵을 무조건 시딩하므로 기존 두 번째 역순 머지
+      // 루프는 불필요하다. 시딩이 조건부가 되면 우선순위를 다시 검토해야 한다.
+      const trackedIssuesByIdentifier = new Map<string, TrackedIssue>(
+        canonicalIssues.map((issue) => [issue.identifier, issue])
+      );
+      const missingLinearActiveIssueIds =
+        tenant.tracker.adapter === "linear"
+          ? [
+              ...new Set(
+                currentActiveRuns
+                  .filter(
+                    (run) => !trackedIssuesByIdentifier.has(run.issueIdentifier)
+                  )
+                  .map((run) => run.issueId)
+              ),
+            ]
+          : [];
+      const supplementalLinearIssues =
+        missingLinearActiveIssueIds.length > 0
+          ? await trackerAdapter.fetchIssueStatesByIds(
+              tenant,
+              missingLinearActiveIssueIds,
+              trackerDependencies
+            )
+          : [];
+      const supplementalLinearIssueIdentifiers = new Set<string>();
+      for (const issue of supplementalLinearIssues) {
+        if (!trackedIssuesByIdentifier.has(issue.identifier)) {
+          trackedIssuesByIdentifier.set(issue.identifier, issue);
+          supplementalLinearIssueIdentifiers.add(issue.identifier);
+        }
+      }
+      const supplementalLinearRateLimits = getTrackedIssueListRateLimits(
+        supplementalLinearIssues
+      );
+      let supplementalLinearRateLimitsRecorded = false;
+      const syncedActiveRuns: OrchestratorRunRecord[] = [];
+      for (const run of currentActiveRuns) {
+        const currentIssue = trackedIssuesByIdentifier.get(run.issueIdentifier);
+        if (
+          currentIssue &&
+          supplementalLinearIssueIdentifiers.has(run.issueIdentifier)
+        ) {
+          const eventRateLimits =
+            supplementalLinearRateLimits &&
+            !supplementalLinearRateLimitsRecorded
+              ? supplementalLinearRateLimits
+              : supplementalLinearRateLimits
+                ? null
+                : (currentIssue.rateLimits ?? null);
+          supplementalLinearRateLimitsRecorded ||=
+            supplementalLinearRateLimits !== null;
+          await this.store.appendRunEvent(run.runId, {
+            at: now.toISOString(),
+            event: "tracker.fetchByIds",
+            projectId: tenant.projectId,
+            ...buildStructuredTrackerEventMetadata(tenant, currentIssue),
+            rateLimits: eventRateLimits,
+          });
+        }
+        if (!currentIssue || currentIssue.state === run.issueState) {
+          syncedActiveRuns.push(run);
+          continue;
+        }
+
+        const updatedRun: OrchestratorRunRecord = {
+          ...run,
+          issueState: currentIssue.state,
+          updatedAt: now.toISOString(),
+        };
+        await this.store.saveRun(updatedRun);
+        syncedActiveRuns.push(updatedRun);
+      }
       const {
         candidates: trackedActionableIssues,
         lifecyclesByIssueIdentifier,
@@ -930,37 +989,14 @@ export class OrchestratorService {
         targetedIssues,
         trackerDependencies
       );
-      const trackedIssuesByIdentifier = new Map<string, TrackedIssue>(
-        syncedIssuesByIdentifier
-      );
-      for (const issue of canonicalIssues) {
-        const existing = trackedIssuesByIdentifier.get(issue.identifier);
-        trackedIssuesByIdentifier.set(issue.identifier, {
-          ...(existing ?? issue),
-          ...issue,
-          rateLimits: issue.rateLimits ?? existing?.rateLimits ?? null,
-        });
-      }
-      for (const [identifier, issue] of syncedIssuesByIdentifier) {
-        const existing = trackedIssuesByIdentifier.get(identifier);
-        if (!existing) {
-          trackedIssuesByIdentifier.set(identifier, issue);
-          continue;
-        }
-        trackedIssuesByIdentifier.set(identifier, {
-          ...issue,
-          ...existing,
-          rateLimits: existing.rateLimits ?? issue.rateLimits ?? null,
-        });
-      }
       rateLimits = resolveProjectRateLimits(
         syncedActiveRuns,
         trackedIssuesByIdentifier.values(),
-        getTrackedIssueListRateLimits(issues)
+        getTrackedIssueListRateLimits(issues) ?? supplementalLinearRateLimits
       );
       trackerRateLimits = resolveTrackerRateLimits(
         trackedIssuesByIdentifier.values(),
-        getTrackedIssueListRateLimits(issues)
+        getTrackedIssueListRateLimits(issues) ?? supplementalLinearRateLimits
       );
       this.rememberTrackerRateLimits(tenant.projectId, trackerRateLimits);
       const concurrency = await this.getProjectConcurrency(tenant);
@@ -1754,11 +1790,7 @@ export class OrchestratorService {
       repositoryDirectory,
       repository
     );
-    return this.resolveWorkflowResolution(
-      repository,
-      cacheRoot,
-      resolution
-    );
+    return this.resolveWorkflowResolution(repository, cacheRoot, resolution);
   }
 
   private async startRun(
@@ -2184,81 +2216,6 @@ export class OrchestratorService {
       runPhase: "preparing_workspace",
       rateLimits: issue.rateLimits ?? null,
       recovery,
-    };
-  }
-
-  private async syncActiveRunIssueStates(
-    tenant: OrchestratorProjectConfig,
-    trackerAdapter: OrchestratorTrackerAdapter,
-    activeRuns: OrchestratorRunRecord[],
-    now: Date
-  ): Promise<{
-    runs: OrchestratorRunRecord[];
-    issuesByIdentifier: Map<string, TrackedIssue>;
-  }> {
-    const activeIssueIds = [...new Set(activeRuns.map((run) => run.issueId))];
-    if (activeIssueIds.length === 0) {
-      return {
-        runs: activeRuns,
-        issuesByIdentifier: new Map(),
-      };
-    }
-
-    const issues = await trackerAdapter.fetchIssueStatesByIds(
-      tenant,
-      activeIssueIds,
-      {
-        fetchImpl: this.dependencies.fetchImpl,
-      }
-    );
-    const issuesByIdentifier = new Map<string, TrackedIssue>(
-      issues.map((issue) => [issue.identifier, issue])
-    );
-    const issueStateByIdentifier = new Map<string, TrackedIssue["state"]>(
-      issues.map((issue) => [issue.identifier, issue.state])
-    );
-    const fetchRateLimits = getTrackedIssueListRateLimits(issues);
-    let fetchRateLimitsRecorded = false;
-
-    const syncedRuns: OrchestratorRunRecord[] = [];
-    for (const run of activeRuns) {
-      const currentIssue = issuesByIdentifier.get(run.issueIdentifier);
-      if (currentIssue) {
-        const eventRateLimits =
-          fetchRateLimits && !fetchRateLimitsRecorded
-            ? fetchRateLimits
-            : fetchRateLimits
-              ? null
-              : (currentIssue.rateLimits ?? null);
-        fetchRateLimitsRecorded ||= fetchRateLimits !== null;
-        await this.store.appendRunEvent(run.runId, {
-          at: now.toISOString(),
-          event: "tracker.fetchByIds",
-          projectId: tenant.projectId,
-          ...buildStructuredTrackerEventMetadata(tenant, currentIssue),
-          rateLimits: eventRateLimits,
-        });
-      }
-      const currentTrackerState = issueStateByIdentifier.get(
-        run.issueIdentifier
-      );
-      if (!currentTrackerState || currentTrackerState === run.issueState) {
-        syncedRuns.push(run);
-        continue;
-      }
-
-      const updatedRun: OrchestratorRunRecord = {
-        ...run,
-        issueState: currentTrackerState,
-        updatedAt: now.toISOString(),
-      };
-      await this.store.saveRun(updatedRun);
-      syncedRuns.push(updatedRun);
-    }
-
-    return {
-      runs: syncedRuns,
-      issuesByIdentifier,
     };
   }
 
@@ -3794,8 +3751,7 @@ function shouldInheritProcessEnvKey(key: string): boolean {
 
 function isWorkflowHookExecutionAllowed(env: Record<string, string>): boolean {
   const value =
-    env[WORKFLOW_HOOK_APPROVAL_ENV] ??
-    process.env[WORKFLOW_HOOK_APPROVAL_ENV];
+    env[WORKFLOW_HOOK_APPROVAL_ENV] ?? process.env[WORKFLOW_HOOK_APPROVAL_ENV];
   return value === "1" || value?.toLowerCase() === "true";
 }
 


### PR DESCRIPTION
## TL;DR

- `listIssues`가 이미 제공하는 canonical project item snapshot으로 active run의 `issueState`를 동기화합니다.
- 중복 `fetchIssueStatesByIds` 호출과 도달 불가능한 역순 머지 루프를 제거해 reconciliation 조회 경로를 일관되게 만들었습니다.
- Linear는 active-state 필터로 snapshot에서 빠진 active run ID만 보완해 upstream terminal cleanup 계약을 유지합니다.

## 변경 지점 다이어그램

```text
trackerAdapter.listIssues (cycle당 1회)
  └─ resolveCanonicalSubjectIssues
       ├─ active run issueState 갱신
       ├─ actionable candidate 계산
       └─ suppression / terminal cleanup 판단

Linear snapshot 누락 active run ── missing ID만 단일 by-ID 배치 보완

GitHub Project의 기존 fetchIssueStatesByIds 중복 경로 ── 제거
```

## 여기부터 보세요

- `packages/orchestrator/src/service.ts` — canonical snapshot 시딩, active run 동기화, 죽은 머지 루프 제거 및 시딩 불변식 주석
- `packages/orchestrator/src/service.test.ts` — targeted snapshot 재사용, Linear terminal 보완, GitHub 보드 이탈 억제 TC
- `.changeset/quiet-active-state-sync.md` — `@gh-symphony/cli` patch changeset

## 위험 & 롤백

- 위험: targeted reconciliation이 unrelated active run을 snapshot에서 누락하면 정상 워커 suppression으로 이어질 수 있습니다. #477의 전체 snapshot/targeted action 분리를 유지하고 전용 회귀 TC로 검증했습니다.
- 위험: GitHub Project에서 이슈가 보드에서 제거되면 canonical snapshot에 없으므로 마지막 `issueState`를 유지한 채 `no longer tracked` 억제로 수렴합니다. 전용 회귀 TC로 고정했습니다.
- 호환성: Linear는 candidate snapshot에 terminal 상태가 없으므로 누락된 active run ID에 한해 기존 by-ID 상태 조회를 유지합니다.
- 롤백: 이 PR의 squash commit을 revert하면 기존 by-ID 동기화·머지 경로로 복귀합니다.

## 변경 파일

- `packages/orchestrator/src/service.ts`
- `packages/orchestrator/src/service.test.ts`
- `.changeset/quiet-active-state-sync.md`

## Evidence

- `pnpm lint` — pass
- `pnpm test` — pass
- `pnpm typecheck` — pass
- `pnpm build` — pass
- `pnpm exec vitest run packages/orchestrator/src/service.test.ts` — 123 tests pass
- Docker E2E: `docker compose -f docker-compose.e2e.yml -f docker-compose.e2e.events.yml up -d --build` — pass (rework HEAD `321a475`)
- Docker blackbox: `Ready` issue dispatch → `running` (`executionPhase: implementation`) → stub `completed` → `retrying` (`retryKind: continuation`) 확인
- CI: `Test` / `Container Smoke` — pass (HEAD `321a475`)
- Spec check: Coordination/Integration Layer의 GitHub 중복 조회를 제거하고 Linear terminal refresh를 보존해 upstream spec divergence 없음

## Issues — Closed #478

Closes #478

## 머지 후/사람 확인

- [ ] targeted reconciliation 중 unrelated active run이 유지되는지 구현·TC를 함께 리뷰
- [ ] canonical snapshot 시딩이 앞으로도 무조건적이라는 불변식 확인
- [ ] GitHub 보드 이탈 억제와 Linear terminal 보완의 adapter별 동작 확인
