### PR TITLE
docs(adr): Project V2 상태 필터 계약 갱신

### DIFF
--- a/.changeset/bright-project-state-filter.md
+++ b/.changeset/bright-project-state-filter.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Use GitHub Project V2 server-side terminal-state filtering while preserving exact unfiltered state lookups for custom workflow fields in #475.

--- a/docs/adr/2026-03-19_github-project-v2-state-filtering-cache.md
+++ b/docs/adr/2026-03-19_github-project-v2-state-filtering-cache.md
@@ -11,7 +11,9 @@
 > **Superseded (2026-08-01):** 2026-07-19 live introspection and board
 > verification confirmed that `ProjectV2.items` supports `query: String`.
 > The successor ADR adopts server-side filtering while retaining a per-tick
-> cache with a revised contract. This document remains as historical context.
+> cache with a revised contract. **All assumptions, decisions, and consequences
+> below are retained only as historical context and must not be used as the
+> current adapter contract.**
 
 GitHub Project V2 GraphQL API는 project item 조회 시 상태 필드 기준의 query-time filtering을 제공하지 않는다.
 따라서 orchestrator가 특정 workflow state만 필요하더라도 전체 project item을 가져온 뒤 코드에서 상태를 필터링해야 한다.

--- a/docs/adr/2026-03-19_github-project-v2-state-filtering-cache.md
+++ b/docs/adr/2026-03-19_github-project-v2-state-filtering-cache.md
@@ -1,11 +1,17 @@
 # ADR: GitHub Project V2 state filtering limitation과 per-tick cache
 
 - **Date**: 2026-03-19
-- **Status**: Accepted
+- **Status**: Superseded by
+  [`2026-08-01_github-project-v2-server-side-state-filtering.md`](./2026-08-01_github-project-v2-server-side-state-filtering.md)
 - **Related Issues**: #59, #60, #61
 - **Related Spec**: `docs/symphony-spec.md` Section 11.2
 
 ## Context
+
+> **Superseded (2026-08-01):** 2026-07-19 live introspection and board
+> verification confirmed that `ProjectV2.items` supports `query: String`.
+> The successor ADR adopts server-side filtering while retaining a per-tick
+> cache with a revised contract. This document remains as historical context.
 
 GitHub Project V2 GraphQL API는 project item 조회 시 상태 필드 기준의 query-time filtering을 제공하지 않는다.
 따라서 orchestrator가 특정 workflow state만 필요하더라도 전체 project item을 가져온 뒤 코드에서 상태를 필터링해야 한다.

--- a/docs/adr/2026-08-01_github-project-v2-server-side-state-filtering.md
+++ b/docs/adr/2026-08-01_github-project-v2-server-side-state-filtering.md
@@ -3,7 +3,7 @@
 - **Date**: 2026-08-01
 - **Status**: Accepted
 - **Related Issues**: #475
-- **Related PRs**: #500 (runtime implementation)
+- **Related PRs**: #500, #515 (runtime implementation and contract correction)
 - **Supersedes**:
   [`2026-03-19_github-project-v2-state-filtering-cache.md`](./2026-03-19_github-project-v2-state-filtering-cache.md)
 - **Related Analysis**:
@@ -100,12 +100,13 @@ cache의 lifetime은 기존 결정대로 단일 poll tick이다. 다음 tick에�
 cache를 만들어 stale project snapshot을 재사용하지 않는다. startup cleanup과
 이후 loop tick도 서로 다른 cache를 사용한다.
 
-cache entry는 “Project 전체 item”이 아니라 **동일한 query와 normalization
-입력으로 만든 snapshot**을 뜻한다. 따라서 key에는 최소한 다음 결과 차원을
-구분할 수 있는 입력이 포함되어야 한다.
+cache entry는 “Project 전체 item”이 아니라 **동일한 server filter mode와
+normalization 입력으로 만든 snapshot**을 뜻한다. 따라서 key에는 최소한 다음
+결과 차원을 구분할 수 있는 입력이 포함되어야 한다.
 
 - Project와 GraphQL endpoint, 인증 주체
 - server-side state filter를 결정하는 workflow lifecycle
+- 정규화된 terminal-state server filter 활성 여부(query가 `null`이면 동일)
 - repository와 assignee scope
 - priority normalization 설정
 - timeout 등 fetch 결과/동작을 구분해야 하는 adapter 입력
@@ -122,10 +123,10 @@ upstream spec §8.6의 startup terminal workspace cleanup처럼 요청받은 ter
 상태 자체를 찾아야 한다. candidate용 `-status:<terminal>` snapshot을 재사용하면
 필요한 item이 이미 제외되어 correctness를 깨뜨린다.
 
-이 경로는 workflow lifecycle을 server query 입력에서 제거해 unfiltered
-snapshot을 조회한 뒤, 요청받은 상태 이름을 trim 및 case-insensitive 비교로
-로컬 필터링한다. 임의의 요청 상태를 긍정 query로 바꾸지 않는 이유는 다음과
-같다.
+이 경로는 workflow lifecycle을 normalization 입력으로 유지하되,
+terminal-state server filter만 비활성화해 unfiltered snapshot을 조회한다. 그런
+다음 요청받은 상태 이름을 trim 및 case-insensitive 비교로 로컬 필터링한다.
+임의의 요청 상태를 긍정 query로 바꾸지 않는 이유는 다음과 같다.
 
 - 존재하지 않거나 rename된 상태가 빈 결과로 성공하는 silent failure를
   피한다.
@@ -163,8 +164,8 @@ snapshot을 조회한 뒤, 요청받은 상태 이름을 trim 및 case-insensiti
 
 - `fetchIssueStatesByIds()`의 `nodes(ids:)` 기반 active-run reconciliation은
   project item candidate cache의 대상이 아니며 이 결정으로 바뀌지 않는다.
-- 이 ADR은 이미 반영된 runtime 동작(#500)을 문서화한다. 새 runtime 또는
-  configuration 변경을 요구하지 않는다.
+- 이 ADR은 #500의 runtime 동작과 #515의 explicit state lookup 보정을
+  문서화한다. 새 configuration 변경을 요구하지 않는다.
 
 ## Validation
 

--- a/docs/adr/2026-08-01_github-project-v2-server-side-state-filtering.md
+++ b/docs/adr/2026-08-01_github-project-v2-server-side-state-filtering.md
@@ -1,0 +1,184 @@
+# ADR: GitHub Project V2 서버사이드 상태 필터와 per-tick cache 계약
+
+- **Date**: 2026-08-01
+- **Status**: Accepted
+- **Related Issues**: #475
+- **Related PRs**: #500 (runtime implementation)
+- **Supersedes**:
+  [`2026-03-19_github-project-v2-state-filtering-cache.md`](./2026-03-19_github-project-v2-state-filtering-cache.md)
+- **Related Analysis**:
+  [`docs/2026-07-19-github-api-rate-limit-audit.md`](../2026-07-19-github-api-rate-limit-audit.md)
+  §2 R1.5
+- **Related Spec**: `docs/symphony-spec.md` §8.1, §8.6, §11.1
+
+## Context
+
+2026-03-19 ADR은 GitHub Project V2 GraphQL API가 project item을 상태로
+query-time filtering할 수 없다는 전제 아래 다음 두 결정을 함께 내렸다.
+
+1. `listIssuesByStates()`가 전체 project item을 조회한 뒤 로컬에서 상태를
+   필터링한다.
+2. 같은 poll tick 안의 중복 전체 조회를 줄이기 위해 `projectItemsCache`를
+   공유한다.
+
+2026-07-19 live schema introspection에서 `ProjectV2.items`에 `query: String`
+인자가 존재함을 확인했고, 실제 보드에서도 다음 표현식이 동작했다.
+
+- `status:Ready`
+- `status:Ready,"In progress"`
+- `-status:Done`
+- `is:open`, `is:issue`
+
+따라서 “서버사이드 필터가 불가능하다”는 전제는 더 이상 유효하지 않다.
+완료 상태가 누적된 보드에서 전체 item을 매 poll마다 페이지네이션하는 것은
+불필요한 GraphQL 요청을 만든다.
+
+다만 `status:NoSuchState` 같은 긍정 필터는 오류가 아니라 빈 결과를
+반환한다. 상태 옵션의 이름이 바뀌면 정상적인 0건과 configuration drift를
+구분할 수 없어 dispatch가 조용히 중단될 수 있다. 또한 candidate listing과
+startup terminal cleanup은 필요한 상태 집합이 서로 다르므로 동일한 필터
+snapshot을 항상 공유할 수도 없다.
+
+## Affected Symphony Layers
+
+| Layer         | 영향     | 설명                                                                        |
+| ------------- | -------- | --------------------------------------------------------------------------- |
+| Policy        | Yes      | candidate 조회에 안전한 부정 필터를 우선하는 원칙을 정한다.                 |
+| Integration   | Yes      | GitHub Project V2 adapter의 `items(query:)`와 cache identity를 정의한다.    |
+| Configuration | No       | 기존 workflow lifecycle 설정을 입력으로 사용하며 새 설정을 추가하지 않는다. |
+| Coordination  | No       | poll, cleanup, reconciliation 순서와 dispatch 판정은 바꾸지 않는다.         |
+| Execution     | No       | worker lifecycle과 workspace 실행 계약은 바꾸지 않는다.                     |
+| Observability | Indirect | 필터 query와 전후 item 수를 기존 tracker event로 관찰한다.                  |
+
+이 결정은 GitHub tracker에 한정된 repository-local 구현 선택이다. upstream
+Symphony spec의 candidate fetch, terminal-state fetch, normalized output 계약은
+변경하지 않는다.
+
+## Decision
+
+### 1. Candidate listing에 서버사이드 필터를 채택한다
+
+`listIssues()`의 candidate snapshot은 `ProjectV2.items(query:)`로 terminal
+상태를 서버에서 제외한다. 반환된 item에는 기존 content type, assignee,
+repository 필터와 최종 lifecycle 판정을 계속 적용한다. 서버 필터는 전송량과
+페이지 수를 줄이는 사전 필터이며 dispatch 적격성의 유일한 판정자가 아니다.
+
+현재 GitHub query 문법의 상태 qualifier는 `status:`이므로 workflow의
+`stateFieldName`이 대소문자를 무시하고 `Status`일 때만 서버 필터를 적용한다.
+사용자 정의 상태 필드에는 검증되지 않은 query를 만들지 않고 unfiltered
+fetch로 안전하게 fallback한다. terminal 상태가 비어 있을 때도 query를
+생성하지 않는다.
+
+### 2. 상태 표현식은 부정 필터를 기본으로 한다
+
+표현식은 다음 형태로 만든다.
+
+```text
+-status:Done,"Won't do"
+```
+
+원칙은 다음과 같다.
+
+- workflow의 terminal 상태만 제외한다.
+- 공백이나 특수문자가 있는 값은 quote하고 `\`와 `"`를 escape한다.
+- 상태 이름은 trim하고 대소문자 기준으로 중복을 제거한다.
+- 같은 상태가 active와 terminal에 동시에 있으면 query를 보내기 전에
+  fail-loud한다.
+- terminal 상태가 rename되어 filter가 더 이상 일치하지 않으면 item을 더
+  많이 가져오는 쪽으로 실패한다. 이후 로컬 lifecycle 판정이 dispatch를
+  방어한다.
+
+긍정 allowlist인 `status:Ready,"In progress"`는 기본 전략으로 사용하지
+않는다. 옵션 rename 또는 존재하지 않는 상태가 오류 없이 빈 결과가 되어
+전체 dispatch를 멈출 수 있기 때문이다. 향후 긍정 필터가 필요해지면 Project
+field option을 먼저 조회해 이름을 검증하고 불일치 시 fail-loud하는 별도
+결정이 필요하다.
+
+### 3. `projectItemsCache`는 per-tick snapshot cache로 유지한다
+
+cache의 lifetime은 기존 결정대로 단일 poll tick이다. 다음 tick에는 새
+cache를 만들어 stale project snapshot을 재사용하지 않는다. startup cleanup과
+이후 loop tick도 서로 다른 cache를 사용한다.
+
+cache entry는 “Project 전체 item”이 아니라 **동일한 query와 normalization
+입력으로 만든 snapshot**을 뜻한다. 따라서 key에는 최소한 다음 결과 차원을
+구분할 수 있는 입력이 포함되어야 한다.
+
+- Project와 GraphQL endpoint, 인증 주체
+- server-side state filter를 결정하는 workflow lifecycle
+- repository와 assignee scope
+- priority normalization 설정
+- timeout 등 fetch 결과/동작을 구분해야 하는 adapter 입력
+
+filtered candidate snapshot과 unfiltered state-lookup snapshot은 서로 다른
+cache entry다. query 또는 normalization 차원이 다른 호출끼리는 한 entry를
+공유하지 않는다. 같은 tick 안에서 key가 완전히 같은 호출만 in-flight promise와
+결과를 재사용한다.
+
+### 4. `listIssuesByStates()`는 full fetch와 로컬 필터를 유지한다
+
+`listIssuesByStates(project, states)`의 원칙은 여전히 유효하다. 이 operation은
+upstream spec §8.6의 startup terminal workspace cleanup처럼 요청받은 terminal
+상태 자체를 찾아야 한다. candidate용 `-status:<terminal>` snapshot을 재사용하면
+필요한 item이 이미 제외되어 correctness를 깨뜨린다.
+
+이 경로는 workflow lifecycle을 server query 입력에서 제거해 unfiltered
+snapshot을 조회한 뒤, 요청받은 상태 이름을 trim 및 case-insensitive 비교로
+로컬 필터링한다. 임의의 요청 상태를 긍정 query로 바꾸지 않는 이유는 다음과
+같다.
+
+- 존재하지 않거나 rename된 상태가 빈 결과로 성공하는 silent failure를
+  피한다.
+- adapter operation이 요청받은 임의 상태 집합을 정확하게 처리한다.
+- startup cleanup의 보수적인 correctness가 candidate 조회 비용 최적화보다
+  우선한다.
+
+따라서 같은 tick의 `listIssues()`와 `listIssuesByStates()`가 항상 단일 fetch를
+공유한다는 2026-03-19 ADR의 결과 설명은 폐기한다. candidate filtering이
+활성화된 경우 두 operation은 의도적으로 filtered/unfiltered entry를 각각
+사용한다.
+
+## Consequences
+
+### Positive
+
+- Done 같은 terminal item이 누적되어도 candidate 조회 페이지 수가 전체 보드
+  크기에 선형으로 증가하지 않는다.
+- 부정 필터는 새 active/wait 상태를 기본적으로 포함하므로 상태 추가에
+  fail-open한다.
+- per-tick cache는 같은 query의 중복과 동시 fetch를 계속 제거한다.
+- startup cleanup은 terminal item을 누락하지 않고 기존 의미를 유지한다.
+
+### Negative
+
+- 한 tick 안에서도 candidate와 arbitrary-state 조회에는 서로 다른 GraphQL
+  fetch가 필요할 수 있다.
+- GitHub의 query parser와 `status:` qualifier는 외부 API 계약이므로 schema 및
+  실보드 동작을 회귀 검증해야 한다.
+- 잘못된 부정 상태 이름은 비용 최적화를 약화시키지만 오류로 드러나지 않을
+  수 있다. 로컬 lifecycle 판정은 안전성을 보존하지만 observability 확인이
+  필요하다.
+
+### Neutral
+
+- `fetchIssueStatesByIds()`의 `nodes(ids:)` 기반 active-run reconciliation은
+  project item candidate cache의 대상이 아니며 이 결정으로 바뀌지 않는다.
+- 이 ADR은 이미 반영된 runtime 동작(#500)을 문서화한다. 새 runtime 또는
+  configuration 변경을 요구하지 않는다.
+
+## Validation
+
+다음 계약을 TC로 유지한다.
+
+1. `Status` lifecycle이면 terminal 상태를 quote한 부정 query를
+   `ProjectV2.items(query:)`에 전달한다.
+2. 사용자 정의 state field 또는 terminal 상태가 없으면 unfiltered fetch로
+   fallback한다.
+3. active/terminal 상태가 겹치면 GraphQL 호출 전에 실패한다.
+4. 같은 query key는 per-tick cache를 공유하고, filtered/unfiltered lifecycle은
+   cache key를 공유하지 않는다.
+5. `listIssuesByStates()`는 server filter 없이 전체 snapshot에서 요청 상태를
+   로컬 필터링한다.
+
+이 계약은 `packages/tracker-github/src/tracker-github.test.ts`의 Project item
+filtering 및 shared cache TC로 검증한다.

--- a/packages/tracker-github/src/adapter.ts
+++ b/packages/tracker-github/src/adapter.ts
@@ -26,6 +26,7 @@ export type GitHubTrackerConfig = {
   token: string;
   apiUrl?: string;
   lifecycle?: WorkflowLifecycleConfig;
+  filterTerminalStates?: boolean;
   pageSize?: number;
   assignedOnly?: boolean;
   repositoryFilter?: { owner: string; name: string } | null;
@@ -546,7 +547,10 @@ export async function fetchProjectIssues(
   fetchImpl: FetchLike = fetch
 ): Promise<GitHubTrackedIssue[] & TrackedIssueList> {
   const cycleConfig = beginGraphQLRateLimitCycle(config);
-  const stateFilterQuery = buildTerminalStatesQuery(config.lifecycle);
+  const stateFilterQuery =
+    config.filterTerminalStates === false
+      ? null
+      : buildTerminalStatesQuery(config.lifecycle);
   const issues: GitHubTrackedIssue[] = [];
   let cursor: string | null = null;
   let pageCount = 0;

--- a/packages/tracker-github/src/orchestrator-adapter.ts
+++ b/packages/tracker-github/src/orchestrator-adapter.ts
@@ -25,9 +25,8 @@ export const githubProjectTrackerAdapter: OrchestratorTrackerAdapter = {
 
     // Terminal-state exclusion is only safe for candidate listing. State
     // lookups (including startup cleanup for Done items) stay unfiltered.
-    const issues = await listProjectIssues(project, {
-      ...dependencies,
-      workflowLifecycle: undefined,
+    const issues = await listProjectIssues(project, dependencies, {
+      filterTerminalStates: false,
     });
     const normalizedStates = new Set(
       states.map((state) => state.trim().toLowerCase())
@@ -123,9 +122,13 @@ export async function findGithubProjectIssue(
 
 async function listProjectIssues(
   project: Parameters<OrchestratorTrackerAdapter["listIssues"]>[0],
-  dependencies: Parameters<OrchestratorTrackerAdapter["listIssues"]>[1] = {}
+  dependencies: Parameters<OrchestratorTrackerAdapter["listIssues"]>[1] = {},
+  options: { filterTerminalStates?: boolean } = {}
 ) {
-  const trackerConfig = resolveGitHubTrackerConfig(project, dependencies);
+  const trackerConfig = {
+    ...resolveGitHubTrackerConfig(project, dependencies),
+    filterTerminalStates: options.filterTerminalStates ?? true,
+  };
   const loadProjectIssues = () =>
     fetchGithubProjectIssues(trackerConfig, dependencies.fetchImpl);
 
@@ -262,12 +265,28 @@ function buildProjectItemsCacheKey(
     priorityFieldName: config.priorityFieldName ?? null,
     projectId: config.projectId,
     workflowLifecycle: config.lifecycle ?? null,
+    terminalStateFilterEnabled: isTerminalStateFilterEnabled(config),
     repositoryFilter: config.repositoryFilter
       ? `${config.repositoryFilter.owner}/${config.repositoryFilter.name}`
       : null,
     timeoutMs: config.timeoutMs,
     tokenFingerprint: hashToken(config.token),
   });
+}
+
+function isTerminalStateFilterEnabled(
+  config: ReturnType<typeof resolveGitHubTrackerConfig> & {
+    filterTerminalStates?: boolean;
+  }
+): boolean {
+  if (config.filterTerminalStates === false || !config.lifecycle) {
+    return false;
+  }
+
+  return (
+    config.lifecycle.stateFieldName.trim().toLowerCase() === "status" &&
+    config.lifecycle.terminalStates.some((state) => state.trim().length > 0)
+  );
 }
 
 function hashToken(token: string | null): string | null {

--- a/packages/tracker-github/src/tracker-github.test.ts
+++ b/packages/tracker-github/src/tracker-github.test.ts
@@ -1629,6 +1629,52 @@ describe("resolveTrackerAdapter", () => {
     expect(issues.map((issue) => issue.state)).toEqual(["Ready"]);
   });
 
+  it("falls back to unfiltered project items when terminal states are empty", async () => {
+    const adapter = resolveTrackerAdapter({
+      adapter: "github-project",
+      bindingId: "project-123",
+      settings: {
+        projectId: "project-123",
+      },
+    });
+
+    const issues = await adapter.listIssues(makeProjectConfig(), {
+      token: "dependencies-token",
+      workflowLifecycle: {
+        stateFieldName: "Status",
+        activeStates: ["Ready", "In progress"],
+        terminalStates: [],
+        blockerCheckStates: ["Ready"],
+        planningStates: ["Ready"],
+      },
+      fetchImpl: async (_url, init) => {
+        const body = JSON.parse(String(init?.body)) as {
+          variables: {
+            query: string | null;
+            includeUnfilteredCount: boolean;
+          };
+        };
+        expect(body.variables.query).toBeNull();
+        expect(body.variables.includeUnfilteredCount).toBe(false);
+
+        return makeJsonResponse(
+          makeProjectItemsPayload([
+            makeProjectItem({
+              itemId: "item-ready",
+              issueId: "issue-ready",
+              number: 1,
+              title: "Ready issue without terminal states",
+              assignees: [],
+              state: "Ready",
+            }),
+          ])
+        );
+      },
+    });
+
+    expect(issues.map((issue) => issue.state)).toEqual(["Ready"]);
+  });
+
   it("fails loudly instead of excluding a state configured as active and terminal", async () => {
     const adapter = resolveTrackerAdapter({
       adapter: "github-project",
@@ -1694,6 +1740,56 @@ describe("resolveTrackerAdapter", () => {
                 title: "Done issue",
                 assignees: [],
                 state: "Done",
+              }),
+            ])
+          );
+        },
+      }
+    );
+
+    expect(issues.map((issue) => issue.state)).toEqual(["Done"]);
+  });
+
+  it("keeps the custom lifecycle field when explicit state lookups disable server filtering", async () => {
+    const adapter = resolveTrackerAdapter({
+      adapter: "github-project",
+      bindingId: "project-123",
+      settings: {
+        projectId: "project-123",
+      },
+    });
+
+    const issues = await adapter.listIssuesByStates(
+      makeProjectConfig(),
+      ["Done"],
+      {
+        token: "dependencies-token",
+        workflowLifecycle: {
+          stateFieldName: "Stage",
+          activeStates: ["Ready", "In progress"],
+          terminalStates: ["Done"],
+          blockerCheckStates: ["Ready"],
+          planningStates: ["Ready"],
+        },
+        fetchImpl: async (_url, init) => {
+          const body = JSON.parse(String(init?.body)) as {
+            variables: {
+              query: string | null;
+              includeUnfilteredCount: boolean;
+            };
+          };
+          expect(body.variables.query).toBeNull();
+          expect(body.variables.includeUnfilteredCount).toBe(false);
+          return makeJsonResponse(
+            makeProjectItemsPayload([
+              makeProjectItem({
+                itemId: "item-done",
+                issueId: "issue-done",
+                number: 3,
+                title: "Done issue with custom state field",
+                assignees: [],
+                state: "Done",
+                stateFieldName: "Stage",
               }),
             ])
           );
@@ -3772,6 +3868,76 @@ describe("resolveTrackerAdapter", () => {
     expect(listed).toHaveLength(1);
     expect(filtered).toHaveLength(1);
     expect(filtered[0]?.identifier).toBe(listed[0]?.identifier);
+  });
+
+  it("uses separate cache entries for filtered candidates and unfiltered state lookups", async () => {
+    const adapter = resolveTrackerAdapter({
+      adapter: "github-project",
+      bindingId: "project-123",
+      settings: {
+        projectId: "project-123",
+      },
+    });
+    const entries = new Map<string, Promise<TrackedIssue[]>>();
+    const projectItemsCache: ProjectItemsCache = {
+      getOrLoad(key, load) {
+        const cached = entries.get(key);
+        if (cached) {
+          return cached;
+        }
+
+        const pending = load();
+        entries.set(key, pending);
+        return pending;
+      },
+    };
+    const fetchImpl = vi.fn(async (_url, init) => {
+      const body = JSON.parse(String(init?.body)) as {
+        variables: { query: string | null };
+      };
+      const filtered = body.variables.query !== null;
+      return makeJsonResponse(
+        makeProjectItemsPayload([
+          makeProjectItem({
+            itemId: filtered ? "item-ready" : "item-done",
+            issueId: filtered ? "issue-ready" : "issue-done",
+            number: filtered ? 1 : 2,
+            title: filtered ? "Ready issue" : "Done issue",
+            assignees: [],
+            state: filtered ? "Ready" : "Done",
+          }),
+        ])
+      );
+    });
+    const workflowLifecycle = {
+      stateFieldName: "Status",
+      activeStates: ["Ready", "In progress"],
+      terminalStates: ["Done"],
+      blockerCheckStates: ["Ready"],
+      planningStates: ["Ready"],
+    };
+
+    const listed = await adapter.listIssues(makeProjectConfig(), {
+      token: "dependencies-token",
+      workflowLifecycle,
+      fetchImpl,
+      projectItemsCache,
+    });
+    const done = await adapter.listIssuesByStates(
+      makeProjectConfig(),
+      ["Done"],
+      {
+        token: "dependencies-token",
+        workflowLifecycle,
+        fetchImpl,
+        projectItemsCache,
+      }
+    );
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(entries).toHaveProperty("size", 2);
+    expect(listed.map((issue) => issue.state)).toEqual(["Ready"]);
+    expect(done.map((issue) => issue.state)).toEqual(["Done"]);
   });
 
   it("uses a non-reversible token fingerprint in the shared project item cache key", async () => {


### PR DESCRIPTION
## TL;DR

- 2026-03-19 ADR의 무효화된 “Project V2 query-time 상태 필터 미지원” 전제를 supersede합니다.
- 후속 ADR에서 candidate 조회의 서버사이드 부정 필터, query-aware per-tick cache 계약, `listIssuesByStates`의 unfiltered fetch 경계를 확정합니다.
- custom state field normalization 보정·회귀 TC 3건과 `@gh-symphony/cli` patch changeset까지 포함합니다.

## 변경 지점 다이어그램

```text
ProjectV2.items(query:)
├─ candidate listing
│  └─ -status:<terminal> → filtered per-tick cache
└─ listIssuesByStates
   └─ query: null + lifecycle normalization → unfiltered per-tick cache → local filter
```

## 여기부터 보세요

1. `docs/adr/2026-08-01_github-project-v2-server-side-state-filtering.md`
2. `packages/tracker-github/src/orchestrator-adapter.ts`
3. `packages/tracker-github/src/tracker-github.test.ts`
4. `docs/adr/2026-03-19_github-project-v2-state-filtering-cache.md`
5. `.changeset/bright-project-state-filter.md`

## 변경 내용

- 기존 ADR을 `Superseded`로 표시하고 아래 본문 전체가 역사적 전제임을 명시했습니다.
- 후속 ADR에 서버사이드 부정 필터 원칙, 실제 filter mode와 normalization 입력에 따른 per-tick cache identity, explicit state lookup의 full fetch + local filter 결정을 기록했습니다.
- `listIssuesByStates()`가 server filter만 끄고 custom lifecycle은 normalization에 유지하도록 수정했습니다.
- empty-terminal fallback, custom state field lookup, filtered/unfiltered cache 분리 TC를 추가했습니다.
- `changeset:patch` 라벨에 맞춰 release package를 `@gh-symphony/cli`로 한정한 patch changeset을 추가했습니다.
- PR actual base `main`의 최신 `1d0005b`에 clean rebase했습니다.

## 위험 & 롤백

- explicit state lookup은 candidate snapshot과 별도 GraphQL fetch를 사용할 수 있어 tick당 요청 수가 늘 수 있지만 terminal item 누락을 방지합니다.
- custom state field normalization과 cache 분리는 회귀 TC 3건으로 방어합니다.
- 문제 발생 시 tracker-github adapter 변경을 revert하고 후속 ADR의 runtime 계약도 함께 되돌립니다. changeset은 함께 제거합니다.

## 변경 파일

- `.changeset/bright-project-state-filter.md` — `@gh-symphony/cli` patch release note
- `docs/adr/2026-03-19_github-project-v2-state-filtering-cache.md` — Superseded 상태·historical 경고
- `docs/adr/2026-08-01_github-project-v2-server-side-state-filtering.md` — 후속 결정과 검증 계약
- `packages/tracker-github/src/adapter.ts` — terminal-state server filter 선택 분리
- `packages/tracker-github/src/orchestrator-adapter.ts` — lifecycle 보존·cache identity 보정
- `packages/tracker-github/src/tracker-github.test.ts` — 회귀 TC 3건

## Evidence

- `pnpm lint` — pass (`379ecf6`)
- `pnpm test` — pass (`379ecf6`)
- `pnpm typecheck` — pass (`379ecf6`)
- `pnpm build` — pass (`379ecf6`)
- `pnpm --filter @gh-symphony/tracker-github test` — pass (2 files, 86 tests)
- `pnpm exec prettier --check .changeset/bright-project-state-filter.md docs/adr/2026-03-19_github-project-v2-state-filtering-cache.md docs/adr/2026-08-01_github-project-v2-server-side-state-filtering.md` — pass
- `pnpm exec changeset status` — `@gh-symphony/cli` patch only
- Docker E2E happy path — health, dispatch, `running → completed`, continuation/failure retry 확인; Cycle 4에서 fixture 제거 후 최종 `idle`·`lastError:null`까지 확인
- `/pull` — `origin/main` (`1d0005b`) clean rebase, HEAD `379ecf6`
- GitHub CI `Test`, `Container Smoke` — running for `379ecf6`

## Issues — Closed #475

- Closes #475

## 머지 후/사람 확인

- [ ] 후속 ADR의 서버 필터·cache·explicit state lookup 계약이 reviewer 기대와 일치하는지 확인
- [ ] GitHub 전용 Integration/Policy 결정이 upstream `docs/symphony-spec.md` 변경 없이 repository-local 확장으로 남았는지 확인
- [ ] `.changeset/bright-project-state-filter.md`가 `@gh-symphony/cli` patch만 릴리스하는지 확인
