### PR TITLE
fix(orchestrator): make stale-run recovery issue-safe

### DIFF
--- a/.changeset/calm-runs-recover.md
+++ b/.changeset/calm-runs-recover.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Prevent stale-run recovery from creating duplicate workers or leaving issue #517 runs falsely active, and make daemon/status process reconciliation safe across PID reuse and stale PID files.

--- a/e2e/scenarios/11-stale-run-recovery.md
+++ b/e2e/scenarios/11-stale-run-recovery.md
@@ -19,15 +19,19 @@ pnpm exec vitest run packages/cli/src/commands/lifecycle.test.ts packages/cli/sr
 
 1. Verify a due stale retry fences the issue to its replacement run before the
    worker is spawned, and terminalizes duplicate runs as
-   `worker_lease_lost: run_not_current`.
+   `worker_lease_lost: run_not_current`. With `currentRunId: null` and a dead
+   record ordered before a live record, verify the live run is selected and
+   persisted before either record is reconciled.
 2. Verify clean-workspace convergence returns the tracker item to the first
    configured active state after confirmed readback; when the tracker cannot
    perform that transition, verify a durable failure retry is queued.
 3. Verify a persisted worker PID with a different process-start identity is
-   rejected before active-run/concurrency accounting.
-4. Verify `repo stop` rejects a daemon with the wrong repository CWD and, when
-   `daemon.pid` is stale, finds and stops the identity/CWD-matching daemon from
-   the project lock.
+   rejected before active-run/concurrency accounting, while a surviving child
+   in the detached process group remains live after its wrapper leader exits.
+4. Verify `repo stop` rejects a daemon with the wrong repository CWD, resolves
+   legacy PID records from the configured repository when invoked elsewhere,
+   and, when `daemon.pid` is stale, finds and stops the identity/CWD-matching
+   daemon from the project lock.
 5. Run the Docker black-box failure/retry lifecycle:
 
    ```bash

--- a/e2e/scenarios/11-stale-run-recovery.md
+++ b/e2e/scenarios/11-stale-run-recovery.md
@@ -1,0 +1,61 @@
+# TC-11: Stale-run ownership and lifecycle recovery
+
+## Setup
+
+```bash
+pnpm install --frozen-lockfile
+pnpm build
+```
+
+The focused service and lifecycle tests cover the fault injections that cannot
+be introduced safely through the public dashboard API:
+
+```bash
+pnpm exec vitest run packages/orchestrator/src/service.test.ts packages/orchestrator/src/lock.test.ts
+pnpm exec vitest run packages/cli/src/commands/lifecycle.test.ts packages/cli/src/config.test.ts packages/cli/src/commands/start.test.ts
+```
+
+## Steps
+
+1. Verify a due stale retry fences the issue to its replacement run before the
+   worker is spawned, and terminalizes duplicate runs as
+   `worker_lease_lost: run_not_current`.
+2. Verify clean-workspace convergence returns the tracker item to the first
+   configured active state after confirmed readback; when the tracker cannot
+   perform that transition, verify a durable failure retry is queued.
+3. Verify a persisted worker PID with a different process-start identity is
+   rejected before active-run/concurrency accounting.
+4. Verify `repo stop` rejects a daemon with the wrong repository CWD and, when
+   `daemon.pid` is stale, finds and stops the identity/CWD-matching daemon from
+   the project lock.
+5. Run the Docker black-box failure/retry lifecycle:
+
+   ```bash
+   ./e2e/run-e2e.sh fail 45
+   ```
+
+6. In the Docker output, confirm the worker reaches `running`, exits as
+   `failed`, enters a retry, releases after fixture removal, and finishes with
+   zero active runs.
+
+## Expected
+
+- Exactly one current run owns each issue before worker spawn.
+- Superseded workers become terminal and do not consume concurrency.
+- Clean convergence is explicit and retryable; it does not remain falsely
+  completed or silently locked in the current tracker state.
+- Reused/dead worker PIDs are excluded from active status after reconciliation.
+- Daemon stopping is bound to the expected repository CWD and reports a clear
+  unresolved-daemon error if neither `daemon.pid` nor the project lock identifies
+  a matching live process.
+- Docker black-box output ends in `PASSED` with a visible failure retry and idle
+  final health.
+
+## Cleanup
+
+`e2e/run-e2e.sh` performs cleanup automatically. For interrupted runs:
+
+```bash
+docker compose -f docker-compose.e2e.yml down
+git restore e2e/fixtures/issues.json
+```

--- a/packages/cli/src/commands/lifecycle.test.ts
+++ b/packages/cli/src/commands/lifecycle.test.ts
@@ -10,12 +10,14 @@ const spawnMock = vi.fn();
 const selectMock = vi.fn();
 const cancelMock = vi.fn();
 const getProcessIdentityMock = vi.fn();
+const getProcessCwdMock = vi.fn();
 const ghAuthMocks = vi.hoisted(() => ({
   resolveGitHubAuth: vi.fn(),
 }));
 
 vi.mock("@gh-symphony/orchestrator", () => ({
   runCli: orchestratorRunCli,
+  getProcessCwd: getProcessCwdMock,
   getProcessIdentity: getProcessIdentityMock,
   resolveOrchestratorLogLevel: (value?: string | null) =>
     value === "verbose" ? "verbose" : "normal",
@@ -61,6 +63,7 @@ beforeEach(() => {
   getProcessIdentityMock.mockImplementation(
     (pid: number) => `node gh-symphony index.js repo start --pid ${pid}`
   );
+  getProcessCwdMock.mockReturnValue(process.cwd());
   ghAuthMocks.resolveGitHubAuth.mockReset();
   ghAuthMocks.resolveGitHubAuth.mockResolvedValue({
     source: "gh",
@@ -74,6 +77,7 @@ afterEach(() => {
   orchestratorRunCli.mockReset();
   spawnMock.mockReset();
   getProcessIdentityMock.mockReset();
+  getProcessCwdMock.mockReset();
   selectMock.mockReset();
   cancelMock.mockReset();
   ghAuthMocks.resolveGitHubAuth.mockReset();
@@ -391,12 +395,56 @@ describe("lifecycle command integration", () => {
     expect(killSpy).toHaveBeenCalledWith(111, 0);
     expect(killSpy).not.toHaveBeenCalledWith(111, "SIGTERM");
     expect(stderr.mock.calls.map((call) => String(call[0])).join("")).toContain(
-      "process identity does not match"
+      "no live orchestrator with repository CWD"
     );
     await expect(
       readFile(join(configDir, "projects", "tenant-a", "daemon.pid"), "utf8")
     ).rejects.toMatchObject({ code: "ENOENT" });
     expect(process.exitCode).toBe(1);
+  });
+
+  it("recovers a repository daemon from the project lock when daemon.pid is stale", async () => {
+    const configDir = await createConfigFixture({
+      activeProject: "tenant-a",
+      projects: [createTenant("tenant-a", "acme", "platform")],
+    });
+    await writeFile(
+      join(configDir, "projects", "tenant-a", "daemon.pid"),
+      JSON.stringify({
+        pid: 111,
+        startedAt: "2026-07-15T00:00:00.000Z",
+        processIdentity: "stale-daemon",
+        cwd: process.cwd(),
+      }) + "\n"
+    );
+    await writeFile(
+      join(configDir, "projects", "tenant-a", ".lock"),
+      JSON.stringify({
+        ownerToken: "222:owner",
+        pid: 222,
+        startedAt: "2026-07-15T00:00:01.000Z",
+        heartbeatAt: "2026-07-15T00:00:02.000Z",
+        processIdentity: "live-daemon",
+      }) + "\n"
+    );
+    getProcessIdentityMock.mockImplementation((pid: number) =>
+      pid === 222 ? "live-daemon" : "unrelated-process"
+    );
+    const killSpy = vi
+      .spyOn(process, "kill")
+      .mockImplementation(
+        ((_pid: number, _signal?: NodeJS.Signals | 0) =>
+          true) as typeof process.kill
+      );
+
+    await stopModule.default([], baseOptions(configDir));
+
+    expect(killSpy).not.toHaveBeenCalledWith(111, "SIGTERM");
+    expect(killSpy).toHaveBeenCalledWith(222, 0);
+    expect(killSpy).toHaveBeenCalledWith(222, "SIGTERM");
+    await expect(
+      readFile(join(configDir, "projects", "tenant-a", "daemon.pid"), "utf8")
+    ).rejects.toMatchObject({ code: "ENOENT" });
   });
 
   it("rejects unknown project stop flags before touching daemon state", async () => {

--- a/packages/cli/src/commands/lifecycle.test.ts
+++ b/packages/cli/src/commands/lifecycle.test.ts
@@ -11,6 +11,7 @@ const selectMock = vi.fn();
 const cancelMock = vi.fn();
 const getProcessIdentityMock = vi.fn();
 const getProcessCwdMock = vi.fn();
+const originalCwd = process.cwd();
 const ghAuthMocks = vi.hoisted(() => ({
   resolveGitHubAuth: vi.fn(),
 }));
@@ -82,6 +83,7 @@ afterEach(() => {
   cancelMock.mockReset();
   ghAuthMocks.resolveGitHubAuth.mockReset();
   vi.restoreAllMocks();
+  process.chdir(originalCwd);
   process.exitCode = undefined;
 });
 
@@ -369,6 +371,46 @@ describe("lifecycle command integration", () => {
     ).rejects.toMatchObject({ code: "ENOENT" });
   });
 
+  it("uses the configured repository CWD for a legacy daemon PID", async () => {
+    const repositoryCwd = await mkdtemp(
+      join(tmpdir(), "cli-stop-repository-cwd-")
+    );
+    const callerCwd = await mkdtemp(join(tmpdir(), "cli-stop-caller-cwd-"));
+    const configDir = await createConfigFixture({
+      activeProject: "tenant-a",
+      projects: [createTenant("tenant-a", "acme", "platform", repositoryCwd)],
+    });
+    await writeFile(
+      join(configDir, "projects", "tenant-a", "daemon.pid"),
+      JSON.stringify({
+        pid: 111,
+        startedAt: "2026-07-15T00:00:00.000Z",
+        processIdentity: "node gh-symphony index.js repo start --pid 111",
+      }) + "\n"
+    );
+    getProcessCwdMock.mockReturnValue(repositoryCwd);
+    process.chdir(callerCwd);
+    const killSpy = vi
+      .spyOn(process, "kill")
+      .mockImplementation((pid: number, signal?: NodeJS.Signals | 0) => {
+        if (signal === 0) {
+          return true;
+        }
+        if (pid !== 111 || signal !== "SIGTERM") {
+          throw new Error(`unexpected kill ${pid} ${String(signal)}`);
+        }
+        return true;
+      });
+
+    await stopModule.default([], baseOptions(configDir));
+
+    expect(killSpy).toHaveBeenCalledWith(111, 0);
+    expect(killSpy).toHaveBeenCalledWith(111, "SIGTERM");
+    await expect(
+      readFile(join(configDir, "projects", "tenant-a", "daemon.pid"), "utf8")
+    ).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
   it("refuses to signal a reused PID with a different process identity", async () => {
     const configDir = await createConfigFixture({
       activeProject: "tenant-a",
@@ -532,12 +574,13 @@ function baseOptions(configDir: string) {
 function createTenant(
   projectId: string,
   owner: string,
-  name: string
+  name: string,
+  workspaceDir = process.cwd()
 ): CliProjectConfig {
   return {
     projectId,
     slug: projectId,
-    workspaceDir: join("/tmp", projectId),
+    workspaceDir,
     repository: {
       owner,
       name,

--- a/packages/cli/src/commands/start.test.ts
+++ b/packages/cli/src/commands/start.test.ts
@@ -761,6 +761,7 @@ describe("start command foreground locking", () => {
     expect(pidRecord).toMatchObject({
       pid: 2468,
       processIdentity: "process-2468",
+      cwd: process.cwd(),
     });
     expect(Date.parse(pidRecord.startedAt)).not.toBeNaN();
   });

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -1278,6 +1278,7 @@ async function startDaemon(
       pid: child.pid,
       startedAt: new Date().toISOString(),
       processIdentity: getProcessIdentity(child.pid),
+      cwd: process.cwd(),
     });
     child.unref();
   } catch (error) {

--- a/packages/cli/src/commands/stop.ts
+++ b/packages/cli/src/commands/stop.ts
@@ -75,7 +75,7 @@ const handler = async (
     process.exitCode = 1;
     return;
   }
-  const expectedCwd = resolve(pidRecord.cwd ?? process.cwd());
+  const expectedCwd = resolve(pidRecord.cwd ?? projectConfig.workspaceDir);
   let target = validateDaemonProcess(
     pidRecord.pid,
     pidRecord.processIdentity,

--- a/packages/cli/src/commands/stop.ts
+++ b/packages/cli/src/commands/stop.ts
@@ -1,5 +1,6 @@
 import { readFile, rm } from "node:fs/promises";
-import { getProcessIdentity } from "@gh-symphony/orchestrator";
+import { join, resolve } from "node:path";
+import { getProcessCwd, getProcessIdentity } from "@gh-symphony/orchestrator";
 import type { GlobalOptions } from "../index.js";
 import { daemonPidPath, parseDaemonPidRecord } from "../config.js";
 import {
@@ -74,35 +75,41 @@ const handler = async (
     process.exitCode = 1;
     return;
   }
-  const pid = pidRecord.pid;
-
-  try {
-    // Check if process is running
-    process.kill(pid, 0);
-  } catch {
+  const expectedCwd = resolve(pidRecord.cwd ?? process.cwd());
+  let target = validateDaemonProcess(
+    pidRecord.pid,
+    pidRecord.processIdentity,
+    expectedCwd
+  );
+  if (!target) {
+    target = await resolveProjectLockDaemon(
+      options.configDir,
+      resolvedProjectId,
+      expectedCwd
+    );
+    if (!target) {
+      process.stderr.write(
+        `Stale daemon PID ${pidRecord.pid} for project "${resolvedProjectId}"; no live orchestrator with repository CWD "${expectedCwd}" was found in the project lock. Cleaning up stale PID file.\n`
+      );
+      await rm(pidPath, { force: true });
+      process.exitCode = 1;
+      return;
+    }
     process.stdout.write(
-      `Daemon for project "${resolvedProjectId}" (PID ${pid}) is not running. Cleaning up PID file.\n`
+      `Recovered orchestrator PID ${target.pid} from the project lock for repository CWD "${expectedCwd}".\n`
     );
-    await rm(pidPath, { force: true });
-    return;
   }
 
-  const checkedIdentity = getProcessIdentity(pid);
-  const identityMatches = pidRecord.processIdentity
-    ? checkedIdentity === pidRecord.processIdentity
-    : isLegacyOrchestratorIdentity(checkedIdentity);
-  if (!identityMatches) {
-    process.stderr.write(
-      `Refusing to stop PID ${pid}: process identity does not match the recorded orchestrator daemon. Cleaning up stale PID file.\n`
-    );
-    await rm(pidPath, { force: true });
-    process.exitCode = 1;
-    return;
-  }
+  const { pid, identity: checkedIdentity } = target;
 
   const signal = resolvedForce ? "SIGKILL" : "SIGTERM";
   try {
-    if (getProcessIdentity(pid) !== checkedIdentity) {
+    const signalCwd = getProcessCwd(pid);
+    if (
+      getProcessIdentity(pid) !== checkedIdentity ||
+      !signalCwd ||
+      resolve(signalCwd) !== expectedCwd
+    ) {
       throw new Error("process identity changed before signal delivery");
     }
     process.kill(pid, signal);
@@ -118,6 +125,52 @@ const handler = async (
   await rm(pidPath, { force: true });
   process.stdout.write("Daemon stopped.\n");
 };
+
+function validateDaemonProcess(
+  pid: number,
+  recordedIdentity: string | null,
+  expectedCwd: string
+): { pid: number; identity: string } | null {
+  try {
+    process.kill(pid, 0);
+  } catch {
+    return null;
+  }
+
+  const identity = getProcessIdentity(pid);
+  const identityMatches = recordedIdentity
+    ? identity === recordedIdentity
+    : isLegacyOrchestratorIdentity(identity);
+  const cwd = getProcessCwd(pid);
+  if (!identity || !identityMatches || !cwd || resolve(cwd) !== expectedCwd) {
+    return null;
+  }
+  return { pid, identity };
+}
+
+async function resolveProjectLockDaemon(
+  configDir: string,
+  projectId: string,
+  expectedCwd: string
+): Promise<{ pid: number; identity: string } | null> {
+  try {
+    const lock = JSON.parse(
+      await readFile(join(configDir, "projects", projectId, ".lock"), "utf8")
+    ) as { pid?: unknown; processIdentity?: unknown };
+    if (!Number.isInteger(lock.pid) || (lock.pid as number) <= 0) {
+      return null;
+    }
+    const processIdentity =
+      typeof lock.processIdentity === "string" ? lock.processIdentity : null;
+    return validateDaemonProcess(
+      lock.pid as number,
+      processIdentity,
+      expectedCwd
+    );
+  } catch {
+    return null;
+  }
+}
 
 function isLegacyOrchestratorIdentity(identity: string | null): boolean {
   return Boolean(

--- a/packages/cli/src/config.test.ts
+++ b/packages/cli/src/config.test.ts
@@ -125,6 +125,7 @@ describe("config persistence", () => {
       pid: 1234,
       startedAt: "",
       processIdentity: null,
+      cwd: null,
     });
     expect(
       parseDaemonPidRecord(
@@ -138,6 +139,7 @@ describe("config persistence", () => {
       pid: 5678,
       startedAt: "2026-07-15T00:00:00.000Z",
       processIdentity: "node gh-symphony repo start",
+      cwd: null,
     });
     expect(parseDaemonPidRecord("not-a-pid")).toBeNull();
   });

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -42,6 +42,7 @@ export type DaemonPidRecord = {
   pid: number;
   startedAt: string;
   processIdentity: string | null;
+  cwd: string | null;
 };
 
 export type CliGlobalConfig = {
@@ -260,7 +261,12 @@ async function writeFileAtomically(path: string, data: string): Promise<void> {
 export function parseDaemonPidRecord(raw: string): DaemonPidRecord | null {
   const legacyPid = Number(raw.trim());
   if (Number.isInteger(legacyPid) && legacyPid > 0) {
-    return { pid: legacyPid, startedAt: "", processIdentity: null };
+    return {
+      pid: legacyPid,
+      startedAt: "",
+      processIdentity: null,
+      cwd: null,
+    };
   }
 
   try {
@@ -270,11 +276,14 @@ export function parseDaemonPidRecord(raw: string): DaemonPidRecord | null {
       (parsed.pid ?? 0) <= 0 ||
       typeof parsed.startedAt !== "string" ||
       (parsed.processIdentity !== null &&
-        typeof parsed.processIdentity !== "string")
+        typeof parsed.processIdentity !== "string") ||
+      (parsed.cwd !== undefined &&
+        parsed.cwd !== null &&
+        typeof parsed.cwd !== "string")
     ) {
       return null;
     }
-    return parsed as DaemonPidRecord;
+    return { ...parsed, cwd: parsed.cwd ?? null } as DaemonPidRecord;
   } catch {
     return null;
   }

--- a/packages/core/src/contracts/status-surface.ts
+++ b/packages/core/src/contracts/status-surface.ts
@@ -100,7 +100,7 @@ export type OrchestratorRunRecord = {
   status: OrchestratorRunStatus;
   attempt: number;
   processId: number | null;
-  /** Stable process start/command identity used to reject PID reuse. */
+  /** Stable process start-time identity used to reject PID reuse. */
   processIdentity?: string | null;
   port: number | null;
   workingDirectory: string;

--- a/packages/core/src/contracts/status-surface.ts
+++ b/packages/core/src/contracts/status-surface.ts
@@ -100,6 +100,8 @@ export type OrchestratorRunRecord = {
   status: OrchestratorRunStatus;
   attempt: number;
   processId: number | null;
+  /** Stable process start/command identity used to reject PID reuse. */
+  processIdentity?: string | null;
   port: number | null;
   workingDirectory: string;
   issueWorkspaceKey: string | null;

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -9,7 +9,9 @@ import {
 import {
   acquireProjectLock,
   assertValidProjectId,
+  getProcessCwd,
   getProcessIdentity,
+  getProcessStartIdentity,
   releaseProjectLock,
   renewProjectLock,
   type ProjectLockHandle,
@@ -27,7 +29,9 @@ export {
 export {
   acquireProjectLock,
   assertValidProjectId,
+  getProcessCwd,
   getProcessIdentity,
+  getProcessStartIdentity,
   releaseProjectLock,
   renewProjectLock,
   type ProjectLockHandle,

--- a/packages/orchestrator/src/lock.test.ts
+++ b/packages/orchestrator/src/lock.test.ts
@@ -8,15 +8,22 @@ import {
   writeFile,
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import {
   acquireProjectLock,
+  getProcessCwd,
+  getProcessStartIdentity,
   releaseProjectLock,
   renewProjectLock,
 } from "./lock.js";
 
 describe("project lock", () => {
+  it("resolves the current process working directory", () => {
+    expect(getProcessCwd(process.pid)).toBe(resolve(process.cwd()));
+    expect(getProcessStartIdentity(process.pid)).not.toBeNull();
+  });
+
   it("creates a project-scoped lock file with pid metadata", async () => {
     const runtimeRoot = await mkdtemp(join(tmpdir(), "orchestrator-lock-"));
 

--- a/packages/orchestrator/src/lock.ts
+++ b/packages/orchestrator/src/lock.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { spawnSync } from "node:child_process";
+import { readlinkSync } from "node:fs";
 import {
   chmod,
   mkdir,
@@ -406,6 +407,46 @@ export function getProcessIdentity(pid: number): string | null {
 
   const identity = result.stdout.trim().replace(/\s+/g, " ");
   return identity.length > 0 ? identity : null;
+}
+
+export function getProcessStartIdentity(pid: number): string | null {
+  if (!Number.isInteger(pid) || pid <= 0) {
+    return null;
+  }
+
+  const result = spawnSync("ps", ["-p", String(pid), "-o", "lstart="], {
+    encoding: "utf8",
+  });
+  if (result.status !== 0) {
+    return null;
+  }
+  const identity = result.stdout.trim().replace(/\s+/g, " ");
+  return identity.length > 0 ? identity : null;
+}
+
+export function getProcessCwd(pid: number): string | null {
+  if (!Number.isInteger(pid) || pid <= 0) {
+    return null;
+  }
+
+  try {
+    return resolve(readlinkSync(`/proc/${pid}/cwd`));
+  } catch {
+    const result = spawnSync(
+      "lsof",
+      ["-a", "-p", String(pid), "-d", "cwd", "-Fn"],
+      { encoding: "utf8" }
+    );
+    if (result.status !== 0) {
+      return null;
+    }
+    const cwd = result.stdout
+      .split("\n")
+      .find((line) => line.startsWith("n"))
+      ?.slice(1)
+      .trim();
+    return cwd ? resolve(cwd) : null;
+  }
 }
 
 function isProcessRunning(pid: number): boolean {

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -1473,7 +1473,7 @@ describe("OrchestratorService", () => {
     }
   });
 
-  it("releases a converged worker session without scheduling a retry", async () => {
+  it("queues a clean convergence failure when the tracker is already in the retryable state", async () => {
     process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
     const tempRoot = await mkdtemp(
       join(tmpdir(), "orchestrator-convergence-release-")
@@ -1561,14 +1561,158 @@ describe("OrchestratorService", () => {
         projectConfig.projectId
       );
 
-      expect(updatedRun?.status).toBe("failed");
-      expect(updatedRun?.retryKind).toBeNull();
-      expect(updatedRun?.nextRetryAt).toBeNull();
-      expect(updatedRun?.completedAt).toBe("2026-03-08T00:01:00.000Z");
+      expect(updatedRun?.status).toBe("retrying");
+      expect(updatedRun?.retryKind).toBe("failure");
+      expect(updatedRun?.nextRetryAt).toBe("2026-03-08T00:01:02.000Z");
+      expect(updatedRun?.completedAt).toBeNull();
       expect(updatedRun?.lastError).toBe(
         "convergence_detected: workspace unchanged"
       );
-      expect(issueRecords[0]?.state).toBe("released");
+      expect(issueRecords[0]).toMatchObject({
+        state: "retry_queued",
+        failureRetryCount: 1,
+        currentRunId: "run-1",
+      });
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("returns clean convergence to the configured retryable tracker state", async () => {
+    const tempRoot = await mkdtemp(
+      join(tmpdir(), "orchestrator-convergence-tracker-retry-")
+    );
+    try {
+      const repository = await createRepositoryFixture(
+        tempRoot,
+        "acme",
+        "platform",
+        {
+          rawWorkflow: `---
+tracker:
+  kind: github-project
+  project_id: project-123
+  state_field: Status
+  active_states: [Ready, In progress]
+  terminal_states: [Done]
+agent:
+  max_concurrent_agents: 10
+codex:
+  command: codex app-server
+---
+Retry inconclusive work.
+`,
+        }
+      );
+      const store = new OrchestratorFsStore(tempRoot);
+      const projectConfig = createProjectConfig(tempRoot, repository);
+      await store.saveProjectConfig(projectConfig);
+      await store.saveProjectIssueOrchestrations(projectConfig.projectId, [
+        {
+          issueId: "issue-1",
+          identifier: "acme/platform#1",
+          workspaceKey: "workspace-1",
+          state: "running",
+          currentRunId: "run-1",
+          retryEntry: null,
+          updatedAt: "2026-03-08T00:00:00.000Z",
+          completedOnce: false,
+          failureRetryCount: 0,
+        },
+      ]);
+      await store.saveRun({
+        runId: "run-1",
+        projectId: projectConfig.projectId,
+        projectSlug: projectConfig.slug,
+        issueId: "issue-1",
+        issueSubjectId: "issue-1",
+        trackerItemId: "item-1",
+        issueIdentifier: "acme/platform#1",
+        issueTitle: "Issue 1",
+        issueState: "In progress",
+        repository,
+        status: "running",
+        attempt: 1,
+        processId: 9999,
+        port: null,
+        workingDirectory: repository.path,
+        issueWorkspaceKey: "workspace-1",
+        workspaceRuntimeDir: join(tempRoot, "runtime-run-1"),
+        workflowPath: join(repository.path, "WORKFLOW.md"),
+        retryKind: null,
+        threadId: "thread-1",
+        cumulativeTurnCount: 3,
+        lastTurnSummary: "turn/completed",
+        createdAt: "2026-03-08T00:00:00.000Z",
+        updatedAt: "2026-03-08T00:00:10.000Z",
+        startedAt: "2026-03-08T00:00:00.000Z",
+        completedAt: null,
+        lastError: "convergence_detected: workspace unchanged",
+        nextRetryAt: null,
+        runPhase: "failed",
+        runtimeSession: {
+          sessionId: "thread-1-turn-3",
+          threadId: "thread-1",
+          status: "completed",
+          startedAt: "2026-03-08T00:00:00.000Z",
+          updatedAt: "2026-03-08T00:00:10.000Z",
+          exitClassification: "convergence-detected",
+        },
+      });
+
+      const requestState = vi.fn().mockResolvedValue({
+        ok: true,
+        outcome: "confirmed",
+        state: "Ready",
+        expectedState: "In progress",
+        targetState: "Ready",
+        reason: "Clean-workspace convergence requires a fresh retry cycle.",
+        rateLimits: null,
+        error: null,
+      });
+      vi.spyOn(trackerAdapters, "resolveTrackerAdapter").mockReturnValue({
+        listIssues: vi.fn().mockResolvedValue([]),
+        listIssuesByStates: vi.fn().mockResolvedValue([]),
+        fetchIssueStatesByIds: vi.fn().mockResolvedValue([]),
+        buildWorkerEnvironment: vi.fn().mockReturnValue({}),
+        reviveIssue: vi.fn(),
+        requestState,
+      });
+      const service = new OrchestratorService(store, projectConfig, {
+        isProcessRunning: () => false,
+        now: () => new Date("2026-03-08T00:01:00.000Z"),
+      });
+
+      await service.runOnce();
+
+      expect(requestState).toHaveBeenCalledWith(
+        projectConfig,
+        {
+          issueSubjectId: "issue-1",
+          itemId: "item-1",
+          request: {
+            type: "transition-request",
+            expectedState: "In progress",
+            targetState: "Ready",
+            reason: "Clean-workspace convergence requires a fresh retry cycle.",
+          },
+        },
+        expect.any(Object)
+      );
+      await expect(store.loadRun("run-1")).resolves.toMatchObject({
+        status: "failed",
+        issueState: "Ready",
+        retryKind: null,
+        nextRetryAt: null,
+        completedAt: "2026-03-08T00:01:00.000Z",
+      });
+      const issueRecords = await store.loadProjectIssueOrchestrations(
+        projectConfig.projectId
+      );
+      expect(issueRecords[0]).toMatchObject({
+        state: "released",
+        currentRunId: null,
+      });
     } finally {
       await rm(tempRoot, { recursive: true, force: true });
     }
@@ -3065,7 +3209,7 @@ Prefer focused changes.
       retryKind: null,
     });
     expect(staleRun?.lastError).toBe(
-      `Superseded by current run ${recoveredRun?.runId}.`
+      `worker_lease_lost: run_not_current; superseded by current run ${recoveredRun?.runId}.`
     );
     expect(recoveredRun?.issueTitle).toBe("Test issue");
     expect(recoveredRun?.issueState).toBe("Todo");

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -108,6 +108,40 @@ describe("OrchestratorService", () => {
     ).toBe(true);
   });
 
+  it("preserves a live worker group after its recorded leader exits", () => {
+    const service = new OrchestratorService(
+      {
+        projectDir: () => "/tmp/orchestrator/projects/tenant-1",
+      } as never,
+      createProjectConfig("/tmp/orchestrator", {
+        owner: "acme",
+        name: "platform",
+        cloneUrl: "https://github.com/acme/platform.git",
+      }),
+      {
+        // The detached process group still has a child, but the recorded shell
+        // leader is gone and therefore has no resolvable start identity.
+        isProcessRunning: () => true,
+        getProcessStartIdentity: () => null,
+      }
+    );
+    const isRunProcessRunning = (
+      service as unknown as {
+        isRunProcessRunning(run: {
+          processId: number | null;
+          processIdentity?: string | null;
+        }): boolean;
+      }
+    ).isRunProcessRunning.bind(service);
+
+    expect(
+      isRunProcessRunning({
+        processId: 4321,
+        processIdentity: "recorded-leader-start",
+      })
+    ).toBe(true);
+  });
+
   it("grants short-lived turn leases only to the current running worker", async () => {
     const tempRoot = await mkdtemp(join(tmpdir(), "orchestrator-turn-lease-"));
     const store = new OrchestratorFsStore(tempRoot);

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -17,7 +17,9 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   deriveIssueWorkspaceKey,
   resolveIssueWorkspaceDirectory,
+  type IssueOrchestrationRecord,
   type OrchestratorProjectConfig,
+  type OrchestratorRunRecord,
   type OrchestratorTrackerDependencies,
   type RepositoryRef,
   type TrackedIssueList,
@@ -3291,6 +3293,128 @@ Prefer focused changes.
     expect(recoveredRun?.cumulativeTurnCount).toBe(4);
     expect(recoveredRun?.lastTurnSummary).toBe("turn/completed");
     expect(recoveredRun?.turnCount).toBe(0);
+  });
+
+  it("selects a live current run before reconciling dead-first duplicates", async () => {
+    process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
+    const tempRoot = await mkdtemp(join(tmpdir(), "orchestrator-live-owner-"));
+    const repository = await createRepositoryFixture(
+      tempRoot,
+      "acme",
+      "platform"
+    );
+    const store = new OrchestratorFsStore(tempRoot);
+    const projectConfig = createProjectConfig(tempRoot, repository);
+    await store.saveProjectConfig(projectConfig);
+    const issueRecords: IssueOrchestrationRecord[] = [
+      {
+        issueId: "issue-1",
+        identifier: "acme/platform#1",
+        workspaceKey: "acme_platform_1",
+        completedOnce: false,
+        failureRetryCount: 0,
+        state: "running",
+        currentRunId: null,
+        retryEntry: null,
+        updatedAt: "2026-03-08T00:00:00.000Z",
+      },
+    ];
+    await store.saveProjectIssueOrchestrations("tenant-1", issueRecords);
+    const baseRun = {
+      projectId: "tenant-1",
+      projectSlug: "tenant-1",
+      issueId: "issue-1",
+      issueSubjectId: "issue-1",
+      issueIdentifier: "acme/platform#1",
+      issueTitle: "Test issue",
+      issueState: "Todo",
+      repository,
+      status: "running" as const,
+      attempt: 1,
+      port: null,
+      workingDirectory: join(tempRoot, "issue-workspace"),
+      issueWorkspaceKey: "acme_platform_1",
+      workspaceRuntimeDir: join(tempRoot, "issue-workspace", ".runtime"),
+      workflowPath: null,
+      retryKind: null,
+      createdAt: "2026-03-08T00:00:00.000Z",
+      startedAt: "2026-03-08T00:00:00.000Z",
+      completedAt: null,
+      lastError: null,
+      nextRetryAt: null,
+    };
+    const deadRun: OrchestratorRunRecord = {
+      ...baseRun,
+      runId: "run-a-dead",
+      processId: 4101,
+      updatedAt: "2026-03-08T00:00:10.000Z",
+    };
+    const liveRun: OrchestratorRunRecord = {
+      ...baseRun,
+      runId: "run-z-live",
+      processId: 4102,
+      updatedAt: "2026-03-08T00:00:20.000Z",
+    };
+    await store.saveRun(deadRun);
+    await store.saveRun(liveRun);
+
+    const killImpl = vi.fn();
+    const service = new OrchestratorService(store, projectConfig, {
+      isProcessRunning: (pid) => pid === 4102,
+      killImpl,
+      now: () => new Date("2026-03-08T00:01:00.000Z"),
+    });
+    const selectCurrentRunsForReconciliation = (
+      service as unknown as {
+        selectCurrentRunsForReconciliation(
+          tenant: OrchestratorProjectConfig,
+          records: IssueOrchestrationRecord[],
+          runs: OrchestratorRunRecord[],
+          now: Date
+        ): Promise<IssueOrchestrationRecord[]>;
+      }
+    ).selectCurrentRunsForReconciliation.bind(service);
+    const reconcileRun = (
+      service as unknown as {
+        reconcileRun(
+          tenant: OrchestratorProjectConfig,
+          run: OrchestratorRunRecord,
+          records: IssueOrchestrationRecord[]
+        ): Promise<{
+          issueRecords: IssueOrchestrationRecord[];
+          recovered: boolean;
+        }>;
+      }
+    ).reconcileRun.bind(service);
+
+    let selectedRecords = await selectCurrentRunsForReconciliation(
+      projectConfig,
+      issueRecords,
+      [deadRun, liveRun],
+      new Date("2026-03-08T00:01:00.000Z")
+    );
+    expect(selectedRecords[0]?.currentRunId).toBe("run-z-live");
+    expect(
+      (await store.loadProjectIssueOrchestrations("tenant-1"))[0]?.currentRunId
+    ).toBe("run-z-live");
+
+    selectedRecords = (
+      await reconcileRun(projectConfig, deadRun, selectedRecords)
+    ).issueRecords;
+    selectedRecords = (
+      await reconcileRun(projectConfig, liveRun, selectedRecords)
+    ).issueRecords;
+
+    expect(killImpl).not.toHaveBeenCalled();
+    expect(await store.loadRun("run-a-dead")).toMatchObject({
+      status: "failed",
+      lastError:
+        "worker_lease_lost: run_not_current; superseded by current run run-z-live.",
+    });
+    expect(await store.loadRun("run-z-live")).toMatchObject({
+      status: "running",
+      processId: 4102,
+    });
   });
 
   it("releases due retrying runs when a Todo issue becomes blocked before restart", async () => {

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -70,6 +70,44 @@ describe("OrchestratorService", () => {
     expect(dependencies.assignedOnly).toBe(true);
   });
 
+  it("rejects a live PID whose worker process identity was reused", () => {
+    const service = new OrchestratorService(
+      {
+        projectDir: () => "/tmp/orchestrator/projects/tenant-1",
+      } as never,
+      createProjectConfig("/tmp/orchestrator", {
+        owner: "acme",
+        name: "platform",
+        cloneUrl: "https://github.com/acme/platform.git",
+      }),
+      {
+        isProcessRunning: () => true,
+        getProcessStartIdentity: () => "new-process-start",
+      }
+    );
+    const isRunProcessRunning = (
+      service as unknown as {
+        isRunProcessRunning(run: {
+          processId: number | null;
+          processIdentity?: string | null;
+        }): boolean;
+      }
+    ).isRunProcessRunning.bind(service);
+
+    expect(
+      isRunProcessRunning({
+        processId: 4321,
+        processIdentity: "old-process-start",
+      })
+    ).toBe(false);
+    expect(
+      isRunProcessRunning({
+        processId: 4321,
+        processIdentity: "new-process-start",
+      })
+    ).toBe(true);
+  });
+
   it("grants short-lived turn leases only to the current running worker", async () => {
     const tempRoot = await mkdtemp(join(tmpdir(), "orchestrator-turn-lease-"));
     const store = new OrchestratorFsStore(tempRoot);
@@ -3175,6 +3213,7 @@ Prefer focused changes.
         json: async () => ({}),
       } as Response) as never,
       spawnImpl: spawnImpl as never,
+      getProcessStartIdentity: (pid) => `worker-${pid}-started-once`,
       now: () => new Date("2026-03-08T00:01:00.000Z"),
     });
 
@@ -3213,6 +3252,7 @@ Prefer focused changes.
     );
     expect(recoveredRun?.issueTitle).toBe("Test issue");
     expect(recoveredRun?.issueState).toBe("Todo");
+    expect(recoveredRun?.processIdentity).toBe("worker-4102-started-once");
     expect(recoveredRun?.threadId).toBeNull();
     expect(recoveredRun?.cumulativeTurnCount).toBe(4);
     expect(recoveredRun?.lastTurnSummary).toBe("turn/completed");

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -1,5 +1,6 @@
 import { execSync } from "node:child_process";
 import { EventEmitter } from "node:events";
+import { readFileSync } from "node:fs";
 import {
   chmod,
   mkdir,
@@ -2839,7 +2840,7 @@ Prefer focused changes.
     expect(waitImpl).not.toHaveBeenCalled();
   });
 
-  it("restarts retrying runs after backoff elapses", async () => {
+  it("restarts only the current retrying run and fences it before spawn", async () => {
     process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
     const tempRoot = await mkdtemp(join(tmpdir(), "orchestrator-retry-"));
     const repository = await createRepositoryFixture(
@@ -2892,11 +2893,60 @@ Prefer focused changes.
       turnCount: 4,
       lastTurnSummary: "turn/completed",
     });
-
-    const spawnImpl = vi.fn().mockReturnValue({
-      pid: 4102,
-      unref: vi.fn(),
+    await store.saveRun({
+      runId: "run-stale",
+      projectId: "tenant-1",
+      projectSlug: "tenant-1",
+      issueId: "issue-1",
+      issueSubjectId: "issue-1",
+      issueIdentifier: "acme/platform#1",
+      issueTitle: "Stale duplicate",
+      issueState: "Todo",
+      repository,
+      status: "retrying",
+      attempt: 2,
+      processId: null,
+      port: 4602,
+      workingDirectory: join(tempRoot, "stale-duplicate"),
+      issueWorkspaceKey: null,
+      workspaceRuntimeDir: join(
+        tempRoot,
+        "stale-duplicate",
+        "workspace-runtime"
+      ),
+      workflowPath: null,
+      retryKind: "recovery",
+      createdAt: "2026-03-08T00:00:01.000Z",
+      updatedAt: "2026-03-08T00:00:11.000Z",
+      startedAt: "2026-03-08T00:00:01.000Z",
+      completedAt: null,
+      lastError: "Stale duplicate run.",
+      nextRetryAt: "2026-03-08T00:00:20.000Z",
     });
+
+    const spawnImpl = vi.fn(
+      (
+        _command: string,
+        _args: readonly string[],
+        options: { env?: object }
+      ) => {
+        const runId = (options.env as NodeJS.ProcessEnv).SYMPHONY_RUN_ID;
+        const persistedIssues = JSON.parse(
+          readFileSync(
+            join(store.projectDir("tenant-1"), "issues.json"),
+            "utf8"
+          )
+        ) as Array<{ currentRunId: string | null; state: string }>;
+        expect(persistedIssues[0]).toMatchObject({
+          currentRunId: runId,
+          state: "running",
+        });
+        return {
+          pid: 4102,
+          unref: vi.fn(),
+        };
+      }
+    );
     const listIssues = vi.fn().mockResolvedValue([
       {
         id: "issue-1",
@@ -3004,8 +3054,19 @@ Prefer focused changes.
     expect(listIssues).toHaveBeenCalled();
 
     const runs = await store.loadAllRuns();
-    const recoveredRun = runs.find((run) => run.runId !== "run-1");
+    const recoveredRun = runs.find(
+      (run) => run.runId !== "run-1" && run.runId !== "run-stale"
+    );
+    const staleRun = runs.find((run) => run.runId === "run-stale");
 
+    expect(staleRun).toMatchObject({
+      status: "failed",
+      nextRetryAt: null,
+      retryKind: null,
+    });
+    expect(staleRun?.lastError).toBe(
+      `Superseded by current run ${recoveredRun?.runId}.`
+    );
     expect(recoveredRun?.issueTitle).toBe("Test issue");
     expect(recoveredRun?.issueState).toBe("Todo");
     expect(recoveredRun?.threadId).toBeNull();

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -61,6 +61,7 @@ import {
   readGitCurrentBranch,
 } from "./git.js";
 import { OrchestratorFsStore } from "./fs-store.js";
+import { getProcessStartIdentity } from "./lock.js";
 import { PersistentIssueCommentCache } from "./issue-comment-cache.js";
 import { resolveTrackerAdapter } from "./tracker-adapters.js";
 import {
@@ -369,6 +370,7 @@ export class OrchestratorService {
       maxAttempts?: number;
       killImpl?: (pid: number, signal?: NodeJS.Signals) => void;
       isProcessRunning?: (pid: number) => boolean;
+      getProcessStartIdentity?: (pid: number) => string | null;
       waitImpl?: (ms: number) => Promise<void>;
       stderr?: Pick<NodeJS.WriteStream, "write">;
       createWriteStreamImpl?: (
@@ -1313,7 +1315,7 @@ export class OrchestratorService {
           if (
             !activeRun ||
             activeRun.processId === null ||
-            !this.isProcessRunning(activeRun.processId)
+            !this.isRunProcessRunning(activeRun)
           ) {
             continue;
           }
@@ -2120,7 +2122,8 @@ export class OrchestratorService {
 
     const runtimeTimeouts = resolveWorkflowRuntimeTimeouts(workflow.workflow);
     const buildRunRecord = (
-      processId: number | null
+      processId: number | null,
+      processIdentity: string | null = null
     ): OrchestratorRunRecord => ({
       runId,
       projectId: tenant.projectId,
@@ -2135,6 +2138,7 @@ export class OrchestratorService {
       status: "running",
       attempt: 1,
       processId,
+      processIdentity,
       port: null,
       workingDirectory: repositoryDirectory,
       issueWorkspaceKey: workspaceKey,
@@ -2359,7 +2363,10 @@ export class OrchestratorService {
     });
     child.unref();
 
-    return buildRunRecord(child.pid ?? null);
+    return buildRunRecord(
+      child.pid ?? null,
+      child.pid ? this.resolveProcessIdentity(child.pid) : null
+    );
   }
 
   private async reconcileRun(
@@ -2377,8 +2384,8 @@ export class OrchestratorService {
     );
 
     if (issueRecord?.currentRunId && issueRecord.currentRunId !== run.runId) {
-      if (run.processId && this.isProcessRunning(run.processId)) {
-        this.sendSignal(run.processId, "SIGTERM");
+      if (this.isRunProcessRunning(run)) {
+        this.sendSignal(run.processId!, "SIGTERM");
         this.retireWorkerPid(run.processId);
       }
       const supersededRun: OrchestratorRunRecord = {
@@ -2403,7 +2410,7 @@ export class OrchestratorService {
       return { issueRecords, recovered: false };
     }
 
-    if (run.processId && this.isProcessRunning(run.processId)) {
+    if (this.isRunProcessRunning(run)) {
       const retryPolicy = await this.loadRetryPolicy(tenant, run.repository);
       const configuredStallTimeoutMs = retryPolicy?.stallTimeoutMs ?? null;
       const lastActivityAtMs = parseTimestampMs(
@@ -2440,7 +2447,7 @@ export class OrchestratorService {
             `[orchestrator] stuck worker detected for ${run.runId} (elapsed ${elapsedSeconds}s > ${timeoutSeconds}s) — sending SIGTERM`
           );
         }
-        this.sendSignal(run.processId, "SIGTERM");
+        this.sendSignal(run.processId!, "SIGTERM");
         // Fall through: treat as a normal exit and retry.
       } else {
         const runningRecord: OrchestratorRunRecord = {
@@ -3779,6 +3786,22 @@ export class OrchestratorService {
     } catch {
       return false;
     }
+  }
+
+  private resolveProcessIdentity(processId: number): string | null {
+    return (
+      this.dependencies.getProcessStartIdentity ?? getProcessStartIdentity
+    )(processId);
+  }
+
+  private isRunProcessRunning(run: OrchestratorRunRecord): boolean {
+    if (!run.processId || !this.isProcessRunning(run.processId)) {
+      return false;
+    }
+    if (!run.processIdentity) {
+      return true;
+    }
+    return this.resolveProcessIdentity(run.processId) === run.processIdentity;
   }
 
   private sendSignal(processId: number, signal: NodeJS.Signals): void {

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -1092,13 +1092,50 @@ export class OrchestratorService {
           retryEntry: null,
           updatedAt: now.toISOString(),
         });
+        await this.store.saveProjectIssueOrchestrations(
+          tenant.projectId,
+          issueRecords
+        );
         let run: OrchestratorRunRecord;
+        let preparedRun: OrchestratorRunRecord | null = null;
         try {
           run = await this.startRun(tenant, issue, {
             recovery: recoveryContext,
+            onPrepared: async (candidate) => {
+              preparedRun = candidate;
+              issueRecords = upsertIssueOrchestration(issueRecords, {
+                issueId: candidate.issueId,
+                identifier: candidate.issueIdentifier,
+                workspaceKey:
+                  candidate.issueWorkspaceKey ?? preferredWorkspaceKey,
+                state: "running",
+                currentRunId: candidate.runId,
+                retryEntry: null,
+                updatedAt: now.toISOString(),
+              });
+              await this.store.saveRun(candidate);
+              await this.store.saveProjectIssueOrchestrations(
+                tenant.projectId,
+                issueRecords
+              );
+            },
           });
         } catch (error) {
+          const failedPreparedRun = preparedRun as OrchestratorRunRecord | null;
+          if (failedPreparedRun) {
+            await this.store.saveRun({
+              ...failedPreparedRun,
+              status: "failed",
+              completedAt: now.toISOString(),
+              updatedAt: now.toISOString(),
+              lastError: `Worker spawn failed: ${this.formatErrorMessage(error)}`,
+            });
+          }
           issueRecords = releaseIssueOrchestration(issueRecords, issue.id, now);
+          await this.store.saveProjectIssueOrchestrations(
+            tenant.projectId,
+            issueRecords
+          );
           throw error;
         }
         issueRecords = upsertIssueOrchestration(issueRecords, {
@@ -1111,6 +1148,10 @@ export class OrchestratorService {
           updatedAt: now.toISOString(),
         });
         await this.store.saveRun(run);
+        await this.store.saveProjectIssueOrchestrations(
+          tenant.projectId,
+          issueRecords
+        );
         const eventRateLimits =
           listRateLimits && !listRateLimitsRecorded
             ? listRateLimits
@@ -1798,6 +1839,7 @@ export class OrchestratorService {
     issue: TrackedIssue,
     options: {
       recovery?: IncompleteTurnRecoveryContext | null;
+      onPrepared?: (run: OrchestratorRunRecord) => Promise<void>;
     } = {}
   ): Promise<OrchestratorRunRecord> {
     if (this.shuttingDown || !this.running) {
@@ -1984,6 +2026,46 @@ export class OrchestratorService {
     );
 
     const runtimeTimeouts = resolveWorkflowRuntimeTimeouts(workflow.workflow);
+    const buildRunRecord = (
+      processId: number | null
+    ): OrchestratorRunRecord => ({
+      runId,
+      projectId: tenant.projectId,
+      projectSlug: tenant.slug,
+      issueId: issue.id,
+      issueSubjectId,
+      trackerItemId: issue.tracker.itemId,
+      issueIdentifier: issue.identifier,
+      issueTitle: issue.title,
+      issueState: issue.state,
+      repository: issue.repository,
+      status: "running",
+      attempt: 1,
+      processId,
+      port: null,
+      workingDirectory: repositoryDirectory,
+      issueWorkspaceKey: workspaceKey,
+      workspaceRuntimeDir,
+      workflowPath: workflow.workflowPath,
+      retryKind: recovery ? "recovery" : null,
+      threadId: null,
+      cumulativeTurnCount: 0,
+      lastTurnSummary: null,
+      createdAt: now.toISOString(),
+      updatedAt: now.toISOString(),
+      startedAt: now.toISOString(),
+      completedAt: null,
+      lastError: null,
+      nextRetryAt: null,
+      runPhase: "preparing_workspace",
+      rateLimits: issue.rateLimits ?? null,
+      recovery,
+    });
+
+    // Fence the issue to this run before the worker can request its first
+    // lease. This also leaves a recoverable preparing record if the daemon
+    // exits between preparation and process spawn.
+    await options.onPrepared?.(buildRunRecord(null));
     mkdirSync(runDir, { recursive: true });
     const workerLogStream = (
       this.dependencies.createWriteStreamImpl ?? createWriteStream
@@ -2184,39 +2266,7 @@ export class OrchestratorService {
     });
     child.unref();
 
-    return {
-      runId,
-      projectId: tenant.projectId,
-      projectSlug: tenant.slug,
-      issueId: issue.id,
-      issueSubjectId,
-      trackerItemId: issue.tracker.itemId,
-      issueIdentifier: issue.identifier,
-      issueTitle: issue.title,
-      issueState: issue.state,
-      repository: issue.repository,
-      status: "running",
-      attempt: 1,
-      processId: child.pid ?? null,
-      port: null,
-      workingDirectory: repositoryDirectory,
-      issueWorkspaceKey: workspaceKey,
-      workspaceRuntimeDir,
-      workflowPath: workflow.workflowPath,
-      retryKind: recovery ? "recovery" : null,
-      threadId: null,
-      cumulativeTurnCount: 0,
-      lastTurnSummary: null,
-      createdAt: now.toISOString(),
-      updatedAt: now.toISOString(),
-      startedAt: now.toISOString(),
-      completedAt: null,
-      lastError: null,
-      nextRetryAt: null,
-      runPhase: "preparing_workspace",
-      rateLimits: issue.rateLimits ?? null,
-      recovery,
-    };
+    return buildRunRecord(child.pid ?? null);
   }
 
   private async reconcileRun(
@@ -2229,6 +2279,36 @@ export class OrchestratorService {
     recovered: boolean;
   }> {
     const now = this.now();
+    const issueRecord = issueRecords.find(
+      (candidate) => candidate.issueId === run.issueId
+    );
+
+    if (issueRecord?.currentRunId && issueRecord.currentRunId !== run.runId) {
+      if (run.processId && this.isProcessRunning(run.processId)) {
+        this.sendSignal(run.processId, "SIGTERM");
+        this.retireWorkerPid(run.processId);
+      }
+      const supersededRun: OrchestratorRunRecord = {
+        ...run,
+        status: "failed",
+        processId: null,
+        completedAt: now.toISOString(),
+        updatedAt: now.toISOString(),
+        nextRetryAt: null,
+        retryKind: null,
+        lastError: `Superseded by current run ${issueRecord.currentRunId}.`,
+      };
+      await this.store.saveRun(supersededRun);
+      await this.store.appendRunEvent(run.runId, {
+        at: now.toISOString(),
+        event: "run-suppressed",
+        projectId: run.projectId,
+        issueIdentifier: run.issueIdentifier,
+        issueId: run.issueId,
+        reason: "run_not_current",
+      } as OrchestratorEvent);
+      return { issueRecords, recovered: false };
+    }
 
     if (run.processId && this.isProcessRunning(run.processId)) {
       const retryPolicy = await this.loadRetryPolicy(tenant, run.repository);
@@ -3237,7 +3317,60 @@ export class OrchestratorService {
       run
     );
     const recovery = await this.resolveRetryRunRecoveryContext(tenant, run);
-    const restarted = await this.startRun(tenant, issue, { recovery });
+    let nextIssueRecords = issueRecords;
+    let preparedRun: OrchestratorRunRecord | null = null;
+    let restarted: OrchestratorRunRecord;
+    try {
+      restarted = await this.startRun(tenant, issue, {
+        recovery,
+        onPrepared: async (candidate) => {
+          preparedRun = candidate;
+          nextIssueRecords = upsertIssueOrchestration(nextIssueRecords, {
+            issueId: candidate.issueId,
+            identifier: candidate.issueIdentifier,
+            workspaceKey:
+              candidate.issueWorkspaceKey ??
+              deriveIssueWorkspaceKey(
+                {
+                  adapter: tenant.tracker.adapter,
+                  issueSubjectId: candidate.issueSubjectId,
+                },
+                candidate.issueIdentifier
+              ),
+            state: "running",
+            currentRunId: candidate.runId,
+            retryEntry: null,
+            updatedAt: now.toISOString(),
+          });
+          await this.store.saveRun(candidate);
+          await this.store.saveProjectIssueOrchestrations(
+            tenant.projectId,
+            nextIssueRecords
+          );
+        },
+      });
+    } catch (error) {
+      const failedPreparedRun = preparedRun as OrchestratorRunRecord | null;
+      if (failedPreparedRun) {
+        await this.store.saveRun({
+          ...failedPreparedRun,
+          status: "failed",
+          completedAt: now.toISOString(),
+          updatedAt: now.toISOString(),
+          lastError: `Worker spawn failed: ${this.formatErrorMessage(error)}`,
+        });
+      }
+      nextIssueRecords = releaseIssueOrchestration(
+        nextIssueRecords,
+        run.issueId,
+        now
+      );
+      await this.store.saveProjectIssueOrchestrations(
+        tenant.projectId,
+        nextIssueRecords
+      );
+      throw error;
+    }
     const recoveredRecord: OrchestratorRunRecord = {
       ...restarted,
       attempt: run.attempt,
@@ -3250,6 +3383,10 @@ export class OrchestratorService {
       turnCount: 0,
     };
     await this.store.saveRun(recoveredRecord);
+    await this.store.saveProjectIssueOrchestrations(
+      tenant.projectId,
+      nextIssueRecords
+    );
     await this.store.appendRunEvent(run.runId, {
       at: now.toISOString(),
       event: "run-recovered",
@@ -3260,7 +3397,7 @@ export class OrchestratorService {
     } as OrchestratorEvent);
 
     return {
-      issueRecords: upsertIssueOrchestration(issueRecords, {
+      issueRecords: upsertIssueOrchestration(nextIssueRecords, {
         issueId: recoveredRecord.issueId,
         identifier: recoveredRecord.issueIdentifier,
         workspaceKey:

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -3801,7 +3801,14 @@ export class OrchestratorService {
     if (!run.processIdentity) {
       return true;
     }
-    return this.resolveProcessIdentity(run.processId) === run.processIdentity;
+    const liveLeaderIdentity = this.resolveProcessIdentity(run.processId);
+    if (liveLeaderIdentity === null) {
+      // isProcessRunning also checks the detached process group. A wrapper leader
+      // may exit while its worker child remains alive, so a missing leader must
+      // not narrow the group-level liveness result and permit a second worker.
+      return true;
+    }
+    return liveLeaderIdentity === run.processIdentity;
   }
 
   private sendSignal(processId: number, signal: NodeJS.Signals): void {

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -939,6 +939,12 @@ export class OrchestratorService {
     const activeRuns = allRuns.filter((run) =>
       isActiveRunRecordStatus(run.status)
     );
+    issueRecords = await this.selectCurrentRunsForReconciliation(
+      tenant,
+      issueRecords,
+      activeRuns,
+      now
+    );
     for (const run of activeRuns) {
       const outcome = await this.reconcileRun(
         tenant,
@@ -2767,6 +2773,87 @@ export class OrchestratorService {
       issueRecords,
       recovered: false,
     };
+  }
+
+  private async selectCurrentRunsForReconciliation(
+    tenant: OrchestratorProjectConfig,
+    issueRecords: IssueOrchestrationRecord[],
+    activeRuns: OrchestratorRunRecord[],
+    now: Date
+  ): Promise<IssueOrchestrationRecord[]> {
+    const runsByIssueId = new Map<string, OrchestratorRunRecord[]>();
+    for (const run of activeRuns) {
+      const matchingRuns = runsByIssueId.get(run.issueId) ?? [];
+      matchingRuns.push(run);
+      runsByIssueId.set(run.issueId, matchingRuns);
+    }
+
+    let selectedIssueRecords = issueRecords;
+    let changed = false;
+    for (const [issueId, matchingRuns] of runsByIssueId) {
+      const issueRecord = selectedIssueRecords.find(
+        (candidate) => candidate.issueId === issueId
+      );
+      if (
+        issueRecord?.currentRunId &&
+        matchingRuns.some((run) => run.runId === issueRecord.currentRunId)
+      ) {
+        continue;
+      }
+
+      const selectedCandidate = matchingRuns
+        .map((run) => ({ run, isLive: this.isRunProcessRunning(run) }))
+        .sort((left, right) => {
+          if (left.isLive !== right.isLive) {
+            return left.isLive ? -1 : 1;
+          }
+          const leftActivityAt =
+            parseTimestampMs(left.run.lastEventAt ?? left.run.updatedAt) ??
+            -Infinity;
+          const rightActivityAt =
+            parseTimestampMs(right.run.lastEventAt ?? right.run.updatedAt) ??
+            -Infinity;
+          if (leftActivityAt !== rightActivityAt) {
+            return rightActivityAt - leftActivityAt;
+          }
+          return left.run.runId.localeCompare(right.run.runId);
+        })[0];
+      if (!selectedCandidate) {
+        continue;
+      }
+      const { run: selectedRun, isLive: selectedRunIsLive } = selectedCandidate;
+      selectedIssueRecords = upsertIssueOrchestration(selectedIssueRecords, {
+        issueId: selectedRun.issueId,
+        identifier: selectedRun.issueIdentifier,
+        workspaceKey:
+          selectedRun.issueWorkspaceKey ??
+          issueRecord?.workspaceKey ??
+          deriveIssueWorkspaceKey(
+            {
+              adapter: tenant.tracker.adapter,
+              issueSubjectId: selectedRun.issueSubjectId,
+            },
+            selectedRun.issueIdentifier
+          ),
+        state:
+          issueRecord?.state ??
+          (selectedRunIsLive || selectedRun.status !== "retrying"
+            ? "running"
+            : "retry_queued"),
+        currentRunId: selectedRun.runId,
+        retryEntry: issueRecord?.retryEntry ?? null,
+        updatedAt: now.toISOString(),
+      });
+      changed = true;
+    }
+
+    if (changed) {
+      await this.store.saveProjectIssueOrchestrations(
+        tenant.projectId,
+        selectedIssueRecords
+      );
+    }
+    return selectedIssueRecords;
   }
 
   private now(): Date {

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -18,6 +18,7 @@ import {
   executeWorkspaceHook,
   isStateTerminal,
   isMatchingIssueRun,
+  matchesWorkflowState,
   isOrchestratorChannelEvent,
   mapIssueOrchestrationStateToStatus,
   readEnvFile,
@@ -591,6 +592,98 @@ export class OrchestratorService {
       error: result.error,
       rateLimits: result.rateLimits,
     });
+  }
+
+  private async returnConvergedIssueToRetryableState(
+    tenant: OrchestratorProjectConfig,
+    run: OrchestratorRunRecord,
+    trackerDependencies: OrchestratorTrackerDependencies
+  ): Promise<{ confirmed: boolean; state: string | null }> {
+    const resolution = await this.loadProjectWorkflow(
+      tenant,
+      run.repository
+    ).catch(() => null);
+    if (!resolution || !isUsableWorkflowResolution(resolution)) {
+      return { confirmed: false, state: null };
+    }
+
+    const retryableState = resolution.workflow.tracker.activeStates[0]?.trim();
+    if (
+      !retryableState ||
+      matchesWorkflowState(run.issueState, [retryableState])
+    ) {
+      return { confirmed: false, state: null };
+    }
+
+    const trackerAdapter = resolveTrackerAdapter(tenant.tracker);
+    if (!trackerAdapter.requestState) {
+      return { confirmed: false, state: null };
+    }
+
+    let canonicalItemId = run.trackerItemId?.trim() ?? "";
+    try {
+      if (!canonicalItemId) {
+        const refreshed = await trackerAdapter.fetchIssueStatesByIds(
+          tenant,
+          [run.issueSubjectId],
+          trackerDependencies
+        );
+        canonicalItemId =
+          refreshed.find((issue) => issue.id === run.issueSubjectId)?.tracker
+            .itemId ?? "";
+      }
+      if (!canonicalItemId) {
+        return { confirmed: false, state: null };
+      }
+
+      const request: TrackerStateRequest = {
+        type: "transition-request",
+        expectedState: run.issueState,
+        targetState: retryableState,
+        reason: "Clean-workspace convergence requires a fresh retry cycle.",
+      };
+      const result = await trackerAdapter.requestState(
+        tenant,
+        {
+          issueSubjectId: run.issueSubjectId,
+          itemId: canonicalItemId,
+          request,
+        },
+        trackerDependencies
+      );
+      await this.appendTrackerStateEvent(
+        { ...run, trackerItemId: canonicalItemId },
+        request,
+        result
+      );
+      this.rememberTrackerRateLimits(tenant.projectId, result.rateLimits);
+      return {
+        confirmed:
+          result.ok &&
+          result.outcome === "confirmed" &&
+          result.state !== null &&
+          matchesWorkflowState(result.state, [retryableState]),
+        state: result.state,
+      };
+    } catch (error) {
+      const request: TrackerStateRequest = {
+        type: "transition-request",
+        expectedState: run.issueState,
+        targetState: retryableState,
+        reason: "Clean-workspace convergence requires a fresh retry cycle.",
+      };
+      await this.appendTrackerStateEvent(run, request, {
+        ok: false,
+        outcome: "failed",
+        state: null,
+        expectedState: run.issueState,
+        targetState: retryableState,
+        reason: request.reason,
+        rateLimits: extractTrackerRateLimitsFromError(error),
+        error: this.formatErrorMessage(error),
+      });
+      return { confirmed: false, state: null };
+    }
   }
 
   async run(
@@ -2296,7 +2389,7 @@ export class OrchestratorService {
         updatedAt: now.toISOString(),
         nextRetryAt: null,
         retryKind: null,
-        lastError: `Superseded by current run ${issueRecord.currentRunId}.`,
+        lastError: `worker_lease_lost: run_not_current; superseded by current run ${issueRecord.currentRunId}.`,
       };
       await this.store.saveRun(supersededRun);
       await this.store.appendRunEvent(run.runId, {
@@ -2453,28 +2546,6 @@ export class OrchestratorService {
       return this.restartRun(tenant, run, issueRecords, now, workerSessionId);
     }
 
-    if (workerInfo.exitClassification === "convergence-detected") {
-      const completedRun: OrchestratorRunRecord = {
-        ...runWithTokens,
-        status: "failed",
-        processId: null,
-        updatedAt: now.toISOString(),
-        completedAt: now.toISOString(),
-        nextRetryAt: null,
-        retryKind: null,
-        lastError: runWithTokens.lastError,
-        runPhase: runWithTokens.runPhase ?? "failed",
-      };
-      await this.store.saveRun(completedRun);
-      this.logVerbose(
-        `[run-completed] ${completedRun.runId} status=${completedRun.status}`
-      );
-      return {
-        issueRecords: releaseIssueOrchestration(issueRecords, run.issueId, now),
-        recovered: false,
-      };
-    }
-
     if (run.issueWorkspaceKey) {
       const issueWorkspacePath = resolveIssueWorkspaceDirectory(
         this.store.projectDir(tenant.projectId),
@@ -2504,13 +2575,47 @@ export class OrchestratorService {
       runWithTokens,
       now
     );
+    const convergenceDetected =
+      workerInfo.exitClassification === "convergence-detected";
+
+    if (convergenceDetected && !recovery) {
+      const trackerRecovery = await this.returnConvergedIssueToRetryableState(
+        tenant,
+        runWithTokens,
+        trackerDependencies
+      );
+      if (trackerRecovery.confirmed) {
+        const completedRun: OrchestratorRunRecord = {
+          ...runWithTokens,
+          issueState: trackerRecovery.state ?? runWithTokens.issueState,
+          status: "failed",
+          processId: null,
+          updatedAt: now.toISOString(),
+          completedAt: now.toISOString(),
+          nextRetryAt: null,
+          retryKind: null,
+          lastError: runWithTokens.lastError,
+          runPhase: runWithTokens.runPhase ?? "failed",
+        };
+        await this.store.saveRun(completedRun);
+        this.logVerbose(
+          `[run-completed] ${completedRun.runId} status=${completedRun.status}`
+        );
+        return {
+          issueRecords: releaseIssueOrchestration(
+            issueRecords,
+            run.issueId,
+            now
+          ),
+          recovered: false,
+        };
+      }
+    }
 
     // Determine retry kind: continuation (issue still actionable) vs failure
-    const retryKind = await this.classifyRetryKind(
-      tenant,
-      run,
-      trackerDependencies
-    );
+    const retryKind = convergenceDetected
+      ? "failure"
+      : await this.classifyRetryKind(tenant, run, trackerDependencies);
     const persistedRetryKind = recovery ? "recovery" : retryKind;
 
     const failureRetryCount =
@@ -2613,8 +2718,10 @@ export class OrchestratorService {
       lastTurnSummary:
         runWithTokens.lastTurnSummary ?? run.lastTurnSummary ?? null,
       runPhase: runWithTokens.runPhase ?? "failed",
-      lastError:
-        recovery || retryKind === "continuation"
+      lastError: convergenceDetected
+        ? (runWithTokens.lastError ??
+          "convergence_detected: repeated non-productive turns")
+        : recovery || retryKind === "continuation"
           ? null
           : "Worker process exited unexpectedly.",
       recovery,


### PR DESCRIPTION
## Issues — Closed #517

- Fixes #517

## TL;DR

- Fence dispatch and restart recovery to one durable current run per issue before worker spawn, including missing-owner and duplicate stale-record cases.
- Turn lease loss and clean-workspace convergence into explicit terminal/retryable outcomes, and reconcile dead/reused worker or daemon process records before they consume concurrency or receive signals.
- Address review edge cases: preserve surviving detached worker groups, prefer a live run when legacy ownership is absent, and resolve legacy daemon CWD from the selected repository.

## 변경 지점 다이어그램

```text
persisted active runs
        |
        v
group by issue -> keep valid owner / prefer live candidate -> persist fence
        |                                                |
        v                                                v
terminalize displaced records                    spawn/reconcile owner
        |                                                |
        +---------- explicit retry/lifecycle cleanup ----+

worker PID + start identity ----> status/concurrency reconciliation
daemon.pid + project lock + CWD -> safe repo stop resolution
```

## 여기부터 보세요

- `packages/orchestrator/src/service.ts` — issue-scoped owner selection, fence-before-spawn recovery, lease-loss/convergence outcomes, and worker process reconciliation.
- `packages/orchestrator/src/service.test.ts` — delayed/restarted recovery, dead-first duplicate ordering, lease loss, clean convergence, PID reuse, and surviving-process-group regressions.
- `packages/orchestrator/src/lock.ts` and `packages/cli/src/commands/stop.ts` — process identity/CWD lookup and stale `daemon.pid` fallback through the project lock.
- `e2e/scenarios/11-stale-run-recovery.md` — TC-11 acceptance mapping and Docker blackbox procedure.

## Changes

- Persist the selected issue owner before any recovery worker starts; preselect once per issue and prefer a live process when legacy state has no valid owner.
- Terminalize non-current workers with durable `worker_lease_lost: run_not_current` state and release their process accounting.
- Treat clean-workspace convergence as inconclusive/retryable and reconcile the tracker to the configured active state after confirmed readback.
- Persist process start identities, reject PID reuse, and preserve process-group liveness when a wrapper leader exits before its child.
- Persist daemon repository CWD; validate identity+CWD before signaling; recover a matching daemon from the project lock; use configured repository CWD for legacy PID records.
- Add TC-11 coverage and `.changeset/calm-runs-recover.md` for the required `@gh-symphony/cli` patch release.

## Evidence

- `pnpm lint` — passed across all workspace packages.
- `pnpm test` — passed across all workspace packages, including 228 orchestrator and 492 CLI tests.
- `pnpm typecheck` — passed across all workspace packages.
- `pnpm build` — passed across all workspace packages.
- `pnpm exec vitest run packages/orchestrator/src/service.test.ts` — 127 tests passed after review fixes.
- `pnpm exec vitest run packages/cli/src/commands/lifecycle.test.ts packages/core/src/core-conformance.test.ts` — 53 tests passed.
- `./e2e/run-e2e.sh fail 45` — passed in 12 seconds: running → continuation retry → idle with zero active runs.
- GitHub CI `Test` and `Container Smoke` — passed for head `0d21659`.
- Changeset: `.changeset/calm-runs-recover.md` (`@gh-symphony/cli`: patch).

## 위험 & 롤백

- Risk: restart recovery now chooses and persists one owner before record reconciliation; deterministic live/activity ranking and dead-first regression coverage constrain ambiguous legacy state.
- Risk: PID/CWD validation is platform-sensitive; Linux/macOS lookup paths and legacy/no-CWD behavior are covered by focused tests.
- Rollback: revert the issue-scoped commits. Added persisted identity/CWD fields remain backward-compatible because legacy missing fields retain guarded fallback behavior.

## 변경 파일

- Orchestrator runtime and tests: `packages/orchestrator/src/service.ts`, `packages/orchestrator/src/service.test.ts`, `packages/orchestrator/src/lock.ts`, `packages/orchestrator/src/lock.test.ts`, `packages/orchestrator/src/index.ts`.
- CLI lifecycle and tests: `packages/cli/src/commands/start.ts`, `packages/cli/src/commands/stop.ts`, `packages/cli/src/commands/start.test.ts`, `packages/cli/src/commands/lifecycle.test.ts`, `packages/cli/src/config.ts`, `packages/cli/src/config.test.ts`.
- Shared contract: `packages/core/src/contracts/status-surface.ts`.
- Validation/release: `e2e/scenarios/11-stale-run-recovery.md`, `.changeset/calm-runs-recover.md`.

## 머지 후/사람 확인

- [ ] Confirm restart recovery retains the correct live worker when legacy state contains multiple active records without `currentRunId`.
- [ ] Confirm clean convergence returns the Project item to the configured retryable active state instead of leaving false `In progress`.
- [ ] Confirm `repo status` releases dead/reused worker PIDs and `repo stop` diagnostics identify unresolved repository daemons clearly.
