### PR TITLE
fix(cli): clarify GitHub auth source failures

### DIFF
--- a/.changeset/clear-github-auth-sources.md
+++ b/.changeset/clear-github-auth-sources.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Report the GitHub authentication source used by CLI operations, aggregate failures across environment and `gh` credentials, and classify runtime authentication failures with typed errors for #448.

--- a/packages/cli/src/commands/start.test.ts
+++ b/packages/cli/src/commands/start.test.ts
@@ -378,6 +378,46 @@ describe("start command foreground locking", () => {
     expect(exitSpy).toHaveBeenCalledWith(0);
   });
 
+  it("warns when both auth sources are configured and names the source used", async () => {
+    const configDir = await createConfigFixture({
+      activeProject: "tenant-a",
+      projects: [createProject("tenant-a", "acme", "platform")],
+    });
+    ghAuthMocks.resolveGitHubAuth.mockResolvedValue({
+      source: "env",
+      token: "env-token",
+      login: "env-user",
+      scopes: ["repo", "read:org", "project"],
+      configuredSources: ["env", "gh"],
+    });
+    acquireProjectLock.mockResolvedValue({
+      lockPath: join(configDir, ".lock"),
+      ownerToken: "owner",
+      pid: 1234,
+      startedAt: "2026-03-17T00:00:00.000Z",
+    });
+    run.mockImplementation(async () => {
+      process.emit("SIGINT");
+    });
+    vi.spyOn(process, "exit").mockImplementation(
+      ((_code?: number) => undefined) as (code?: number) => never
+    );
+    const stderr = captureWrites(process.stderr);
+
+    try {
+      await startModule.default([], baseOptions(configDir));
+    } finally {
+      stderr.restore();
+    }
+
+    expect(stderr.output()).toContain(
+      "Both GITHUB_GRAPHQL_TOKEN and gh CLI authentication are configured"
+    );
+    expect(stderr.output()).toContain(
+      "This operation is using GITHUB_GRAPHQL_TOKEN"
+    );
+  });
+
   it("does not offer interactive gh remediation for env-token auth failures", async () => {
     const restoreTty = forceTty(true);
     const configDir = await createConfigFixture({
@@ -833,7 +873,7 @@ describe("start command foreground locking", () => {
     expect(exitSpy).toHaveBeenCalledWith(0);
   });
 
-  it("shuts down cleanly when a tick reports a GitHub auth failure", async () => {
+  it("does not classify snapshot error text as a GitHub auth failure", async () => {
     const configDir = await createConfigFixture({
       activeProject: "tenant-a",
       projects: [createProject("tenant-a", "acme", "platform")],
@@ -859,6 +899,7 @@ describe("start command foreground locking", () => {
         retryQueue: [],
         lastError: "Token is missing required GitHub scopes.",
       });
+      process.emit("SIGINT");
       await onTick?.({
         repository: { owner: "acme", name: "platform" },
         tracker: { adapter: "github-project", bindingId: "project-1" },
@@ -883,15 +924,12 @@ describe("start command foreground locking", () => {
       stderr.restore();
     }
 
-    expect(stderr.output()).toContain(
+    expect(stderr.output()).not.toContain(
       "Stopping repo start because GitHub authentication can no longer be validated."
-    );
-    expect(stderr.output()).toContain(
-      "Run 'gh auth refresh --scopes repo,read:org,project', then re-run 'gh-symphony repo start'."
     );
     expect(shutdown).toHaveBeenCalledTimes(1);
     expect(releaseProjectLock).toHaveBeenCalledWith(lock);
-    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(exitSpy).toHaveBeenCalledWith(0);
   });
 
   it("does not classify non-GitHub tracker 401 snapshots as GitHub auth failures", async () => {
@@ -1034,7 +1072,7 @@ describe("start command foreground locking", () => {
     expect(exitSpy).toHaveBeenCalledWith(1);
   });
 
-  it("retries the foreground run loop after a service.run error", async () => {
+  it("does not classify an untyped status 401 message as an auth error", async () => {
     const configDir = await createConfigFixture({
       activeProject: "tenant-a",
       projects: [createProject("tenant-a", "acme", "platform")],
@@ -1051,7 +1089,7 @@ describe("start command foreground locking", () => {
     run.mockImplementation(async () => {
       attempts += 1;
       if (attempts === 1) {
-        throw new Error("transient failure");
+        throw new Error("temporary proxy failure with status 401");
       }
 
       const onTick = serviceDependencies.at(-1)?.onTick as
@@ -1076,9 +1114,18 @@ describe("start command foreground locking", () => {
         ((_code?: number) => undefined) as (code?: number) => never
       );
 
-    await startModule.default([], baseOptions(configDir));
+    const stderr = captureWrites(process.stderr);
+
+    try {
+      await startModule.default([], baseOptions(configDir));
+    } finally {
+      stderr.restore();
+    }
 
     expect(run).toHaveBeenCalledTimes(2);
+    expect(stderr.output()).not.toContain(
+      "Stopping repo start because GitHub authentication can no longer be validated."
+    );
     expect(releaseProjectLock).toHaveBeenCalledWith(lock);
     expect(shutdown).toHaveBeenCalledTimes(1);
     expect(exitSpy).toHaveBeenCalledWith(0);

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -46,7 +46,7 @@ import { rejectRemovedProjectId } from "../removed-project-id.js";
 import { bold, dim, green, red, yellow, cyan, setNoColor } from "../ansi.js";
 import {
   formatGhAuthRemediation,
-  GhAuthError,
+  GitHubAuthError,
   type GitHubAuthSource,
   resolveGitHubAuth,
   runGhAuthLogin,
@@ -77,7 +77,7 @@ function isInteractiveTerminal(): boolean {
   return process.stdin.isTTY === true && process.stdout.isTTY === true;
 }
 
-function displayGhAuthError(error: GhAuthError): void {
+function displayGhAuthError(error: GitHubAuthError): void {
   const remediation = formatGhAuthRemediation(error, {
     retryCommand: REPO_START_COMMAND,
   });
@@ -92,7 +92,13 @@ function formatAuthSource(source: "env" | "gh"): string {
 function displayGitHubAuthSuccess(auth: {
   source: "env" | "gh";
   login: string;
+  configuredSources?: GitHubAuthSource[];
 }): void {
+  if ((auth.configuredSources?.length ?? 0) > 1) {
+    process.stderr.write(
+      `Warning: Both GITHUB_GRAPHQL_TOKEN and gh CLI authentication are configured. This operation is using ${formatAuthSource(auth.source)}.\n`
+    );
+  }
   process.stdout.write(
     `Authenticated via ${formatAuthSource(auth.source)} as ${auth.login}\n`
   );
@@ -107,7 +113,7 @@ async function resolveRepoStartGitHubAuth(input: {
     displayGitHubAuthSuccess(auth);
     return { ok: true, githubAuthSource: auth.source };
   } catch (error) {
-    if (!(error instanceof GhAuthError)) {
+    if (!(error instanceof GitHubAuthError)) {
       throw error;
     }
 
@@ -151,7 +157,7 @@ async function resolveRepoStartGitHubAuth(input: {
       displayGitHubAuthSuccess(auth);
       return { ok: true, githubAuthSource: auth.source };
     } catch (retryError) {
-      if (retryError instanceof GhAuthError) {
+      if (retryError instanceof GitHubAuthError) {
         displayGhAuthError(retryError);
         process.exitCode = 1;
         return { ok: false };
@@ -185,46 +191,35 @@ async function preflightRepoStartAuth(
   return { ok: true };
 }
 
-function isGitHubAuthRuntimeError(error: unknown): error is Error {
+type GitHubAuthRuntimeError =
+  | GitHubAuthError
+  | GitHubScopeError
+  | GitHubApiError;
+
+function isGitHubAuthRuntimeError(
+  error: unknown
+): error is GitHubAuthRuntimeError {
   if (error instanceof GitHubScopeError) {
     return true;
   }
-  if (error instanceof GhAuthError) {
+  if (error instanceof GitHubAuthError) {
     return error.code === "missing_scopes" || error.code === "invalid_token";
   }
   if (error instanceof GitHubApiError) {
     return error.status === 401;
   }
-  if (error instanceof Error) {
-    const maybeStatus = (error as { status?: unknown }).status;
-    if (maybeStatus === 401) {
-      return true;
-    }
-    const message = error.message.toLowerCase();
-    return (
-      message.includes("missing required github scopes") ||
-      message.includes("missing required scopes") ||
-      message.includes("missing required scope") ||
-      message.includes("missing_scopes") ||
-      message.includes("bad credentials") ||
-      message.includes("invalid token") ||
-      message.includes("authentication failed") ||
-      message.includes("status 401") ||
-      message.includes("401 unauthorized")
-    );
-  }
   return false;
 }
 
 function ghRuntimeErrorToAuthError(
-  error: Error,
+  error: GitHubAuthRuntimeError,
   source?: GitHubAuthSource
-): GhAuthError {
-  if (error instanceof GhAuthError) {
+): GitHubAuthError {
+  if (error instanceof GitHubAuthError) {
     return error;
   }
   if (error instanceof GitHubScopeError) {
-    return new GhAuthError(
+    return new GitHubAuthError(
       "missing_scopes",
       `GitHub token is missing required scopes: ${error.requiredScopes.join(", ")}`,
       {
@@ -234,14 +229,7 @@ function ghRuntimeErrorToAuthError(
       }
     );
   }
-  if (
-    error.message.toLowerCase().includes("missing required github scopes") ||
-    error.message.toLowerCase().includes("missing required scopes") ||
-    error.message.toLowerCase().includes("missing_scopes")
-  ) {
-    return new GhAuthError("missing_scopes", error.message, { source });
-  }
-  return new GhAuthError(
+  return new GitHubAuthError(
     "invalid_token",
     error.message || "GitHub token validation failed.",
     { source }
@@ -249,7 +237,7 @@ function ghRuntimeErrorToAuthError(
 }
 
 function displayRuntimeAuthShutdown(
-  error: Error,
+  error: GitHubAuthRuntimeError,
   source?: GitHubAuthSource
 ): void {
   const authError = ghRuntimeErrorToAuthError(error, source);
@@ -915,23 +903,6 @@ const handler = async (
         try {
           if (authShutdownRequested) {
             return;
-          }
-
-          if (
-            projectConfig.tracker.adapter === "github-project" &&
-            snapshot.lastError
-          ) {
-            const runtimeError = new Error(snapshot.lastError);
-            if (isGitHubAuthRuntimeError(runtimeError)) {
-              authShutdownRequested = true;
-              displayRuntimeAuthShutdown(
-                runtimeError,
-                authPreflight.githubAuthSource
-              );
-              process.exitCode = 1;
-              requestShutdown?.();
-              return;
-            }
           }
 
           logTickResult(snapshot, prevSnapshot, isFirst);

--- a/packages/cli/src/github/gh-auth.test.ts
+++ b/packages/cli/src/github/gh-auth.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { GitHubApiError } from "./client.js";
 import {
   GhAuthError,
+  GitHubAuthError,
   checkGhAuthenticated,
   checkGhInstalled,
   checkGhScopes,
@@ -527,7 +528,72 @@ describe("resolveGitHubAuth", () => {
       token: "ghp_good_token",
       login: "gh-user",
       scopes: ["repo", "read:org", "project"],
+      configuredSources: ["env", "gh"],
     });
+  });
+
+  it("reports both configured sources while using a valid env token", async () => {
+    process.env.GITHUB_GRAPHQL_TOKEN = "env-token";
+    const execImpl = vi.fn(() => "gh version 2.0.0") as ExecMock;
+    const spawnImpl = vi.fn(() =>
+      buildSpawnResult(0, "", "Logged in to github.com account gh-user")
+    ) as SpawnMock;
+
+    await expect(
+      resolveGitHubAuth({
+        execImpl,
+        spawnImpl,
+        createClientImpl: vi.fn((token: string) => ({ token })) as never,
+        validateTokenImpl: vi.fn(async () => ({
+          login: "env-user",
+          name: "Env User",
+          scopes: ["repo", "read:org", "project"],
+        })) as never,
+      })
+    ).resolves.toEqual({
+      source: "env",
+      token: "env-token",
+      login: "env-user",
+      scopes: ["repo", "read:org", "project"],
+      configuredSources: ["env", "gh"],
+    });
+  });
+
+  it("aggregates failures from the env token and gh CLI auth", async () => {
+    process.env.GITHUB_GRAPHQL_TOKEN = "bad-env-token";
+    const execImpl = vi.fn(() => "gh version 2.0.0") as ExecMock;
+    const spawnImpl = vi.fn(() =>
+      buildSpawnResult(1, "not logged in")
+    ) as SpawnMock;
+
+    const error = await resolveGitHubAuth({
+      execImpl,
+      spawnImpl,
+      createClientImpl: vi.fn((token: string) => ({ token })) as never,
+      validateTokenImpl: vi.fn(async () => {
+        throw new GitHubApiError("Bad credentials", 401);
+      }) as never,
+    }).catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(GitHubAuthError);
+    expect(error).toMatchObject({
+      code: "all_sources_failed",
+      details: {
+        attempts: [
+          {
+            source: "env",
+            code: "invalid_token",
+            message: "GITHUB_GRAPHQL_TOKEN is invalid or expired.",
+          },
+          {
+            source: "gh",
+            code: "not_authenticated",
+          },
+        ],
+      },
+    });
+    expect((error as Error).message).toContain("GITHUB_GRAPHQL_TOKEN");
+    expect((error as Error).message).toContain("gh CLI");
   });
 });
 

--- a/packages/cli/src/github/gh-auth.ts
+++ b/packages/cli/src/github/gh-auth.ts
@@ -20,6 +20,12 @@ type ExecError = Error & {
 export const REQUIRED_GH_SCOPES = ["repo", "read:org", "project"] as const;
 export type GitHubAuthSource = "env" | "gh";
 
+export type GitHubAuthAttemptFailure = {
+  source: GitHubAuthSource;
+  code: GitHubAuthError["code"];
+  message: string;
+};
+
 export type GhAuthRemediationResult = {
   mode: "login" | "refresh";
   status: "applied" | "manual";
@@ -27,25 +33,30 @@ export type GhAuthRemediationResult = {
   summary: string;
 };
 
-export class GhAuthError extends Error {
+export class GitHubAuthError extends Error {
   constructor(
     public readonly code:
       | "not_installed"
       | "not_authenticated"
       | "missing_scopes"
       | "token_failed"
-      | "invalid_token",
+      | "invalid_token"
+      | "all_sources_failed",
     message: string,
     public readonly details: {
       missingScopes?: string[];
       currentScopes?: string[];
       source?: GitHubAuthSource;
+      attempts?: GitHubAuthAttemptFailure[];
     } = {}
   ) {
     super(message);
-    this.name = "GhAuthError";
+    this.name = "GitHubAuthError";
   }
 }
+
+// Backward-compatible export for existing CLI consumers.
+export { GitHubAuthError as GhAuthError };
 
 export type GhAuthRemediation = {
   title: string;
@@ -59,6 +70,7 @@ export type ResolvedGitHubAuth = {
   token: string;
   login: string;
   scopes: string[];
+  configuredSources?: GitHubAuthSource[];
 };
 
 function ghTokenReadErrorMessage(): string {
@@ -81,7 +93,7 @@ function parseMissingScopes(message: string): string[] {
 }
 
 export function formatGhAuthRemediation(
-  error: GhAuthError,
+  error: GitHubAuthError,
   opts?: { retryCommand?: string }
 ): GhAuthRemediation {
   const retryCommand = opts?.retryCommand ?? "gh-symphony repo start";
@@ -149,9 +161,15 @@ export function formatGhAuthRemediation(
         hint: `Run '${command}' to re-authenticate, then re-run '${retryCommand}'.`,
       };
     }
+    case "all_sources_failed":
+      return {
+        title: "GitHub authentication sources failed",
+        message: error.message,
+        hint: `Update or unset GITHUB_GRAPHQL_TOKEN and verify 'gh auth status', then re-run '${retryCommand}'.`,
+      };
     default: {
       const exhaustive: never = error.code;
-      throw new Error(`Unhandled GhAuthError code: ${exhaustive}`);
+      throw new Error(`Unhandled GitHubAuthError code: ${exhaustive}`);
     }
   }
 }
@@ -159,14 +177,14 @@ export function formatGhAuthRemediation(
 function classifyTokenValidationError(
   error: unknown,
   source: GitHubAuthSource
-): GhAuthError {
-  if (error instanceof GhAuthError) {
+): GitHubAuthError {
+  if (error instanceof GitHubAuthError) {
     return error;
   }
 
   if (error instanceof GitHubApiError) {
     if (error.status === 401) {
-      return new GhAuthError(
+      return new GitHubAuthError(
         source === "env" ? "invalid_token" : "token_failed",
         source === "env"
           ? "GITHUB_GRAPHQL_TOKEN is invalid or expired."
@@ -179,7 +197,7 @@ function classifyTokenValidationError(
       source === "env"
         ? "GITHUB_GRAPHQL_TOKEN could not be validated"
         : "gh CLI token could not be validated";
-    return new GhAuthError("token_failed", `${prefix}: ${error.message}`, {
+    return new GitHubAuthError("token_failed", `${prefix}: ${error.message}`, {
       source,
     });
   }
@@ -189,12 +207,12 @@ function classifyTokenValidationError(
       source === "env"
         ? "GITHUB_GRAPHQL_TOKEN could not be validated"
         : "gh CLI token could not be validated";
-    return new GhAuthError("token_failed", `${prefix}: ${error.message}`, {
+    return new GitHubAuthError("token_failed", `${prefix}: ${error.message}`, {
       source,
     });
   }
 
-  return new GhAuthError(
+  return new GitHubAuthError(
     "token_failed",
     source === "env"
       ? "GITHUB_GRAPHQL_TOKEN could not be validated."
@@ -257,6 +275,24 @@ export function checkGhAuthenticated(opts?: {
 
   const login = parseLogin((result.stdout ?? "").toString());
   return { authenticated: true, login };
+}
+
+function hasConfiguredGhAuth(opts?: {
+  execImpl?: ExecImpl;
+  spawnImpl?: SpawnImpl;
+  hostname?: string;
+}): boolean {
+  try {
+    return (
+      checkGhInstalled({ execImpl: opts?.execImpl }) &&
+      checkGhAuthenticated({
+        spawnImpl: opts?.spawnImpl,
+        hostname: opts?.hostname,
+      }).authenticated
+    );
+  } catch {
+    return false;
+  }
 }
 
 export function checkGhScopes(opts?: {
@@ -345,16 +381,20 @@ export function getGhTokenWithSource(opts?: {
       .trim();
 
     if (!token) {
-      throw new GhAuthError("token_failed", ghTokenReadErrorMessage());
+      throw new GitHubAuthError("token_failed", ghTokenReadErrorMessage(), {
+        source: "gh",
+      });
     }
 
     return { token, source: "gh" };
   } catch (error) {
-    if (error instanceof GhAuthError) {
+    if (error instanceof GitHubAuthError) {
       throw error;
     }
 
-    throw new GhAuthError("token_failed", ghTokenReadErrorMessage());
+    throw new GitHubAuthError("token_failed", ghTokenReadErrorMessage(), {
+      source: "gh",
+    });
   }
 }
 
@@ -386,7 +426,7 @@ export async function validateGitHubToken(
   const scopeCheck = checkRequiredScopesImpl(viewer.scopes);
   if (!scopeCheck.valid) {
     if (source === "env") {
-      throw new GhAuthError(
+      throw new GitHubAuthError(
         "missing_scopes",
         `GITHUB_GRAPHQL_TOKEN is missing required scopes: ${scopeCheck.missing.join(", ")}`,
         {
@@ -397,7 +437,7 @@ export async function validateGitHubToken(
       );
     }
 
-    throw new GhAuthError(
+    throw new GitHubAuthError(
       "missing_scopes",
       missingGhScopesMessage(scopeCheck.missing),
       {
@@ -426,13 +466,16 @@ export async function resolveGitHubAuth(opts?: {
   checkRequiredScopesImpl?: typeof checkRequiredScopes;
 }): Promise<ResolvedGitHubAuth> {
   const envToken = getEnvGitHubToken();
-  let envError: GhAuthError | null = null;
+  let envError: GitHubAuthError | null = null;
 
   if (envToken) {
     try {
-      return await validateGitHubToken(envToken, "env", opts);
+      const resolved = await validateGitHubToken(envToken, "env", opts);
+      return hasConfiguredGhAuth(opts)
+        ? { ...resolved, configuredSources: ["env", "gh"] }
+        : resolved;
     } catch (error) {
-      if (error instanceof GhAuthError) {
+      if (error instanceof GitHubAuthError) {
         envError = error;
       } else {
         throw error;
@@ -442,10 +485,30 @@ export async function resolveGitHubAuth(opts?: {
 
   try {
     const auth = ensureGhAuth(opts);
-    return await validateGitHubToken(auth.token, "gh", opts);
+    const resolved = await validateGitHubToken(auth.token, "gh", opts);
+    return envToken
+      ? { ...resolved, configuredSources: ["env", "gh"] }
+      : resolved;
   } catch (error) {
-    if (envError && error instanceof GhAuthError) {
-      throw envError;
+    if (envError && error instanceof GitHubAuthError) {
+      const attempts: GitHubAuthAttemptFailure[] = [envError, error].map(
+        (failure) => ({
+          source: failure.details.source ?? "gh",
+          code: failure.code,
+          message: failure.message,
+        })
+      );
+      throw new GitHubAuthError(
+        "all_sources_failed",
+        [
+          "All configured GitHub authentication sources failed:",
+          ...attempts.map(
+            (attempt) =>
+              `- ${attempt.source === "env" ? "GITHUB_GRAPHQL_TOKEN" : "gh CLI"}: ${attempt.message}`
+          ),
+        ].join("\n"),
+        { attempts }
+      );
     }
     throw error;
   }
@@ -464,7 +527,7 @@ export function ensureGhAuth(opts?: {
   const spawnImpl = opts?.spawnImpl ?? spawnSync;
 
   if (!checkGhInstalled({ execImpl })) {
-    throw new GhAuthError(
+    throw new GitHubAuthError(
       "not_installed",
       "gh CLI is not installed. Install it from https://cli.github.com or set GITHUB_GRAPHQL_TOKEN.",
       { source: "gh" }
@@ -473,7 +536,7 @@ export function ensureGhAuth(opts?: {
 
   const auth = checkGhAuthenticated({ spawnImpl, hostname: opts?.hostname });
   if (!auth.authenticated) {
-    throw new GhAuthError(
+    throw new GitHubAuthError(
       "not_authenticated",
       "Run 'gh auth login --scopes repo,read:org,project' or set GITHUB_GRAPHQL_TOKEN.",
       { source: "gh" }
@@ -482,7 +545,7 @@ export function ensureGhAuth(opts?: {
 
   const scopeCheck = checkGhScopes({ spawnImpl, hostname: opts?.hostname });
   if (!scopeCheck.valid) {
-    throw new GhAuthError(
+    throw new GitHubAuthError(
       "missing_scopes",
       missingGhScopesMessage(scopeCheck.missing),
       {


### PR DESCRIPTION
## TL;DR

- CLI가 실제 사용한 GitHub 인증 소스를 명시하고, env 토큰과 `gh` 인증이 함께 구성되면 경고합니다.
- 두 인증 소스가 모두 실패하면 각 시도의 원인과 소스를 하나의 `GitHubAuthError`에 집계합니다.
- `status 401` 같은 문자열 휴리스틱을 제거하고 `GitHubAuthError`·`GitHubScopeError`·`GitHubApiError` 타입으로 런타임 인증 실패를 분류합니다.

## 변경 지점 다이어그램

```text
GITHUB_GRAPHQL_TOKEN ─┐
                     ├─ resolveGitHubAuth ─ source report / warning
gh CLI token ─────────┘         │
                                └─ typed failure aggregation
                                      │
GitHubAuthError / GitHubScopeError / GitHubApiError
                                      └─ repo start shutdown/remediation
```

## 여기부터 보세요

- `packages/cli/src/github/gh-auth.ts` — 인증 소스 선택, 복수 소스 실패 집계, `GitHubAuthError`
- `packages/cli/src/commands/start.ts` — 인증 소스 안내와 타입 기반 런타임 종료 분류
- `packages/cli/src/github/gh-auth.test.ts` — 복수 소스 구성·실패 집계 TC
- `packages/cli/src/commands/start.test.ts` — 문자열 401 오분류 방지와 소스 경고 TC

## Changes

- env 인증 성공 시에도 `gh` 인증 구성 여부를 감지해 `configuredSources`를 반환합니다.
- env 인증 실패 후 `gh` fallback도 실패하면 두 실패의 source/code/message를 보존합니다.
- 기존 `GhAuthError` export는 호환 alias로 유지하면서 명시적인 `GitHubAuthError`를 제공합니다.
- snapshot/error message 문자열 매칭을 제거해 네트워크·프록시 오류의 auth 오분류를 방지합니다.
- `@gh-symphony/cli` patch changeset을 추가했습니다.

## Evidence

- `pnpm --filter @gh-symphony/cli test -- gh-auth.test.ts start.test.ts` — pass (2 files, 64 tests)
- `pnpm --filter @gh-symphony/cli lint` — pass
- `pnpm --filter @gh-symphony/cli test` — pass (35 files, 493 tests)
- `pnpm --filter @gh-symphony/cli typecheck` — pass
- `pnpm --filter @gh-symphony/cli build` — pass
- `pnpm lint && pnpm test && pnpm typecheck && pnpm build` — pass
- GitHub Actions `Test`, `Container Smoke` — 이전 구현 commit에서 pass; changeset commit 결과 재확인 중
- Docker E2E — N/A (CLI 인증 진단·오류 분류 단위 변경이며 orchestrator dispatch/worker lifecycle은 변경하지 않음)

## 위험 & 롤백

- 위험: 타입드 오류로 승격되지 않은 인증성 오류는 일반 재시도 경로에 남습니다. 이는 네트워크 오류의 불필요 종료를 막기 위한 보수적 경계입니다.
- 호환성: `GhAuthError` alias를 유지해 기존 CLI 내부 소비자를 보호합니다.
- 롤백: 이 PR의 변경과 `.changeset/clear-github-auth-sources.md`를 함께 revert하면 기존 동작으로 복구됩니다.

## 변경 파일

- `packages/cli/src/github/gh-auth.ts`
- `packages/cli/src/github/gh-auth.test.ts`
- `packages/cli/src/commands/start.ts`
- `packages/cli/src/commands/start.test.ts`
- `.changeset/clear-github-auth-sources.md`

## Issues — Closed #448

- Closed #448

## 머지 후/사람 확인

- [ ] env 토큰과 `gh` CLI 인증을 함께 설정한 실제 환경에서 사용 소스 경고 문구 확인
- [ ] 만료된 env 토큰과 실패한 `gh` 인증 조합에서 두 소스의 진단이 함께 보이는지 확인
