### PR TITLE
fix(observability): redact free-form secrets

### DIFF
--- a/.changeset/redact-observability-tokens.md
+++ b/.changeset/redact-observability-tokens.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Redact free-form observability and doctor output secrets, including fine-grained GitHub PATs and URL-embedded credentials, for #442.

--- a/packages/cli/src/commands/doctor.test.ts
+++ b/packages/cli/src/commands/doctor.test.ts
@@ -1617,6 +1617,58 @@ describe("doctor command handler", () => {
     });
   });
 
+  it("redacts API error secrets from JSON output", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "doctor-json-redaction-"));
+    const workspaceDir = join(configDir, "workspaces");
+    await prepareDoctorPaths(configDir, workspaceDir);
+    const { repoDir, pathEnv } = await createWorkflowFixture();
+    const secret = "gho_11AA22bb33CC44dd55EE66ff";
+    const stdout = captureWrites(process.stdout);
+
+    try {
+      await withCwd(repoDir, () =>
+        runDoctorCommand(
+          ["--smoke"],
+          { ...baseOptions(configDir), json: true },
+          {
+            ...authDependencies(),
+            inspectManagedProjectSelection: async () => ({
+              kind: "resolved",
+              projectId: "tenant-a",
+              projectConfig: createProjectConfig(workspaceDir, "PVT_test", [
+                {
+                  owner: "acme",
+                  name: "widgets",
+                  url: "https://github.com/acme/widgets",
+                  cloneUrl: "https://github.com/acme/widgets.git",
+                },
+              ]),
+            }),
+            getProjectDetail: (async () =>
+              createProjectDetail() as never) as never,
+            fetchProjectIssues: (async () => {
+              throw new Error(`GitHub Project query failed with ${secret}`);
+            }) as never,
+            pathEnv,
+          }
+        )
+      );
+    } finally {
+      stdout.restore();
+    }
+
+    const report = JSON.parse(stdout.output()) as {
+      checks: Array<{
+        id: string;
+        details?: { error?: string };
+      }>;
+    };
+    expect(
+      report.checks.find((check) => check.id === "smoke_issue")?.details?.error
+    ).toBe("GitHub Project query failed with [REDACTED]");
+    expect(stdout.output()).not.toContain(secret);
+  });
+
   it("sets exit code 2 for invalid args", async () => {
     const configDir = await mkdtemp(join(tmpdir(), "doctor-config-"));
     const stderr = captureWrites(process.stderr);
@@ -1629,6 +1681,22 @@ describe("doctor command handler", () => {
 
     expect(process.exitCode).toBe(2);
     expect(stderr.output()).toContain("Usage: gh-symphony doctor");
+  });
+
+  it("redacts secrets from top-level stderr output", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "doctor-config-"));
+    const secret = "github_pat_11AA22bb33CC44dd55EE66ff";
+    const stderr = captureWrites(process.stderr);
+
+    try {
+      await doctorCommand([`--${secret}`], baseOptions(configDir));
+    } finally {
+      stderr.restore();
+    }
+
+    expect(process.exitCode).toBe(2);
+    expect(stderr.output()).toContain("[REDACTED]");
+    expect(stderr.output()).not.toContain(secret);
   });
 
   it("applies missing directory fixes and reports structured JSON remediation steps", async () => {
@@ -1923,7 +1991,8 @@ describe("doctor command handler", () => {
       "---\ntracker:\n  kind: github-project\ncodex:\n  command: fake-agent\n---\nAuthorization: Bearer abc123\n",
       "utf8"
     );
-    const outputPath = join(repoDir, "tmp", "support-bundle");
+    const outputSecret = "github_pat_11AA22bb33CC44dd55EE66ff";
+    const outputPath = join(repoDir, "tmp", `support-bundle-${outputSecret}`);
     const stdout = captureWrites(process.stdout);
 
     try {
@@ -1957,7 +2026,8 @@ describe("doctor command handler", () => {
       redactionClasses: Array<{ class: string; count: number }>;
       truncationCount: number;
     };
-    expect(summary.outputPath).toBe(outputPath);
+    expect(summary.outputPath).toContain("[REDACTED]");
+    expect(stdout.output()).not.toContain(outputSecret);
     expect(summary.includedCount).toBeGreaterThanOrEqual(9);
     expect(summary.missingCount).toBe(0);
     expect(summary.redactionCount).toBeGreaterThan(0);

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -4,6 +4,8 @@ import { access, mkdir, readFile, stat } from "node:fs/promises";
 import { isAbsolute, join, resolve } from "node:path";
 import {
   parseWorkflowMarkdown,
+  redactObservabilitySecrets,
+  redactObservabilityText,
   type ParsedWorkflow,
   type TrackedIssue,
 } from "@gh-symphony/core";
@@ -2661,6 +2663,15 @@ function renderBundleSummary(summary: SupportBundleSummary): string {
   ].join("\n");
 }
 
+function writeDoctorJson(value: unknown): void {
+  const redacted = redactObservabilitySecrets(value);
+  process.stdout.write(JSON.stringify(redacted, null, 2) + "\n");
+}
+
+function writeDoctorText(value: string): void {
+  process.stdout.write(redactObservabilityText(value) + "\n");
+}
+
 export async function runDoctorCommand(
   args: string[],
   options: GlobalOptions,
@@ -2688,9 +2699,9 @@ export async function runDoctorCommand(
         doctorReport: initialReport,
       });
       if (options.json) {
-        process.stdout.write(JSON.stringify(summary, null, 2) + "\n");
+        writeDoctorJson(summary);
       } else {
-        process.stdout.write(renderBundleSummary(summary) + "\n");
+        writeDoctorText(renderBundleSummary(summary));
       }
       process.exitCode = initialReport.ok ? 0 : 1;
       return;
@@ -2708,9 +2719,9 @@ export async function runDoctorCommand(
       );
       report.remediation = remediation;
       if (options.json) {
-        process.stdout.write(JSON.stringify(report, null, 2) + "\n");
+        writeDoctorJson(report);
       } else {
-        process.stdout.write(renderTextReport(report) + "\n");
+        writeDoctorText(renderTextReport(report));
       }
       process.exitCode = report.ok ? 0 : 1;
       return;
@@ -2718,14 +2729,16 @@ export async function runDoctorCommand(
 
     const report = initialReport;
     if (options.json) {
-      process.stdout.write(JSON.stringify(report, null, 2) + "\n");
+      writeDoctorJson(report);
     } else {
-      process.stdout.write(renderTextReport(report) + "\n");
+      writeDoctorText(renderTextReport(report));
     }
     process.exitCode = report.ok ? 0 : 1;
   } catch (error) {
     process.stderr.write(
-      `${error instanceof Error ? error.message : "Unknown error"}\n`
+      `${redactObservabilityText(
+        error instanceof Error ? error.message : "Unknown error"
+      )}\n`
     );
     process.exitCode = 2;
   }

--- a/packages/core/src/observability/redaction.test.ts
+++ b/packages/core/src/observability/redaction.test.ts
@@ -85,6 +85,8 @@ describe("redactObservabilitySecrets", () => {
         "callback https://example.test/path?custom_access_token=gho_11AA22bb33CC44dd55EE66ff&safe=yes",
       stderr: `CUSTOM_VALUE=${highEntropySecret}`,
       safe: "commit 0123456789abcdef0123456789abcdef01234567",
+      safePath: "/tmp/doctor-config-gMkszL/WORKFLOW.md",
+      safeArtifact: "gh-symphony-support-bundle-20260802-145748Z",
     });
     const output = JSON.stringify(redacted);
 
@@ -94,6 +96,8 @@ describe("redactObservabilitySecrets", () => {
         "callback https://example.test/path?custom_access_token=[REDACTED]&safe=yes",
       stderr: "CUSTOM_VALUE=[REDACTED]",
       safe: "commit 0123456789abcdef0123456789abcdef01234567",
+      safePath: "/tmp/doctor-config-gMkszL/WORKFLOW.md",
+      safeArtifact: "gh-symphony-support-bundle-20260802-145748Z",
     });
     expect(output).not.toContain("github_pat_");
     expect(output).not.toContain("gho_");

--- a/packages/core/src/observability/redaction.test.ts
+++ b/packages/core/src/observability/redaction.test.ts
@@ -229,6 +229,20 @@ describe("redactObservabilitySecrets", () => {
     }
   });
 
+  it("redacts complete YAML plain scalars without leaking words", () => {
+    const raw =
+      "password: correct horse battery staple # diagnostic\nstatus: failed";
+
+    const redacted = redactObservabilityTextWithStats(raw);
+
+    expect(redacted.value).toBe(
+      "password: [REDACTED] # diagnostic\nstatus: failed"
+    );
+    for (const fragment of ["correct", "horse", "battery", "staple"]) {
+      expect(redacted.value).not.toContain(fragment);
+    }
+  });
+
   it("redacts complete unquoted secret values containing punctuation", () => {
     const raw = ["GITHUB_TOKEN=abc,def", "CUSTOM_PASSWORD=abc;def"].join("\n");
 
@@ -349,14 +363,17 @@ describe("redactObservabilitySecrets", () => {
 
   it("redacts standard Base64 secrets containing slashes without masking paths", () => {
     const base64Secret = "Ab3dEf5hIj7kLm9nOp1q/Rs3tUv5wXy7zA9bCd2e";
-    const relativePath = ".runtime/projects/tenant-a/ENG-123/repository";
+    const slashPrefixedBase64Secret =
+      "/Ab3dEf5hIj7kLm9nOp1q/Rs3tUv5wXy7zA9bCd2e";
+    const relativePath = "runtime/projects/tenantA/ENG123/repository";
     const redacted = redactObservabilityTextWithStats(
-      `error: upstream opaque credential ${base64Secret}\nworking directory ${relativePath}\nartifact at /tmp/doctor-config-gMkszL/WORKFLOW.md`
+      `error: upstream opaque credential ${base64Secret}\nerror: slash-prefixed credential ${slashPrefixedBase64Secret}\nworking directory ${relativePath}\nartifact at /tmp/doctor-config-gMkszL/WORKFLOW.md`
     );
 
     expect(redacted.value).toBe(
-      `error: upstream opaque credential [REDACTED]\nworking directory ${relativePath}\nartifact at /tmp/doctor-config-gMkszL/WORKFLOW.md`
+      `error: upstream opaque credential [REDACTED]\nerror: slash-prefixed credential [REDACTED]\nworking directory ${relativePath}\nartifact at /tmp/doctor-config-gMkszL/WORKFLOW.md`
     );
     expect(redacted.value).not.toContain(base64Secret);
+    expect(redacted.value).not.toContain(slashPrefixedBase64Secret);
   });
 });

--- a/packages/core/src/observability/redaction.test.ts
+++ b/packages/core/src/observability/redaction.test.ts
@@ -243,6 +243,37 @@ describe("redactObservabilitySecrets", () => {
     }
   });
 
+  it("redacts YAML block scalar payloads through the indentation boundary", () => {
+    const raw = [
+      "config:",
+      "  password: |-",
+      "    correct horse battery staple",
+      "    second secret line",
+      "  status: failed",
+      "result: failed",
+    ].join("\n");
+
+    const redacted = redactObservabilityTextWithStats(raw);
+
+    expect(redacted.value).toBe(
+      [
+        "config:",
+        "  password: [REDACTED]",
+        "  status: failed",
+        "result: failed",
+      ].join("\n")
+    );
+    for (const fragment of [
+      "correct",
+      "horse",
+      "battery",
+      "staple",
+      "second secret line",
+    ]) {
+      expect(redacted.value).not.toContain(fragment);
+    }
+  });
+
   it("redacts complete unquoted secret values containing punctuation", () => {
     const raw = ["GITHUB_TOKEN=abc,def", "CUSTOM_PASSWORD=abc;def"].join("\n");
 
@@ -375,5 +406,13 @@ describe("redactObservabilitySecrets", () => {
     );
     expect(redacted.value).not.toContain(base64Secret);
     expect(redacted.value).not.toContain(slashPrefixedBase64Secret);
+  });
+
+  it("preserves absolute paths under arbitrary configured roots", () => {
+    const workingDirectory = "/data/workspaces/tenantA/ENG123/repository";
+
+    const redacted = redactObservabilitySecrets({ workingDirectory });
+
+    expect(redacted).toEqual({ workingDirectory });
   });
 });

--- a/packages/core/src/observability/redaction.test.ts
+++ b/packages/core/src/observability/redaction.test.ts
@@ -168,6 +168,38 @@ describe("redactObservabilitySecrets", () => {
     expect(redacted.redactions).toEqual([{ class: "secret_key", count: 2 }]);
   });
 
+  it("preserves JSON when a sensitive query parameter is last in a URL", () => {
+    const raw = JSON.stringify({
+      url: "https://example.test/?access_token=abc",
+      status: "failed",
+    });
+
+    const redacted = redactObservabilityTextWithStats(raw);
+
+    expect(JSON.parse(redacted.value)).toEqual({
+      url: "https://example.test/?access_token=[REDACTED]",
+      status: "failed",
+    });
+    expect(redacted.value).not.toContain("abc");
+  });
+
+  it("redacts quoted values containing escaped quotes without leaking fragments", () => {
+    const raw = JSON.stringify({
+      password: 'abc "def" rest',
+      status: "failed",
+    });
+
+    const redacted = redactObservabilityTextWithStats(raw);
+
+    expect(JSON.parse(redacted.value)).toEqual({
+      password: "[REDACTED]",
+      status: "failed",
+    });
+    for (const fragment of ["abc", "def", "rest"]) {
+      expect(redacted.value).not.toContain(fragment);
+    }
+  });
+
   it("reports structured and free-form redaction stats", () => {
     const structured = redactObservabilitySecretsWithStats({
       token: "ghp_xxx",

--- a/packages/core/src/observability/redaction.test.ts
+++ b/packages/core/src/observability/redaction.test.ts
@@ -165,7 +165,10 @@ describe("redactObservabilitySecrets", () => {
       { token: "[REDACTED]", message: "safe" },
       { custom_secret: "[REDACTED]", status: "failed" },
     ]);
-    expect(redacted.redactions).toEqual([{ class: "secret_key", count: 2 }]);
+    expect(redacted.redactions).toEqual([
+      { class: "env_token", count: 1 },
+      { class: "secret_key", count: 1 },
+    ]);
   });
 
   it("preserves JSON when a sensitive query parameter is last in a URL", () => {
@@ -270,7 +273,10 @@ describe("redactObservabilitySecrets", () => {
       { custom_secret: "[REDACTED]", status: "failed" },
       { password: "[REDACTED]", status: "failed" },
     ]);
-    expect(redacted.redactions).toEqual([{ class: "secret_key", count: 3 }]);
+    expect(redacted.redactions).toEqual([
+      { class: "env_token", count: 1 },
+      { class: "secret_key", count: 2 },
+    ]);
   });
 
   it("preserves token usage metrics in raw turn-completed NDJSON", () => {
@@ -295,7 +301,7 @@ describe("redactObservabilitySecrets", () => {
         totalTokens: 30,
       },
     });
-    expect(redacted.redactions).toEqual([{ class: "secret_key", count: 1 }]);
+    expect(redacted.redactions).toEqual([{ class: "env_token", count: 1 }]);
   });
 
   it("reports structured and free-form redaction stats", () => {
@@ -312,5 +318,31 @@ describe("redactObservabilitySecrets", () => {
       { class: "authorization_header", count: 1 },
       { class: "env_token", count: 1 },
     ]);
+  });
+
+  it("preserves redaction classes for raw assignments", () => {
+    const redacted = redactObservabilityTextWithStats(
+      ["GITHUB_TOKEN=abc", "OPENAI_API_KEY=def"].join("\n")
+    );
+
+    expect(redacted.value).toBe(
+      ["GITHUB_TOKEN=[REDACTED]", "OPENAI_API_KEY=[REDACTED]"].join("\n")
+    );
+    expect(redacted.redactions).toEqual([
+      { class: "api_key", count: 1 },
+      { class: "env_token", count: 1 },
+    ]);
+  });
+
+  it("redacts standard Base64 secrets containing slashes without masking paths", () => {
+    const base64Secret = "Ab3dEf5hIj7kLm9nOp1q/Rs3tUv5wXy7zA9bCd2e";
+    const redacted = redactObservabilityTextWithStats(
+      `error: upstream opaque credential ${base64Secret}\nartifact at /tmp/doctor-config-gMkszL/WORKFLOW.md`
+    );
+
+    expect(redacted.value).toBe(
+      "error: upstream opaque credential [REDACTED]\nartifact at /tmp/doctor-config-gMkszL/WORKFLOW.md"
+    );
+    expect(redacted.value).not.toContain(base64Secret);
   });
 });

--- a/packages/core/src/observability/redaction.test.ts
+++ b/packages/core/src/observability/redaction.test.ts
@@ -273,6 +273,31 @@ describe("redactObservabilitySecrets", () => {
     expect(redacted.redactions).toEqual([{ class: "secret_key", count: 3 }]);
   });
 
+  it("preserves token usage metrics in raw turn-completed NDJSON", () => {
+    const raw = JSON.stringify({
+      event: "turn_completed",
+      githubGraphqlToken: "abc",
+      tokenUsage: {
+        inputTokens: 20,
+        outputTokens: 10,
+        totalTokens: 30,
+      },
+    });
+
+    const redacted = redactObservabilityTextWithStats(raw);
+
+    expect(JSON.parse(redacted.value)).toEqual({
+      event: "turn_completed",
+      githubGraphqlToken: "[REDACTED]",
+      tokenUsage: {
+        inputTokens: 20,
+        outputTokens: 10,
+        totalTokens: 30,
+      },
+    });
+    expect(redacted.redactions).toEqual([{ class: "secret_key", count: 1 }]);
+  });
+
   it("reports structured and free-form redaction stats", () => {
     const structured = redactObservabilitySecretsWithStats({
       token: "ghp_xxx",

--- a/packages/core/src/observability/redaction.test.ts
+++ b/packages/core/src/observability/redaction.test.ts
@@ -215,6 +215,17 @@ describe("redactObservabilitySecrets", () => {
     }
   });
 
+  it("redacts YAML doubled-quote values without leaking fragments", () => {
+    const raw = "password: 'abc''def'\nstatus: failed";
+
+    const redacted = redactObservabilityTextWithStats(raw);
+
+    expect(redacted.value).toBe("password: '[REDACTED]'\nstatus: failed");
+    for (const fragment of ["abc", "def"]) {
+      expect(redacted.value).not.toContain(fragment);
+    }
+  });
+
   it("redacts complete unquoted secret values containing punctuation", () => {
     const raw = ["GITHUB_TOKEN=abc,def", "CUSTOM_PASSWORD=abc;def"].join("\n");
 
@@ -226,6 +237,22 @@ describe("redactObservabilitySecrets", () => {
     for (const fragment of ["abc", "def"]) {
       expect(redacted.value).not.toContain(fragment);
     }
+  });
+
+  it("preserves adjacent compact log fields after unquoted secrets", () => {
+    const raw = ["token=abc,status=failed", "password=abc;result=denied"].join(
+      "\n"
+    );
+
+    const redacted = redactObservabilityTextWithStats(raw);
+
+    expect(redacted.value).toBe(
+      [
+        "token=[REDACTED],status=failed",
+        "password=[REDACTED];result=denied",
+      ].join("\n")
+    );
+    expect(redacted.value).not.toContain("abc");
   });
 
   it("preserves JSON when redacting sensitive literal values", () => {

--- a/packages/core/src/observability/redaction.test.ts
+++ b/packages/core/src/observability/redaction.test.ts
@@ -215,6 +215,37 @@ describe("redactObservabilitySecrets", () => {
     }
   });
 
+  it("redacts complete unquoted secret values containing punctuation", () => {
+    const raw = ["GITHUB_TOKEN=abc,def", "CUSTOM_PASSWORD=abc;def"].join("\n");
+
+    const redacted = redactObservabilityTextWithStats(raw);
+
+    expect(redacted.value).toBe(
+      ["GITHUB_TOKEN=[REDACTED]", "CUSTOM_PASSWORD=[REDACTED]"].join("\n")
+    );
+    for (const fragment of ["abc", "def"]) {
+      expect(redacted.value).not.toContain(fragment);
+    }
+  });
+
+  it("preserves JSON when redacting sensitive literal values", () => {
+    const raw = [
+      '{"token":123,"status":"failed"}',
+      '{"custom_secret":false,"status":"failed"}',
+      '{"password":null,"status":"failed"}',
+    ].join("\n");
+
+    const redacted = redactObservabilityTextWithStats(raw);
+    const records = redacted.value.split("\n").map((line) => JSON.parse(line));
+
+    expect(records).toEqual([
+      { token: "[REDACTED]", status: "failed" },
+      { custom_secret: "[REDACTED]", status: "failed" },
+      { password: "[REDACTED]", status: "failed" },
+    ]);
+    expect(redacted.redactions).toEqual([{ class: "secret_key", count: 3 }]);
+  });
+
   it("reports structured and free-form redaction stats", () => {
     const structured = redactObservabilitySecretsWithStats({
       token: "ghp_xxx",

--- a/packages/core/src/observability/redaction.test.ts
+++ b/packages/core/src/observability/redaction.test.ts
@@ -58,16 +58,46 @@ describe("redactObservabilitySecrets", () => {
     expect(JSON.stringify(redacted)).not.toContain("lin_secret");
   });
 
-  it("keeps shared structured redaction key-focused", () => {
+  it("redacts secrets embedded in persisted free-form fields", () => {
     const redacted = redactObservabilitySecrets({
       event: "worker",
-      message: "token: ordinary-diagnostic-text",
+      message: "request failed with github_pat_11AA22bb33CC44dd55EE66ff",
+      error: "Authorization: token gho_11AA22bb33CC44dd55EE66ff",
+      reason: "upstream returned ghs_11AA22bb33CC44dd55EE66ff",
+      stderr: "CUSTOM_CREDENTIAL=plain-text-secret",
     });
 
     expect(redacted).toEqual({
       event: "worker",
-      message: "token: ordinary-diagnostic-text",
+      message: "request failed with [REDACTED]",
+      error: "Authorization: [REDACTED]",
+      reason: "upstream returned [REDACTED]",
+      stderr: "CUSTOM_CREDENTIAL=[REDACTED]",
     });
+  });
+
+  it("redacts URL credentials, sensitive query values, and opaque high-entropy values", () => {
+    const highEntropySecret = "A9fK2mP7qR4tV8xZ1bC6dE3gH5jL0nQs";
+    const redacted = redactObservabilitySecrets({
+      message:
+        "clone https://oauth2:github_pat_11AA22bb33CC44dd55EE66ff@github.com/org/repo",
+      reason:
+        "callback https://example.test/path?custom_access_token=gho_11AA22bb33CC44dd55EE66ff&safe=yes",
+      stderr: `CUSTOM_VALUE=${highEntropySecret}`,
+      safe: "commit 0123456789abcdef0123456789abcdef01234567",
+    });
+    const output = JSON.stringify(redacted);
+
+    expect(redacted).toEqual({
+      message: "clone https://[REDACTED]@github.com/org/repo",
+      reason:
+        "callback https://example.test/path?custom_access_token=[REDACTED]&safe=yes",
+      stderr: "CUSTOM_VALUE=[REDACTED]",
+      safe: "commit 0123456789abcdef0123456789abcdef01234567",
+    });
+    expect(output).not.toContain("github_pat_");
+    expect(output).not.toContain("gho_");
+    expect(output).not.toContain(highEntropySecret);
   });
 
   it("redacts structured and raw support diagnostics secrets with class counts", () => {
@@ -118,7 +148,7 @@ describe("redactObservabilitySecrets", () => {
     );
   });
 
-  it("reports key-only structured redaction stats without scanning strings", () => {
+  it("reports structured and free-form redaction stats", () => {
     const structured = redactObservabilitySecretsWithStats({
       token: "ghp_xxx",
       message: "Authorization: Bearer abc123",
@@ -126,8 +156,11 @@ describe("redactObservabilitySecrets", () => {
 
     expect(structured.value).toEqual({
       token: "[REDACTED]",
-      message: "Authorization: Bearer abc123",
+      message: "Authorization: [REDACTED]",
     });
-    expect(structured.redactions).toEqual([{ class: "env_token", count: 1 }]);
+    expect(structured.redactions).toEqual([
+      { class: "authorization_header", count: 1 },
+      { class: "env_token", count: 1 },
+    ]);
   });
 });

--- a/packages/core/src/observability/redaction.test.ts
+++ b/packages/core/src/observability/redaction.test.ts
@@ -183,6 +183,21 @@ describe("redactObservabilitySecrets", () => {
     expect(redacted.value).not.toContain("abc");
   });
 
+  it("preserves JSON delimiters when redacting Authorization values", () => {
+    const raw = JSON.stringify({
+      error: "Authorization: Basic YWJjZA==",
+      status: "failed",
+    });
+
+    const redacted = redactObservabilityTextWithStats(raw);
+
+    expect(JSON.parse(redacted.value)).toEqual({
+      error: "Authorization: [REDACTED]",
+      status: "failed",
+    });
+    expect(redacted.value).not.toContain("YWJjZA==");
+  });
+
   it("redacts quoted values containing escaped quotes without leaking fragments", () => {
     const raw = JSON.stringify({
       password: 'abc "def" rest',

--- a/packages/core/src/observability/redaction.test.ts
+++ b/packages/core/src/observability/redaction.test.ts
@@ -152,6 +152,22 @@ describe("redactObservabilitySecrets", () => {
     );
   });
 
+  it("preserves JSON and NDJSON syntax when redacting quoted values", () => {
+    const raw = [
+      '{"token":"abc def","message":"safe"}',
+      '{"custom_secret":"line one","status":"failed"}',
+    ].join("\n");
+
+    const redacted = redactObservabilityTextWithStats(raw);
+    const records = redacted.value.split("\n").map((line) => JSON.parse(line));
+
+    expect(records).toEqual([
+      { token: "[REDACTED]", message: "safe" },
+      { custom_secret: "[REDACTED]", status: "failed" },
+    ]);
+    expect(redacted.redactions).toEqual([{ class: "secret_key", count: 2 }]);
+  });
+
   it("reports structured and free-form redaction stats", () => {
     const structured = redactObservabilitySecretsWithStats({
       token: "ghp_xxx",

--- a/packages/core/src/observability/redaction.test.ts
+++ b/packages/core/src/observability/redaction.test.ts
@@ -242,6 +242,19 @@ describe("redactObservabilitySecrets", () => {
     }
   });
 
+  it("consumes JSON delimiter characters in raw assignments", () => {
+    const raw = ["GITHUB_TOKEN=abc}def", "CUSTOM_PASSWORD=one]two"].join("\n");
+
+    const redacted = redactObservabilityTextWithStats(raw);
+
+    expect(redacted.value).toBe(
+      ["GITHUB_TOKEN=[REDACTED]", "CUSTOM_PASSWORD=[REDACTED]"].join("\n")
+    );
+    for (const fragment of ["abc", "def", "one", "two"]) {
+      expect(redacted.value).not.toContain(fragment);
+    }
+  });
+
   it("preserves adjacent compact log fields after unquoted secrets", () => {
     const raw = ["token=abc,status=failed", "password=abc;result=denied"].join(
       "\n"
@@ -336,12 +349,13 @@ describe("redactObservabilitySecrets", () => {
 
   it("redacts standard Base64 secrets containing slashes without masking paths", () => {
     const base64Secret = "Ab3dEf5hIj7kLm9nOp1q/Rs3tUv5wXy7zA9bCd2e";
+    const relativePath = ".runtime/projects/tenant-a/ENG-123/repository";
     const redacted = redactObservabilityTextWithStats(
-      `error: upstream opaque credential ${base64Secret}\nartifact at /tmp/doctor-config-gMkszL/WORKFLOW.md`
+      `error: upstream opaque credential ${base64Secret}\nworking directory ${relativePath}\nartifact at /tmp/doctor-config-gMkszL/WORKFLOW.md`
     );
 
     expect(redacted.value).toBe(
-      "error: upstream opaque credential [REDACTED]\nartifact at /tmp/doctor-config-gMkszL/WORKFLOW.md"
+      `error: upstream opaque credential [REDACTED]\nworking directory ${relativePath}\nartifact at /tmp/doctor-config-gMkszL/WORKFLOW.md`
     );
     expect(redacted.value).not.toContain(base64Secret);
   });

--- a/packages/core/src/observability/redaction.test.ts
+++ b/packages/core/src/observability/redaction.test.ts
@@ -287,6 +287,48 @@ describe("redactObservabilitySecrets", () => {
     }
   });
 
+  it("redacts YAML block scalars with digit-first modifiers", () => {
+    const raw = [
+      "password: |2-",
+      "  correct horse battery staple",
+      "apiKey: |-2",
+      "  second secret line",
+      "status: failed",
+    ].join("\n");
+
+    const redacted = redactObservabilityTextWithStats(raw);
+
+    expect(redacted.value).toBe(
+      ["password: [REDACTED]", "apiKey: [REDACTED]", "status: failed"].join(
+        "\n"
+      )
+    );
+    expect(redacted.value).not.toContain("correct horse battery staple");
+    expect(redacted.value).not.toContain("second secret line");
+  });
+
+  it("preserves YAML siblings after sequence block scalar payloads", () => {
+    const raw = [
+      "items:",
+      "  - password: |-",
+      "      correct horse battery staple",
+      "    status: failed",
+      "next: ok",
+    ].join("\n");
+
+    const redacted = redactObservabilityTextWithStats(raw);
+
+    expect(redacted.value).toBe(
+      [
+        "items:",
+        "  - password: [REDACTED]",
+        "    status: failed",
+        "next: ok",
+      ].join("\n")
+    );
+    expect(redacted.value).not.toContain("correct horse battery staple");
+  });
+
   it("consumes JSON delimiter characters in raw assignments", () => {
     const raw = ["GITHUB_TOKEN=abc}def", "CUSTOM_PASSWORD=one]two"].join("\n");
 
@@ -362,6 +404,24 @@ describe("redactObservabilitySecrets", () => {
     expect(redacted.redactions).toEqual([{ class: "env_token", count: 1 }]);
   });
 
+  it("redacts sensitive JSON containers while preserving record syntax", () => {
+    const raw = [
+      '{"credentials":{"value":"container-secret"},"status":"failed"}',
+      '{"credentials":["first-secret","second-secret"],"status":"failed"}',
+    ].join("\n");
+
+    const redacted = redactObservabilityTextWithStats(raw);
+    const records = redacted.value.split("\n").map((line) => JSON.parse(line));
+
+    expect(records).toEqual([
+      { credentials: "[REDACTED]", status: "failed" },
+      { credentials: "[REDACTED]", status: "failed" },
+    ]);
+    expect(redacted.value).not.toContain("container-secret");
+    expect(redacted.value).not.toContain("first-secret");
+    expect(redacted.value).not.toContain("second-secret");
+  });
+
   it("reports structured and free-form redaction stats", () => {
     const structured = redactObservabilitySecretsWithStats({
       token: "ghp_xxx",
@@ -414,5 +474,18 @@ describe("redactObservabilitySecrets", () => {
     const redacted = redactObservabilitySecrets({ workingDirectory });
 
     expect(redacted).toEqual({ workingDirectory });
+  });
+
+  it("redacts slash-delimited Base64 that resembles a path without path context", () => {
+    const base64Secret = "/abc/DEF/Gh1jKl3mNo5pQr7sTu9vWxYzAbCdEfG";
+
+    const redacted = redactObservabilityTextWithStats(
+      `message: upstream opaque credential ${base64Secret}`
+    );
+
+    expect(redacted.value).toBe(
+      "message: upstream opaque credential [REDACTED]"
+    );
+    expect(redacted.value).not.toContain(base64Secret);
   });
 });

--- a/packages/core/src/observability/redaction.test.ts
+++ b/packages/core/src/observability/redaction.test.ts
@@ -488,4 +488,47 @@ describe("redactObservabilitySecrets", () => {
     );
     expect(redacted.value).not.toContain(base64Secret);
   });
+
+  it("requires path context before preserving readable slash-delimited candidates", () => {
+    const base64Secret = "abc/DEF/ghi/Jk1Lm3No5Pq7Rs9TuVwX";
+
+    const redacted = redactObservabilityTextWithStats(
+      `message: upstream credential ${base64Secret}`
+    );
+
+    expect(redacted.value).toBe("message: upstream credential [REDACTED]");
+    expect(redacted.value).not.toContain(base64Secret);
+  });
+
+  it("redacts complete YAML mapping and sequence containers", () => {
+    const raw = [
+      "credentials:",
+      "  - first-secret",
+      "  - second-secret",
+      "status: failed",
+      "password:",
+      "  primary: first-passphrase",
+      "  secondary: second-passphrase",
+      "result: denied",
+    ].join("\n");
+
+    const redacted = redactObservabilityTextWithStats(raw);
+
+    expect(redacted.value).toBe(
+      [
+        "credentials: [REDACTED]",
+        "status: failed",
+        "password: [REDACTED]",
+        "result: denied",
+      ].join("\n")
+    );
+    for (const fragment of [
+      "first-secret",
+      "second-secret",
+      "first-passphrase",
+      "second-passphrase",
+    ]) {
+      expect(redacted.value).not.toContain(fragment);
+    }
+  });
 });

--- a/packages/core/src/observability/redaction.ts
+++ b/packages/core/src/observability/redaction.ts
@@ -213,11 +213,12 @@ function replaceSensitiveKeyAndCount(
   return text.replace(pattern, (...args: unknown[]) => {
     const matched = typeof args[0] === "string" ? args[0] : "";
     const key = typeof args[2] === "string" ? args[2] : "";
-    if (!redactionClassForKey(key) || matched.includes(REDACTED)) {
+    const redactionClass = redactionClassForKey(key);
+    if (!redactionClass || matched.includes(REDACTED)) {
       return matched;
     }
 
-    incrementRedaction(counts, "secret_key");
+    incrementRedaction(counts, redactionClass);
     return replacement.replace(/\$(\d+)/g, (_placeholder, index: string) => {
       const group = args[Number.parseInt(index, 10)];
       return typeof group === "string" ? group : "";
@@ -229,7 +230,7 @@ function redactHighEntropyValues(
   text: string,
   counts: Map<RedactionClass, number>
 ): string {
-  return text.replace(/[A-Za-z0-9+_-]{32,}={0,2}/g, (candidate) => {
+  return text.replace(/[A-Za-z0-9+/_-]{32,}={0,2}/g, (candidate) => {
     const separatorCount = candidate.match(/[_-]/g)?.length ?? 0;
     if (
       separatorCount > 2 ||

--- a/packages/core/src/observability/redaction.ts
+++ b/packages/core/src/observability/redaction.ts
@@ -171,7 +171,14 @@ function redactTextValue(
   );
   redacted = replaceAndCount(
     redacted,
-    /((?:["'])?\b[A-Za-z0-9_.-]*(?:token|secret|api[-_.]?key|password|passwd|credential|private[-_.]?key)[A-Za-z0-9_.-]*(?:["'])?\s*[:=]\s*)(?!["']|\[REDACTED\])([^\s,;}\]"']+)/gi,
+    /((?:")?\b[A-Za-z0-9_.-]*(?:token|secret|api[-_.]?key|password|passwd|credential|private[-_.]?key)[A-Za-z0-9_.-]*(?:")?\s*:\s*)(-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?|true|false|null)(?=\s*[,}\]])/gi,
+    "secret_key",
+    counts,
+    '$1"[REDACTED]"'
+  );
+  redacted = replaceAndCount(
+    redacted,
+    /((?:["'])?\b[A-Za-z0-9_.-]*(?:token|secret|api[-_.]?key|password|passwd|credential|private[-_.]?key)[A-Za-z0-9_.-]*(?:["'])?\s*[:=]\s*)(?!["']|\[REDACTED\])([^\s}\]"']+)/gi,
     "secret_key",
     counts,
     "$1[REDACTED]"

--- a/packages/core/src/observability/redaction.ts
+++ b/packages/core/src/observability/redaction.ts
@@ -162,24 +162,21 @@ function redactTextValue(
     counts,
     "$1[REDACTED]"
   );
-  redacted = replaceAndCount(
+  redacted = replaceSensitiveKeyAndCount(
     redacted,
-    /((?:["'])?\b[A-Za-z0-9_.-]*(?:token|secret|api[-_.]?key|password|passwd|credential|private[-_.]?key)[A-Za-z0-9_.-]*(?:["'])?\s*[:=]\s*)(["'])((?:\\.|\2\2|(?!\2)[^\\])*)\2/gi,
-    "secret_key",
+    /((?:["'])?\b([A-Za-z0-9_.-]+)(?:["'])?\s*[:=]\s*)(["'])((?:\\.|\3\3|(?!\3)[^\\])*)\3/gi,
     counts,
-    "$1$2[REDACTED]$2"
+    "$1$3[REDACTED]$3"
   );
-  redacted = replaceAndCount(
+  redacted = replaceSensitiveKeyAndCount(
     redacted,
-    /((?:")?\b[A-Za-z0-9_.-]*(?:token|secret|api[-_.]?key|password|passwd|credential|private[-_.]?key)[A-Za-z0-9_.-]*(?:")?\s*:\s*)(-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?|true|false|null)(?=\s*[,}\]])/gi,
-    "secret_key",
+    /((?:")?\b([A-Za-z0-9_.-]+)(?:")?\s*:\s*)(-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?|true|false|null)(?=\s*[,}\]])/gi,
     counts,
     '$1"[REDACTED]"'
   );
-  redacted = replaceAndCount(
+  redacted = replaceSensitiveKeyAndCount(
     redacted,
-    /((?:["'])?\b[A-Za-z0-9_.-]*(?:token|secret|api[-_.]?key|password|passwd|credential|private[-_.]?key)[A-Za-z0-9_.-]*(?:["'])?\s*[:=]\s*)(?!["']|\[REDACTED\])([^\s}\]"']+?)(?=[,;](?=[A-Za-z0-9_.-]+\s*=)|\s|[}\]"']|$)/gi,
-    "secret_key",
+    /((?:["'])?\b([A-Za-z0-9_.-]+)(?:["'])?\s*[:=]\s*)(?!["']|\[REDACTED\])([^\s}\]"']+?)(?=[,;](?=[A-Za-z0-9_.-]+\s*=)|\s|[}\]"']|$)/gi,
     counts,
     "$1[REDACTED]"
   );
@@ -205,6 +202,27 @@ function redactTextValue(
     "[REDACTED]"
   );
   return redactHighEntropyValues(redacted, counts);
+}
+
+function replaceSensitiveKeyAndCount(
+  text: string,
+  pattern: RegExp,
+  counts: Map<RedactionClass, number>,
+  replacement: string
+): string {
+  return text.replace(pattern, (...args: unknown[]) => {
+    const matched = typeof args[0] === "string" ? args[0] : "";
+    const key = typeof args[2] === "string" ? args[2] : "";
+    if (!redactionClassForKey(key) || matched.includes(REDACTED)) {
+      return matched;
+    }
+
+    incrementRedaction(counts, "secret_key");
+    return replacement.replace(/\$(\d+)/g, (_placeholder, index: string) => {
+      const group = args[Number.parseInt(index, 10)];
+      return typeof group === "string" ? group : "";
+    });
+  });
 }
 
 function redactHighEntropyValues(

--- a/packages/core/src/observability/redaction.ts
+++ b/packages/core/src/observability/redaction.ts
@@ -176,7 +176,13 @@ function redactTextValue(
   );
   redacted = replaceSensitiveKeyAndCount(
     redacted,
-    /((?:["'])?\b([A-Za-z0-9_.-]+)(?:["'])?\s*[:=]\s*)(?!["']|\[REDACTED\])([^\s}\]"']+?)(?=[,;](?=[A-Za-z0-9_.-]+\s*=)|\s|[}\]"']|$)/gi,
+    /((?:["'])?\b([A-Za-z0-9_.-]+)(?:["'])?\s*=\s*)(?!["']|\[REDACTED\])([^\s]+?)(?=[,;](?=[A-Za-z0-9_.-]+\s*=)|\s|$)/gi,
+    counts,
+    "$1[REDACTED]"
+  );
+  redacted = replaceSensitiveKeyAndCount(
+    redacted,
+    /((?:["'])?\b([A-Za-z0-9_.-]+)(?:["'])?\s*:\s*)(?!["']|\[REDACTED\])([^\s}\]"']+?)(?=[,;](?=[A-Za-z0-9_.-]+\s*=)|\s|[}\]"']|$)/gi,
     counts,
     "$1[REDACTED]"
   );
@@ -230,21 +236,52 @@ function redactHighEntropyValues(
   text: string,
   counts: Map<RedactionClass, number>
 ): string {
-  return text.replace(/[A-Za-z0-9+/_-]{32,}={0,2}/g, (candidate) => {
-    const separatorCount = candidate.match(/[_-]/g)?.length ?? 0;
-    if (
-      separatorCount > 2 ||
-      !/[a-z]/.test(candidate) ||
-      !/[A-Z]/.test(candidate) ||
-      !/\d/.test(candidate) ||
-      shannonEntropy(candidate) < 4
-    ) {
-      return candidate;
-    }
+  return text.replace(
+    /[A-Za-z0-9+/_-]{32,}={0,2}/g,
+    (candidate, offset: number, source: string) => {
+      if (isLikelyFilesystemPath(candidate, source, offset)) {
+        return candidate;
+      }
 
-    incrementRedaction(counts, "secret_key");
-    return REDACTED;
-  });
+      const separatorCount = candidate.match(/[_-]/g)?.length ?? 0;
+      if (
+        separatorCount > 2 ||
+        !/[a-z]/.test(candidate) ||
+        !/[A-Z]/.test(candidate) ||
+        !/\d/.test(candidate) ||
+        shannonEntropy(candidate) < 4
+      ) {
+        return candidate;
+      }
+
+      incrementRedaction(counts, "secret_key");
+      return REDACTED;
+    }
+  );
+}
+
+function isLikelyFilesystemPath(
+  candidate: string,
+  source: string,
+  offset: number
+): boolean {
+  const segments = candidate.split("/");
+  if (segments.length < 3) {
+    return false;
+  }
+
+  const preceding = source[offset - 1] ?? "";
+  const startsAtPathBoundary =
+    offset === 0 || /[\s([{"'=]/.test(preceding) || preceding === ".";
+  if (!startsAtPathBoundary) {
+    return false;
+  }
+
+  if (candidate.startsWith("/") || preceding === ".") {
+    return true;
+  }
+
+  return segments.some((segment) => /[-_]/.test(segment));
 }
 
 function shannonEntropy(value: string): number {

--- a/packages/core/src/observability/redaction.ts
+++ b/packages/core/src/observability/redaction.ts
@@ -136,7 +136,7 @@ function redactTextValue(
 ): string {
   let redacted = replaceAndCount(
     text,
-    /\b(Authorization\s*[:=]\s*)(?:Bearer\s+|Basic\s+|token\s+)?([^\s,;]+)/gi,
+    /\b(Authorization\s*[:=]\s*)(?:Bearer\s+|Basic\s+|token\s+)?([^\s,;"'}\]]+)/gi,
     "authorization_header",
     counts,
     "$1[REDACTED]"

--- a/packages/core/src/observability/redaction.ts
+++ b/packages/core/src/observability/redaction.ts
@@ -182,6 +182,13 @@ function redactTextValue(
   );
   redacted = replaceSensitiveKeyAndCount(
     redacted,
+    /(^|\r?\n)([ \t]*)(-\s+)?([A-Za-z0-9_.-]+)(\s*:\s+)(?!["']|\[REDACTED\])([^\r\n]*?\S)([ \t]+#.*)?(?=\r?\n|$)/gm,
+    counts,
+    "$1$2$3$4$5[REDACTED]$7",
+    4
+  );
+  redacted = replaceSensitiveKeyAndCount(
+    redacted,
     /((?:["'])?\b([A-Za-z0-9_.-]+)(?:["'])?\s*:\s*)(?!["']|\[REDACTED\])([^\s}\]"']+?)(?=[,;](?=[A-Za-z0-9_.-]+\s*=)|\s|[}\]"']|$)/gi,
     counts,
     "$1[REDACTED]"
@@ -214,11 +221,13 @@ function replaceSensitiveKeyAndCount(
   text: string,
   pattern: RegExp,
   counts: Map<RedactionClass, number>,
-  replacement: string
+  replacement: string,
+  keyGroupIndex = 2
 ): string {
   return text.replace(pattern, (...args: unknown[]) => {
     const matched = typeof args[0] === "string" ? args[0] : "";
-    const key = typeof args[2] === "string" ? args[2] : "";
+    const key =
+      typeof args[keyGroupIndex] === "string" ? args[keyGroupIndex] : "";
     const redactionClass = redactionClassForKey(key);
     if (!redactionClass || matched.includes(REDACTED)) {
       return matched;
@@ -277,11 +286,50 @@ function isLikelyFilesystemPath(
     return false;
   }
 
-  if (candidate.startsWith("/") || preceding === ".") {
+  if (preceding === ".") {
     return true;
   }
 
-  return segments.some((segment) => /[-_]/.test(segment));
+  const firstSegment = (candidate.startsWith("/") ? segments[1] : segments[0])
+    .replace(/^\/+/, "")
+    .toLowerCase();
+  const knownPathRoot = new Set([
+    "bin",
+    "dev",
+    "etc",
+    "home",
+    "opt",
+    "private",
+    "proc",
+    "root",
+    "run",
+    "srv",
+    "sys",
+    "tmp",
+    "usr",
+    "var",
+    "users",
+    "workspace",
+    "workspaces",
+  ]);
+  if (knownPathRoot.has(firstSegment)) {
+    return true;
+  }
+
+  const pathContext = source.slice(Math.max(0, offset - 80), offset);
+  if (
+    /\b(?:artifact|cwd|directory|file|path|repo(?:sitory)?|workspace|working\s+directory)\s*(?:is|at|=|:)?\s*$/i.test(
+      pathContext
+    )
+  ) {
+    return true;
+  }
+
+  return (
+    firstSegment === "runtime" ||
+    firstSegment === "project" ||
+    firstSegment === "projects"
+  );
 }
 
 function shannonEntropy(value: string): number {

--- a/packages/core/src/observability/redaction.ts
+++ b/packages/core/src/observability/redaction.ts
@@ -204,9 +204,11 @@ function redactHighEntropyValues(
   text: string,
   counts: Map<RedactionClass, number>
 ): string {
-  return text.replace(/[A-Za-z0-9+/_-]{32,}={0,2}/g, (candidate) => {
+  return text.replace(/[A-Za-z0-9+_-]{32,}={0,2}/g, (candidate) => {
+    const separatorCount = candidate.match(/[_-]/g)?.length ?? 0;
     if (
       candidate.includes(REDACTED) ||
+      separatorCount > 2 ||
       !/[a-z]/.test(candidate) ||
       !/[A-Z]/.test(candidate) ||
       !/\d/.test(candidate) ||

--- a/packages/core/src/observability/redaction.ts
+++ b/packages/core/src/observability/redaction.ts
@@ -2,9 +2,16 @@ const REDACTED = "[REDACTED]";
 const SENSITIVE_KEY_SUBSTRINGS = [
   "authorization",
   "secret",
-  "apiKey",
+  "apikey",
   "api-key",
   "api_key",
+  "api.key",
+  "credential",
+  "password",
+  "passwd",
+  "privatekey",
+  "private-key",
+  "private_key",
 ];
 
 export type RedactionClass =
@@ -32,7 +39,7 @@ export function redactObservabilitySecretsWithStats<T>(
 ): RedactionResult<T> {
   const counts = createRedactionCounts();
   const redacted = redactValue(value, counts, {
-    redactStringValues: false,
+    redactStringValues: true,
   }) as T;
   return { value: redacted, redactions: summarizeRedactionCounts(counts) };
 }
@@ -129,7 +136,7 @@ function redactTextValue(
 ): string {
   let redacted = replaceAndCount(
     text,
-    /\b(Authorization\s*:\s*Bearer\s+)([^\s]+)/gi,
+    /\b(Authorization\s*[:=]\s*)(?:Bearer\s+|Basic\s+|token\s+)?([^\s,;]+)/gi,
     "authorization_header",
     counts,
     "$1[REDACTED]"
@@ -143,49 +150,35 @@ function redactTextValue(
   );
   redacted = replaceAndCount(
     redacted,
-    /^([A-Z0-9_]*(?:TOKEN)\w*\s*=\s*)([^\s]+)/gim,
-    "env_token",
+    /(https?:\/\/)([^\s/@]+@)/gi,
+    "secret_key",
     counts,
-    "$1[REDACTED]"
+    "$1[REDACTED]@"
   );
   redacted = replaceAndCount(
     redacted,
-    /^([A-Z0-9_]*(?:API_KEY)\w*\s*=\s*)([^\s]+)/gim,
-    "api_key",
-    counts,
-    "$1[REDACTED]"
-  );
-  redacted = replaceAndCount(
-    redacted,
-    /^([A-Z0-9_]*(?:SECRET)\w*\s*=\s*)([^\s]+)/gim,
+    /([?&](?:[^\s&#=]*(?:token|secret|api[-_.]?key|password|passwd|credential|authorization)[^\s&#=]*)=)([^\s&#]*)/gi,
     "secret_key",
     counts,
     "$1[REDACTED]"
   );
   redacted = replaceAndCount(
     redacted,
-    /((?:"token"|'token'|token)\s*:\s*)(?:"([^"]*)"|'([^']*)'|([^\s,}\]]+))/gi,
-    "env_token",
-    counts,
-    '$1"[REDACTED]"'
-  );
-  redacted = replaceAndCount(
-    redacted,
-    /((?:"secret"|'secret'|secret)\s*:\s*)(?:"([^"]*)"|'([^']*)'|([^\s,}\]]+))/gi,
+    /((?:["'])?\b[A-Za-z0-9_.-]*(?:token|secret|api[-_.]?key|password|passwd|credential|private[-_.]?key)[A-Za-z0-9_.-]*(?:["'])?\s*[:=]\s*)(["'])(.*?)\2/gi,
     "secret_key",
     counts,
-    '$1"[REDACTED]"'
+    "$1$2[REDACTED]$2"
   );
   redacted = replaceAndCount(
     redacted,
-    /((?:"apiKey"|'apiKey'|apiKey)\s*:\s*)(?:"([^"]*)"|'([^']*)'|([^\s,}\]]+))/g,
-    "api_key",
+    /((?:["'])?\b[A-Za-z0-9_.-]*(?:token|secret|api[-_.]?key|password|passwd|credential|private[-_.]?key)[A-Za-z0-9_.-]*(?:["'])?\s*[:=]\s*)(?!\[REDACTED\])([^\s,;}\]]+)/gi,
+    "secret_key",
     counts,
-    '$1"[REDACTED]"'
+    "$1[REDACTED]"
   );
   redacted = replaceAndCount(
     redacted,
-    /\bghp_[A-Za-z0-9_]+/g,
+    /\b(?:github_pat_|gh[pousr]_)[A-Za-z0-9_]+/g,
     "env_token",
     counts,
     "[REDACTED]"
@@ -204,7 +197,39 @@ function redactTextValue(
     counts,
     "[REDACTED]"
   );
-  return redacted;
+  return redactHighEntropyValues(redacted, counts);
+}
+
+function redactHighEntropyValues(
+  text: string,
+  counts: Map<RedactionClass, number>
+): string {
+  return text.replace(/[A-Za-z0-9+/_-]{32,}={0,2}/g, (candidate) => {
+    if (
+      candidate.includes(REDACTED) ||
+      !/[a-z]/.test(candidate) ||
+      !/[A-Z]/.test(candidate) ||
+      !/\d/.test(candidate) ||
+      shannonEntropy(candidate) < 4
+    ) {
+      return candidate;
+    }
+
+    incrementRedaction(counts, "secret_key");
+    return REDACTED;
+  });
+}
+
+function shannonEntropy(value: string): number {
+  const frequencies = new Map<string, number>();
+  for (const character of value) {
+    frequencies.set(character, (frequencies.get(character) ?? 0) + 1);
+  }
+
+  return Array.from(frequencies.values()).reduce((entropy, frequency) => {
+    const probability = frequency / value.length;
+    return entropy - probability * Math.log2(probability);
+  }, 0);
 }
 
 function replaceAndCount(

--- a/packages/core/src/observability/redaction.ts
+++ b/packages/core/src/observability/redaction.ts
@@ -162,6 +162,7 @@ function redactTextValue(
     counts,
     "$1[REDACTED]"
   );
+  redacted = redactSensitiveJsonContainers(redacted, counts);
   redacted = replaceSensitiveKeyAndCount(
     redacted,
     /((?:["'])?\b([A-Za-z0-9_.-]+)(?:["'])?\s*[:=]\s*)(["'])((?:\\.|\3\3|(?!\3)[^\\])*)\3/gi,
@@ -242,6 +243,102 @@ function replaceSensitiveKeyAndCount(
   });
 }
 
+function redactSensitiveJsonContainers(
+  text: string,
+  counts: Map<RedactionClass, number>
+): string {
+  const keyPattern = /("(?:\\.|[^"\\])*")\s*:\s*(\{|\[)/g;
+  let redacted = "";
+  let cursor = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = keyPattern.exec(text)) !== null) {
+    const preceding = previousNonWhitespaceCharacter(text, match.index - 1);
+    if (preceding !== "{" && preceding !== ",") {
+      continue;
+    }
+
+    let key: string;
+    try {
+      key = JSON.parse(match[1]) as string;
+    } catch {
+      continue;
+    }
+
+    const redactionClass = redactionClassForKey(key);
+    if (!redactionClass) {
+      continue;
+    }
+
+    const containerStart = match.index + match[0].length - 1;
+    const containerEnd = findJsonContainerEnd(text, containerStart);
+    if (containerEnd === null) {
+      continue;
+    }
+
+    redacted += text.slice(cursor, containerStart);
+    redacted += `"${REDACTED}"`;
+    cursor = containerEnd;
+    keyPattern.lastIndex = containerEnd;
+    incrementRedaction(counts, redactionClass);
+  }
+
+  return cursor === 0 ? text : redacted + text.slice(cursor);
+}
+
+function previousNonWhitespaceCharacter(text: string, end: number): string {
+  for (let index = end; index >= 0; index -= 1) {
+    if (!/\s/.test(text[index])) {
+      return text[index];
+    }
+  }
+  return "";
+}
+
+function findJsonContainerEnd(text: string, start: number): number | null {
+  const opening = text[start];
+  if (opening !== "{" && opening !== "[") {
+    return null;
+  }
+
+  const containers: string[] = [];
+  let inString = false;
+  let escaped = false;
+
+  for (let index = start; index < text.length; index += 1) {
+    const character = text[index];
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (character === "\\") {
+        escaped = true;
+      } else if (character === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (character === '"') {
+      inString = true;
+      continue;
+    }
+    if (character === "{" || character === "[") {
+      containers.push(character === "{" ? "}" : "]");
+      continue;
+    }
+    if (character === "}" || character === "]") {
+      if (containers.pop() !== character) {
+        return null;
+      }
+      if (containers.length === 0) {
+        return index + 1;
+      }
+    }
+  }
+
+  return null;
+}
+
 function redactHighEntropyValues(
   text: string,
   counts: Map<RedactionClass, number>
@@ -292,7 +389,11 @@ function isLikelyFilesystemPath(
   }
 
   const pathSegments = candidate.startsWith("/") ? segments.slice(1) : segments;
-  if (pathSegments.some(isReadableFilesystemSegment)) {
+  const readableSegments = pathSegments.filter(isReadableFilesystemSegment);
+  if (
+    readableSegments.length >= 3 ||
+    pathSegments.some((segment) => segment.includes("."))
+  ) {
     return true;
   }
 
@@ -333,7 +434,7 @@ function redactYamlBlockScalars(
 
   for (let index = 0; index < lines.length; index += 1) {
     const match =
-      /^([ \t]*)(-\s+)?([A-Za-z0-9_.-]+)(\s*:\s+)(?!["']|\[REDACTED\])([|>])(?:[-+]?\d?)([ \t]+#.*)?$/.exec(
+      /^([ \t]*)(-\s+)?([A-Za-z0-9_.-]+)(\s*:\s+)(?!["']|\[REDACTED\])([|>])(?:[-+]?\d?|\d[-+]?)?([ \t]+#.*)?$/.exec(
         lines[index].content
       );
     if (!match) {
@@ -345,7 +446,7 @@ function redactYamlBlockScalars(
       continue;
     }
 
-    const headerIndent = match[1].length;
+    const headerIndent = match[1].length + (match[2]?.length ?? 0);
     let end = index + 1;
     let hasPayload = false;
     while (end < lines.length) {

--- a/packages/core/src/observability/redaction.ts
+++ b/packages/core/src/observability/redaction.ts
@@ -171,7 +171,7 @@ function redactTextValue(
   );
   redacted = replaceAndCount(
     redacted,
-    /((?:["'])?\b[A-Za-z0-9_.-]*(?:token|secret|api[-_.]?key|password|passwd|credential|private[-_.]?key)[A-Za-z0-9_.-]*(?:["'])?\s*[:=]\s*)(?!\[REDACTED\])([^\s,;}\]]+)/gi,
+    /((?:["'])?\b[A-Za-z0-9_.-]*(?:token|secret|api[-_.]?key|password|passwd|credential|private[-_.]?key)[A-Za-z0-9_.-]*(?:["'])?\s*[:=]\s*)(?!["']|\[REDACTED\])([^\s,;}\]"']+)/gi,
     "secret_key",
     counts,
     "$1[REDACTED]"

--- a/packages/core/src/observability/redaction.ts
+++ b/packages/core/src/observability/redaction.ts
@@ -157,14 +157,14 @@ function redactTextValue(
   );
   redacted = replaceAndCount(
     redacted,
-    /([?&](?:[^\s&#=]*(?:token|secret|api[-_.]?key|password|passwd|credential|authorization)[^\s&#=]*)=)([^\s&#]*)/gi,
+    /([?&](?:[^\s&#=]*(?:token|secret|api[-_.]?key|password|passwd|credential|authorization)[^\s&#=]*)=)([^\s&#"'}\]]*)/gi,
     "secret_key",
     counts,
     "$1[REDACTED]"
   );
   redacted = replaceAndCount(
     redacted,
-    /((?:["'])?\b[A-Za-z0-9_.-]*(?:token|secret|api[-_.]?key|password|passwd|credential|private[-_.]?key)[A-Za-z0-9_.-]*(?:["'])?\s*[:=]\s*)(["'])(.*?)\2/gi,
+    /((?:["'])?\b[A-Za-z0-9_.-]*(?:token|secret|api[-_.]?key|password|passwd|credential|private[-_.]?key)[A-Za-z0-9_.-]*(?:["'])?\s*[:=]\s*)(["'])((?:\\.|(?!\2)[^\\])*)\2/gi,
     "secret_key",
     counts,
     "$1$2[REDACTED]$2"
@@ -207,7 +207,6 @@ function redactHighEntropyValues(
   return text.replace(/[A-Za-z0-9+_-]{32,}={0,2}/g, (candidate) => {
     const separatorCount = candidate.match(/[_-]/g)?.length ?? 0;
     if (
-      candidate.includes(REDACTED) ||
       separatorCount > 2 ||
       !/[a-z]/.test(candidate) ||
       !/[A-Z]/.test(candidate) ||

--- a/packages/core/src/observability/redaction.ts
+++ b/packages/core/src/observability/redaction.ts
@@ -180,6 +180,7 @@ function redactTextValue(
     counts,
     "$1[REDACTED]"
   );
+  redacted = redactYamlBlockScalars(redacted, counts);
   redacted = replaceSensitiveKeyAndCount(
     redacted,
     /(^|\r?\n)([ \t]*)(-\s+)?([A-Za-z0-9_.-]+)(\s*:\s+)(?!["']|\[REDACTED\])([^\r\n]*?\S)([ \t]+#.*)?(?=\r?\n|$)/gm,
@@ -290,29 +291,8 @@ function isLikelyFilesystemPath(
     return true;
   }
 
-  const firstSegment = (candidate.startsWith("/") ? segments[1] : segments[0])
-    .replace(/^\/+/, "")
-    .toLowerCase();
-  const knownPathRoot = new Set([
-    "bin",
-    "dev",
-    "etc",
-    "home",
-    "opt",
-    "private",
-    "proc",
-    "root",
-    "run",
-    "srv",
-    "sys",
-    "tmp",
-    "usr",
-    "var",
-    "users",
-    "workspace",
-    "workspaces",
-  ]);
-  if (knownPathRoot.has(firstSegment)) {
+  const pathSegments = candidate.startsWith("/") ? segments.slice(1) : segments;
+  if (pathSegments.some(isReadableFilesystemSegment)) {
     return true;
   }
 
@@ -325,11 +305,103 @@ function isLikelyFilesystemPath(
     return true;
   }
 
-  return (
-    firstSegment === "runtime" ||
-    firstSegment === "project" ||
-    firstSegment === "projects"
-  );
+  return false;
+}
+
+function isReadableFilesystemSegment(segment: string): boolean {
+  if (
+    segment.length > 24 ||
+    !/^[A-Za-z0-9._-]+$/.test(segment) ||
+    /\d/.test(segment)
+  ) {
+    return false;
+  }
+
+  return /[a-z]{3,}/.test(segment) || /[A-Z]{3,}/.test(segment);
+}
+
+type TextLine = {
+  content: string;
+  ending: "" | "\n" | "\r\n";
+};
+
+function redactYamlBlockScalars(
+  text: string,
+  counts: Map<RedactionClass, number>
+): string {
+  const lines = splitTextLines(text);
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const match =
+      /^([ \t]*)(-\s+)?([A-Za-z0-9_.-]+)(\s*:\s+)(?!["']|\[REDACTED\])([|>])(?:[-+]?\d?)([ \t]+#.*)?$/.exec(
+        lines[index].content
+      );
+    if (!match) {
+      continue;
+    }
+
+    const redactionClass = redactionClassForKey(match[3]);
+    if (!redactionClass) {
+      continue;
+    }
+
+    const headerIndent = match[1].length;
+    let end = index + 1;
+    let hasPayload = false;
+    while (end < lines.length) {
+      const content = lines[end].content;
+      const indentation = content.match(/^[ \t]*/)?.[0].length ?? 0;
+      if (content.trim() === "") {
+        const nextContent = lines[end + 1]?.content ?? "";
+        const nextIndentation = nextContent.match(/^[ \t]*/)?.[0].length ?? 0;
+        if (nextContent.trim() !== "" && nextIndentation <= headerIndent) {
+          break;
+        }
+        end += 1;
+        continue;
+      }
+      if (indentation <= headerIndent) {
+        break;
+      }
+      hasPayload = true;
+      end += 1;
+    }
+
+    incrementRedaction(counts, redactionClass);
+    lines[index] = {
+      content: `${match[1]}${match[2] ?? ""}${match[3]}${match[4]}${REDACTED}${match[6] ?? ""}`,
+      ending: lines[index].ending,
+    };
+    if (hasPayload || end > index + 1) {
+      lines.splice(index + 1, end - index - 1);
+    }
+  }
+
+  return lines.map((line) => `${line.content}${line.ending}`).join("");
+}
+
+function splitTextLines(text: string): TextLine[] {
+  const lines: TextLine[] = [];
+  let start = 0;
+  while (start < text.length) {
+    const newline = text.indexOf("\n", start);
+    if (newline === -1) {
+      lines.push({ content: text.slice(start), ending: "" });
+      return lines;
+    }
+
+    const hasCarriageReturn = newline > start && text[newline - 1] === "\r";
+    lines.push({
+      content: text.slice(start, hasCarriageReturn ? newline - 1 : newline),
+      ending: hasCarriageReturn ? "\r\n" : "\n",
+    });
+    start = newline + 1;
+  }
+
+  if (text.length === 0 || text.endsWith("\n")) {
+    lines.push({ content: "", ending: "" });
+  }
+  return lines;
 }
 
 function shannonEntropy(value: string): number {

--- a/packages/core/src/observability/redaction.ts
+++ b/packages/core/src/observability/redaction.ts
@@ -71,14 +71,17 @@ export function redactObservabilityTextWithStats(
 function redactValue(
   value: unknown,
   counts: Map<RedactionClass, number>,
-  options: { redactStringValues: boolean }
+  options: {
+    redactStringValues: boolean;
+    preserveFilesystemPaths?: boolean;
+  }
 ): unknown {
   if (Array.isArray(value)) {
     return value.map((item) => redactValue(item, counts, options));
   }
 
   if (typeof value === "string" && options.redactStringValues) {
-    return redactTextValue(value, counts);
+    return redactTextValue(value, counts, options);
   }
 
   if (!isRecord(value)) {
@@ -93,7 +96,14 @@ function redactValue(
         return [key, REDACTED];
       }
 
-      return [key, redactValue(nested, counts, options)];
+      return [
+        key,
+        redactValue(nested, counts, {
+          ...options,
+          preserveFilesystemPaths:
+            options.preserveFilesystemPaths || isFilesystemPathKey(key),
+        }),
+      ];
     })
   );
 }
@@ -132,7 +142,8 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function redactTextValue(
   text: string,
-  counts: Map<RedactionClass, number>
+  counts: Map<RedactionClass, number>,
+  options: { preserveFilesystemPaths?: boolean } = {}
 ): string {
   let redacted = replaceAndCount(
     text,
@@ -163,6 +174,7 @@ function redactTextValue(
     "$1[REDACTED]"
   );
   redacted = redactSensitiveJsonContainers(redacted, counts);
+  redacted = redactYamlContainers(redacted, counts);
   redacted = replaceSensitiveKeyAndCount(
     redacted,
     /((?:["'])?\b([A-Za-z0-9_.-]+)(?:["'])?\s*[:=]\s*)(["'])((?:\\.|\3\3|(?!\3)[^\\])*)\3/gi,
@@ -216,7 +228,17 @@ function redactTextValue(
     counts,
     "[REDACTED]"
   );
-  return redactHighEntropyValues(redacted, counts);
+  return redactHighEntropyValues(
+    redacted,
+    counts,
+    options.preserveFilesystemPaths ?? false
+  );
+}
+
+function isFilesystemPathKey(key: string): boolean {
+  return /(?:artifact|cwd|directory|file|path|repo(?:sitory)?|workspace)/i.test(
+    key
+  );
 }
 
 function replaceSensitiveKeyAndCount(
@@ -341,12 +363,20 @@ function findJsonContainerEnd(text: string, start: number): number | null {
 
 function redactHighEntropyValues(
   text: string,
-  counts: Map<RedactionClass, number>
+  counts: Map<RedactionClass, number>,
+  preserveFilesystemPaths: boolean
 ): string {
   return text.replace(
     /[A-Za-z0-9+/_-]{32,}={0,2}/g,
     (candidate, offset: number, source: string) => {
-      if (isLikelyFilesystemPath(candidate, source, offset)) {
+      if (
+        isLikelyFilesystemPath(
+          candidate,
+          source,
+          offset,
+          preserveFilesystemPaths
+        )
+      ) {
         return candidate;
       }
 
@@ -370,7 +400,8 @@ function redactHighEntropyValues(
 function isLikelyFilesystemPath(
   candidate: string,
   source: string,
-  offset: number
+  offset: number,
+  preserveFilesystemPaths: boolean
 ): boolean {
   const segments = candidate.split("/");
   if (segments.length < 3) {
@@ -384,29 +415,22 @@ function isLikelyFilesystemPath(
     return false;
   }
 
-  if (preceding === ".") {
-    return true;
+  const pathContext = source.slice(Math.max(0, offset - 80), offset);
+  const hasPathContext =
+    preserveFilesystemPaths ||
+    /\b(?:artifact|cwd|directory|file|path|repo(?:sitory)?|workspace|working\s+directory)\s*(?:is|at|=|:)?\s*(?:\.\/?\s*)?$/i.test(
+      pathContext
+    );
+  if (!hasPathContext) {
+    return false;
   }
 
   const pathSegments = candidate.startsWith("/") ? segments.slice(1) : segments;
   const readableSegments = pathSegments.filter(isReadableFilesystemSegment);
-  if (
+  return (
     readableSegments.length >= 3 ||
     pathSegments.some((segment) => segment.includes("."))
-  ) {
-    return true;
-  }
-
-  const pathContext = source.slice(Math.max(0, offset - 80), offset);
-  if (
-    /\b(?:artifact|cwd|directory|file|path|repo(?:sitory)?|workspace|working\s+directory)\s*(?:is|at|=|:)?\s*$/i.test(
-      pathContext
-    )
-  ) {
-    return true;
-  }
-
-  return false;
+  );
 }
 
 function isReadableFilesystemSegment(segment: string): boolean {
@@ -425,6 +449,65 @@ type TextLine = {
   content: string;
   ending: "" | "\n" | "\r\n";
 };
+
+function redactYamlContainers(
+  text: string,
+  counts: Map<RedactionClass, number>
+): string {
+  const lines = splitTextLines(text);
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const match =
+      /^([ \t]*)(-\s+)?((?:["'])?[A-Za-z0-9_.-]+(?:["'])?)([ \t]*:[ \t]*)(#.*)?$/.exec(
+        lines[index].content
+      );
+    if (!match) {
+      continue;
+    }
+
+    const key = match[3].replace(/^["']|["']$/g, "");
+    const redactionClass = redactionClassForKey(key);
+    if (!redactionClass) {
+      continue;
+    }
+
+    const headerIndent = match[1].length + (match[2]?.length ?? 0);
+    let end = index + 1;
+    let hasPayload = false;
+    while (end < lines.length) {
+      const content = lines[end].content;
+      const indentation = content.match(/^[ \t]*/)?.[0].length ?? 0;
+      if (content.trim() === "") {
+        const nextContent = lines[end + 1]?.content ?? "";
+        const nextIndentation = nextContent.match(/^[ \t]*/)?.[0].length ?? 0;
+        if (nextContent.trim() !== "" && nextIndentation <= headerIndent) {
+          break;
+        }
+        end += 1;
+        continue;
+      }
+      if (indentation <= headerIndent) {
+        break;
+      }
+      hasPayload = true;
+      end += 1;
+    }
+
+    if (!hasPayload) {
+      continue;
+    }
+
+    incrementRedaction(counts, redactionClass);
+    const valueSeparator = /[ \t]$/.test(match[4]) ? match[4] : `${match[4]} `;
+    lines[index] = {
+      content: `${match[1]}${match[2] ?? ""}${match[3]}${valueSeparator}${REDACTED}${match[5] ?? ""}`,
+      ending: lines[index].ending,
+    };
+    lines.splice(index + 1, end - index - 1);
+  }
+
+  return lines.map((line) => `${line.content}${line.ending}`).join("");
+}
 
 function redactYamlBlockScalars(
   text: string,

--- a/packages/core/src/observability/redaction.ts
+++ b/packages/core/src/observability/redaction.ts
@@ -164,7 +164,7 @@ function redactTextValue(
   );
   redacted = replaceAndCount(
     redacted,
-    /((?:["'])?\b[A-Za-z0-9_.-]*(?:token|secret|api[-_.]?key|password|passwd|credential|private[-_.]?key)[A-Za-z0-9_.-]*(?:["'])?\s*[:=]\s*)(["'])((?:\\.|(?!\2)[^\\])*)\2/gi,
+    /((?:["'])?\b[A-Za-z0-9_.-]*(?:token|secret|api[-_.]?key|password|passwd|credential|private[-_.]?key)[A-Za-z0-9_.-]*(?:["'])?\s*[:=]\s*)(["'])((?:\\.|\2\2|(?!\2)[^\\])*)\2/gi,
     "secret_key",
     counts,
     "$1$2[REDACTED]$2"
@@ -178,7 +178,7 @@ function redactTextValue(
   );
   redacted = replaceAndCount(
     redacted,
-    /((?:["'])?\b[A-Za-z0-9_.-]*(?:token|secret|api[-_.]?key|password|passwd|credential|private[-_.]?key)[A-Za-z0-9_.-]*(?:["'])?\s*[:=]\s*)(?!["']|\[REDACTED\])([^\s}\]"']+)/gi,
+    /((?:["'])?\b[A-Za-z0-9_.-]*(?:token|secret|api[-_.]?key|password|passwd|credential|private[-_.]?key)[A-Za-z0-9_.-]*(?:["'])?\s*[:=]\s*)(?!["']|\[REDACTED\])([^\s}\]"']+?)(?=[,;](?=[A-Za-z0-9_.-]+\s*=)|\s|[}\]"']|$)/gi,
     "secret_key",
     counts,
     "$1[REDACTED]"


### PR DESCRIPTION
## TL;DR

- 관측성 영속화 전 free-form 문자열과 `doctor` 출력 전체에 공통 시크릿 리댁션을 적용합니다.
- fine-grained GitHub PAT, provider 토큰, URL credential/query, custom key, high-entropy opaque token을 소독합니다.
- 최신 rework에서 JSON container, slash-delimited Base64 path 오탐, YAML block/container payload 경계를 보강했습니다.

## 변경 지점 다이어그램

```text
runtime events / doctor diagnostics / support bundle
  → structured key + free-form text redaction
  → JSON container / YAML scalar + container / path-context opaque-value handling
  → PAT · URL credential · sensitive query · high-entropy detection
  → persisted events / doctor JSON · text · bundle · stderr
```

## 여기부터 보세요

- `packages/core/src/observability/redaction.ts`
  - 모든 구조화 string value에 `redactStringValues: true` 적용
  - `github_pat_`, `gho_`, `ghs_`, URL credential/query, custom key 및 high-entropy 토큰 탐지
  - 민감 JSON container를 balanced scan 후 `"[REDACTED]"`로 치환해 JSON 구조 보존
  - 실제 path context가 있을 때만 readable slash-delimited candidate를 filesystem path로 보존
  - 민감 YAML mapping/sequence container를 indentation sibling 경계까지 전체 소독
- `packages/core/src/observability/redaction.test.ts`
  - 샘플 토큰·URL·JSON/NDJSON/YAML·path 오탐·nested/container 회귀 TC
- `packages/cli/src/commands/doctor.ts`
  - JSON, text, bundle summary, top-level stderr가 공통 redaction boundary 통과

## 검증

- `pnpm lint` — pass
- `pnpm test` — pass (core 201, orchestrator 223, worker 146, CLI 492 포함)
- `pnpm typecheck` — pass
- `pnpm build` — pass
- `pnpm exec vitest run packages/core/src/observability/redaction.test.ts` — pass, 26 tests
- CI `Test`, `Container Smoke` — pass at `8064ae8`
- Docker E2E — N/A; observability matcher/doctor output 변경이며 integration lifecycle 변경 없음

## 위험 & 롤백

- 위험: entropy 기반 탐지는 산문·filesystem path와 경계가 겹칠 수 있습니다. 실제 path context 또는 구조화 path 필드가 있을 때만 path 예외를 적용하고 회귀 TC로 보호합니다.
- 위험: 민감 JSON/YAML 값을 `[REDACTED]`로 축약하므로 진단 원문이 보존되지 않습니다. 보안상 의도된 동작입니다.
- 롤백: commit `8064ae8`부터 이 PR의 관측성 redaction commits를 revert하면 됩니다.

## 변경 파일

- `.changeset/redact-observability-tokens.md`
- `packages/core/src/observability/redaction.ts`
- `packages/core/src/observability/redaction.test.ts`
- `packages/cli/src/commands/doctor.ts`
- `packages/cli/src/commands/doctor.test.ts`

## Issues — Closed #442

Fixes #442

### 머지 후/사람 확인

- deploy, external URL smoke test, manual UX 확인은 사람 확인 사항입니다.
- PR head가 `8064ae8`인지 확인해 주세요.
- `doctor --json` 및 support bundle이 token 조각을 남기지 않고 JSON/YAML 구조를 보존하는지 확인해 주세요.
