### PR TITLE
fix(tracker-github): serialize GraphQL rate limits

### DIFF
--- a/.changeset/quiet-gates-wait.md
+++ b/.changeset/quiet-gates-wait.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Serialize GitHub GraphQL rate-limit checks and recover from rate-limited responses with bounded retries for #450.

--- a/packages/core/src/contracts/tracker-adapter.ts
+++ b/packages/core/src/contracts/tracker-adapter.ts
@@ -5,6 +5,18 @@ import type {
 } from "./status-surface.js";
 import type { WorkflowLifecycleConfig } from "../workflow/lifecycle.js";
 
+export class TrackerRateLimitError extends Error {
+  readonly name: string = "TrackerRateLimitError";
+
+  constructor(
+    message: string,
+    readonly rateLimits: Record<string, unknown> | null,
+    readonly retryAt: string | null
+  ) {
+    super(message);
+  }
+}
+
 export type TrackerAdapterKind = "github-project" | (string & {});
 
 export type TrackerBindingSummary = {

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -25,6 +25,7 @@ import {
   type TrackedIssueList,
   type WorkflowResolution,
 } from "@gh-symphony/core";
+import { GitHubGraphQLRateLimitError } from "@gh-symphony/tracker-github";
 import { OrchestratorFsStore } from "./fs-store.js";
 import * as gitModule from "./git.js";
 import { OrchestratorService } from "./service.js";
@@ -4226,11 +4227,18 @@ Prefer focused changes.
           rateLimits,
         },
       ]),
-      listIssues: vi.fn().mockRejectedValue(
-        Object.assign(new Error("Rate limit near exhaustion"), {
-          rateLimits,
-        })
-      ),
+      listIssues: vi
+        .fn()
+        .mockRejectedValue(
+          new GitHubGraphQLRateLimitError(
+            "GitHub GraphQL rate limit near exhaustion",
+            null,
+            "Cached GitHub GraphQL rate limit is exhausted.",
+            rateLimits,
+            null,
+            rateLimits.resetAt
+          )
+        ),
       listIssuesByStates: vi.fn().mockResolvedValue([]),
       buildWorkerEnvironment: vi.fn().mockReturnValue({}),
       reviveIssue: vi.fn(),
@@ -4247,7 +4255,9 @@ Prefer focused changes.
     const snapshot = await service.runOnce();
 
     expect(snapshot.health).toBe("degraded");
-    expect(snapshot.lastError).toBe("Rate limit near exhaustion");
+    expect(snapshot.lastError).toBe(
+      "GitHub GraphQL rate limit near exhaustion"
+    );
     expect(snapshot.rateLimits).toEqual(rateLimits);
     expect(snapshot.dispatchSuppressedUntil).toBe("2026-07-03T15:56:07.000Z");
     expect(stderr.write).toHaveBeenCalledWith(
@@ -4282,7 +4292,16 @@ Prefer focused changes.
     const listIssues = vi
       .fn()
       .mockResolvedValueOnce(listedIssues)
-      .mockRejectedValueOnce(new Error("Rate limit near exhaustion"));
+      .mockRejectedValueOnce(
+        new GitHubGraphQLRateLimitError(
+          "GitHub GraphQL rate limit near exhaustion",
+          null,
+          "Cached GitHub GraphQL rate limit is exhausted.",
+          rateLimits,
+          null,
+          rateLimits.resetAt
+        )
+      );
     vi.spyOn(trackerAdapters, "resolveTrackerAdapter").mockReturnValue({
       listIssues,
       listIssuesByStates: vi.fn().mockResolvedValue([]),
@@ -4304,7 +4323,9 @@ Prefer focused changes.
 
     expect(listIssues).toHaveBeenCalledTimes(2);
     expect(snapshot.health).toBe("degraded");
-    expect(snapshot.lastError).toBe("Rate limit near exhaustion");
+    expect(snapshot.lastError).toBe(
+      "GitHub GraphQL rate limit near exhaustion"
+    );
     expect(snapshot.rateLimits).toEqual(rateLimits);
     expect(snapshot.dispatchSuppressedUntil).toBe("2026-07-03T15:56:07.000Z");
     expect(stderr.write).toHaveBeenLastCalledWith(
@@ -4334,10 +4355,14 @@ Prefer focused changes.
       resetAt: "2026-07-03T15:56:07.000Z",
       resource: "graphql",
     };
-    const error = new Error("Rate limit near exhaustion") as Error & {
-      rateLimits: Record<string, unknown>;
-    };
-    error.rateLimits = rateLimits;
+    const error = new GitHubGraphQLRateLimitError(
+      "GitHub GraphQL rate limit near exhaustion",
+      null,
+      "Cached GitHub GraphQL rate limit is exhausted.",
+      rateLimits,
+      null,
+      rateLimits.resetAt
+    );
     vi.spyOn(trackerAdapters, "resolveTrackerAdapter").mockReturnValue({
       fetchIssueStatesByIds: vi.fn().mockResolvedValue([]),
       listIssues: vi.fn().mockRejectedValue(error),
@@ -4357,7 +4382,9 @@ Prefer focused changes.
     const snapshot = await service.runOnce();
 
     expect(snapshot.health).toBe("degraded");
-    expect(snapshot.lastError).toBe("Rate limit near exhaustion");
+    expect(snapshot.lastError).toBe(
+      "GitHub GraphQL rate limit near exhaustion"
+    );
     expect(snapshot.rateLimits).toEqual(rateLimits);
     expect(snapshot.dispatchSuppressedUntil).toBe("2026-07-03T15:56:07.000Z");
     expect(stderr.write).toHaveBeenCalledWith(

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -8,6 +8,7 @@ import { fileURLToPath } from "node:url";
 import {
   DEFAULT_MAX_FAILURE_RETRIES,
   DEFAULT_WORKFLOW_LIFECYCLE,
+  TrackerRateLimitError,
   attributeDirtyWorkToIssue,
   buildHookEnv,
   buildIssueIdentityHeader,
@@ -924,6 +925,7 @@ export class OrchestratorService {
     const trackerAdapter = resolveTrackerAdapter(tenant.tracker);
     const now = this.now();
     let lastError: string | null = null;
+    let trackerError: unknown = null;
     let dispatched = 0;
     let suppressed = 0;
     let recovered = 0;
@@ -1452,6 +1454,7 @@ export class OrchestratorService {
         await this.cleanupTerminalIssueWorkspace(tenant, issue, now);
       }
     } catch (error) {
+      trackerError = error;
       lastError =
         error instanceof Error ? error.message : "Unknown orchestration error";
       trackerRateLimits =
@@ -1516,7 +1519,7 @@ export class OrchestratorService {
       lastError,
       rateLimits,
       dispatchSuppressedUntil: resolveDispatchSuppressedUntil(
-        lastError,
+        trackerError,
         dispatchRateLimits
       ),
       issueWorkspaces,
@@ -4333,17 +4336,20 @@ function isLowRateLimit(
 }
 
 function resolveDispatchSuppressedUntil(
-  lastError: string | null,
+  error: unknown,
   rateLimits: Record<string, unknown> | null
 ): string | null {
-  if (
-    lastError !== "Rate limit near exhaustion" ||
-    !isTrackerGraphqlRateLimits(rateLimits)
-  ) {
+  if (!(error instanceof TrackerRateLimitError)) {
     return null;
   }
 
-  return typeof rateLimits.resetAt === "string" ? rateLimits.resetAt : null;
+  if (error.retryAt) {
+    return error.retryAt;
+  }
+  return isTrackerGraphqlRateLimits(rateLimits) &&
+    typeof rateLimits.resetAt === "string"
+    ? rateLimits.resetAt
+    : null;
 }
 
 function buildRuntimeSession(

--- a/packages/tracker-github/src/adapter.ts
+++ b/packages/tracker-github/src/adapter.ts
@@ -10,12 +10,16 @@ import {
   type WorkflowPriorityConfig,
   type WorkflowLifecycleConfig,
 } from "@gh-symphony/core";
+import {
+  GitHubGraphQLRateLimitPolicy,
+  isGitHubRateLimitResponse,
+  parseGitHubRetryAfterMs,
+  type GitHubGraphQLAttemptResult,
+} from "./github-rate-limit.js";
 
 const DEFAULT_API_URL = "https://api.github.com/graphql";
 const DEFAULT_PAGE_SIZE = 25;
 const DEFAULT_NETWORK_TIMEOUT_MS = 30_000;
-const RATE_LIMIT_SOFT_THRESHOLD = 100;
-const RATE_LIMIT_HARD_THRESHOLD = 0;
 const MAX_RATE_LIMIT_WAIT_MS = 60_000;
 const MAX_TRANSITION_QUEUE_DEPTH = 100;
 const TRANSITION_RETRY_ATTEMPTS = 3;
@@ -398,10 +402,7 @@ type GitHubRateLimitCollector = {
   observations: GitHubRateLimitObservation[];
 };
 
-const cachedGitHubGraphQLRateLimits = new Map<
-  string,
-  GitHubRateLimitPayload | null
->();
+const graphQLRateLimitPolicy = new GitHubGraphQLRateLimitPolicy();
 const ARCHIVED_PROJECT_ITEM_STATE = "Archived";
 const transitionQueueTails = new Map<string, Promise<void>>();
 const transitionQueueDepths = new Map<string, number>();
@@ -771,9 +772,7 @@ export async function requestGithubProjectItemState(
         input.request.type === "transition-request"
           ? input.request.reason
           : null,
-      rateLimits:
-        cachedGitHubGraphQLRateLimits.get(fingerprintToken(config.token)) ??
-        null,
+      rateLimits: graphQLRateLimitPolicy.get(fingerprintToken(config.token)),
       error: "tracker_transition_queue_full",
     };
   }
@@ -1084,10 +1083,7 @@ function isRetryableTransitionError(error: unknown): boolean {
   ) {
     return true;
   }
-  return (
-    error instanceof GitHubTrackerError &&
-    error.message.toLowerCase().includes("rate limit")
-  );
+  return false;
 }
 
 function statesEqual(left: string, right: string): boolean {
@@ -2368,35 +2364,71 @@ async function executeGraphQLQueryWithMetadata<TData>(
   rateLimits: GitHubRateLimitPayload | null;
 }> {
   const tokenFingerprint = fingerprintToken(config.token);
-  await guardGraphQLRateLimit(tokenFingerprint);
+  const requestResult = await graphQLRateLimitPolicy.execute(
+    tokenFingerprint,
+    async (): Promise<
+      GitHubGraphQLAttemptResult<
+        {
+          response: Response;
+          payload: GraphQLResponse<TData>;
+        },
+        GitHubRateLimitPayload
+      >
+    > => {
+      const response = await fetchImpl(config.apiUrl ?? DEFAULT_API_URL, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${config.token}`,
+        },
+        body: JSON.stringify({
+          query,
+          variables,
+        }),
+        signal: buildRequestSignal(config.timeoutMs),
+      });
+      const rateLimits = extractGitHubRateLimits(response.headers);
+      if (!response.ok) {
+        const details = await response.text();
+        return {
+          ok: false,
+          status: response.status,
+          details,
+          rateLimits,
+          retryAfterMs: parseGitHubRetryAfterMs(
+            response.headers?.get?.("retry-after") ?? null
+          ),
+          rateLimited: isGitHubRateLimitResponse(
+            response.status,
+            details,
+            response.headers
+          ),
+        };
+      }
 
-  const response = await fetchImpl(config.apiUrl ?? DEFAULT_API_URL, {
-    method: "POST",
-    headers: {
-      "content-type": "application/json",
-      authorization: `Bearer ${config.token}`,
-    },
-    body: JSON.stringify({
-      query,
-      variables,
-    }),
-    signal: buildRequestSignal(config.timeoutMs),
-  });
+      const payload = (await response.json()) as GraphQLResponse<TData>;
+      const fieldRateLimits = extractGraphQLRateLimitField(
+        payload.data?.rateLimit
+      );
+      return {
+        ok: true,
+        value: { response, payload },
+        rateLimits: extractGitHubRateLimits(response.headers, fieldRateLimits),
+      };
+    }
+  );
 
-  if (!response.ok) {
-    const details = await response.text();
-    const rateLimits = extractGitHubRateLimits(response.headers);
-    cachedGitHubGraphQLRateLimits.set(tokenFingerprint, rateLimits);
+  if (!requestResult.ok) {
     throw new GitHubTrackerHttpError(
-      `GitHub GraphQL request failed with status ${response.status}`,
-      response.status,
-      details,
-      rateLimits,
-      parseRetryAfterMs(response.headers?.get?.("retry-after") ?? null)
+      `GitHub GraphQL request failed with status ${requestResult.status}`,
+      requestResult.status,
+      requestResult.details,
+      requestResult.rateLimits,
+      requestResult.retryAfterMs
     );
   }
 
-  const payload = (await response.json()) as GraphQLResponse<TData>;
+  const { payload, response } = requestResult.value;
 
   if (payload.errors?.length) {
     throw new GitHubTrackerQueryError(
@@ -2420,44 +2452,10 @@ async function executeGraphQLQueryWithMetadata<TData>(
       payload: rateLimits,
     });
   }
-  cachedGitHubGraphQLRateLimits.set(tokenFingerprint, rateLimits);
   return {
     data,
     rateLimits,
   };
-}
-
-async function guardGraphQLRateLimit(tokenFingerprint: string): Promise<void> {
-  const rateLimit = cachedGitHubGraphQLRateLimits.get(tokenFingerprint) ?? null;
-  if (!rateLimit) {
-    return;
-  }
-
-  const remaining = rateLimit.remaining;
-  if (remaining === null || remaining > RATE_LIMIT_SOFT_THRESHOLD) {
-    return;
-  }
-
-  const resetAtMs = parseTimestampMs(rateLimit.resetAt);
-  if (resetAtMs === null) {
-    if (remaining <= RATE_LIMIT_HARD_THRESHOLD) {
-      throw new GitHubTrackerError("Rate limit near exhaustion", rateLimit);
-    }
-    return;
-  }
-
-  const waitMs = Math.max(0, resetAtMs - Date.now());
-  if (waitMs > MAX_RATE_LIMIT_WAIT_MS) {
-    if (remaining <= RATE_LIMIT_HARD_THRESHOLD) {
-      throw new GitHubTrackerError("Rate limit near exhaustion", rateLimit);
-    }
-    return;
-  }
-
-  cachedGitHubGraphQLRateLimits.delete(tokenFingerprint);
-  if (waitMs > 0) {
-    await sleep(waitMs);
-  }
 }
 
 function fingerprintToken(token: string): string {
@@ -2617,20 +2615,6 @@ function parseTimestampMs(value: string | null): number | null {
   return Number.isFinite(timestampMs) ? timestampMs : null;
 }
 
-function parseRetryAfterMs(value: string | null): number | null {
-  if (!value) {
-    return null;
-  }
-  const seconds = Number(value);
-  if (Number.isFinite(seconds) && seconds >= 0) {
-    return seconds * 1_000;
-  }
-  const retryAtMs = Date.parse(value);
-  return Number.isFinite(retryAtMs)
-    ? Math.max(0, retryAtMs - Date.now())
-    : null;
-}
-
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => {
     setTimeout(resolve, ms);
@@ -2638,7 +2622,7 @@ function sleep(ms: number): Promise<void> {
 }
 
 export function resetGitHubRateLimitCacheForTests(): void {
-  cachedGitHubGraphQLRateLimits.clear();
+  graphQLRateLimitPolicy.reset();
   transitionQueueTails.clear();
   transitionQueueDepths.clear();
 }

--- a/packages/tracker-github/src/github-rate-limit.test.ts
+++ b/packages/tracker-github/src/github-rate-limit.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it, vi } from "vitest";
+import { TrackerRateLimitError } from "@gh-symphony/core";
+import {
+  GitHubGraphQLRateLimitError,
+  GitHubGraphQLRateLimitPolicy,
+  isGitHubRateLimitResponse,
+  parseGitHubRetryAfterMs,
+  type GitHubGraphQLAttemptResult,
+} from "./github-rate-limit.js";
+
+type TestResult = GitHubGraphQLAttemptResult<string>;
+
+describe("GitHubGraphQLRateLimitPolicy", () => {
+  it("serializes concurrent requests for the same token", async () => {
+    let releaseFirst = (): void => undefined;
+    let markFirstStarted = (): void => undefined;
+    const firstPending = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const firstStarted = new Promise<void>((resolve) => {
+      markFirstStarted = resolve;
+    });
+    let activeRequests = 0;
+    let maxActiveRequests = 0;
+    const policy = new GitHubGraphQLRateLimitPolicy();
+    const attempt = vi.fn(async (): Promise<TestResult> => {
+      activeRequests += 1;
+      maxActiveRequests = Math.max(maxActiveRequests, activeRequests);
+      if (attempt.mock.calls.length === 1) {
+        markFirstStarted();
+        await firstPending;
+      }
+      activeRequests -= 1;
+      return { ok: true, value: "ok", rateLimits: null };
+    });
+
+    const first = policy.execute("token-a", attempt);
+    const second = policy.execute("token-a", attempt);
+    await firstStarted;
+
+    expect(attempt).toHaveBeenCalledTimes(1);
+    releaseFirst();
+    await expect(Promise.all([first, second])).resolves.toHaveLength(2);
+    expect(attempt).toHaveBeenCalledTimes(2);
+    expect(maxActiveRequests).toBe(1);
+  });
+
+  it("honors Retry-After before retrying a rate-limited response", async () => {
+    const sleep = vi.fn().mockResolvedValue(undefined);
+    const policy = new GitHubGraphQLRateLimitPolicy({
+      now: () => Date.parse("2026-08-02T00:00:00.000Z"),
+      sleep,
+    });
+    const attempt = vi
+      .fn<() => Promise<TestResult>>()
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 429,
+        details: "rate limit exceeded",
+        rateLimits: null,
+        retryAfterMs: 5_000,
+        rateLimited: true,
+      })
+      .mockResolvedValueOnce({ ok: true, value: "ok", rateLimits: null });
+
+    await expect(policy.execute("token-a", attempt)).resolves.toMatchObject({
+      ok: true,
+      value: "ok",
+    });
+    expect(sleep).toHaveBeenCalledWith(5_000);
+    expect(attempt).toHaveBeenCalledTimes(2);
+  });
+
+  it("prefers Retry-After over an unrelated primary reset", async () => {
+    const now = Date.parse("2026-08-02T00:00:00.000Z");
+    const sleep = vi.fn().mockResolvedValue(undefined);
+    const policy = new GitHubGraphQLRateLimitPolicy({ now: () => now, sleep });
+    const attempt = vi
+      .fn<() => Promise<TestResult>>()
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 403,
+        details: "secondary rate limit",
+        rateLimits: {
+          remaining: 4_000,
+          resetAt: "2026-08-02T01:00:00.000Z",
+        },
+        retryAfterMs: 5_000,
+        rateLimited: true,
+      })
+      .mockResolvedValueOnce({ ok: true, value: "ok", rateLimits: null });
+
+    await expect(policy.execute("token-a", attempt)).resolves.toMatchObject({
+      ok: true,
+      value: "ok",
+    });
+    expect(sleep).toHaveBeenCalledWith(5_000);
+  });
+
+  it("uses the primary reset when the primary quota is exhausted", async () => {
+    const now = Date.parse("2026-08-02T00:00:00.000Z");
+    const sleep = vi.fn().mockResolvedValue(undefined);
+    const policy = new GitHubGraphQLRateLimitPolicy({ now: () => now, sleep });
+    const attempt = vi
+      .fn<() => Promise<TestResult>>()
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 429,
+        details: "primary rate limit",
+        rateLimits: {
+          remaining: 0,
+          resetAt: "2026-08-02T00:00:10.000Z",
+        },
+        retryAfterMs: 5_000,
+        rateLimited: true,
+      })
+      .mockResolvedValueOnce({ ok: true, value: "ok", rateLimits: null });
+
+    await expect(policy.execute("token-a", attempt)).resolves.toMatchObject({
+      ok: true,
+      value: "ok",
+    });
+    expect(sleep).toHaveBeenCalledWith(10_000);
+  });
+
+  it("uses bounded exponential backoff for repeated 429 responses", async () => {
+    const sleep = vi.fn().mockResolvedValue(undefined);
+    const policy = new GitHubGraphQLRateLimitPolicy({ sleep });
+    const limited: TestResult = {
+      ok: false,
+      status: 429,
+      details: "rate limit exceeded",
+      rateLimits: null,
+      retryAfterMs: null,
+      rateLimited: true,
+    };
+    const attempt = vi
+      .fn<() => Promise<TestResult>>()
+      .mockResolvedValueOnce(limited)
+      .mockResolvedValueOnce(limited)
+      .mockResolvedValueOnce({ ok: true, value: "ok", rateLimits: null });
+
+    await policy.execute("token-a", attempt);
+
+    expect(sleep.mock.calls).toEqual([[1_000], [2_000]]);
+    expect(attempt).toHaveBeenCalledTimes(3);
+  });
+
+  it("throws a typed error after the retry limit", async () => {
+    const policy = new GitHubGraphQLRateLimitPolicy({
+      retryAttempts: 2,
+      sleep: vi.fn().mockResolvedValue(undefined),
+    });
+    const attempt = vi.fn<() => Promise<TestResult>>().mockResolvedValue({
+      ok: false,
+      status: 403,
+      details: "secondary rate limit",
+      rateLimits: { source: "github", remaining: 0 },
+      retryAfterMs: null,
+      rateLimited: true,
+    });
+
+    const pending = policy.execute("token-a", attempt);
+    await expect(pending).rejects.toBeInstanceOf(GitHubGraphQLRateLimitError);
+    await expect(pending).rejects.toBeInstanceOf(TrackerRateLimitError);
+    expect(attempt).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("GitHub rate-limit response classification", () => {
+  it("distinguishes secondary rate-limit 403 from authentication failures", () => {
+    expect(
+      isGitHubRateLimitResponse(
+        403,
+        "You have exceeded a secondary rate limit.",
+        new Headers()
+      )
+    ).toBe(true);
+    expect(
+      isGitHubRateLimitResponse(
+        403,
+        "Resource not accessible by personal access token",
+        new Headers()
+      )
+    ).toBe(false);
+  });
+
+  it("parses Retry-After seconds and HTTP dates", () => {
+    const now = Date.parse("2026-08-02T00:00:00.000Z");
+    expect(parseGitHubRetryAfterMs("7", now)).toBe(7_000);
+    expect(parseGitHubRetryAfterMs("Sun, 02 Aug 2026 00:00:09 GMT", now)).toBe(
+      9_000
+    );
+  });
+});

--- a/packages/tracker-github/src/github-rate-limit.ts
+++ b/packages/tracker-github/src/github-rate-limit.ts
@@ -1,0 +1,322 @@
+import { TrackerRateLimitError } from "@gh-symphony/core";
+
+const DEFAULT_SOFT_THRESHOLD = 100;
+const DEFAULT_HARD_THRESHOLD = 0;
+const DEFAULT_MAX_WAIT_MS = 60_000;
+const DEFAULT_RETRY_ATTEMPTS = 3;
+const DEFAULT_RETRY_BASE_MS = 1_000;
+
+export type GitHubRateLimitState = Record<string, unknown> & {
+  remaining?: number | null;
+  reset?: number | null;
+  resetAt?: string | null;
+};
+
+export type GitHubGraphQLAttemptResult<
+  T,
+  TRateLimits extends GitHubRateLimitState = GitHubRateLimitState,
+> =
+  | {
+      ok: true;
+      value: T;
+      rateLimits: TRateLimits | null;
+    }
+  | {
+      ok: false;
+      status: number;
+      details: string;
+      rateLimits: TRateLimits | null;
+      retryAfterMs: number | null;
+      rateLimited: boolean;
+    };
+
+export class GitHubGraphQLRateLimitError extends TrackerRateLimitError {
+  readonly name = "GitHubGraphQLRateLimitError";
+
+  constructor(
+    message: string,
+    readonly status: number | null,
+    readonly details: string,
+    rateLimits: GitHubRateLimitState | null,
+    readonly retryAfterMs: number | null,
+    retryAt: string | null
+  ) {
+    super(message, rateLimits, retryAt);
+  }
+}
+
+export class GitHubGraphQLRateLimitPolicy {
+  private readonly states = new Map<string, GitHubRateLimitState | null>();
+  private readonly queueTails = new Map<string, Promise<void>>();
+
+  constructor(
+    private readonly options: {
+      softThreshold?: number;
+      hardThreshold?: number;
+      maxWaitMs?: number;
+      retryAttempts?: number;
+      retryBaseMs?: number;
+      now?: () => number;
+      sleep?: (ms: number) => Promise<void>;
+    } = {}
+  ) {}
+
+  get(tokenKey: string): GitHubRateLimitState | null {
+    return this.states.get(tokenKey) ?? null;
+  }
+
+  set(tokenKey: string, state: GitHubRateLimitState | null): void {
+    this.states.set(tokenKey, state);
+  }
+
+  async execute<
+    T,
+    TRateLimits extends GitHubRateLimitState = GitHubRateLimitState,
+  >(
+    tokenKey: string,
+    attempt: () => Promise<GitHubGraphQLAttemptResult<T, TRateLimits>>
+  ): Promise<GitHubGraphQLAttemptResult<T, TRateLimits>> {
+    return this.runSerialized(tokenKey, async () => {
+      await this.guard(tokenKey);
+
+      const retryAttempts =
+        this.options.retryAttempts ?? DEFAULT_RETRY_ATTEMPTS;
+      for (let retry = 0; retry < retryAttempts; retry += 1) {
+        const result = await attempt();
+        this.states.set(tokenKey, result.rateLimits);
+        if (result.ok || !result.rateLimited) {
+          return result;
+        }
+
+        const error = this.buildRateLimitError(result);
+        if (retry + 1 >= retryAttempts) {
+          throw error;
+        }
+
+        const delayMs = this.resolveRetryDelay(error, retry);
+        if (delayMs === null) {
+          throw error;
+        }
+        await this.sleep(delayMs);
+      }
+
+      throw new Error("GitHub GraphQL rate-limit retry loop exhausted");
+    });
+  }
+
+  reset(): void {
+    this.states.clear();
+    this.queueTails.clear();
+  }
+
+  private async guard(tokenKey: string): Promise<void> {
+    const rateLimits = this.states.get(tokenKey) ?? null;
+    if (!rateLimits) {
+      return;
+    }
+
+    const remaining = finiteNumber(rateLimits.remaining);
+    const softThreshold = this.options.softThreshold ?? DEFAULT_SOFT_THRESHOLD;
+    if (remaining === null || remaining > softThreshold) {
+      return;
+    }
+
+    const resetAtMs = resolveResetAtMs(rateLimits);
+    const hardThreshold = this.options.hardThreshold ?? DEFAULT_HARD_THRESHOLD;
+    if (resetAtMs === null) {
+      if (remaining <= hardThreshold) {
+        throw this.buildGuardError(rateLimits, null);
+      }
+      return;
+    }
+
+    const waitMs = Math.max(0, resetAtMs - this.now());
+    if (waitMs > this.maxWaitMs()) {
+      if (remaining <= hardThreshold) {
+        throw this.buildGuardError(rateLimits, resetAtMs);
+      }
+      return;
+    }
+
+    this.states.delete(tokenKey);
+    if (waitMs > 0) {
+      await this.sleep(waitMs);
+    }
+  }
+
+  private buildGuardError(
+    rateLimits: GitHubRateLimitState,
+    retryAtMs: number | null
+  ): GitHubGraphQLRateLimitError {
+    return new GitHubGraphQLRateLimitError(
+      "GitHub GraphQL rate limit near exhaustion",
+      null,
+      "Cached GitHub GraphQL rate limit is exhausted.",
+      rateLimits,
+      null,
+      toIsoTimestamp(retryAtMs)
+    );
+  }
+
+  private buildRateLimitError(
+    result: Extract<GitHubGraphQLAttemptResult<unknown>, { ok: false }>
+  ): GitHubGraphQLRateLimitError {
+    const retryAfterAtMs =
+      result.retryAfterMs === null ? null : this.now() + result.retryAfterMs;
+    const remaining = finiteNumber(result.rateLimits?.remaining);
+    const hardThreshold = this.options.hardThreshold ?? DEFAULT_HARD_THRESHOLD;
+    const primaryResetAtMs =
+      remaining !== null && remaining <= hardThreshold
+        ? resolveResetAtMs(result.rateLimits)
+        : null;
+    const retryAtMs = maxNullable(primaryResetAtMs, retryAfterAtMs);
+    return new GitHubGraphQLRateLimitError(
+      `GitHub GraphQL rate limited request with status ${result.status}`,
+      result.status,
+      result.details,
+      result.rateLimits,
+      result.retryAfterMs,
+      toIsoTimestamp(retryAtMs)
+    );
+  }
+
+  private resolveRetryDelay(
+    error: GitHubGraphQLRateLimitError,
+    retry: number
+  ): number | null {
+    const retryBaseMs = this.options.retryBaseMs ?? DEFAULT_RETRY_BASE_MS;
+    const exponentialMs = Math.min(this.maxWaitMs(), retryBaseMs * 2 ** retry);
+    const retryAtMs = parseTimestampMs(error.retryAt);
+    const providerWaitMs =
+      retryAtMs === null ? 0 : Math.max(0, retryAtMs - this.now());
+    const delayMs = Math.max(exponentialMs, providerWaitMs);
+    return delayMs <= this.maxWaitMs() ? delayMs : null;
+  }
+
+  private async runSerialized<T>(
+    tokenKey: string,
+    operation: () => Promise<T>
+  ): Promise<T> {
+    const previous = this.queueTails.get(tokenKey) ?? Promise.resolve();
+    let release = (): void => undefined;
+    const current = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const tail = previous.catch(() => undefined).then(() => current);
+    this.queueTails.set(tokenKey, tail);
+
+    await previous.catch(() => undefined);
+    try {
+      return await operation();
+    } finally {
+      release();
+      if (this.queueTails.get(tokenKey) === tail) {
+        this.queueTails.delete(tokenKey);
+      }
+    }
+  }
+
+  private now(): number {
+    return (this.options.now ?? Date.now)();
+  }
+
+  private maxWaitMs(): number {
+    return this.options.maxWaitMs ?? DEFAULT_MAX_WAIT_MS;
+  }
+
+  private sleep(ms: number): Promise<void> {
+    const sleepImpl =
+      this.options.sleep ??
+      ((delayMs: number) =>
+        new Promise<void>((resolve) => {
+          setTimeout(resolve, delayMs);
+        }));
+    return sleepImpl(ms);
+  }
+}
+
+export function isGitHubRateLimitResponse(
+  status: number,
+  details: string,
+  headers: Pick<Headers, "get"> | null | undefined
+): boolean {
+  if (status === 429) {
+    return true;
+  }
+  if (status !== 403) {
+    return false;
+  }
+
+  const remaining = finiteNumber(headers?.get("x-ratelimit-remaining"));
+  if (remaining === 0 || headers?.get("retry-after")) {
+    return true;
+  }
+
+  const normalizedDetails = details.toLowerCase();
+  return (
+    normalizedDetails.includes("rate limit") ||
+    normalizedDetails.includes("abuse detection")
+  );
+}
+
+export function parseGitHubRetryAfterMs(
+  value: string | null,
+  now: number = Date.now()
+): number | null {
+  if (!value) {
+    return null;
+  }
+  const seconds = Number(value);
+  if (Number.isFinite(seconds) && seconds >= 0) {
+    return seconds * 1_000;
+  }
+  const retryAtMs = Date.parse(value);
+  return Number.isFinite(retryAtMs) ? Math.max(0, retryAtMs - now) : null;
+}
+
+function resolveResetAtMs(
+  rateLimits: GitHubRateLimitState | null
+): number | null {
+  if (!rateLimits) {
+    return null;
+  }
+  return (
+    parseTimestampMs(
+      typeof rateLimits.resetAt === "string" ? rateLimits.resetAt : null
+    ) ??
+    (typeof rateLimits.reset === "number" ? rateLimits.reset * 1_000 : null)
+  );
+}
+
+function parseTimestampMs(value: string | null): number | null {
+  if (!value) {
+    return null;
+  }
+  const timestampMs = Date.parse(value);
+  return Number.isFinite(timestampMs) ? timestampMs : null;
+}
+
+function finiteNumber(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function maxNullable(left: number | null, right: number | null): number | null {
+  if (left === null) {
+    return right;
+  }
+  if (right === null) {
+    return left;
+  }
+  return Math.max(left, right);
+}
+
+function toIsoTimestamp(value: number | null): string | null {
+  return value === null ? null : new Date(value).toISOString();
+}

--- a/packages/tracker-github/src/index.ts
+++ b/packages/tracker-github/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./adapter.js";
+export * from "./github-rate-limit.js";
 export * from "./orchestrator-adapter.js";
 export * from "./validation.js";

--- a/packages/tracker-github/src/tracker-github.test.ts
+++ b/packages/tracker-github/src/tracker-github.test.ts
@@ -21,6 +21,7 @@ import {
   detectDuplicatePlacements,
   detectTransferRebindRequired,
 } from "./validation.js";
+import { GitHubGraphQLRateLimitError } from "./github-rate-limit.js";
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -2597,6 +2598,99 @@ describe("resolveTrackerAdapter", () => {
     expect(fetchImpl).toHaveBeenCalledTimes(2);
   });
 
+  it("retries a secondary rate-limit 403 after Retry-After", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-19T04:00:00.000Z"));
+    const adapter = resolveTrackerAdapter({
+      adapter: "github-project",
+      bindingId: "project-123",
+      settings: { projectId: "project-123" },
+    });
+    const success = new Response(
+      JSON.stringify({
+        data: {
+          node: {
+            __typename: "ProjectV2",
+            items: {
+              nodes: [],
+              pageInfo: { endCursor: null, hasNextPage: false },
+            },
+          },
+        },
+      }),
+      { status: 200, headers: { "content-type": "application/json" } }
+    );
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response("secondary rate limit exceeded", {
+          status: 403,
+          headers: { "retry-after": "2" },
+        })
+      )
+      .mockResolvedValueOnce(success);
+
+    const pending = adapter.listIssues(
+      {
+        projectId: "workspace-1",
+        slug: "workspace-1",
+        workspaceDir: "/tmp/workspace-1",
+        repository: {
+          owner: "acme",
+          name: "platform",
+          cloneUrl: "https://github.com/acme/platform.git",
+        },
+        tracker: {
+          adapter: "github-project",
+          bindingId: "project-123",
+          settings: { projectId: "project-123" },
+        },
+      },
+      { token: "dependencies-token", fetchImpl }
+    );
+
+    await vi.advanceTimersByTimeAsync(1_999);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1);
+    await pending;
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry an authentication or permission 403", async () => {
+    const adapter = resolveTrackerAdapter({
+      adapter: "github-project",
+      bindingId: "project-123",
+      settings: { projectId: "project-123" },
+    });
+    const fetchImpl = vi.fn().mockResolvedValue(
+      new Response("Resource not accessible by personal access token", {
+        status: 403,
+      })
+    );
+
+    await expect(
+      adapter.listIssues(
+        {
+          projectId: "workspace-1",
+          slug: "workspace-1",
+          workspaceDir: "/tmp/workspace-1",
+          repository: {
+            owner: "acme",
+            name: "platform",
+            cloneUrl: "https://github.com/acme/platform.git",
+          },
+          tracker: {
+            adapter: "github-project",
+            bindingId: "project-123",
+            settings: { projectId: "project-123" },
+          },
+        },
+        { token: "dependencies-token", fetchImpl }
+      )
+    ).rejects.toMatchObject({ status: 403 });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
   it("allows a soft-threshold GraphQL request when the cached reset is too far away", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-03-19T04:00:00.000Z"));
@@ -2780,8 +2874,10 @@ describe("resolveTrackerAdapter", () => {
       thrown = error;
     }
 
-    expect(thrown).toBeInstanceOf(Error);
-    expect((thrown as Error).message).toBe("Rate limit near exhaustion");
+    expect(thrown).toBeInstanceOf(GitHubGraphQLRateLimitError);
+    expect((thrown as Error).message).toBe(
+      "GitHub GraphQL rate limit near exhaustion"
+    );
     expect((thrown as { rateLimits?: unknown }).rateLimits).toEqual({
       source: "github",
       limit: 5000,


### PR DESCRIPTION
## Issues — Closed #450

- Fixes #450

## TL;DR

- token별 직렬화 게이트로 GitHub GraphQL rate-limit 확인과 요청을 원자적으로 묶어 동시 요청 버스트를 방지합니다.
- secondary rate-limit 403과 429는 `Retry-After` 및 primary quota 소진 시의 reset을 준수해 제한된 지수 백오프로 재시도하고, 일반 인증 403은 즉시 HTTP 오류로 분류합니다.
- rework에서 primary quota가 남은 secondary-limit 응답의 먼 reset이 `Retry-After`를 덮어쓰지 않도록 수정했습니다.
- 오케스트레이터의 디스패치 억제는 오류 문자열 대신 provider-neutral `TrackerRateLimitError` 타입을 사용합니다.

## 변경 지점 다이어그램

```text
GitHub GraphQL 호출자
  → token-scoped serialized rate-limit policy
      → cached quota 선제 가드
      → GitHub 요청
      → 403/429 분류
      → secondary: Retry-After 우선
      → primary exhausted: reset 고려
      → bounded exponential backoff
  → TrackerRateLimitError
  → orchestrator typed dispatch suppression
```

## 여기부터 보세요

- `packages/tracker-github/src/github-rate-limit.ts` — 직렬화, 선제 가드, 응답 분류, 재시도 정책과 secondary/primary retry 시각 선택
- `packages/tracker-github/src/adapter.ts` — 모든 GraphQL 요청을 공유 정책으로 통합
- `packages/core/src/contracts/tracker-adapter.ts` 및 `packages/orchestrator/src/service.ts` — provider-neutral 타입과 타입 기반 억제
- `packages/tracker-github/src/github-rate-limit.test.ts` — 동시성, 403/429, `Retry-After`, primary reset fallback, 백오프 TC

## Evidence

- `pnpm lint` — pass
- `pnpm test` — pass
- `pnpm typecheck` — pass
- `pnpm build` — pass
- `pnpm --filter @gh-symphony/tracker-github test` — pass (3 files, 97 tests)
- CI `Test`, `Container Smoke` — pass on `baa1e0a3b48f2dccae9cc28dec078828b4468277`
- Docker E2E happy path — worker completed event 관찰; fixture 제거 후 `health: idle`, `activeRuns: 0`, retry queue 비어 있음, `lastError: null`
- `/pull` — `main` clean rebase; PR base 최신 상태 확인
- P1 inline feedback — concrete reply 게시 및 thread resolved

## 위험 & 롤백

- token 단위 직렬화로 같은 자격 증명을 공유하는 GraphQL 처리량이 낮아질 수 있습니다. 서로 다른 token은 독립적으로 진행하고, 재시도 횟수와 단일 대기 시간은 상한을 둡니다.
- secondary-limit에서는 `Retry-After`를 우선하므로 primary quota가 남아 있는 정상적인 reset 시각 때문에 과도하게 억제되지 않습니다. primary quota가 소진된 경우에는 reset을 계속 준수합니다.
- 문제가 발생하면 `github-rate-limit` 정책 연결과 `TrackerRateLimitError` 기반 억제 변경을 함께 되돌릴 수 있습니다.

## 변경 파일

- `.changeset/quiet-gates-wait.md`
- `packages/core/src/contracts/tracker-adapter.ts`
- `packages/orchestrator/src/service.ts`, `packages/orchestrator/src/service.test.ts`
- `packages/tracker-github/src/adapter.ts`, `packages/tracker-github/src/github-rate-limit.ts`
- `packages/tracker-github/src/github-rate-limit.test.ts`, `packages/tracker-github/src/tracker-github.test.ts`, `packages/tracker-github/src/index.ts`

## 머지 후/사람 확인

- [ ] 실제 GitHub secondary rate-limit 응답에서 `Retry-After` 기준 대기·회복 로그가 기대대로 보이는지 확인
- [ ] 실제 잘못된 자격 증명의 403이 rate-limit 재시도 없이 인증 실패로 노출되는지 확인

## Human Validation

- [ ] 동시 GraphQL 요청에서 API 버스트가 억제되는지 확인
- [ ] 403 인증 실패와 secondary rate limit이 구분되는지 확인
- [ ] primary quota가 남은 secondary-limit 응답에서 `Retry-After`가 먼 reset보다 우선되는지 확인
- [ ] reviewer-visible behavior가 이슈 완료 조건과 일치하는지 확인
