### PR TITLE
fix(orchestrator): surface cleanup failures

### DIFF
--- a/.changeset/surface-cleanup-failures.md
+++ b/.changeset/surface-cleanup-failures.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Surface orchestrator hook and workspace cleanup failures, preserve cleanup-pending state when deletion fails, and guarantee project lock release during shutdown for #451.

--- a/packages/orchestrator/src/index.test.ts
+++ b/packages/orchestrator/src/index.test.ts
@@ -334,6 +334,38 @@ describe("orchestrator CLI", () => {
     ).rejects.toMatchObject({ code: "ENOENT" });
   });
 
+  it("releases the project lock when service shutdown fails", async () => {
+    const runtimeRoot = await mkdtemp(join(tmpdir(), "orchestrator-cli-"));
+    const service = createMockService();
+    (service.shutdown as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error("shutdown failed")
+    );
+    const lock = {
+      lockPath: join(runtimeRoot, ".lock"),
+      ownerToken: "owner-1",
+      pid: 1234,
+      startedAt: "2026-03-16T00:00:00.000Z",
+      heartbeatAt: "2026-03-16T00:00:00.000Z",
+      processIdentity: "test-process",
+    };
+    const acquireLock = vi.fn().mockResolvedValue(lock);
+    const releaseLock = vi.fn().mockResolvedValue(undefined);
+
+    await expect(
+      runCli(
+        ["run", "--runtime-root", runtimeRoot, "--project-id", "tenant-1"],
+        {
+          createService: () => service,
+          acquireLock,
+          releaseLock,
+        }
+      )
+    ).rejects.toThrow("shutdown failed");
+
+    expect(releaseLock).toHaveBeenCalledOnce();
+    expect(releaseLock).toHaveBeenCalledWith(lock);
+  });
+
   it.each(["run-once", "dispatch", "run-issue", "recover"])(
     "holds the project lock across the %s mutation",
     async (command) => {

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -2533,6 +2533,142 @@ Test hook failures.
     );
   });
 
+  it("continues terminal cleanup after a workspace deletion fails", async () => {
+    process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
+    const tempRoot = await mkdtemp(
+      join(tmpdir(), "orchestrator-terminal-cleanup-continue-")
+    );
+    const repository = await createRepositoryFixture(
+      tempRoot,
+      "acme",
+      "platform"
+    );
+    const store = new OrchestratorFsStore(tempRoot);
+    const projectConfig = createProjectConfig(tempRoot, repository);
+    await store.saveProjectConfig(projectConfig);
+
+    const failedWorkspaceKey = deriveIssueWorkspaceKey("acme/platform#1");
+    const removedWorkspaceKey = deriveIssueWorkspaceKey("acme/platform#2");
+    const failedWorkspacePath = resolveIssueWorkspaceDirectory(
+      store.projectDir(projectConfig.projectId),
+      failedWorkspaceKey
+    );
+    const removedWorkspacePath = resolveIssueWorkspaceDirectory(
+      store.projectDir(projectConfig.projectId),
+      removedWorkspaceKey
+    );
+    await mkdir(join(failedWorkspacePath, "repository"), { recursive: true });
+    await mkdir(join(removedWorkspacePath, "repository"), { recursive: true });
+    await writeFile(join(failedWorkspacePath, "sentinel.txt"), "keep", "utf8");
+    await writeFile(
+      join(removedWorkspacePath, "sentinel.txt"),
+      "remove",
+      "utf8"
+    );
+    await store.saveProjectIssueOrchestrations("tenant-1", [
+      {
+        issueId: "issue-1",
+        identifier: "acme/platform#1",
+        workspaceKey: failedWorkspaceKey,
+        completedOnce: false,
+        failureRetryCount: 0,
+        state: "released",
+        currentRunId: null,
+        retryEntry: null,
+        updatedAt: "2026-03-08T00:00:00.000Z",
+      },
+      {
+        issueId: "issue-2",
+        identifier: "acme/platform#2",
+        workspaceKey: removedWorkspaceKey,
+        completedOnce: false,
+        failureRetryCount: 0,
+        state: "released",
+        currentRunId: null,
+        retryEntry: null,
+        updatedAt: "2026-03-08T00:00:00.000Z",
+      },
+    ]);
+    for (const [
+      issueSubjectId,
+      issueIdentifier,
+      workspaceKey,
+      workspacePath,
+    ] of [
+      ["issue-1", "acme/platform#1", failedWorkspaceKey, failedWorkspacePath],
+      ["issue-2", "acme/platform#2", removedWorkspaceKey, removedWorkspacePath],
+    ] as const) {
+      await store.saveIssueWorkspace({
+        workspaceKey,
+        projectId: "tenant-1",
+        adapter: "github-project",
+        issueSubjectId,
+        issueIdentifier,
+        workspacePath,
+        repositoryPath: join(workspacePath, "repository"),
+        status: "active",
+        createdAt: "2026-03-08T00:00:00.000Z",
+        updatedAt: "2026-03-08T00:00:00.000Z",
+        lastError: null,
+      });
+    }
+
+    const stderr = { write: vi.fn() };
+    const rmImpl = vi.fn(async (workspacePath: Parameters<typeof rm>[0]) => {
+      if (workspacePath === failedWorkspacePath) {
+        throw new Error("disk busy");
+      }
+      await rm(workspacePath, { recursive: true, force: true });
+    });
+    const service = new OrchestratorService(store, projectConfig, {
+      fetchImpl: vi
+        .fn()
+        .mockResolvedValueOnce(createEmptyTrackerResponse())
+        .mockResolvedValueOnce(
+          createTrackerResponseWithItems(repository, [
+            {
+              id: "issue-1",
+              identifier: "acme/platform#1",
+              state: "Done",
+            },
+            {
+              id: "issue-2",
+              identifier: "acme/platform#2",
+              state: "Done",
+            },
+          ])
+        ) as never,
+      spawnImpl: vi.fn().mockReturnValue({
+        pid: 4105,
+        unref: vi.fn(),
+      }) as never,
+      now: () => new Date("2026-03-08T00:00:00.000Z"),
+      stderr,
+      rmImpl,
+    });
+
+    await service.run({ once: true });
+
+    await expect(
+      readFile(join(failedWorkspacePath, "sentinel.txt"), "utf8")
+    ).resolves.toBe("keep");
+    await expect(
+      readFile(join(removedWorkspacePath, "sentinel.txt"), "utf8")
+    ).rejects.toThrow();
+    await expect(
+      store.loadIssueWorkspace("tenant-1", failedWorkspaceKey)
+    ).resolves.toMatchObject({
+      status: "cleanup_pending",
+      lastError: "Failed to remove workspace for acme/platform#1: disk busy",
+    });
+    await expect(
+      store.loadIssueWorkspace("tenant-1", removedWorkspaceKey)
+    ).resolves.toMatchObject({ status: "removed", lastError: null });
+    expect(stderr.write).toHaveBeenCalledWith(
+      "[orchestrator] Terminal workspace cleanup failed for acme/platform#1; continuing: Failed to remove workspace for acme/platform#1: disk busy\n"
+    );
+  });
+
   it("logs a warning and continues startup when terminal issue fetch fails", async () => {
     process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
     const tempRoot = await mkdtemp(

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -2332,7 +2332,7 @@ Prefer focused changes.
       lastError: null,
     });
 
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const stderr = { write: vi.fn() };
     const service = new OrchestratorService(store, projectConfig, {
       fetchImpl: vi
         .fn()
@@ -2345,6 +2345,7 @@ Prefer focused changes.
         unref: vi.fn(),
       }) as never,
       now: () => new Date("2026-03-08T00:00:00.000Z"),
+      stderr,
     });
 
     await service.run({ once: true });
@@ -2356,11 +2357,180 @@ Prefer focused changes.
     await expect(readFile(sentinelPath, "utf8")).rejects.toThrow();
     expect(workspaceRecord?.status).toBe("removed");
     expect(workspaceRecord?.lastError).toBeNull();
-    expect(warnSpy).toHaveBeenCalledWith(
-      "[orchestrator] before_remove hook failed for acme/platform#1; continuing cleanup: cleanup hook failed"
+    expect(stderr.write).toHaveBeenCalledWith(
+      "[orchestrator] before_remove hook failed for acme/platform#1: cleanup hook failed\n"
     );
-    warnSpy.mockRestore();
     delete process.env.SYMPHONY_ALLOW_WORKFLOW_HOOKS;
+  });
+
+  it("logs hook failures and appends a hook-failed run event", async () => {
+    process.env.SYMPHONY_ALLOW_WORKFLOW_HOOKS = "1";
+    const tempRoot = await mkdtemp(join(tmpdir(), "orchestrator-hook-event-"));
+    const repository = await createRepositoryFixture(
+      tempRoot,
+      "acme",
+      "platform",
+      {
+        rawWorkflow: `---
+tracker:
+  kind: github-project
+  project_id: project-123
+  state_field: Status
+  active_states: [Todo]
+  terminal_states: [Done]
+hooks:
+  after_run: hooks/after_run.sh
+workspace:
+  root: .runtime/symphony-workspaces
+agent:
+  max_concurrent_agents: 1
+codex:
+  command: codex app-server
+---
+Test hook failures.
+`,
+      }
+    );
+    await mkdir(join(repository.path, "hooks"), { recursive: true });
+    await writeFile(
+      join(repository.path, "hooks", "after_run.sh"),
+      "#!/usr/bin/env bash\nprintf 'after run failed' >&2\nexit 1\n",
+      "utf8"
+    );
+    await chmod(join(repository.path, "hooks", "after_run.sh"), 0o755);
+
+    const store = new OrchestratorFsStore(tempRoot);
+    const projectConfig = createProjectConfig(tempRoot, repository);
+    const stderr = { write: vi.fn() };
+    const service = new OrchestratorService(store, projectConfig, {
+      now: () => new Date("2026-03-08T00:00:00.000Z"),
+      stderr,
+    });
+
+    const result = await (
+      service as unknown as {
+        runHook(
+          kind: "after_run",
+          tenant: OrchestratorProjectConfig,
+          repositoryDirectory: string,
+          repository: RepositoryRef,
+          context: {
+            projectId: string;
+            workspaceKey: string;
+            issueSubjectId: string;
+            issueIdentifier: string;
+            workspacePath: string;
+            repositoryPath: string;
+            runId: string;
+          }
+        ): Promise<{ outcome: string; error: string | null }>;
+      }
+    ).runHook("after_run", projectConfig, repository.path, repository, {
+      projectId: "tenant-1",
+      workspaceKey: "issue-1",
+      issueSubjectId: "issue-1",
+      issueIdentifier: "acme/platform#1",
+      workspacePath: repository.path,
+      repositoryPath: repository.path,
+      runId: "run-hook-failure",
+    });
+
+    expect(result).toMatchObject({
+      outcome: "failure",
+      error: "after run failed",
+    });
+    expect(stderr.write).toHaveBeenCalledWith(
+      "[orchestrator] after_run hook failed for acme/platform#1: after run failed\n"
+    );
+    await expect(
+      readFile(
+        join(store.runDir("run-hook-failure", "tenant-1"), "events.ndjson"),
+        "utf8"
+      )
+    ).resolves.toContain(
+      '"event":"hook-failed","projectId":"tenant-1","hook":"after_run","error":"after run failed"'
+    );
+  });
+
+  it("keeps cleanup pending when workspace deletion fails", async () => {
+    process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
+    const tempRoot = await mkdtemp(
+      join(tmpdir(), "orchestrator-startup-remove-failure-")
+    );
+    const repository = await createRepositoryFixture(
+      tempRoot,
+      "acme",
+      "platform"
+    );
+    const store = new OrchestratorFsStore(tempRoot);
+    const projectConfig = createProjectConfig(tempRoot, repository);
+    await store.saveProjectConfig(projectConfig);
+    const workspaceKey = deriveIssueWorkspaceKey("acme/platform#1");
+    const workspacePath = resolveIssueWorkspaceDirectory(
+      store.projectDir(projectConfig.projectId),
+      workspaceKey
+    );
+    const repositoryPath = join(workspacePath, "repository");
+    const sentinelPath = join(workspacePath, "sentinel.txt");
+    await mkdir(repositoryPath, { recursive: true });
+    await writeFile(sentinelPath, "preserve me", "utf8");
+    await store.saveProjectIssueOrchestrations("tenant-1", [
+      {
+        issueId: "issue-1",
+        identifier: "acme/platform#1",
+        workspaceKey,
+        completedOnce: false,
+        failureRetryCount: 0,
+        state: "released",
+        currentRunId: null,
+        retryEntry: null,
+        updatedAt: "2026-03-08T00:00:00.000Z",
+      },
+    ]);
+    await store.saveIssueWorkspace({
+      workspaceKey,
+      projectId: "tenant-1",
+      adapter: "github-project",
+      issueSubjectId: "issue-1",
+      issueIdentifier: "acme/platform#1",
+      workspacePath,
+      repositoryPath,
+      status: "active",
+      createdAt: "2026-03-08T00:00:00.000Z",
+      updatedAt: "2026-03-08T00:00:00.000Z",
+      lastError: null,
+    });
+    const stderr = { write: vi.fn() };
+    const service = new OrchestratorService(store, projectConfig, {
+      fetchImpl: vi
+        .fn()
+        .mockResolvedValueOnce(
+          createTrackerResponseWithState(repository, "Done")
+        )
+        .mockResolvedValueOnce(createTrackerResponse(repository)) as never,
+      spawnImpl: vi.fn().mockReturnValue({
+        pid: 4104,
+        unref: vi.fn(),
+      }) as never,
+      now: () => new Date("2026-03-08T00:00:00.000Z"),
+      stderr,
+      rmImpl: vi.fn().mockRejectedValue(new Error("disk busy")),
+    });
+
+    await service.run({ once: true });
+
+    const workspaceRecord = await store.loadIssueWorkspace(
+      "tenant-1",
+      workspaceKey
+    );
+    await expect(readFile(sentinelPath, "utf8")).resolves.toBe("preserve me");
+    expect(workspaceRecord).toMatchObject({
+      status: "cleanup_pending",
+      lastError: "Failed to remove workspace for acme/platform#1: disk busy",
+    });
+    expect(stderr.write).toHaveBeenCalledWith(
+      "[orchestrator] Failed to remove workspace for acme/platform#1: disk busy\n"
+    );
   });
 
   it("logs a warning and continues startup when terminal issue fetch fails", async () => {

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -381,6 +381,7 @@ export class OrchestratorService {
       logLevel?: OrchestratorLogLevel;
       onTick?: OrchestratorTickHandler;
       assignedOnly?: boolean;
+      rmImpl?: typeof rm;
     } = {}
   ) {}
 
@@ -3410,8 +3411,8 @@ export class OrchestratorService {
 
   /**
    * Execute a workspace lifecycle hook using the workflow configuration
-   * loaded from the repository. Returns the hook result or null if the
-   * workflow could not be loaded.
+   * loaded from the repository. Failures are logged and mirrored to the
+   * run event stream when a run id is available.
    */
   private async runHook(
     kind: "after_create" | "before_run" | "after_run" | "before_remove",
@@ -3429,32 +3430,71 @@ export class OrchestratorService {
       state?: string;
     },
     resolution?: ProjectWorkflowResolution
-  ): Promise<HookResult | null> {
+  ): Promise<HookResult> {
+    let result: HookResult;
     try {
       const workflowResolution =
         resolution ?? (await this.loadProjectWorkflow(tenant, repository));
       if (!isUsableWorkflowResolution(workflowResolution)) {
-        return null;
+        result = {
+          kind,
+          outcome: "failure",
+          exitCode: null,
+          durationMs: 0,
+          error:
+            workflowResolution.validationError ??
+            "Repository WORKFLOW.md could not be loaded.",
+        };
+      } else {
+        const hookEnv = this.buildProjectExecutionEnv(
+          tenant.projectId,
+          buildHookEnv(context)
+        );
+        result = await executeWorkspaceHook({
+          kind,
+          hooks: workflowResolution.workflow.hooks,
+          repositoryPath: repositoryDirectory,
+          env: hookEnv,
+          trusted: isWorkflowHookExecutionAllowed(hookEnv),
+          envAllowlist: parseCommaSeparatedEnvList(
+            hookEnv[WORKFLOW_HOOK_ENV_ALLOWLIST_ENV]
+          ),
+          timeoutMs: workflowResolution.workflow.hooks.timeoutMs,
+        });
       }
-      const hookEnv = this.buildProjectExecutionEnv(
-        tenant.projectId,
-        buildHookEnv(context)
-      );
-      return executeWorkspaceHook({
+    } catch (error) {
+      result = {
         kind,
-        hooks: workflowResolution.workflow.hooks,
-        repositoryPath: repositoryDirectory,
-        env: hookEnv,
-        trusted: isWorkflowHookExecutionAllowed(hookEnv),
-        envAllowlist: parseCommaSeparatedEnvList(
-          hookEnv[WORKFLOW_HOOK_ENV_ALLOWLIST_ENV]
-        ),
-        timeoutMs: workflowResolution.workflow.hooks.timeoutMs,
-      });
-    } catch {
-      // If workflow cannot be loaded, skip hook execution
-      return null;
+        outcome: "failure",
+        exitCode: null,
+        durationMs: 0,
+        error: this.formatErrorMessage(error),
+      };
     }
+
+    if (result.outcome !== "success" && result.outcome !== "skipped") {
+      const errorMessage = result.error ?? `${kind} hook ${result.outcome}`;
+      this.writeStderr(
+        `[orchestrator] ${kind} hook failed for ${context.issueIdentifier}: ${errorMessage}`
+      );
+      if (context.runId) {
+        try {
+          await this.store.appendRunEvent(context.runId, {
+            at: this.now().toISOString(),
+            event: "hook-failed",
+            projectId: tenant.projectId,
+            hook: kind,
+            error: errorMessage,
+          });
+        } catch (error) {
+          this.writeStderr(
+            `[orchestrator] Failed to persist ${kind} hook failure event for ${context.issueIdentifier}: ${this.formatErrorMessage(error)}`
+          );
+        }
+      }
+    }
+
+    return result;
   }
 
   private readProjectEnv(projectId: string): Record<string, string> {
@@ -3998,7 +4038,7 @@ export class OrchestratorService {
     await this.store.saveIssueWorkspace(pendingRecord);
 
     // Run before_remove hook. Failures are logged but do not block cleanup.
-    const hookResult = await this.runHook(
+    await this.runHook(
       "before_remove",
       tenant,
       workspaceRecord.repositoryPath,
@@ -4014,23 +4054,23 @@ export class OrchestratorService {
       workflowResolution
     );
 
-    if (
-      hookResult &&
-      hookResult.outcome !== "success" &&
-      hookResult.outcome !== "skipped"
-    ) {
-      const errorMessage =
-        hookResult.error ?? `before_remove hook ${hookResult.outcome}`;
-      console.warn(
-        `[orchestrator] before_remove hook failed for ${issue.identifier}; continuing cleanup: ${errorMessage}`
-      );
-    }
-
-    // Hook succeeded or was skipped — remove workspace directory
+    // Hook failures are observable but do not block removal per spec 9.4.
     try {
-      await rm(workspaceRecord.workspacePath, { recursive: true, force: true });
-    } catch {
-      // Directory removal failure is not fatal to the record transition
+      await (this.dependencies.rmImpl ?? rm)(workspaceRecord.workspacePath, {
+        recursive: true,
+        force: true,
+      });
+    } catch (error) {
+      const removalError =
+        error instanceof Error ? error.message : String(error);
+      const errorMessage = `Failed to remove workspace for ${issue.identifier}: ${removalError}`;
+      await this.store.saveIssueWorkspace({
+        ...pendingRecord,
+        updatedAt: this.now().toISOString(),
+        lastError: errorMessage,
+      });
+      this.writeStderr(`[orchestrator] ${errorMessage}`);
+      throw new Error(errorMessage, { cause: error });
     }
 
     const removedRecord: IssueWorkspaceRecord = {

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -1452,7 +1452,17 @@ export class OrchestratorService {
       }
 
       for (const issue of terminalIssuesByIdentifier.values()) {
-        await this.cleanupTerminalIssueWorkspace(tenant, issue, now);
+        try {
+          await this.cleanupTerminalIssueWorkspace(tenant, issue, now);
+        } catch (error) {
+          const message =
+            error instanceof Error
+              ? error.message
+              : "Unknown terminal workspace cleanup error";
+          this.writeStderr(
+            `[orchestrator] Terminal workspace cleanup failed for ${issue.identifier}; continuing: ${message}`
+          );
+        }
       }
     } catch (error) {
       trackerError = error;


### PR DESCRIPTION
## TL;DR

- workspace hook 실패를 stderr와 `hook-failed` 이벤트로 표면화합니다.
- 실제 디렉터리 삭제가 실패하면 `removed`로 오기록하지 않고 `cleanup_pending + lastError`를 유지합니다.
- 한 workspace 삭제 실패가 같은 tick의 이후 terminal workspace cleanup을 막지 않도록 실패를 workspace 단위로 격리합니다.
- shutdown 실패 시에도 project lock이 해제되는 보장을 회귀 TC로 고정합니다.

## 변경 지점 다이어그램

```text
hook 실행 ── 실패 ──> stderr + hook-failed event

terminal workspace loop
  ├─ workspace A rm 실패 ──> cleanup_pending + lastError + log
  │                         └─ continue
  └─ workspace B rm 성공 ──> removed

shutdown ── 실패 포함 ──> finally ──> project lock release
```

## 여기부터 보세요

- `packages/orchestrator/src/service.ts`: `runHook()` 실패 관측, 삭제 실패 상태 보존, terminal cleanup loop의 workspace별 오류 격리
- `packages/orchestrator/src/service.test.ts`: hook 이벤트·삭제 실패 상태·후속 workspace cleanup 지속 TC
- `packages/orchestrator/src/index.test.ts`: shutdown 실패 시 lock release TC

## 위험 & 롤백

- cleanup 실패가 상태 API에서 `cleanup_pending`과 `lastError`로 남으므로 기존의 거짓 `removed` 상태를 기대한 운영 자동화는 조정이 필요할 수 있습니다.
- 한 workspace의 반복 삭제 실패가 다른 terminal workspace 정리를 더 이상 지연시키지 않습니다.
- 회귀 시 이 PR의 단일 squash commit을 되돌릴 수 있습니다.

## 변경 파일

- `.changeset/surface-cleanup-failures.md`
- `packages/orchestrator/src/service.ts`
- `packages/orchestrator/src/service.test.ts`
- `packages/orchestrator/src/index.test.ts`

## Evidence

- `pnpm --filter @gh-symphony/orchestrator exec vitest run src/service.test.ts -t 'continues terminal cleanup after a workspace deletion fails'` — 1 passed
- `pnpm --filter @gh-symphony/orchestrator test` — 11 files, 233 tests passed
- `pnpm lint` — passed
- `pnpm test` — passed
- `pnpm typecheck` — passed
- `pnpm build` — passed
- `docker compose -f docker-compose.e2e.yml -f docker-compose.e2e.events.yml up -d --build` + `/healthz` + `/api/v1/refresh` — health OK, API에서 `running → completed` 관찰

## Issues — Closed #451

- Fixes #451

## 머지 후/사람 확인

- [ ] cleanup 실패 로그와 `cleanup_pending + lastError` 상태가 운영 기대와 일치하는지 확인
- [ ] hook failure 이벤트가 운영 관측 파이프라인에 표시되는지 확인
- [ ] 여러 terminal workspace 중 하나의 삭제 실패가 나머지 cleanup을 막지 않는지 운영 환경에서 확인
