### PR TITLE
fix(core): classify reconciled cancellations

### DIFF
--- a/.changeset/bright-cancel-classification.md
+++ b/.changeset/bright-cancel-classification.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Classify reconciliation-canceled sessions separately from errors (#452).

--- a/packages/core/src/contracts/status-surface.ts
+++ b/packages/core/src/contracts/status-surface.ts
@@ -69,6 +69,7 @@ export const SESSION_EXIT_CLASSIFICATIONS = [
   "max-turns-reached",
   "user-input-required",
   "timeout",
+  "canceled_by_reconciliation",
   "error",
   "incomplete-turn-dirty-workspace",
 ] as const;

--- a/packages/core/src/workflow/exit-classification.test.ts
+++ b/packages/core/src/workflow/exit-classification.test.ts
@@ -35,6 +35,18 @@ describe("classifySessionExit", () => {
     ).toBe("timeout");
   });
 
+  it("classifies reconciliation cancellations separately from errors", () => {
+    expect(
+      classifySessionExit({
+        runPhase: "canceled_by_reconciliation",
+        userInputRequired: false,
+        budgetExceeded: false,
+        convergenceDetected: false,
+        maxTurnsReached: false,
+      })
+    ).toBe("canceled_by_reconciliation");
+  });
+
   it("classifies budget exits distinctly from per-session turn limits", () => {
     expect(
       classifySessionExit({

--- a/packages/core/src/workflow/exit-classification.ts
+++ b/packages/core/src/workflow/exit-classification.ts
@@ -20,6 +20,10 @@ export function classifySessionExit(params: {
     return "convergence-detected";
   }
 
+  if (params.runPhase === "canceled_by_reconciliation") {
+    return "canceled_by_reconciliation";
+  }
+
   if (params.runPhase === "timed_out" || params.runPhase === "stalled") {
     return "timeout";
   }


### PR DESCRIPTION
## TL;DR

- `canceled_by_reconciliation` sessions now receive a dedicated exit classification.
- Intentional reconciliation cancellations are excluded from `error` metrics.

## 변경 지점 다이어그램

RunAttemptPhase (`canceled_by_reconciliation`)
→ `classifySessionExit`
→ SessionExitClassification / observability metrics

## 여기부터 보세요

- `packages/core/src/workflow/exit-classification.ts`
- `packages/core/src/contracts/status-surface.ts`
- `packages/core/src/workflow/exit-classification.test.ts`

## 위험 & 롤백

- Low risk: adds a valid classification and preserves existing precedence for other terminal states.
- Rollback: revert commit `14740ce`.

## 변경 파일

- `packages/core/src/contracts/status-surface.ts` — registers the classification.
- `packages/core/src/workflow/exit-classification.ts` — maps reconciliation cancellation to the dedicated classification.
- `packages/core/src/workflow/exit-classification.test.ts` — adds the TC.
- `.changeset/bright-cancel-classification.md` — patch release note for `@gh-symphony/cli`.

## Issues — Closed #452

## Evidence

- `pnpm lint` — passed.
- `pnpm --filter @gh-symphony/core test` — 205 passed.
- `pnpm test` — 232 passed; one unrelated orchestrator lease test timed out at 5s in the full run, and the isolated rerun passed.
- `pnpm typecheck` — passed.
- `pnpm build` — passed.
- `git diff --check` — passed.
- Docker E2E — N/A; core classification behavior is covered by unit tests.

## 머지 후/사람 확인

- [ ] Review the classification name and metric presentation.
- [ ] Confirm no regression in adjacent exit classifications.
- No deploy, external URL smoke test, or manual UX validation is in scope.
