### PR TITLE
fix(worker): validate Codex policy enums

### DIFF
--- a/.changeset/validate-codex-policy-enums.md
+++ b/.changeset/validate-codex-policy-enums.md
@@ -4,4 +4,4 @@
 
 Validate Codex approval and sandbox policy environment values and fail loudly on unknown values (#530).
 
-When configuring `turn_sandbox_policy`, use the Codex app-server's camelCase values (`dangerFullAccess`, `readOnly`, `externalSandbox`, or `workspaceWrite`). The thread-level `thread_sandbox` values remain kebab-case (`read-only`, `workspace-write`, or `danger-full-access`).
+For the current string-based `turn_sandbox_policy` setting, use the Codex app-server's `dangerFullAccess` value. The other app-server turn variants (`readOnly`, `externalSandbox`, and `workspaceWrite`) require structured fields that this setting cannot provide and are rejected rather than sent as incomplete payloads. The thread-level `thread_sandbox` values remain kebab-case (`read-only`, `workspace-write`, or `danger-full-access`).

--- a/.changeset/validate-codex-policy-enums.md
+++ b/.changeset/validate-codex-policy-enums.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Validate Codex approval and sandbox policy environment values and fail loudly on unknown values (#530).

--- a/.changeset/validate-codex-policy-enums.md
+++ b/.changeset/validate-codex-policy-enums.md
@@ -3,3 +3,5 @@
 ---
 
 Validate Codex approval and sandbox policy environment values and fail loudly on unknown values (#530).
+
+When configuring `turn_sandbox_policy`, use the Codex app-server's camelCase values (`dangerFullAccess`, `readOnly`, `externalSandbox`, or `workspaceWrite`). The thread-level `thread_sandbox` values remain kebab-case (`read-only`, `workspace-write`, or `danger-full-access`).

--- a/e2e/seed/WORKFLOW.md
+++ b/e2e/seed/WORKFLOW.md
@@ -22,8 +22,9 @@ codex:
   command: node /app/e2e/stub-worker.js
   approval_policy: on-request
   thread_sandbox: workspace-write
-  turn_sandbox_policy: workspaceWrite
+  turn_sandbox_policy: dangerFullAccess
   stall_timeout_ms: 60000
 ---
+
 You are an AI agent working on issue {{issue.identifier}}.
 This is an E2E test environment. Complete the task and report success.

--- a/e2e/seed/WORKFLOW.md
+++ b/e2e/seed/WORKFLOW.md
@@ -22,7 +22,7 @@ codex:
   command: node /app/e2e/stub-worker.js
   approval_policy: on-request
   thread_sandbox: workspace-write
-  turn_sandbox_policy: workspace-write
+  turn_sandbox_policy: workspaceWrite
   stall_timeout_ms: 60000
 ---
 You are an AI agent working on issue {{issue.identifier}}.

--- a/e2e/seed/init-local.sh
+++ b/e2e/seed/init-local.sh
@@ -62,7 +62,7 @@ codex:
   command: node $STUB_WORKER_JS
   approval_policy: on-request
   thread_sandbox: workspace-write
-  turn_sandbox_policy: workspaceWrite
+  turn_sandbox_policy: dangerFullAccess
   stall_timeout_ms: 60000
 ---
 You are an AI agent working on issue {{issue.identifier}}.

--- a/e2e/seed/init-local.sh
+++ b/e2e/seed/init-local.sh
@@ -62,7 +62,7 @@ codex:
   command: node $STUB_WORKER_JS
   approval_policy: on-request
   thread_sandbox: workspace-write
-  turn_sandbox_policy: workspace-write
+  turn_sandbox_policy: workspaceWrite
   stall_timeout_ms: 60000
 ---
 You are an AI agent working on issue {{issue.identifier}}.

--- a/packages/worker/src/codex-policy.test.ts
+++ b/packages/worker/src/codex-policy.test.ts
@@ -6,7 +6,7 @@ describe("resolveCodexPolicySettings", () => {
     expect(() =>
       resolveCodexPolicySettings({ SYMPHONY_APPROVAL_POLICY: "on-reqest" })
     ).toThrow(
-      'Invalid SYMPHONY_APPROVAL_POLICY value "on-reqest". Expected one of: never, on-request, on-failure, untrusted.'
+      'Invalid SYMPHONY_APPROVAL_POLICY value "on-reqest". Expected one of: never, on-request, untrusted.'
     );
 
     expect(() =>
@@ -20,17 +20,22 @@ describe("resolveCodexPolicySettings", () => {
         SYMPHONY_TURN_SANDBOX_POLICY: "dangerFullAcess",
       })
     ).toThrow(
-      'Invalid SYMPHONY_TURN_SANDBOX_POLICY value "dangerFullAcess". Expected one of: dangerFullAccess, readOnly, externalSandbox, workspaceWrite.'
+      'Invalid SYMPHONY_TURN_SANDBOX_POLICY value "dangerFullAcess". Expected one of: dangerFullAccess.'
+    );
+  });
+
+  it("rejects structured turn sandbox variants without accepting incomplete payloads", () => {
+    expect(() =>
+      resolveCodexPolicySettings({
+        SYMPHONY_TURN_SANDBOX_POLICY: "workspaceWrite",
+      })
+    ).toThrow(
+      'Invalid SYMPHONY_TURN_SANDBOX_POLICY value "workspaceWrite". Expected one of: dangerFullAccess.'
     );
   });
 
   it("accepts every supported policy value", () => {
-    for (const approvalPolicy of [
-      "never",
-      "on-request",
-      "on-failure",
-      "untrusted",
-    ]) {
+    for (const approvalPolicy of ["never", "on-request", "untrusted"]) {
       expect(
         resolveCodexPolicySettings({
           SYMPHONY_APPROVAL_POLICY: approvalPolicy,
@@ -50,12 +55,7 @@ describe("resolveCodexPolicySettings", () => {
       ).toBe(threadSandbox);
     }
 
-    for (const turnSandboxPolicy of [
-      "dangerFullAccess",
-      "readOnly",
-      "externalSandbox",
-      "workspaceWrite",
-    ]) {
+    for (const turnSandboxPolicy of ["dangerFullAccess"]) {
       expect(
         resolveCodexPolicySettings({
           SYMPHONY_TURN_SANDBOX_POLICY: turnSandboxPolicy,

--- a/packages/worker/src/codex-policy.test.ts
+++ b/packages/worker/src/codex-policy.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { resolveCodexPolicySettings } from "./codex-policy.js";
+
+describe("resolveCodexPolicySettings", () => {
+  it("rejects unknown approval and sandbox values with allowed values", () => {
+    expect(() =>
+      resolveCodexPolicySettings({ SYMPHONY_APPROVAL_POLICY: "on-reqest" })
+    ).toThrow(
+      'Invalid SYMPHONY_APPROVAL_POLICY value "on-reqest". Expected one of: never, on-failure, on-request, untrusted.'
+    );
+
+    expect(() =>
+      resolveCodexPolicySettings({ SYMPHONY_THREAD_SANDBOX: "workpace-write" })
+    ).toThrow(
+      'Invalid SYMPHONY_THREAD_SANDBOX value "workpace-write". Expected one of: read-only, workspace-write, danger-full-access.'
+    );
+
+    expect(() =>
+      resolveCodexPolicySettings({
+        SYMPHONY_TURN_SANDBOX_POLICY: "danger-full-acess",
+      })
+    ).toThrow(
+      'Invalid SYMPHONY_TURN_SANDBOX_POLICY value "danger-full-acess". Expected one of: read-only, workspace-write, danger-full-access.'
+    );
+  });
+
+  it("accepts every supported policy value", () => {
+    expect(
+      resolveCodexPolicySettings({
+        SYMPHONY_APPROVAL_POLICY: "on-request",
+        SYMPHONY_THREAD_SANDBOX: "workspace-write",
+        SYMPHONY_TURN_SANDBOX_POLICY: "read-only",
+      })
+    ).toEqual({
+      approvalPolicy: "on-request",
+      threadSandbox: "workspace-write",
+      turnSandboxPolicy: { type: "read-only" },
+    });
+  });
+
+  it("retains the defaults when policy variables are unset or empty", () => {
+    expect(resolveCodexPolicySettings({})).toEqual({
+      approvalPolicy: "never",
+      threadSandbox: "danger-full-access",
+      turnSandboxPolicy: undefined,
+    });
+
+    expect(
+      resolveCodexPolicySettings({
+        SYMPHONY_APPROVAL_POLICY: "",
+        SYMPHONY_THREAD_SANDBOX: "",
+        SYMPHONY_TURN_SANDBOX_POLICY: "",
+      })
+    ).toEqual({
+      approvalPolicy: "never",
+      threadSandbox: "danger-full-access",
+      turnSandboxPolicy: undefined,
+    });
+  });
+});

--- a/packages/worker/src/codex-policy.test.ts
+++ b/packages/worker/src/codex-policy.test.ts
@@ -6,7 +6,7 @@ describe("resolveCodexPolicySettings", () => {
     expect(() =>
       resolveCodexPolicySettings({ SYMPHONY_APPROVAL_POLICY: "on-reqest" })
     ).toThrow(
-      'Invalid SYMPHONY_APPROVAL_POLICY value "on-reqest". Expected one of: never, on-request, untrusted.'
+      'Invalid SYMPHONY_APPROVAL_POLICY value "on-reqest". Expected one of: never, on-request, on-failure, untrusted.'
     );
 
     expect(() =>
@@ -25,7 +25,12 @@ describe("resolveCodexPolicySettings", () => {
   });
 
   it("accepts every supported policy value", () => {
-    for (const approvalPolicy of ["never", "on-request", "untrusted"]) {
+    for (const approvalPolicy of [
+      "never",
+      "on-request",
+      "on-failure",
+      "untrusted",
+    ]) {
       expect(
         resolveCodexPolicySettings({
           SYMPHONY_APPROVAL_POLICY: approvalPolicy,

--- a/packages/worker/src/codex-policy.test.ts
+++ b/packages/worker/src/codex-policy.test.ts
@@ -6,7 +6,7 @@ describe("resolveCodexPolicySettings", () => {
     expect(() =>
       resolveCodexPolicySettings({ SYMPHONY_APPROVAL_POLICY: "on-reqest" })
     ).toThrow(
-      'Invalid SYMPHONY_APPROVAL_POLICY value "on-reqest". Expected one of: never, on-failure, on-request, untrusted.'
+      'Invalid SYMPHONY_APPROVAL_POLICY value "on-reqest". Expected one of: never, on-request, untrusted.'
     );
 
     expect(() =>
@@ -17,25 +17,46 @@ describe("resolveCodexPolicySettings", () => {
 
     expect(() =>
       resolveCodexPolicySettings({
-        SYMPHONY_TURN_SANDBOX_POLICY: "danger-full-acess",
+        SYMPHONY_TURN_SANDBOX_POLICY: "dangerFullAcess",
       })
     ).toThrow(
-      'Invalid SYMPHONY_TURN_SANDBOX_POLICY value "danger-full-acess". Expected one of: read-only, workspace-write, danger-full-access.'
+      'Invalid SYMPHONY_TURN_SANDBOX_POLICY value "dangerFullAcess". Expected one of: dangerFullAccess, readOnly, externalSandbox, workspaceWrite.'
     );
   });
 
   it("accepts every supported policy value", () => {
-    expect(
-      resolveCodexPolicySettings({
-        SYMPHONY_APPROVAL_POLICY: "on-request",
-        SYMPHONY_THREAD_SANDBOX: "workspace-write",
-        SYMPHONY_TURN_SANDBOX_POLICY: "read-only",
-      })
-    ).toEqual({
-      approvalPolicy: "on-request",
-      threadSandbox: "workspace-write",
-      turnSandboxPolicy: { type: "read-only" },
-    });
+    for (const approvalPolicy of ["never", "on-request", "untrusted"]) {
+      expect(
+        resolveCodexPolicySettings({
+          SYMPHONY_APPROVAL_POLICY: approvalPolicy,
+        }).approvalPolicy
+      ).toBe(approvalPolicy);
+    }
+
+    for (const threadSandbox of [
+      "read-only",
+      "workspace-write",
+      "danger-full-access",
+    ]) {
+      expect(
+        resolveCodexPolicySettings({
+          SYMPHONY_THREAD_SANDBOX: threadSandbox,
+        }).threadSandbox
+      ).toBe(threadSandbox);
+    }
+
+    for (const turnSandboxPolicy of [
+      "dangerFullAccess",
+      "readOnly",
+      "externalSandbox",
+      "workspaceWrite",
+    ]) {
+      expect(
+        resolveCodexPolicySettings({
+          SYMPHONY_TURN_SANDBOX_POLICY: turnSandboxPolicy,
+        }).turnSandboxPolicy
+      ).toEqual({ type: turnSandboxPolicy });
+    }
   });
 
   it("retains the defaults when policy variables are unset or empty", () => {

--- a/packages/worker/src/codex-policy.ts
+++ b/packages/worker/src/codex-policy.ts
@@ -16,7 +16,7 @@ export const TURN_SANDBOX_POLICY_TYPES = [
 ] as const;
 export type TurnSandboxPolicyType = (typeof TURN_SANDBOX_POLICY_TYPES)[number];
 export type TurnSandboxPolicy = { type: TurnSandboxPolicyType } | undefined;
-type CodexPolicyEnv = Partial<
+export type CodexPolicyEnv = Partial<
   Record<
     | "SYMPHONY_APPROVAL_POLICY"
     | "SYMPHONY_THREAD_SANDBOX"
@@ -25,11 +25,15 @@ type CodexPolicyEnv = Partial<
   >
 >;
 
-export function resolveCodexPolicySettings(env: CodexPolicyEnv): {
+export type CodexPolicySettings = {
   approvalPolicy: ApprovalPolicy;
   threadSandbox: ThreadSandboxMode;
   turnSandboxPolicy: TurnSandboxPolicy;
-} {
+};
+
+export function resolveCodexPolicySettings(
+  env: CodexPolicyEnv
+): CodexPolicySettings {
   const approvalPolicy = resolvePolicyValue(
     env.SYMPHONY_APPROVAL_POLICY,
     "never",

--- a/packages/worker/src/codex-policy.ts
+++ b/packages/worker/src/codex-policy.ts
@@ -1,16 +1,15 @@
 /**
  * Keep these values aligned with the Codex contracts used by the worker:
- * `ApprovalMode` from @openai/codex-sdk@0.147.0 (`dist/index.d.ts`) and
- * sandbox types from `codex app-server generate-ts` (`v2/SandboxMode.ts` and
- * `v2/SandboxPolicy.ts`). `codex.command` is user-configurable, so update
- * these lists when the targeted Codex protocol changes.
+ * string variants of `AskForApproval`, `SandboxMode`, and `SandboxPolicy`
+ * from `codex app-server generate-ts`@0.147.0
+ * (`v2/AskForApproval.ts`, `v2/SandboxMode.ts`, and
+ * `v2/SandboxPolicy.ts`). The granular approval object and structured turn
+ * sandbox variants cannot be represented by the current string environment
+ * settings, so they are intentionally not accepted here. `codex.command`
+ * is user-configurable; update these lists when the targeted Codex protocol
+ * changes.
  */
-export const APPROVAL_POLICIES = [
-  "never",
-  "on-request",
-  "on-failure",
-  "untrusted",
-] as const;
+export const APPROVAL_POLICIES = ["never", "on-request", "untrusted"] as const;
 export type ApprovalPolicy = (typeof APPROVAL_POLICIES)[number];
 
 export const THREAD_SANDBOX_MODES = [
@@ -20,12 +19,7 @@ export const THREAD_SANDBOX_MODES = [
 ] as const;
 export type ThreadSandboxMode = (typeof THREAD_SANDBOX_MODES)[number];
 
-export const TURN_SANDBOX_POLICY_TYPES = [
-  "dangerFullAccess",
-  "readOnly",
-  "externalSandbox",
-  "workspaceWrite",
-] as const;
+export const TURN_SANDBOX_POLICY_TYPES = ["dangerFullAccess"] as const;
 export type TurnSandboxPolicyType = (typeof TURN_SANDBOX_POLICY_TYPES)[number];
 export type TurnSandboxPolicy = { type: TurnSandboxPolicyType } | undefined;
 export type CodexPolicyEnv = Partial<

--- a/packages/worker/src/codex-policy.ts
+++ b/packages/worker/src/codex-policy.ts
@@ -1,4 +1,16 @@
-export const APPROVAL_POLICIES = ["never", "on-request", "untrusted"] as const;
+/**
+ * Keep these values aligned with the Codex contracts used by the worker:
+ * `ApprovalMode` from @openai/codex-sdk@0.147.0 (`dist/index.d.ts`) and
+ * sandbox types from `codex app-server generate-ts` (`v2/SandboxMode.ts` and
+ * `v2/SandboxPolicy.ts`). `codex.command` is user-configurable, so update
+ * these lists when the targeted Codex protocol changes.
+ */
+export const APPROVAL_POLICIES = [
+  "never",
+  "on-request",
+  "on-failure",
+  "untrusted",
+] as const;
 export type ApprovalPolicy = (typeof APPROVAL_POLICIES)[number];
 
 export const THREAD_SANDBOX_MODES = [

--- a/packages/worker/src/codex-policy.ts
+++ b/packages/worker/src/codex-policy.ts
@@ -1,4 +1,18 @@
-export type TurnSandboxPolicy = { type: string } | undefined;
+export const APPROVAL_POLICIES = [
+  "never",
+  "on-failure",
+  "on-request",
+  "untrusted",
+] as const;
+export type ApprovalPolicy = (typeof APPROVAL_POLICIES)[number];
+
+export const SANDBOX_POLICIES = [
+  "read-only",
+  "workspace-write",
+  "danger-full-access",
+] as const;
+export type SandboxPolicyType = (typeof SANDBOX_POLICIES)[number];
+export type TurnSandboxPolicy = { type: SandboxPolicyType } | undefined;
 type CodexPolicyEnv = Partial<
   Record<
     | "SYMPHONY_APPROVAL_POLICY"
@@ -8,18 +22,54 @@ type CodexPolicyEnv = Partial<
   >
 >;
 
-export function resolveCodexPolicySettings(
-  env: CodexPolicyEnv
-): {
-  approvalPolicy: string;
-  threadSandbox: string;
+export function resolveCodexPolicySettings(env: CodexPolicyEnv): {
+  approvalPolicy: ApprovalPolicy;
+  threadSandbox: SandboxPolicyType;
   turnSandboxPolicy: TurnSandboxPolicy;
 } {
+  const approvalPolicy = resolvePolicyValue(
+    env.SYMPHONY_APPROVAL_POLICY,
+    "never",
+    APPROVAL_POLICIES,
+    "SYMPHONY_APPROVAL_POLICY"
+  );
+  const threadSandbox = resolvePolicyValue(
+    env.SYMPHONY_THREAD_SANDBOX,
+    "danger-full-access",
+    SANDBOX_POLICIES,
+    "SYMPHONY_THREAD_SANDBOX"
+  );
+
   return {
-    approvalPolicy: env.SYMPHONY_APPROVAL_POLICY || "never",
-    threadSandbox: env.SYMPHONY_THREAD_SANDBOX || "danger-full-access",
+    approvalPolicy,
+    threadSandbox,
     turnSandboxPolicy: env.SYMPHONY_TURN_SANDBOX_POLICY
-      ? { type: env.SYMPHONY_TURN_SANDBOX_POLICY }
+      ? {
+          type: resolvePolicyValue(
+            env.SYMPHONY_TURN_SANDBOX_POLICY,
+            undefined,
+            SANDBOX_POLICIES,
+            "SYMPHONY_TURN_SANDBOX_POLICY"
+          ),
+        }
       : undefined,
   };
+}
+
+function resolvePolicyValue<const T extends readonly string[]>(
+  value: string | undefined,
+  defaultValue: T[number] | undefined,
+  allowedValues: T,
+  variableName: string
+): T[number] {
+  const resolvedValue = value || defaultValue;
+
+  if (resolvedValue && allowedValues.includes(resolvedValue)) {
+    return resolvedValue;
+  }
+
+  throw new Error(
+    `Invalid ${variableName} value ${JSON.stringify(resolvedValue)}. ` +
+      `Expected one of: ${allowedValues.join(", ")}.`
+  );
 }

--- a/packages/worker/src/codex-policy.ts
+++ b/packages/worker/src/codex-policy.ts
@@ -1,18 +1,21 @@
-export const APPROVAL_POLICIES = [
-  "never",
-  "on-failure",
-  "on-request",
-  "untrusted",
-] as const;
+export const APPROVAL_POLICIES = ["never", "on-request", "untrusted"] as const;
 export type ApprovalPolicy = (typeof APPROVAL_POLICIES)[number];
 
-export const SANDBOX_POLICIES = [
+export const THREAD_SANDBOX_MODES = [
   "read-only",
   "workspace-write",
   "danger-full-access",
 ] as const;
-export type SandboxPolicyType = (typeof SANDBOX_POLICIES)[number];
-export type TurnSandboxPolicy = { type: SandboxPolicyType } | undefined;
+export type ThreadSandboxMode = (typeof THREAD_SANDBOX_MODES)[number];
+
+export const TURN_SANDBOX_POLICY_TYPES = [
+  "dangerFullAccess",
+  "readOnly",
+  "externalSandbox",
+  "workspaceWrite",
+] as const;
+export type TurnSandboxPolicyType = (typeof TURN_SANDBOX_POLICY_TYPES)[number];
+export type TurnSandboxPolicy = { type: TurnSandboxPolicyType } | undefined;
 type CodexPolicyEnv = Partial<
   Record<
     | "SYMPHONY_APPROVAL_POLICY"
@@ -24,7 +27,7 @@ type CodexPolicyEnv = Partial<
 
 export function resolveCodexPolicySettings(env: CodexPolicyEnv): {
   approvalPolicy: ApprovalPolicy;
-  threadSandbox: SandboxPolicyType;
+  threadSandbox: ThreadSandboxMode;
   turnSandboxPolicy: TurnSandboxPolicy;
 } {
   const approvalPolicy = resolvePolicyValue(
@@ -36,7 +39,7 @@ export function resolveCodexPolicySettings(env: CodexPolicyEnv): {
   const threadSandbox = resolvePolicyValue(
     env.SYMPHONY_THREAD_SANDBOX,
     "danger-full-access",
-    SANDBOX_POLICIES,
+    THREAD_SANDBOX_MODES,
     "SYMPHONY_THREAD_SANDBOX"
   );
 
@@ -48,7 +51,7 @@ export function resolveCodexPolicySettings(env: CodexPolicyEnv): {
           type: resolvePolicyValue(
             env.SYMPHONY_TURN_SANDBOX_POLICY,
             undefined,
-            SANDBOX_POLICIES,
+            TURN_SANDBOX_POLICY_TYPES,
             "SYMPHONY_TURN_SANDBOX_POLICY"
           ),
         }

--- a/packages/worker/src/codex-startup.test.ts
+++ b/packages/worker/src/codex-startup.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from "vitest";
+import { launchCodexWithValidatedPolicy } from "./codex-startup.js";
+
+describe("launchCodexWithValidatedPolicy", () => {
+  it("rejects an invalid policy before launching the app-server", () => {
+    const launch = vi.fn();
+
+    expect(() =>
+      launchCodexWithValidatedPolicy(
+        { SYMPHONY_APPROVAL_POLICY: "on-reqest" },
+        launch
+      )
+    ).toThrow(/Invalid SYMPHONY_APPROVAL_POLICY/);
+    expect(launch).not.toHaveBeenCalled();
+  });
+
+  it("launches with typed policy settings after validation succeeds", () => {
+    const child = { pid: 42 };
+    const launch = vi.fn(() => child);
+
+    expect(
+      launchCodexWithValidatedPolicy(
+        {
+          SYMPHONY_APPROVAL_POLICY: "on-request",
+          SYMPHONY_THREAD_SANDBOX: "workspace-write",
+          SYMPHONY_TURN_SANDBOX_POLICY: "workspaceWrite",
+        },
+        launch
+      )
+    ).toEqual({
+      child,
+      policySettings: {
+        approvalPolicy: "on-request",
+        threadSandbox: "workspace-write",
+        turnSandboxPolicy: { type: "workspaceWrite" },
+      },
+    });
+    expect(launch).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/worker/src/codex-startup.test.ts
+++ b/packages/worker/src/codex-startup.test.ts
@@ -31,7 +31,7 @@ describe("launchCodexWithValidatedPolicy", () => {
         {
           SYMPHONY_APPROVAL_POLICY: "on-request",
           SYMPHONY_THREAD_SANDBOX: "workspace-write",
-          SYMPHONY_TURN_SANDBOX_POLICY: "workspaceWrite",
+          SYMPHONY_TURN_SANDBOX_POLICY: "dangerFullAccess",
         },
         launch,
         onPolicyValidationFailure
@@ -41,7 +41,7 @@ describe("launchCodexWithValidatedPolicy", () => {
       policySettings: {
         approvalPolicy: "on-request",
         threadSandbox: "workspace-write",
-        turnSandboxPolicy: { type: "workspaceWrite" },
+        turnSandboxPolicy: { type: "dangerFullAccess" },
       },
     });
     expect(launch).toHaveBeenCalledOnce();

--- a/packages/worker/src/codex-startup.test.ts
+++ b/packages/worker/src/codex-startup.test.ts
@@ -2,32 +2,41 @@ import { describe, expect, it, vi } from "vitest";
 import { launchCodexWithValidatedPolicy } from "./codex-startup.js";
 
 describe("launchCodexWithValidatedPolicy", () => {
-  it("rejects an invalid policy before launching the app-server", () => {
+  it("routes an invalid policy through controlled startup failure before launch", async () => {
     const launch = vi.fn();
+    const onPolicyValidationFailure = vi.fn(async () => undefined);
 
-    expect(() =>
+    await expect(
       launchCodexWithValidatedPolicy(
         { SYMPHONY_APPROVAL_POLICY: "on-reqest" },
-        launch
+        launch,
+        onPolicyValidationFailure
       )
-    ).toThrow(/Invalid SYMPHONY_APPROVAL_POLICY/);
+    ).resolves.toBeNull();
+    expect(onPolicyValidationFailure).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Codex policy validation failed: Invalid SYMPHONY_APPROVAL_POLICY"
+      )
+    );
     expect(launch).not.toHaveBeenCalled();
   });
 
-  it("launches with typed policy settings after validation succeeds", () => {
+  it("launches with typed policy settings after validation succeeds", async () => {
     const child = { pid: 42 };
     const launch = vi.fn(() => child);
+    const onPolicyValidationFailure = vi.fn(async () => undefined);
 
-    expect(
+    await expect(
       launchCodexWithValidatedPolicy(
         {
           SYMPHONY_APPROVAL_POLICY: "on-request",
           SYMPHONY_THREAD_SANDBOX: "workspace-write",
           SYMPHONY_TURN_SANDBOX_POLICY: "workspaceWrite",
         },
-        launch
+        launch,
+        onPolicyValidationFailure
       )
-    ).toEqual({
+    ).resolves.toEqual({
       child,
       policySettings: {
         approvalPolicy: "on-request",
@@ -36,5 +45,6 @@ describe("launchCodexWithValidatedPolicy", () => {
       },
     });
     expect(launch).toHaveBeenCalledOnce();
+    expect(onPolicyValidationFailure).not.toHaveBeenCalled();
   });
 });

--- a/packages/worker/src/codex-startup.ts
+++ b/packages/worker/src/codex-startup.ts
@@ -1,0 +1,17 @@
+import {
+  resolveCodexPolicySettings,
+  type CodexPolicyEnv,
+  type CodexPolicySettings,
+} from "./codex-policy.js";
+
+export function launchCodexWithValidatedPolicy<T>(
+  env: CodexPolicyEnv,
+  launch: () => T
+): { child: T; policySettings: CodexPolicySettings } {
+  const policySettings = resolveCodexPolicySettings(env);
+
+  return {
+    child: launch(),
+    policySettings,
+  };
+}

--- a/packages/worker/src/codex-startup.ts
+++ b/packages/worker/src/codex-startup.ts
@@ -4,11 +4,24 @@ import {
   type CodexPolicySettings,
 } from "./codex-policy.js";
 
-export function launchCodexWithValidatedPolicy<T>(
+export async function launchCodexWithValidatedPolicy<T>(
   env: CodexPolicyEnv,
-  launch: () => T
-): { child: T; policySettings: CodexPolicySettings } {
-  const policySettings = resolveCodexPolicySettings(env);
+  launch: () => T,
+  onPolicyValidationFailure: (message: string) => Promise<void>
+): Promise<{ child: T; policySettings: CodexPolicySettings } | null> {
+  let policySettings: CodexPolicySettings;
+  try {
+    policySettings = resolveCodexPolicySettings(env);
+  } catch (error) {
+    const message =
+      error instanceof Error
+        ? error.message
+        : "Unknown policy validation error";
+    await onPolicyValidationFailure(
+      `Codex policy validation failed: ${message}`
+    );
+    return null;
+  }
 
   return {
     child: launch(),

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -571,9 +571,14 @@ async function startAssignedRun() {
     config.linearAuthorization = launcherEnv.LINEAR_AUTHORIZATION;
     config.linearGraphqlUrl = launcherEnv.LINEAR_GRAPHQL_URL;
     const plan = await prepareCodexRuntimePlan(config);
-    const codexLaunch = launchCodexWithValidatedPolicy(launcherEnv, () =>
-      launchCodexAppServer(plan)
+    const codexLaunch = await launchCodexWithValidatedPolicy(
+      launcherEnv,
+      () => launchCodexAppServer(plan),
+      exitWorkerStartupFailure
     );
+    if (!codexLaunch) {
+      return;
+    }
     childProcess = codexLaunch.child;
     runtimeState.status = "running";
     runtimeState.runPhase = "initializing_session";

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -36,7 +36,8 @@ import {
   resolveFinalExecutionPhase,
   resolveInitialExecutionPhase,
 } from "./execution-phase.js";
-import { resolveCodexPolicySettings } from "./codex-policy.js";
+import type { CodexPolicySettings } from "./codex-policy.js";
+import { launchCodexWithValidatedPolicy } from "./codex-startup.js";
 import {
   captureTurnBoundarySnapshot,
   evaluateTurnProgress,
@@ -570,7 +571,10 @@ async function startAssignedRun() {
     config.linearAuthorization = launcherEnv.LINEAR_AUTHORIZATION;
     config.linearGraphqlUrl = launcherEnv.LINEAR_GRAPHQL_URL;
     const plan = await prepareCodexRuntimePlan(config);
-    childProcess = launchCodexAppServer(plan);
+    const codexLaunch = launchCodexWithValidatedPolicy(launcherEnv, () =>
+      launchCodexAppServer(plan)
+    );
+    childProcess = codexLaunch.child;
     runtimeState.status = "running";
     runtimeState.runPhase = "initializing_session";
 
@@ -581,6 +585,7 @@ async function startAssignedRun() {
     // Wire up the codex app-server client protocol (multi-turn)
     void runCodexClientProtocol(childProcess, plan, launcherEnv, {
       continuationGuidance: workflow.continuationGuidance,
+      policySettings: codexLaunch.policySettings,
     });
 
     childProcess.once(
@@ -1005,6 +1010,7 @@ async function runCodexClientProtocol(
   env: NodeJS.ProcessEnv,
   options: {
     continuationGuidance: string | null;
+    policySettings: CodexPolicySettings;
   }
 ): Promise<void> {
   const renderedPrompt = env.SYMPHONY_RENDERED_PROMPT;
@@ -1032,7 +1038,7 @@ async function runCodexClientProtocol(
   const continuationGuidance =
     env.SYMPHONY_CONTINUATION_GUIDANCE ?? options.continuationGuidance;
   const { approvalPolicy, threadSandbox, turnSandboxPolicy } =
-    resolveCodexPolicySettings(env);
+    options.policySettings;
   let previousTurnProgressSnapshot = {
     ...captureTurnBoundarySnapshot(plan.cwd),
     lastError: runtimeState.run?.lastError ?? null,

--- a/packages/worker/src/worker-protocol.test.ts
+++ b/packages/worker/src/worker-protocol.test.ts
@@ -1417,7 +1417,7 @@ describe("read timeout (3.5)", () => {
       SYMPHONY_ISSUE_IDENTIFIER: "acme/repo#1",
       SYMPHONY_ISSUE_TITLE: "Test issue",
       SYMPHONY_THREAD_SANDBOX: "workspace-write",
-      SYMPHONY_TURN_SANDBOX_POLICY: "workspace-write",
+      SYMPHONY_TURN_SANDBOX_POLICY: "workspaceWrite",
     });
 
     const messages = readSentMessages(ctx.fake.stdin);
@@ -1444,7 +1444,7 @@ describe("read timeout (3.5)", () => {
           cwd: "/tmp",
           title: "acme/repo#1: Test issue",
           approvalPolicy: "on-request",
-          sandboxPolicy: { type: "workspace-write" },
+          sandboxPolicy: { type: "workspaceWrite" },
         },
       },
     ]);
@@ -1458,7 +1458,7 @@ describe("read timeout (3.5)", () => {
       SYMPHONY_ISSUE_IDENTIFIER: "acme/repo#1",
       SYMPHONY_ISSUE_TITLE: "Test issue",
       SYMPHONY_THREAD_SANDBOX: "workspace-write",
-      SYMPHONY_TURN_SANDBOX_POLICY: "workspace-write",
+      SYMPHONY_TURN_SANDBOX_POLICY: "workspaceWrite",
     });
 
     const messages = readSentMessages(ctx.fake.stdin);
@@ -1499,7 +1499,7 @@ describe("read timeout (3.5)", () => {
           cwd: "/tmp",
           title: "acme/repo#1: Test issue",
           approvalPolicy: "on-request",
-          sandboxPolicy: { type: "workspace-write" },
+          sandboxPolicy: { type: "workspaceWrite" },
         },
       },
     ]);

--- a/packages/worker/src/worker-protocol.test.ts
+++ b/packages/worker/src/worker-protocol.test.ts
@@ -1236,7 +1236,9 @@ describe("multi-turn loop (2.7)", () => {
     expect(turnResults).toEqual(["turn-1"]);
     expect(ctx.runtimeState.status).toBe("failed");
     expect(ctx.runtimeState.runPhase).toBe("failed");
-    expect(ctx.runtimeState.run.lastError).toBe("turn_failed: tool execution failed");
+    expect(ctx.runtimeState.run.lastError).toBe(
+      "turn_failed: tool execution failed"
+    );
   });
 
   it("stops immediately when turn/cancelled is received", async () => {
@@ -1417,7 +1419,7 @@ describe("read timeout (3.5)", () => {
       SYMPHONY_ISSUE_IDENTIFIER: "acme/repo#1",
       SYMPHONY_ISSUE_TITLE: "Test issue",
       SYMPHONY_THREAD_SANDBOX: "workspace-write",
-      SYMPHONY_TURN_SANDBOX_POLICY: "workspaceWrite",
+      SYMPHONY_TURN_SANDBOX_POLICY: "dangerFullAccess",
     });
 
     const messages = readSentMessages(ctx.fake.stdin);
@@ -1444,7 +1446,7 @@ describe("read timeout (3.5)", () => {
           cwd: "/tmp",
           title: "acme/repo#1: Test issue",
           approvalPolicy: "on-request",
-          sandboxPolicy: { type: "workspaceWrite" },
+          sandboxPolicy: { type: "dangerFullAccess" },
         },
       },
     ]);
@@ -1458,7 +1460,7 @@ describe("read timeout (3.5)", () => {
       SYMPHONY_ISSUE_IDENTIFIER: "acme/repo#1",
       SYMPHONY_ISSUE_TITLE: "Test issue",
       SYMPHONY_THREAD_SANDBOX: "workspace-write",
-      SYMPHONY_TURN_SANDBOX_POLICY: "workspaceWrite",
+      SYMPHONY_TURN_SANDBOX_POLICY: "dangerFullAccess",
     });
 
     const messages = readSentMessages(ctx.fake.stdin);
@@ -1499,7 +1501,7 @@ describe("read timeout (3.5)", () => {
           cwd: "/tmp",
           title: "acme/repo#1: Test issue",
           approvalPolicy: "on-request",
-          sandboxPolicy: { type: "workspaceWrite" },
+          sandboxPolicy: { type: "dangerFullAccess" },
         },
       },
     ]);
@@ -1736,7 +1738,9 @@ describe("turn timeout (3.6)", () => {
 
     expect(ctx.runtimeState.status).toBe("failed");
     expect(ctx.runtimeState.runPhase).toBe("failed");
-    expect(ctx.runtimeState.run.lastError).toBe("turn_failed: model backend failed");
+    expect(ctx.runtimeState.run.lastError).toBe(
+      "turn_failed: model backend failed"
+    );
   });
 
   it("resolves pending turn wait when turn/cancelled is received", async () => {
@@ -1822,7 +1826,9 @@ describe("turn timeout (3.6)", () => {
 
     expect(ctx.runtimeState.status).toBe("failed");
     expect(ctx.runtimeState.runPhase).toBe("failed");
-    expect(ctx.runtimeState.run.lastError).toBe("turn_failed: tool execution failed");
+    expect(ctx.runtimeState.run.lastError).toBe(
+      "turn_failed: tool execution failed"
+    );
   });
 });
 


### PR DESCRIPTION
+## Issues — Closed #530

## TL;DR

- Codex approval·thread sandbox·turn sandbox 설정을 app-server wire 계약 기준 whitelist와 TypeScript string union으로 검증합니다.
- 오타·미지원 값은 허용값을 열거한 오류로 즉시 거부해 permissive fallback을 차단합니다.
- approval은 `never`·`on-request`·`untrusted`, thread sandbox는 kebab-case 3종, 현재 문자열 turn 설정은 실제 `{ type }` payload로 표현 가능한 `dangerFullAccess`만 허용합니다.
- 검증 실패는 app-server launch 전 controlled startup-failure 경로로 보내 최종 failed heartbeat, usage 저장, channel flush, nonzero exit를 보장합니다.

## 변경 지점 다이어그램

`WORKFLOW.md codex.*` → `SYMPHONY_* env` → enum validation → 성공 시 app-server launch → typed settings로 `thread/start` / `turn/start`

잘못된 값 → fail-loud Error → `exitWorkerStartupFailure` → failed state/error → final heartbeat → usage persistence → channel flush → `exit(1)`

구조화 turn variant(`readOnly`·`externalSandbox`·`workspaceWrite`) → 현재 문자열 설정으로 필수 필드 표현 불가 → 명시적 거부

## 여기부터 보세요

- `packages/worker/src/codex-policy.ts` — app-server generated binding 기반 whitelist, union type, fail-loud resolver와 protocol provenance
- `packages/worker/src/codex-policy.test.ts` — typo rejection, 지원값 통과, 구조화 turn variant 거부, unset/empty defaults TC
- `packages/worker/src/codex-startup.ts` — validation-before-launch와 controlled failure callback 경계
- `packages/worker/src/codex-startup.test.ts` — invalid policy에서 launch 0회·failure callback 1회 회귀 TC
- `packages/worker/src/index.ts` — `exitWorkerStartupFailure`를 주입하는 실제 lifecycle 연결
- `packages/worker/src/worker-protocol.test.ts` — 실제 request wire value TC
- `.changeset/validate-codex-policy-enums.md` — 지원 범위와 turn sandbox migration/거부 안내

## 위험 & 롤백

- 잘못된 설정은 app-server child 생성 전에 명시적인 worker startup 실패로 노출됩니다. 이는 #530의 fail-loud 요구사항입니다.
- 현재 단일 문자열 `turn_sandbox_policy`는 `dangerFullAccess`만 지원합니다. 나머지 Codex variant를 지원하려면 구조화 필드용 Configuration Layer 확장이 필요합니다.
- whitelist는 `codex app-server generate-ts@0.147.0`의 `v2/AskForApproval.ts`, `v2/SandboxMode.ts`, `v2/SandboxPolicy.ts`를 기준으로 하며 `codex.command`가 사용자 설정 가능하므로 protocol 변경 시 갱신해야 합니다.
- 롤백은 PR #533의 squash merge commit을 revert하면 됩니다.

## 변경 파일

- `.changeset/validate-codex-policy-enums.md`
- `e2e/seed/WORKFLOW.md`
- `e2e/seed/init-local.sh`
- `packages/worker/src/codex-policy.ts`
- `packages/worker/src/codex-policy.test.ts`
- `packages/worker/src/codex-startup.ts`
- `packages/worker/src/codex-startup.test.ts`
- `packages/worker/src/index.ts`
- `packages/worker/src/worker-protocol.test.ts`

## Evidence

- `pnpm --filter @gh-symphony/worker test -- src/codex-policy.test.ts src/codex-startup.test.ts src/worker-protocol.test.ts` — 3 files, 66 tests passed.
- `pnpm --filter @gh-symphony/worker test` — 21 files, 160 tests passed.
- `pnpm lint` — passed.
- `pnpm test` — passed across all 14 test-bearing workspace packages; worker 21 files/160 tests, orchestrator 12 files/240 tests, CLI 35 files/497 tests included.
- `pnpm typecheck` — passed.
- `pnpm build` — passed.
- `pnpm exec prettier --check` on changed TypeScript/Markdown files — passed.
- `git diff --check` — passed.
- Current Cycle 11 commit: `f54a4d9` (`fix(worker): align policy values with app-server wire`).
- Existing PR lifecycle changes retain prior Docker happy-path and GitHub Container Smoke evidence; Cycle 11 enum/provenance/changeset delta does not alter orchestrator dispatch or tracker lifecycle behavior, so additional Docker E2E is N/A.
- Latest P1 inline comments `3734728974`, `3734728979`, `3734742025`, `3734744223` — all answered with implementation and validation evidence.

## 머지 후/사람 확인

- [ ] 잘못된 policy 환경값에서 app-server child가 생성되지 않고 최종 failed heartbeat와 nonzero exit가 기록되는지 확인
- [ ] `never`·`on-request`·`untrusted` approval과 thread sandbox 3종이 Codex에 그대로 전달되는지 확인
- [ ] `turn_sandbox_policy`는 `dangerFullAccess`만 사용하고, 구조화 필드가 필요한 다른 variant가 의도적으로 거부되는지 확인
- [ ] 향후 Codex app-server protocol upgrade 시 generated binding enum과 payload shape drift 여부 확인
- [ ] 배포 및 외부 URL smoke test는 이 PR 범위 밖

## Human Validation

- [ ] 주요 policy fail-loud 흐름이 요구사항과 일치하는지 확인
- [ ] controlled startup-failure 연결이 인접 runtime route를 회귀시키지 않는지 확인
- [ ] 최신 head `f54a4d9`의 review feedback 대응 결과 확인

## Spec 정합성

- Policy/Configuration Layer의 typed validation과 Execution/Observability Layer의 안전한 subprocess failure 경계를 강화합니다.
- 구조화 turn policy 입력을 받는 Configuration Layer 확장은 별도 범위로 명시적으로 위임했습니다.
- `docs/symphony-spec.md`를 수정하지 않았고 upstream spec과 의도적 divergence가 없습니다.

