### PR TITLE
fix(core): harden workspace path containment

### DIFF
--- a/.changeset/528-workspace-path-safety.md
+++ b/.changeset/528-workspace-path-safety.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Harden workspace path validation against traversal and symlink escapes across platforms (hojinzs/github-symphony#528).

--- a/packages/core/src/core-conformance.test.ts
+++ b/packages/core/src/core-conformance.test.ts
@@ -16,6 +16,9 @@ import {
   resolveIssueWorkspaceDirectory,
   scheduleRetryAt,
 } from "./index.js";
+import { mkdtempSync, rmSync, symlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { RunDispatchedEvent } from "./observability/structured-events.js";
 
 describe("deriveWorkspaceKey", () => {
@@ -80,6 +83,12 @@ describe("resolveIssueWorkspaceDirectory", () => {
     expect(result).toBe("/runtime/orchestrator/abc123");
   });
 
+  it("accepts Windows-style separators in an issue workspace key", () => {
+    expect(() =>
+      resolveIssueWorkspaceDirectory("/runtime/orchestrator", "abc\\nested")
+    ).not.toThrow();
+  });
+
   it("rejects path traversal that escapes the root", () => {
     expect(() =>
       resolveIssueWorkspaceDirectory(
@@ -96,6 +105,21 @@ describe("resolveIssueWorkspaceDirectory", () => {
     expect(() =>
       resolveIssueWorkspaceDirectory("/runtime/orchestrator", ".lock")
     ).toThrow("reserved");
+  });
+
+  it("rejects an issue workspace symlink that resolves outside the runtime root", () => {
+    const root = mkdtempSync(join(tmpdir(), "symphony-runtime-root-"));
+    const outside = mkdtempSync(join(tmpdir(), "symphony-runtime-outside-"));
+    symlinkSync(outside, join(root, "linked"));
+
+    try {
+      expect(() => resolveIssueWorkspaceDirectory(root, "linked")).toThrow(
+        "Issue workspace path escapes"
+      );
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+      rmSync(outside, { force: true, recursive: true });
+    }
   });
 });
 

--- a/packages/core/src/core-conformance.test.ts
+++ b/packages/core/src/core-conformance.test.ts
@@ -121,6 +121,20 @@ describe("resolveIssueWorkspaceDirectory", () => {
       rmSync(outside, { force: true, recursive: true });
     }
   });
+
+  it("rejects a dangling issue workspace symlink that points outside the runtime root", () => {
+    const root = mkdtempSync(join(tmpdir(), "symphony-runtime-root-"));
+    const outside = join(tmpdir(), "symphony-runtime-missing-target");
+    symlinkSync(outside, join(root, "linked"));
+
+    try {
+      expect(() => resolveIssueWorkspaceDirectory(root, "linked")).toThrow(
+        "Issue workspace path escapes"
+      );
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
 });
 
 describe("resolveIssueRepositoryPath", () => {

--- a/packages/core/src/workspace-safety.test.ts
+++ b/packages/core/src/workspace-safety.test.ts
@@ -1,11 +1,22 @@
-import { describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync, symlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
 import { assertRepositoryAllowed, resolveWorkspaceDirectory } from "./index.js";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { force: true, recursive: true });
+  }
+});
 
 describe("resolveWorkspaceDirectory", () => {
   it("keeps workspaces inside the configured root", () => {
-    expect(resolveWorkspaceDirectory("/tmp/github-symphony", "workspace-1")).toBe(
-      "/tmp/github-symphony/workspace-1"
-    );
+    expect(
+      resolveWorkspaceDirectory("/tmp/github-symphony", "workspace-1")
+    ).toBe("/tmp/github-symphony/workspace-1");
   });
 
   it("rejects path traversal", () => {
@@ -13,13 +24,33 @@ describe("resolveWorkspaceDirectory", () => {
       resolveWorkspaceDirectory("/tmp/github-symphony", "../outside")
     ).toThrow("Workspace path escapes");
   });
+
+  it("rejects a symlink that resolves outside the workspace root", () => {
+    const root = mkdtempSync(join(tmpdir(), "symphony-workspace-root-"));
+    const outside = mkdtempSync(join(tmpdir(), "symphony-workspace-outside-"));
+    temporaryDirectories.push(root, outside);
+    symlinkSync(outside, join(root, "linked"));
+
+    expect(() => resolveWorkspaceDirectory(root, "linked")).toThrow(
+      "Workspace path escapes"
+    );
+    expect(() => resolveWorkspaceDirectory(root, "linked/new")).toThrow(
+      "Workspace path escapes"
+    );
+  });
+
+  it("accepts paths containing Windows-style separators as workspace names", () => {
+    expect(() =>
+      resolveWorkspaceDirectory("/tmp/github-symphony", "workspace\\nested")
+    ).not.toThrow();
+  });
 });
 
 describe("assertRepositoryAllowed", () => {
   it("rejects repositories outside the workspace allowlist", () => {
     expect(() =>
       assertRepositoryAllowed("https://github.com/acme/other.git", [
-        "https://github.com/acme/platform.git"
+        "https://github.com/acme/platform.git",
       ])
     ).toThrow("Repository is not in the workspace allowlist");
   });

--- a/packages/core/src/workspace-safety.test.ts
+++ b/packages/core/src/workspace-safety.test.ts
@@ -39,6 +39,17 @@ describe("resolveWorkspaceDirectory", () => {
     );
   });
 
+  it("rejects a dangling symlink that points outside the workspace root", () => {
+    const root = mkdtempSync(join(tmpdir(), "symphony-workspace-root-"));
+    const outside = join(tmpdir(), "symphony-workspace-missing-target");
+    temporaryDirectories.push(root);
+    symlinkSync(outside, join(root, "linked"));
+
+    expect(() => resolveWorkspaceDirectory(root, "linked")).toThrow(
+      "Workspace path escapes"
+    );
+  });
+
   it("accepts paths containing Windows-style separators as workspace names", () => {
     expect(() =>
       resolveWorkspaceDirectory("/tmp/github-symphony", "workspace\\nested")

--- a/packages/core/src/workspace/identity.ts
+++ b/packages/core/src/workspace/identity.ts
@@ -1,6 +1,7 @@
 import { resolve, join } from "node:path";
 import { createHash } from "node:crypto";
 import type { IssueSubjectIdentity } from "../domain/issue.js";
+import { isPathWithinRoot } from "./path-safety.js";
 
 const RESERVED_WORKSPACE_KEYS = new Set([
   "cache",
@@ -72,7 +73,7 @@ export function resolveIssueWorkspaceDirectory(
   const normalizedRuntimeRoot = resolve(runtimeRoot);
   const candidate = resolve(normalizedRuntimeRoot, workspaceKey);
 
-  if (!candidate.startsWith(`${normalizedRuntimeRoot}/`)) {
+  if (!isPathWithinRoot(normalizedRuntimeRoot, candidate, false)) {
     throw new Error(
       "Issue workspace path escapes the configured runtime root."
     );
@@ -87,8 +88,7 @@ export function resolveIssueWorkspaceDirectory(
 
 function isReservedWorkspaceKey(workspaceKey: string): boolean {
   return (
-    workspaceKey.startsWith(".") ||
-    RESERVED_WORKSPACE_KEYS.has(workspaceKey)
+    workspaceKey.startsWith(".") || RESERVED_WORKSPACE_KEYS.has(workspaceKey)
   );
 }
 

--- a/packages/core/src/workspace/path-safety.ts
+++ b/packages/core/src/workspace/path-safety.ts
@@ -1,0 +1,33 @@
+import { existsSync, realpathSync } from "node:fs";
+import { basename, dirname, isAbsolute, join, relative } from "node:path";
+
+function realpathWithMissingTail(path: string): string {
+  let current = path;
+  const missingTail: string[] = [];
+
+  while (!existsSync(current)) {
+    const parent = dirname(current);
+    if (parent === current) {
+      return path;
+    }
+    missingTail.unshift(basename(current));
+    current = parent;
+  }
+
+  return join(realpathSync(current), ...missingTail);
+}
+
+export function isPathWithinRoot(
+  root: string,
+  candidate: string,
+  allowRoot = true
+): boolean {
+  const realRoot = realpathWithMissingTail(root);
+  const realCandidate = realpathWithMissingTail(candidate);
+  const rel = relative(realRoot, realCandidate);
+
+  return (
+    (allowRoot && rel === "") ||
+    (rel !== "" && !rel.startsWith("..") && !isAbsolute(rel))
+  );
+}

--- a/packages/core/src/workspace/path-safety.ts
+++ b/packages/core/src/workspace/path-safety.ts
@@ -1,20 +1,41 @@
-import { existsSync, realpathSync } from "node:fs";
+import { lstatSync, realpathSync } from "node:fs";
 import { basename, dirname, isAbsolute, join, relative } from "node:path";
 
-function realpathWithMissingTail(path: string): string {
+function realpathWithMissingTail(path: string): string | null {
   let current = path;
   const missingTail: string[] = [];
 
-  while (!existsSync(current)) {
+  while (true) {
+    try {
+      return join(realpathSync(current), ...missingTail);
+    } catch (error) {
+      if (
+        !(error instanceof Error && "code" in error && error.code === "ENOENT")
+      ) {
+        return null;
+      }
+    }
+
     const parent = dirname(current);
     if (parent === current) {
-      return path;
+      return null;
     }
+
+    try {
+      if (lstatSync(current).isSymbolicLink()) {
+        return null;
+      }
+    } catch (error) {
+      if (
+        !(error instanceof Error && "code" in error && error.code === "ENOENT")
+      ) {
+        return null;
+      }
+    }
+
     missingTail.unshift(basename(current));
     current = parent;
   }
-
-  return join(realpathSync(current), ...missingTail);
 }
 
 export function isPathWithinRoot(
@@ -24,6 +45,11 @@ export function isPathWithinRoot(
 ): boolean {
   const realRoot = realpathWithMissingTail(root);
   const realCandidate = realpathWithMissingTail(candidate);
+
+  if (!realRoot || !realCandidate) {
+    return false;
+  }
+
   const rel = relative(realRoot, realCandidate);
 
   return (

--- a/packages/core/src/workspace/safety.ts
+++ b/packages/core/src/workspace/safety.ts
@@ -1,4 +1,5 @@
 import { resolve } from "node:path";
+import { isPathWithinRoot } from "./path-safety.js";
 
 export function resolveWorkspaceDirectory(
   workspaceRoot: string,
@@ -7,7 +8,7 @@ export function resolveWorkspaceDirectory(
   const normalizedRoot = resolve(workspaceRoot);
   const candidate = resolve(normalizedRoot, workspaceId);
 
-  if (candidate !== normalizedRoot && !candidate.startsWith(`${normalizedRoot}/`)) {
+  if (!isPathWithinRoot(normalizedRoot, candidate)) {
     throw new Error("Workspace path escapes the configured workspace root.");
   }
 
@@ -19,6 +20,8 @@ export function assertRepositoryAllowed(
   allowedRepositoryCloneUrls: string[]
 ): void {
   if (!allowedRepositoryCloneUrls.includes(targetRepositoryCloneUrl)) {
-    throw new Error(`Repository is not in the workspace allowlist: ${targetRepositoryCloneUrl}`);
+    throw new Error(
+      `Repository is not in the workspace allowlist: ${targetRepositoryCloneUrl}`
+    );
   }
 }


### PR DESCRIPTION
## TL;DR

- Workspace containment now uses platform-native `path.relative` checks.
- Existing symlinks and missing descendant paths are resolved through the nearest existing real path before containment is checked.
- Dangling symlink components are detected with `lstat` and rejected fail-closed.
- Added traversal, symlink escape, Windows-style separator, and regression tests.

## 변경 지점 다이어그램

```text
workspace/safety.ts ─┐
                     ├─> workspace/path-safety.ts ─> realpath + path.relative containment
workspace/identity.ts┘
                     └─> workspace-safety/core-conformance tests
```

## 여기부터 보세요

- `packages/core/src/workspace/path-safety.ts`
- `packages/core/src/workspace/safety.ts`
- `packages/core/src/workspace/identity.ts`
- `packages/core/src/workspace-safety.test.ts`
- `packages/core/src/core-conformance.test.ts`

## Issues

- Fixes #528

## Summary

Workspace paths are rejected when traversal or symlink resolution escapes the configured root, without hardcoding `/` as the separator.

## Changes

- Centralized realpath-aware containment validation for existing paths and non-existing descendant tails.
- Fail-closed handling for dangling symlink components prevents a later-created target from redirecting I/O outside the root.
- Applied the validator to both workspace directory resolvers.
- Added required path safety regression coverage, including dangling symlink cases, and retained the CLI patch changeset.

## Evidence

- `pnpm lint` — passed
- `pnpm -r --workspace-concurrency=1 test` — passed (all workspace packages; core 208 tests, orchestrator 233 tests, worker 152 tests, CLI 497 tests)
- `pnpm --filter @gh-symphony/orchestrator exec vitest run src/index.test.ts -t "gracefully shuts down on SIGTERM"` — passed in isolation
- `pnpm typecheck` — passed
- `pnpm build` — passed
- `pnpm exec prettier --check <changed files>` — passed
- `pnpm --filter @gh-symphony/core test` — passed (210 tests, including both dangling symlink regressions)
- GitHub CI `Test` and `Container Smoke` — passed

## 위험 & 롤백

- Risk: realpath resolution adds filesystem metadata reads during workspace path validation.
- Rollback: revert commits `d23e536` and `22dda93` to restore the previous containment implementation.

## 변경 파일

- `.changeset/528-workspace-path-safety.md`
- `packages/core/src/workspace/path-safety.ts`
- `packages/core/src/workspace/safety.ts`
- `packages/core/src/workspace/identity.ts`
- `packages/core/src/workspace-safety.test.ts`
- `packages/core/src/core-conformance.test.ts`

## 머지 후/사람 확인

- [ ] Review the path containment behavior on Windows.
- [ ] Confirm no regression in workspace creation and cleanup flows.
- Deployment, external URL smoke test, and manual UX validation are out of scope.

## Human Validation

- [ ] Confirm the main user flow works as expected
- [ ] Confirm there is no obvious regression in adjacent behavior

## Risks

- Filesystem behavior is covered by unit tests; reviewer focus should be platform-specific path semantics and symlink handling.
