### PR TITLE
fix(security): bound HTTP and polling inputs

### DIFF
--- a/.changeset/bright-limits-refresh.md
+++ b/.changeset/bright-limits-refresh.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Harden HTTP refresh input, Linear pagination, and polling intervals for issue #468.

--- a/.changeset/bright-limits-refresh.md
+++ b/.changeset/bright-limits-refresh.md
@@ -2,4 +2,8 @@
 "@gh-symphony/cli": patch
 ---
 
-Harden HTTP refresh input, Linear pagination, and polling intervals for issue #468.
+Harden HTTP refresh input and Linear pagination for issue #468. As an explicit
+repository policy that diverges from the upstream configured-cadence behavior,
+workflow polling inputs are clamped to 1 second–5 minutes: smaller values run
+every second and larger values run every 5 minutes, while adaptive rate-limit
+backoff may still schedule a longer delay.

--- a/packages/control-plane/src/server.test.ts
+++ b/packages/control-plane/src/server.test.ts
@@ -63,6 +63,27 @@ describe("createControlPlaneHandler", () => {
     expect(onRefreshRequest).toHaveBeenCalledOnce();
   });
 
+  it("rejects refresh bodies over the configured limit", async () => {
+    const onRefreshRequest = vi.fn();
+    const handler = createControlPlaneHandler({
+      reader: createReader() as never,
+      apiToken: API_TOKEN,
+      onRefreshRequest,
+    });
+
+    const response = await fetchWithHandler(handler, "/api/v1/refresh", {
+      method: "POST",
+      body: Buffer.alloc(64 * 1024 + 1),
+      headers: AUTHORIZATION,
+    });
+
+    expect(response.status).toBe(413);
+    await expect(response.json()).resolves.toEqual({
+      error: "Request body too large",
+    });
+    expect(onRefreshRequest).not.toHaveBeenCalled();
+  });
+
   it("delegates GET /api/v1/state to the dashboard resolver", async () => {
     const reader = createReader();
     reader.loadProjectState.mockResolvedValue({

--- a/packages/control-plane/src/server.test.ts
+++ b/packages/control-plane/src/server.test.ts
@@ -84,6 +84,73 @@ describe("createControlPlaneHandler", () => {
     expect(onRefreshRequest).not.toHaveBeenCalled();
   });
 
+  it("finishes handling a streaming request as soon as its body is oversized", async () => {
+    const http = await import("node:http");
+    const handler = createControlPlaneHandler({
+      reader: createReader() as never,
+      apiToken: API_TOKEN,
+    });
+    let resolveHandled: (() => void) | undefined;
+    const handled = new Promise<void>((resolve) => {
+      resolveHandled = resolve;
+    });
+    const instance = http.createServer((request, response) => {
+      void handler(request, response).then(() => resolveHandled?.());
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      instance.listen(0, "127.0.0.1", (error?: Error) =>
+        error ? reject(error) : resolve()
+      );
+    });
+    const address = instance.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Expected TCP address");
+    }
+
+    const request = http.request({
+      host: "127.0.0.1",
+      port: address.port,
+      path: "/api/v1/refresh",
+      method: "POST",
+      headers: {
+        ...AUTHORIZATION,
+        "Transfer-Encoding": "chunked",
+      },
+    });
+    try {
+      const response = new Promise<{
+        statusCode: number | undefined;
+        body: string;
+      }>((resolve, reject) => {
+        request.on("response", (incoming) => {
+          const chunks: Buffer[] = [];
+          incoming.on("data", (chunk: Buffer) => chunks.push(chunk));
+          incoming.on("end", () =>
+            resolve({
+              statusCode: incoming.statusCode,
+              body: Buffer.concat(chunks).toString("utf8"),
+            })
+          );
+        });
+        request.on("error", reject);
+      });
+
+      request.write(Buffer.alloc(64 * 1024 + 1));
+
+      await expect(response).resolves.toEqual({
+        statusCode: 413,
+        body: JSON.stringify({ error: "Request body too large" }),
+      });
+      await expect(handled).resolves.toBeUndefined();
+    } finally {
+      request.destroy();
+      await new Promise<void>((resolve, reject) =>
+        instance.close((error) => (error ? reject(error) : resolve()))
+      );
+    }
+  });
+
   it("delegates GET /api/v1/state to the dashboard resolver", async () => {
     const reader = createReader();
     reader.loadProjectState.mockResolvedValue({

--- a/packages/control-plane/src/server.ts
+++ b/packages/control-plane/src/server.ts
@@ -35,6 +35,7 @@ const CLIENT_DIST_DIR_CANDIDATES = [
   WORKSPACE_CLIENT_DIST_DIR,
   NODE_MODULES_CLIENT_DIST_DIR,
 ];
+export const MAX_REFRESH_BODY_BYTES = 64 * 1024;
 let clientDistDirPromise: Promise<string | null> | undefined;
 
 const TEXT_CONTENT_TYPES = new Set([
@@ -214,9 +215,39 @@ async function handleRefreshRequest(
     return;
   }
 
-  request.resume();
-  options.onRefreshRequest?.();
-  respondJson(response, 202, { ok: true });
+  const contentLength = Number.parseInt(
+    request.headers["content-length"] ?? "",
+    10
+  );
+  if (
+    Number.isFinite(contentLength) &&
+    contentLength > MAX_REFRESH_BODY_BYTES
+  ) {
+    request.resume();
+    respondJson(response, 413, { error: "Request body too large" });
+    return;
+  }
+
+  await new Promise<void>((resolve) => {
+    let received = 0;
+    let rejected = false;
+    request.on("data", (chunk: Buffer | string) => {
+      received += Buffer.byteLength(chunk);
+      if (received > MAX_REFRESH_BODY_BYTES && !rejected) {
+        rejected = true;
+        request.resume();
+        respondJson(response, 413, { error: "Request body too large" });
+      }
+    });
+    request.on("end", () => {
+      if (!rejected) {
+        options.onRefreshRequest?.();
+        respondJson(response, 202, { ok: true });
+      }
+      resolve();
+    });
+    request.on("error", () => resolve());
+  });
 }
 
 function isDashboardRequest(pathname: string): boolean {

--- a/packages/control-plane/src/server.ts
+++ b/packages/control-plane/src/server.ts
@@ -223,31 +223,59 @@ async function handleRefreshRequest(
     Number.isFinite(contentLength) &&
     contentLength > MAX_REFRESH_BODY_BYTES
   ) {
-    request.resume();
-    respondJson(response, 413, { error: "Request body too large" });
+    rejectOversizedRefreshRequest(request, response);
     return;
   }
 
   await new Promise<void>((resolve) => {
     let received = 0;
-    let rejected = false;
-    request.on("data", (chunk: Buffer | string) => {
+    const onData = (chunk: Buffer | string) => {
       received += Buffer.byteLength(chunk);
-      if (received > MAX_REFRESH_BODY_BYTES && !rejected) {
-        rejected = true;
-        request.resume();
-        respondJson(response, 413, { error: "Request body too large" });
+      if (received > MAX_REFRESH_BODY_BYTES) {
+        cleanup();
+        rejectOversizedRefreshRequest(request, response);
+        resolve();
       }
-    });
-    request.on("end", () => {
-      if (!rejected) {
-        options.onRefreshRequest?.();
-        respondJson(response, 202, { ok: true });
+    };
+    const onEnd = () => {
+      cleanup();
+      options.onRefreshRequest?.();
+      respondJson(response, 202, { ok: true });
+      resolve();
+    };
+    const onAborted = () => {
+      cleanup();
+      resolve();
+    };
+    const onError = () => {
+      cleanup();
+      if (!response.headersSent) {
+        respondJson(response, 400, { error: "Invalid request body" });
       }
       resolve();
-    });
-    request.on("error", () => resolve());
+    };
+    const cleanup = () => {
+      request.off("data", onData);
+      request.off("end", onEnd);
+      request.off("aborted", onAborted);
+      request.off("error", onError);
+    };
+
+    request.on("data", onData);
+    request.on("end", onEnd);
+    request.on("aborted", onAborted);
+    request.on("error", onError);
   });
+}
+
+function rejectOversizedRefreshRequest(
+  request: IncomingMessage,
+  response: ServerResponse
+): void {
+  response.shouldKeepAlive = false;
+  response.setHeader("Connection", "close");
+  response.once("finish", () => request.destroy());
+  respondJson(response, 413, { error: "Request body too large" });
 }
 
 function isDashboardRequest(pathname: string): boolean {

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -28,12 +28,18 @@ import {
 import { GitHubGraphQLRateLimitError } from "@gh-symphony/tracker-github";
 import { OrchestratorFsStore } from "./fs-store.js";
 import * as gitModule from "./git.js";
-import { OrchestratorService } from "./service.js";
+import { clampPollInterval, OrchestratorService } from "./service.js";
 import * as trackerAdapters from "./tracker-adapters.js";
 
 describe("OrchestratorService", () => {
   const originalToken = process.env.GITHUB_GRAPHQL_TOKEN;
   const originalAllowWorkflowHooks = process.env.SYMPHONY_ALLOW_WORKFLOW_HOOKS;
+
+  it("clamps polling intervals to prevent spins and excessive sleeps", () => {
+    expect(clampPollInterval(0)).toBe(1_000);
+    expect(clampPollInterval(10 * 60_000)).toBe(5 * 60_000);
+    expect(clampPollInterval(30_000)).toBe(30_000);
+  });
 
   afterEach(() => {
     vi.restoreAllMocks();

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -4359,13 +4359,19 @@ Prefer focused changes.
     const tempRoot = await mkdtemp(join(tmpdir(), "orchestrator-rate-limit-"));
     const createServiceWithRemaining = async (
       suffix: string,
-      remainingRef: { value: number }
+      remainingRef: { value: number },
+      schedulerPollIntervalMs = 30_000
     ) => {
       const repository = await createRepositoryFixture(
         tempRoot,
         "acme",
         `platform-${suffix}`
       );
+      if (schedulerPollIntervalMs !== 30_000) {
+        await commitWorkflowFixture(repository.path, {
+          schedulerPollIntervalMs,
+        });
+      }
       const store = new OrchestratorFsStore(tempRoot);
       const projectConfig = createProjectConfig(tempRoot, repository);
       await store.saveProjectConfig(projectConfig);
@@ -4416,14 +4422,15 @@ Prefer focused changes.
     const exhaustedRemaining = { value: 100 };
     const exhaustedService = await createServiceWithRemaining(
       "exhausted",
-      exhaustedRemaining
+      exhaustedRemaining,
+      60_000
     );
     await exhaustedService.runOnce();
-    expect(exhaustedService.getEffectivePollIntervalMs()).toBe(300_000);
+    expect(exhaustedService.getEffectivePollIntervalMs()).toBe(600_000);
 
     exhaustedRemaining.value = 4000;
     await exhaustedService.runOnce();
-    expect(exhaustedService.getEffectivePollIntervalMs()).toBe(30_000);
+    expect(exhaustedService.getEffectivePollIntervalMs()).toBe(60_000);
   });
 
   it("logs a warning when GitHub rate limits fall below five percent", async () => {

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -74,6 +74,8 @@ import {
 } from "./explain.js";
 
 const DEFAULT_POLL_INTERVAL_MS = 30_000;
+export const MIN_POLL_INTERVAL_MS = 1_000;
+export const MAX_POLL_INTERVAL_MS = 5 * 60_000;
 const DEFAULT_CONCURRENCY = 3;
 const DEFAULT_RETRY_BACKOFF_MS = 30_000;
 const CONTINUATION_RETRY_DELAY_MS = 1_000;
@@ -101,6 +103,13 @@ const INHERITED_ENV_ALLOWLIST = new Set([
 ]);
 const WORKFLOW_HOOK_APPROVAL_ENV = "SYMPHONY_ALLOW_WORKFLOW_HOOKS";
 const WORKFLOW_HOOK_ENV_ALLOWLIST_ENV = "SYMPHONY_WORKFLOW_HOOK_ENV_ALLOWLIST";
+
+export function clampPollInterval(intervalMs: number): number {
+  return Math.min(
+    MAX_POLL_INTERVAL_MS,
+    Math.max(MIN_POLL_INTERVAL_MS, intervalMs)
+  );
+}
 
 type ProjectWorkflowResolution = Awaited<
   ReturnType<typeof loadRepositoryWorkflow>
@@ -907,14 +916,14 @@ export class OrchestratorService {
 
   getEffectivePollIntervalMs(): number {
     if (this.dependencies.pollIntervalMs) {
-      return this.dependencies.pollIntervalMs;
+      return clampPollInterval(this.dependencies.pollIntervalMs);
     }
 
     const configuredIntervals = [...this.projectPollIntervals.values()].filter(
       (value) => Number.isFinite(value) && value > 0
     );
     return configuredIntervals.length
-      ? Math.min(...configuredIntervals)
+      ? clampPollInterval(Math.min(...configuredIntervals))
       : DEFAULT_POLL_INTERVAL_MS;
   }
 
@@ -3714,7 +3723,7 @@ export class OrchestratorService {
       ? resolution.workflow.polling.intervalMs
       : NaN;
     return Number.isFinite(interval) && interval > 0
-      ? interval
+      ? clampPollInterval(interval)
       : DEFAULT_POLL_INTERVAL_MS;
   }
 

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -923,7 +923,7 @@ export class OrchestratorService {
       (value) => Number.isFinite(value) && value > 0
     );
     return configuredIntervals.length
-      ? clampPollInterval(Math.min(...configuredIntervals))
+      ? Math.min(...configuredIntervals)
       : DEFAULT_POLL_INTERVAL_MS;
   }
 

--- a/packages/tracker-linear/src/orchestrator-adapter.ts
+++ b/packages/tracker-linear/src/orchestrator-adapter.ts
@@ -11,6 +11,10 @@ import {
 
 export const DEFAULT_LINEAR_GRAPHQL_URL = CORE_DEFAULT_LINEAR_GRAPHQL_URL;
 const DEFAULT_PAGE_SIZE = 50;
+export const DEFAULT_LINEAR_MAX_PAGES = 100;
+export const MAX_LINEAR_MAX_PAGES = 1_000;
+export const DEFAULT_LINEAR_PAGE_TIMEOUT_MS = 10_000;
+export const MAX_LINEAR_PAGE_TIMEOUT_MS = 60_000;
 const LINEAR_IDENTIFIER_PATTERN = /^[A-Z][A-Z0-9]*-\d+$/;
 
 type LinearRateLimitPayload = {
@@ -263,6 +267,8 @@ async function listLinearIssues(
         : undefined,
     assignedOnly: config.assignedOnly,
     pageSize: config.pageSize,
+    maxPages: config.maxPages,
+    pageTimeoutMs: config.pageTimeoutMs,
   });
 
   const fetchedIssues = result.nodes.map((node) =>
@@ -301,6 +307,8 @@ async function fetchPaginatedLinearIssues(
     issueIdentifiers?: string[];
     assignedOnly: boolean;
     pageSize: number;
+    maxPages: number;
+    pageTimeoutMs: number;
   }
 ): Promise<{
   nodes: LinearIssueNode[];
@@ -310,7 +318,7 @@ async function fetchPaginatedLinearIssues(
   let latestRateLimits: LinearRateLimitPayload | null = null;
   let after: string | null = null;
 
-  do {
+  for (let page = 0; page < input.maxPages; page += 1) {
     const query = input.issueIdentifiers
       ? LINEAR_ISSUES_BY_IDENTIFIERS_QUERY
       : input.issueIds
@@ -331,7 +339,10 @@ async function fetchPaginatedLinearIssues(
     after = connection?.pageInfo?.hasNextPage
       ? (connection.pageInfo.endCursor ?? null)
       : null;
-  } while (after);
+    if (!after) {
+      break;
+    }
+  }
 
   return {
     nodes: issues,
@@ -428,14 +439,22 @@ function createLinearGraphqlClient(
     data: TData;
     rateLimits: LinearRateLimitPayload | null;
   }> => {
-    const response = await fetchImpl(config.endpoint, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: config.token,
-      },
-      body: JSON.stringify({ query, variables }),
-    });
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), config.pageTimeoutMs);
+    let response: Response;
+    try {
+      response = await fetchImpl(config.endpoint, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: config.token,
+        },
+        body: JSON.stringify({ query, variables }),
+        signal: controller.signal,
+      });
+    } finally {
+      clearTimeout(timeout);
+    }
     const rateLimits = extractLinearRateLimits(response.headers);
 
     if (!response.ok) {
@@ -559,6 +578,16 @@ function resolveLinearTrackerConfig(
     pageSize:
       readPositiveIntegerSetting(project.tracker, "pageSize") ??
       DEFAULT_PAGE_SIZE,
+    maxPages: Math.min(
+      readPositiveIntegerSetting(project.tracker, "maxPages") ??
+        DEFAULT_LINEAR_MAX_PAGES,
+      MAX_LINEAR_MAX_PAGES
+    ),
+    pageTimeoutMs: Math.min(
+      readPositiveIntegerSetting(project.tracker, "pageTimeoutMs") ??
+        DEFAULT_LINEAR_PAGE_TIMEOUT_MS,
+      MAX_LINEAR_PAGE_TIMEOUT_MS
+    ),
     pickupLabels: resolvePickupLabels(project.tracker),
     projectSlug,
     token,

--- a/packages/tracker-linear/src/orchestrator-adapter.ts
+++ b/packages/tracker-linear/src/orchestrator-adapter.ts
@@ -268,7 +268,6 @@ async function listLinearIssues(
     assignedOnly: config.assignedOnly,
     pageSize: config.pageSize,
     maxPages: config.maxPages,
-    pageTimeoutMs: config.pageTimeoutMs,
   });
 
   const fetchedIssues = result.nodes.map((node) =>
@@ -308,7 +307,6 @@ async function fetchPaginatedLinearIssues(
     assignedOnly: boolean;
     pageSize: number;
     maxPages: number;
-    pageTimeoutMs: number;
   }
 ): Promise<{
   nodes: LinearIssueNode[];
@@ -441,9 +439,8 @@ function createLinearGraphqlClient(
   }> => {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), config.pageTimeoutMs);
-    let response: Response;
     try {
-      response = await fetchImpl(config.endpoint, {
+      const response = await fetchImpl(config.endpoint, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -452,44 +449,44 @@ function createLinearGraphqlClient(
         body: JSON.stringify({ query, variables }),
         signal: controller.signal,
       });
+      const rateLimits = extractLinearRateLimits(response.headers);
+
+      if (!response.ok) {
+        const retryAfter = rateLimits?.retryAfter;
+        const retrySuffix =
+          typeof retryAfter === "number"
+            ? ` Retry after ${retryAfter} seconds.`
+            : "";
+        throw new Error(
+          `Linear GraphQL request failed with HTTP ${response.status}.${retrySuffix}`
+        );
+      }
+
+      const payload = (await response.json()) as {
+        data?: TData;
+        errors?: Array<{ message?: string }>;
+      };
+
+      if (payload.errors?.length) {
+        const message =
+          payload.errors
+            .map((error) => error.message)
+            .filter(Boolean)
+            .join("; ") || "Unknown Linear GraphQL error";
+        throw new Error(`Linear GraphQL request failed: ${message}`);
+      }
+
+      if (!payload.data) {
+        throw new Error("Linear GraphQL response did not include data.");
+      }
+
+      return {
+        data: payload.data,
+        rateLimits,
+      };
     } finally {
       clearTimeout(timeout);
     }
-    const rateLimits = extractLinearRateLimits(response.headers);
-
-    if (!response.ok) {
-      const retryAfter = rateLimits?.retryAfter;
-      const retrySuffix =
-        typeof retryAfter === "number"
-          ? ` Retry after ${retryAfter} seconds.`
-          : "";
-      throw new Error(
-        `Linear GraphQL request failed with HTTP ${response.status}.${retrySuffix}`
-      );
-    }
-
-    const payload = (await response.json()) as {
-      data?: TData;
-      errors?: Array<{ message?: string }>;
-    };
-
-    if (payload.errors?.length) {
-      const message =
-        payload.errors
-          .map((error) => error.message)
-          .filter(Boolean)
-          .join("; ") || "Unknown Linear GraphQL error";
-      throw new Error(`Linear GraphQL request failed: ${message}`);
-    }
-
-    if (!payload.data) {
-      throw new Error("Linear GraphQL response did not include data.");
-    }
-
-    return {
-      data: payload.data,
-      rateLimits,
-    };
   };
 }
 

--- a/packages/tracker-linear/src/tracker-linear.test.ts
+++ b/packages/tracker-linear/src/tracker-linear.test.ts
@@ -211,6 +211,41 @@ describe("linearTrackerAdapter", () => {
     expect(fetchImpl.mock.calls[0]?.[1]?.signal).toBeInstanceOf(AbortSignal);
   });
 
+  it("keeps the per-page timeout active while reading the response body", async () => {
+    const fetchImpl = vi.fn(
+      async (_input: RequestInfo | URL, init?: RequestInit) => {
+        const signal = init?.signal;
+        if (!signal) {
+          throw new Error("Expected an abort signal");
+        }
+        return {
+          ok: true,
+          status: 200,
+          headers: new Headers(),
+          json: () =>
+            new Promise<never>((_resolve, reject) => {
+              signal.addEventListener("abort", () => reject(signal.reason), {
+                once: true,
+              });
+            }),
+        } as unknown as Response;
+      }
+    );
+
+    await expect(
+      linearTrackerAdapter.listIssues(
+        makeProject({
+          settings: {
+            projectSlug: "symphony-0c79b11b75ea",
+            activeStates: "Todo",
+            pageTimeoutMs: 1,
+          },
+        }),
+        { fetchImpl, token: "linear-token" }
+      )
+    ).rejects.toMatchObject({ name: "AbortError" });
+  });
+
   it("listIssuesByStates queries Linear directly without using projectItemsCache", async () => {
     const fetchImpl = vi.fn().mockResolvedValue(
       jsonResponse({

--- a/packages/tracker-linear/src/tracker-linear.test.ts
+++ b/packages/tracker-linear/src/tracker-linear.test.ts
@@ -182,6 +182,35 @@ describe("linearTrackerAdapter", () => {
     ]);
   });
 
+  it("limits pagination and supplies a per-page abort signal", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonResponse({
+        data: {
+          issues: {
+            nodes: [linearIssueNode("ENG-1", [])],
+            pageInfo: { hasNextPage: true, endCursor: "cursor-1" },
+          },
+        },
+      })
+    );
+
+    const issues = await linearTrackerAdapter.listIssues(
+      makeProject({
+        settings: {
+          projectSlug: "symphony-0c79b11b75ea",
+          activeStates: "Todo",
+          maxPages: 1,
+          pageTimeoutMs: 1_000,
+        },
+      }),
+      { fetchImpl, token: "linear-token" }
+    );
+
+    expect(issues).toHaveLength(1);
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    expect(fetchImpl.mock.calls[0]?.[1]?.signal).toBeInstanceOf(AbortSignal);
+  });
+
   it("listIssuesByStates queries Linear directly without using projectItemsCache", async () => {
     const fetchImpl = vi.fn().mockResolvedValue(
       jsonResponse({


### PR DESCRIPTION
## TL;DR

- `POST /api/v1/refresh` body를 64 KiB로 제한하고, Content-Length 및 chunked 초과 요청을 즉시 413으로 완료합니다.
- Linear pagination을 최대 page 수로 제한하고, 각 page의 fetch와 response body 파싱 전체에 타임아웃을 적용합니다.
- workflow polling 설정 입력을 1초–5분으로 제한하되 기존 적응형 rate-limit 백오프는 보존합니다.

## 변경 지점 다이어그램

```text
HTTP refresh stream ──> 64 KiB guard ──> 413 + connection close
Linear page request ──> maxPages ──> fetch + body timeout
WORKFLOW interval ──> input clamp ──> adaptive backoff ──> scheduler wait
```

## 여기부터 보세요

- `packages/control-plane/src/server.ts`: 초과 body 즉시 종료와 스트림 오류 응답
- `packages/tracker-linear/src/orchestrator-adapter.ts`: bounded pagination과 body 포함 timeout
- `packages/orchestrator/src/service.ts`: 설정 입력 clamp와 adaptive 결과 보존 경계
- 각 패키지의 `*.test.ts`: chunked body, stalled Linear body, 60초 base → 600초 backoff 회귀 TC

## 위험 & 롤백

- 64 KiB를 넘는 refresh client는 413과 connection close를 받습니다. 기존 정상 호출은 의미 있는 body를 보내지 않습니다.
- 1초 미만/5분 초과 polling 설정은 repository policy에 따라 각각 1초/5분으로 동작합니다. 이 upstream spec divergence는 changeset에 명시했습니다.
- 롤백: rebased head `052d712`의 두 #468 커밋을 되돌립니다.

## 변경 파일

- `packages/control-plane/src/server.ts`, `server.test.ts`
- `packages/tracker-linear/src/orchestrator-adapter.ts`, `tracker-linear.test.ts`
- `packages/orchestrator/src/service.ts`, `service.test.ts`
- `.changeset/bright-limits-refresh.md`

## Evidence

- `pnpm lint` — 통과
- `pnpm test` — 통과 (재실행에서 전체 workspace 통과; 첫 실행의 기존 SIGTERM timing flake는 격리 재실행도 통과)
- `pnpm typecheck` — 통과
- `pnpm build` — 통과
- 영향 패키지 TC — control-plane 36/36, tracker-linear 25/25, orchestrator 234/234 통과
- Docker E2E — 새 이미지 build, control-plane 정상 refresh 202, Content-Length 65,537 bytes 413, chunked 65,537 bytes 413 확인
- GitHub CI head `052d712` — `Test`, `Container Smoke` 통과
- Changeset — `.changeset/bright-limits-refresh.md` (`@gh-symphony/cli` patch)

## Issues — Closed #468

- Fixes #468

## 머지 후/사람 확인

- [ ] 운영 환경의 413 로그와 refresh client 호환성을 확인합니다.
- [ ] Linear `maxPages`/page timeout 기본값이 배포 정책과 맞는지 확인합니다.
- [ ] 1초–5분 설정 상한과 더 긴 adaptive backoff cadence를 확인합니다.

## Risks

- 리뷰 초점은 chunked 초과 요청 종료, stalled Linear body abort, adaptive polling 결과가 5분 이상 유지되는지입니다.
