### PR TITLE
fix(security): harden server responses and logs

### DIFF
--- a/.changeset/tidy-servers-guard.md
+++ b/.changeset/tidy-servers-guard.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Harden control-plane and dashboard HTTP responses with security headers, consistent UTF-8 content types, and sanitized request error logs (#469).

--- a/packages/control-plane/src/server.test.ts
+++ b/packages/control-plane/src/server.test.ts
@@ -232,6 +232,7 @@ describe("createControlPlaneHandler", () => {
     const response = await fetchWithHandler(handler, "/assets/app.js");
 
     expect(response.status).toBe(200);
+    expectSecurityHeaders(response);
     expect(response.headers.get("content-type")).toContain(
       "application/javascript"
     );
@@ -289,6 +290,7 @@ describe("createControlPlaneHandler", () => {
     );
 
     expect(response.status).toBe(200);
+    expectSecurityHeaders(response);
     expect(response.headers.get("content-type")).toContain("text/html");
     await expect(response.text()).resolves.toContain('<div id="root"></div>');
   });
@@ -308,6 +310,30 @@ describe("createControlPlaneHandler", () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get("cache-control")).toBe("no-cache");
+  });
+
+  it("logs a sanitized error type without message, stack, or path", async () => {
+    const reader = createReader();
+    const sensitiveError = new Error(
+      "token=super-secret at /Users/operator/private/workspace"
+    );
+    reader.loadProjectState.mockRejectedValue(sensitiveError);
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const handler = createControlPlaneHandler({
+      reader: reader as never,
+      apiToken: API_TOKEN,
+    });
+
+    const response = await fetchWithHandler(handler, "/api/v1/state", {
+      headers: AUTHORIZATION,
+    });
+
+    expect(response.status).toBe(500);
+    expect(errorSpy).toHaveBeenCalledWith("Control plane request failed.", {
+      errorType: "Error",
+    });
+    expect(JSON.stringify(errorSpy.mock.calls)).not.toContain("super-secret");
+    expect(JSON.stringify(errorSpy.mock.calls)).not.toContain("/Users/");
   });
 });
 
@@ -386,6 +412,18 @@ async function fetchWithHandler(
       server.instance.close((error) => (error ? reject(error) : resolve()))
     );
   }
+}
+
+function expectSecurityHeaders(response: Response): void {
+  expect(response.headers.get("content-security-policy")).toContain(
+    "frame-ancestors 'none'"
+  );
+  expect(response.headers.get("permissions-policy")).toBe(
+    "camera=(), geolocation=(), microphone=()"
+  );
+  expect(response.headers.get("referrer-policy")).toBe("no-referrer");
+  expect(response.headers.get("x-content-type-options")).toBe("nosniff");
+  expect(response.headers.get("x-frame-options")).toBe("DENY");
 }
 
 async function startEphemeralServer(

--- a/packages/control-plane/src/server.ts
+++ b/packages/control-plane/src/server.ts
@@ -11,6 +11,8 @@ import {
   DashboardFsReader,
   isAuthorizedApiRequest,
   resolveDashboardResponse,
+  sanitizeErrorForLog,
+  SECURITY_RESPONSE_HEADERS,
 } from "@gh-symphony/dashboard";
 
 const CLIENT_DIST_DIR = join(
@@ -136,7 +138,10 @@ export function createControlPlaneHandler(
 
       await respondFile(response, asset.path, method, asset.fallback);
     } catch (error) {
-      console.error("Control plane request failed.", error);
+      console.error(
+        "Control plane request failed.",
+        sanitizeErrorForLog(error)
+      );
       if (!response.headersSent) {
         respondJson(response, 500, { error: "Internal server error" });
       } else {
@@ -382,6 +387,7 @@ async function respondFile(
       ? "no-cache"
       : "public, max-age=31536000, immutable";
   response.writeHead(200, {
+    ...SECURITY_RESPONSE_HEADERS,
     "cache-control": cacheControl,
     "content-type": contentType,
   });
@@ -407,6 +413,7 @@ function respondJson(
   payload: unknown
 ): void {
   response.writeHead(status, {
+    ...SECURITY_RESPONSE_HEADERS,
     "content-type": "application/json; charset=utf-8",
   });
   response.end(JSON.stringify(payload));

--- a/packages/dashboard/src/index.ts
+++ b/packages/dashboard/src/index.ts
@@ -3,5 +3,7 @@ export {
   createDashboardRequestHandler,
   isAuthorizedApiRequest,
   resolveDashboardResponse,
+  sanitizeErrorForLog,
+  SECURITY_RESPONSE_HEADERS,
   startDashboardServer,
 } from "./server.js";

--- a/packages/dashboard/src/server.test.ts
+++ b/packages/dashboard/src/server.test.ts
@@ -478,6 +478,10 @@ describe("startDashboardServer", () => {
       const baseUrl = `http://127.0.0.1:${addressInfo.port}`;
       const unauthorized = await fetch(`${baseUrl}/api/v1/state`);
       expect(unauthorized.status).toBe(401);
+      expectSecurityHeaders(unauthorized);
+      expect(unauthorized.headers.get("content-type")).toBe(
+        "application/json; charset=utf-8"
+      );
       await expect(unauthorized.json()).resolves.toEqual({
         error: "Unauthorized",
       });
@@ -519,7 +523,9 @@ describe("startDashboardServer", () => {
 
   it("returns a 500 JSON payload when request handling throws", async () => {
     const reader = createReader();
-    reader.loadProjectState.mockRejectedValue(new Error("boom"));
+    reader.loadProjectState.mockRejectedValue(
+      new Error("token=super-secret at /Users/operator/private/workspace")
+    );
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const server = startDashboardServer({
       host: "127.0.0.1",
@@ -545,8 +551,25 @@ describe("startDashboardServer", () => {
         error: "Internal server error",
       });
       expect(errorSpy).toHaveBeenCalledOnce();
+      expect(errorSpy).toHaveBeenCalledWith("Dashboard request failed.", {
+        errorType: "Error",
+      });
+      expect(JSON.stringify(errorSpy.mock.calls)).not.toContain("super-secret");
+      expect(JSON.stringify(errorSpy.mock.calls)).not.toContain("/Users/");
     } finally {
       server.close();
     }
   });
 });
+
+function expectSecurityHeaders(response: Response): void {
+  expect(response.headers.get("content-security-policy")).toContain(
+    "frame-ancestors 'none'"
+  );
+  expect(response.headers.get("permissions-policy")).toBe(
+    "camera=(), geolocation=(), microphone=()"
+  );
+  expect(response.headers.get("referrer-policy")).toBe("no-referrer");
+  expect(response.headers.get("x-content-type-options")).toBe("nosniff");
+  expect(response.headers.get("x-frame-options")).toBe("DENY");
+}

--- a/packages/dashboard/src/server.ts
+++ b/packages/dashboard/src/server.ts
@@ -8,6 +8,33 @@ import { timingSafeEqual } from "node:crypto";
 import { DashboardFsReader, statusForIssue } from "./store.js";
 
 const REDACTED = "[REDACTED]";
+const SAFE_ERROR_NAMES = new Set([
+  "AggregateError",
+  "Error",
+  "EvalError",
+  "RangeError",
+  "ReferenceError",
+  "SyntaxError",
+  "TypeError",
+  "URIError",
+]);
+export const SECURITY_RESPONSE_HEADERS = Object.freeze({
+  "content-security-policy": [
+    "default-src 'self'",
+    "base-uri 'none'",
+    "connect-src 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'none'",
+    "img-src 'self' data:",
+    "object-src 'none'",
+    "script-src 'self'",
+    "style-src 'self' 'unsafe-inline'",
+  ].join("; "),
+  "permissions-policy": "camera=(), geolocation=(), microphone=()",
+  "referrer-policy": "no-referrer",
+  "x-content-type-options": "nosniff",
+  "x-frame-options": "DENY",
+});
 const STATE_REDACTED_KEYS = new Set([
   "lastError",
   "sessionId",
@@ -136,7 +163,7 @@ export function createDashboardRequestHandler(options: {
       });
       respondJson(response, resolved.status, resolved.payload);
     } catch (error) {
-      console.error("Dashboard request failed.", error);
+      console.error("Dashboard request failed.", sanitizeErrorForLog(error));
       if (!response.headersSent) {
         respondJson(response, 500, {
           error: "Internal server error",
@@ -216,7 +243,18 @@ function respondJson(
   payload: unknown
 ): void {
   response.writeHead(status, {
-    "content-type": "application/json",
+    ...SECURITY_RESPONSE_HEADERS,
+    "content-type": "application/json; charset=utf-8",
   });
   response.end(JSON.stringify(payload));
+}
+
+export function sanitizeErrorForLog(error: unknown): {
+  errorType: string;
+} {
+  if (!(error instanceof Error) || !SAFE_ERROR_NAMES.has(error.name)) {
+    return { errorType: "UnknownError" };
+  }
+
+  return { errorType: error.name };
 }


### PR DESCRIPTION
## Issues — Closed #469

Fixes #469

## TL;DR

- control-plane과 dashboard의 모든 HTTP 응답에 일관된 보안 헤더와 UTF-8 charset을 적용합니다.
- 요청 실패 로그에서 message·stack·절대 경로·민감정보를 제외하고 allowlist된 오류 타입만 남깁니다.
- shallow clone history를 복원해 PR branch를 최신 `main` 위로 clean rebase하고 #469 관련 6개 파일만 유지했습니다.

## 변경 지점 다이어그램

```text
HTTP request
  ├─ control-plane server ─┐
  └─ dashboard server ─────┼─ CSP / frame / nosniff / permissions / referrer headers
                           ├─ UTF-8 JSON·text content types
                           └─ sanitized { errorType } request-error logging
```

## 여기부터 보세요

- `packages/dashboard/src/server.ts`: 양 서버가 재사용하는 보안 헤더와 오류 소독 기준
- `packages/control-plane/src/server.ts`: 정적 파일/API 응답에 동일 기준 적용
- `packages/dashboard/src/server.test.ts`, `packages/control-plane/src/server.test.ts`: 실제 헤더·charset·민감 로그 미노출 TC

## 변경 사항

- CSP, `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, Permissions-Policy, Referrer-Policy를 양 서버 응답에 적용했습니다.
- JSON과 text 응답의 charset을 UTF-8로 정합했습니다.
- 전체 오류 객체 대신 allowlist 기반 `{ errorType }`만 기록해 message, stack, 토큰, 로컬 경로 노출을 방지했습니다.
- `changeset:patch` 정책에 따라 `@gh-symphony/cli` changeset을 추가했습니다.
- shallow clone의 누락된 parent history를 복구한 뒤 최신 `main` 위에 보안 구현·changeset 2개 커밋을 clean rebase했습니다.

## Evidence

- `pnpm lint` — pass
- `pnpm test` — pass (최종 전체 재실행; 최초 실행의 비관련 orchestrator 타이밍 TC 2건은 단독 18/18 pass 후 전체 재실행 pass)
- `pnpm typecheck` — pass
- `pnpm build` — pass
- `pnpm --filter @gh-symphony/dashboard --filter @gh-symphony/control-plane test` — 7 files, 58 tests pass
- Docker blackbox — 새 이미지의 control-plane `http://127.0.0.1:4781/healthz`에서 5종 보안 헤더와 `application/json; charset=utf-8` assertion pass
- PR CI head `f5d6f8480eeb02e917f44c2f342e1e1735e53041` — `Test`, `Container Smoke` pass; merge state `CLEAN`
- Base freshness — `origin/main` (`9890928`)이 head의 ancestor
- Changeset — `.changeset/tidy-servers-guard.md` (`@gh-symphony/cli`: patch)

## 위험 & 롤백

- CSP가 향후 dashboard 자산 로딩 방식과 어긋나면 UI 자산이 차단될 수 있습니다. 현재 inline style 요구만 제한적으로 허용하고 정적 응답 TC와 Docker blackbox로 정책을 고정했습니다.
- 오류 로그는 민감정보 노출을 막는 대신 상세 원인 문자열을 남기지 않습니다. 회귀 시 이 PR의 공통 헤더/소독 로직을 되돌리면 기존 응답·로그 동작으로 복원됩니다.

## 변경 파일

- `.changeset/tidy-servers-guard.md`
- `packages/control-plane/src/server.ts`
- `packages/control-plane/src/server.test.ts`
- `packages/dashboard/src/server.ts`
- `packages/dashboard/src/server.test.ts`
- `packages/dashboard/src/index.ts`

## 머지 후/사람 확인

- [ ] 브라우저에서 dashboard 주요 화면과 정적 자산이 CSP 하에서 정상 로드되는지 확인
- [ ] 운영 로그에서 요청 실패 원인 식별에 필요한 최소 정보가 유지되는지 확인

## Human Validation

- [ ] 양 서버 응답에서 보안 헤더와 UTF-8 charset 확인
- [ ] 의도적으로 요청 오류를 유발해 절대 경로·민감정보가 로그에 노출되지 않는지 확인
