### PR TITLE
fix(cli): report stopped daemon status

### DIFF
--- a/.changeset/wise-dolphins-repair.md
+++ b/.changeset/wise-dolphins-repair.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Report daemon liveness accurately in `repo status`, including stale snapshot and adaptive polling status (#546).

--- a/packages/cli/src/commands/lifecycle.test.ts
+++ b/packages/cli/src/commands/lifecycle.test.ts
@@ -489,6 +489,43 @@ describe("lifecycle command integration", () => {
     ).rejects.toMatchObject({ code: "ENOENT" });
   });
 
+  it("does not signal an identity-unverified daemon recovered from a lock", async () => {
+    const configDir = await createConfigFixture({
+      activeProject: "tenant-a",
+      projects: [createTenant("tenant-a", "acme", "platform")],
+    });
+    await writeFile(
+      join(configDir, "projects", "tenant-a", ".lock"),
+      JSON.stringify({
+        ownerToken: "222:owner",
+        pid: 222,
+        startedAt: "2026-07-15T00:00:01.000Z",
+        heartbeatAt: new Date().toISOString(),
+        processIdentity: null,
+        cwd: process.cwd(),
+      }) + "\n"
+    );
+    getProcessIdentityMock.mockReturnValue(null);
+    const killSpy = vi
+      .spyOn(process, "kill")
+      .mockImplementation(
+        ((_pid: number, _signal?: NodeJS.Signals | 0) =>
+          true) as typeof process.kill
+      );
+    const stderr = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+
+    await stopModule.default([], baseOptions(configDir));
+
+    expect(killSpy).toHaveBeenCalledWith(222, 0);
+    expect(killSpy).not.toHaveBeenCalledWith(222, "SIGTERM");
+    expect(stderr).toHaveBeenCalledWith(
+      expect.stringContaining("process identity could not be verified")
+    );
+    expect(process.exitCode).toBe(1);
+  });
+
   it("rejects unknown project stop flags before touching daemon state", async () => {
     const configDir = await createConfigFixture({
       activeProject: "tenant-a",

--- a/packages/cli/src/commands/status.test.ts
+++ b/packages/cli/src/commands/status.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -8,11 +8,16 @@ import type { CliProjectConfig } from "../config.js";
 const daemonProcessMocks = vi.hoisted(() => ({
   getProcessCwd: vi.fn(),
   getProcessIdentity: vi.fn(),
+  resolveAdaptivePollIntervalMs: vi.fn(
+    (basePollIntervalMs: number) => basePollIntervalMs
+  ),
 }));
 
 vi.mock("@gh-symphony/orchestrator", () => ({
   getProcessCwd: daemonProcessMocks.getProcessCwd,
   getProcessIdentity: daemonProcessMocks.getProcessIdentity,
+  resolveAdaptivePollIntervalMs:
+    daemonProcessMocks.resolveAdaptivePollIntervalMs,
 }));
 
 function captureWrites(stream: NodeJS.WriteStream): {
@@ -168,6 +173,10 @@ async function writeProjectLock(
 beforeEach(() => {
   daemonProcessMocks.getProcessCwd.mockReset();
   daemonProcessMocks.getProcessIdentity.mockReset();
+  daemonProcessMocks.resolveAdaptivePollIntervalMs.mockReset();
+  daemonProcessMocks.resolveAdaptivePollIntervalMs.mockImplementation(
+    (basePollIntervalMs: number) => basePollIntervalMs
+  );
   daemonProcessMocks.getProcessCwd.mockReturnValue(join("/tmp", "tenant-a"));
   daemonProcessMocks.getProcessIdentity.mockReturnValue("live-daemon");
 });
@@ -175,6 +184,7 @@ beforeEach(() => {
 afterEach(() => {
   daemonProcessMocks.getProcessCwd.mockReset();
   daemonProcessMocks.getProcessIdentity.mockReset();
+  daemonProcessMocks.resolveAdaptivePollIntervalMs.mockReset();
   vi.restoreAllMocks();
   process.exitCode = undefined;
 });
@@ -357,6 +367,41 @@ describe("status command", () => {
     expect(stdout.output()).toContain("● Health    running");
     expect(stdout.output()).not.toContain("stopped");
     expect(stdout.output()).not.toContain("stale");
+  });
+
+  it("uses the adaptive rate-limit poll interval for stale detection", async () => {
+    const configDir = await createConfigFixture();
+    await writeDaemonPid(configDir);
+    await writeFile(
+      join(configDir, "status.json"),
+      JSON.stringify({
+        ...JSON.parse(await readFile(join(configDir, "status.json"), "utf8")),
+        rateLimits: { limit: 5_000, remaining: 0 },
+      }) + "\n",
+      "utf8"
+    );
+    daemonProcessMocks.resolveAdaptivePollIntervalMs.mockReturnValue(300_000);
+    vi.spyOn(process, "kill").mockImplementation(() => true);
+    vi.spyOn(Date, "now").mockReturnValue(
+      new Date("2026-03-30T11:02:00.000Z").getTime()
+    );
+    const stdout = captureWrites(process.stdout);
+
+    try {
+      await statusCommand([], {
+        configDir,
+        verbose: false,
+        json: false,
+        noColor: true,
+      });
+    } finally {
+      stdout.restore();
+    }
+
+    expect(stdout.output()).not.toContain("(stale)");
+    expect(
+      daemonProcessMocks.resolveAdaptivePollIntervalMs
+    ).toHaveBeenCalledWith(30_000, { limit: 5_000, remaining: 0 });
   });
 
   it("adds daemonRunning to JSON output", async () => {

--- a/packages/cli/src/commands/status.test.ts
+++ b/packages/cli/src/commands/status.test.ts
@@ -1,9 +1,19 @@
 import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it, vi } from "vitest";
-import statusCommand from "./status.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import statusCommand, { relativeTime } from "./status.js";
 import type { CliProjectConfig } from "../config.js";
+
+const daemonProcessMocks = vi.hoisted(() => ({
+  getProcessCwd: vi.fn(),
+  getProcessIdentity: vi.fn(),
+}));
+
+vi.mock("@gh-symphony/orchestrator", () => ({
+  getProcessCwd: daemonProcessMocks.getProcessCwd,
+  getProcessIdentity: daemonProcessMocks.getProcessIdentity,
+}));
 
 function captureWrites(stream: NodeJS.WriteStream): {
   output: () => string;
@@ -120,12 +130,157 @@ async function createConfigFixture(
   return configDir;
 }
 
+async function writeDaemonPid(
+  configDir: string,
+  options: { pid?: number; identity?: string; cwd?: string } = {}
+): Promise<void> {
+  await writeFile(
+    join(configDir, "projects", "tenant-a", "daemon.pid"),
+    JSON.stringify({
+      pid: options.pid ?? 111,
+      startedAt: "2026-03-30T11:00:00.000Z",
+      processIdentity: options.identity ?? "live-daemon",
+      cwd: options.cwd ?? join("/tmp", "tenant-a"),
+    }) + "\n",
+    "utf8"
+  );
+}
+
+beforeEach(() => {
+  daemonProcessMocks.getProcessCwd.mockReset();
+  daemonProcessMocks.getProcessIdentity.mockReset();
+  daemonProcessMocks.getProcessCwd.mockReturnValue(join("/tmp", "tenant-a"));
+  daemonProcessMocks.getProcessIdentity.mockReturnValue("live-daemon");
+});
+
 afterEach(() => {
+  daemonProcessMocks.getProcessCwd.mockReset();
+  daemonProcessMocks.getProcessIdentity.mockReset();
   vi.restoreAllMocks();
   process.exitCode = undefined;
 });
 
 describe("status command", () => {
+  it("renders a stopped banner and restart hint when the PID file is missing", async () => {
+    const configDir = await createConfigFixture();
+    const stdout = captureWrites(process.stdout);
+
+    try {
+      await statusCommand([], {
+        configDir,
+        verbose: false,
+        json: false,
+        noColor: true,
+      });
+    } finally {
+      stdout.restore();
+    }
+
+    expect(stdout.output()).toContain("● Health    stopped");
+    expect(stdout.output()).toContain(
+      "daemon not running — run 'gh-symphony repo start'"
+    );
+    expect(stdout.output()).toContain("Last known state: running");
+  });
+
+  it("renders a stopped banner for a stale PID", async () => {
+    const configDir = await createConfigFixture();
+    await writeDaemonPid(configDir, { pid: 999_999 });
+    vi.spyOn(process, "kill").mockImplementation(() => {
+      throw new Error("ESRCH");
+    });
+    const stdout = captureWrites(process.stdout);
+
+    try {
+      await statusCommand([], {
+        configDir,
+        verbose: false,
+        json: false,
+        noColor: true,
+      });
+    } finally {
+      stdout.restore();
+    }
+
+    expect(stdout.output()).toContain("● Health    stopped");
+  });
+
+  it("keeps live daemon health and annotates a stale last tick", async () => {
+    const configDir = await createConfigFixture();
+    await writeDaemonPid(configDir);
+    vi.spyOn(process, "kill").mockImplementation(() => true);
+    vi.spyOn(Date, "now").mockReturnValue(
+      new Date("2026-03-30T11:02:00.000Z").getTime()
+    );
+    const stdout = captureWrites(process.stdout);
+
+    try {
+      await statusCommand([], {
+        configDir,
+        verbose: false,
+        json: false,
+        noColor: true,
+      });
+    } finally {
+      stdout.restore();
+    }
+
+    expect(stdout.output()).toContain("● Health    running");
+    expect(stdout.output()).toContain("Last tick  2m ago (stale)");
+    expect(stdout.output()).not.toContain("daemon not running");
+  });
+
+  it("keeps fresh live daemon output free of stopped and stale warnings", async () => {
+    const configDir = await createConfigFixture();
+    await writeDaemonPid(configDir);
+    vi.spyOn(process, "kill").mockImplementation(() => true);
+    vi.spyOn(Date, "now").mockReturnValue(
+      new Date("2026-03-30T11:00:30.000Z").getTime()
+    );
+    const stdout = captureWrites(process.stdout);
+
+    try {
+      await statusCommand([], {
+        configDir,
+        verbose: false,
+        json: false,
+        noColor: true,
+      });
+    } finally {
+      stdout.restore();
+    }
+
+    expect(stdout.output()).toContain("● Health    running");
+    expect(stdout.output()).not.toContain("stopped");
+    expect(stdout.output()).not.toContain("stale");
+  });
+
+  it("adds daemonRunning to JSON output", async () => {
+    const configDir = await createConfigFixture();
+    const stdout = captureWrites(process.stdout);
+
+    try {
+      await statusCommand([], {
+        configDir,
+        verbose: false,
+        json: true,
+        noColor: true,
+      });
+    } finally {
+      stdout.restore();
+    }
+
+    expect(JSON.parse(stdout.output())).toMatchObject({
+      health: "running",
+      daemonRunning: false,
+    });
+  });
+
+  it("renders durations of at least 48 hours in days", () => {
+    const now = new Date("2026-04-01T12:00:00.000Z").getTime();
+    expect(relativeTime("2026-03-30T11:00:00.000Z", now)).toBe("2d ago");
+  });
+
   it("prints JSON for missing runtime config when --json is set", async () => {
     const configDir = await mkdtemp(join(tmpdir(), "cli-status-missing-"));
     const stdout = captureWrites(process.stdout);

--- a/packages/cli/src/commands/status.test.ts
+++ b/packages/cli/src/commands/status.test.ts
@@ -146,7 +146,11 @@ async function writeDaemonPid(
   );
 }
 
-async function writeProjectLock(configDir: string, pid = 222): Promise<void> {
+async function writeProjectLock(
+  configDir: string,
+  pid = 222,
+  cwd?: string
+): Promise<void> {
   await writeFile(
     join(configDir, "projects", "tenant-a", ".lock"),
     JSON.stringify({
@@ -155,6 +159,7 @@ async function writeProjectLock(configDir: string, pid = 222): Promise<void> {
       startedAt: "2026-03-30T11:00:00.000Z",
       heartbeatAt: "2026-03-30T11:00:00.000Z",
       processIdentity: null,
+      ...(cwd ? { cwd } : {}),
     }) + "\n",
     "utf8"
   );
@@ -222,6 +227,32 @@ describe("status command", () => {
       health: "running",
       daemonRunning: true,
     });
+  });
+
+  it("uses the foreground daemon CWD recorded in the project lock", async () => {
+    const configDir = await createConfigFixture();
+    const foregroundCwd = join("/tmp", "foreground-daemon");
+    await writeProjectLock(configDir, 222, foregroundCwd);
+    daemonProcessMocks.getProcessCwd.mockReturnValue(foregroundCwd);
+    daemonProcessMocks.getProcessIdentity.mockReturnValue(null);
+    vi.spyOn(process, "kill").mockImplementation(() => true);
+    vi.spyOn(Date, "now").mockReturnValue(
+      new Date("2026-03-30T11:00:30.000Z").getTime()
+    );
+    const stdout = captureWrites(process.stdout);
+
+    try {
+      await statusCommand([], {
+        configDir,
+        verbose: false,
+        json: true,
+        noColor: true,
+      });
+    } finally {
+      stdout.restore();
+    }
+
+    expect(JSON.parse(stdout.output())).toMatchObject({ daemonRunning: true });
   });
 
   it("recognizes a live foreground daemon when the PID file is malformed", async () => {

--- a/packages/cli/src/commands/status.test.ts
+++ b/packages/cli/src/commands/status.test.ts
@@ -404,6 +404,41 @@ describe("status command", () => {
     ).toHaveBeenCalledWith(30_000, { limit: 5_000, remaining: 0 });
   });
 
+  it("uses the daemon's recorded tracker polling interval for stale detection", async () => {
+    const configDir = await createConfigFixture();
+    await writeDaemonPid(configDir);
+    await writeFile(
+      join(configDir, "status.json"),
+      JSON.stringify({
+        ...JSON.parse(await readFile(join(configDir, "status.json"), "utf8")),
+        effectivePollIntervalMs: 300_000,
+        rateLimits: { source: "codex", limit: 5_000, remaining: 5_000 },
+      }) + "\n",
+      "utf8"
+    );
+    vi.spyOn(process, "kill").mockImplementation(() => true);
+    vi.spyOn(Date, "now").mockReturnValue(
+      new Date("2026-03-30T11:02:00.000Z").getTime()
+    );
+    const stdout = captureWrites(process.stdout);
+
+    try {
+      await statusCommand([], {
+        configDir,
+        verbose: false,
+        json: false,
+        noColor: true,
+      });
+    } finally {
+      stdout.restore();
+    }
+
+    expect(stdout.output()).not.toContain("(stale)");
+    expect(
+      daemonProcessMocks.resolveAdaptivePollIntervalMs
+    ).not.toHaveBeenCalled();
+  });
+
   it("adds daemonRunning to JSON output", async () => {
     const configDir = await createConfigFixture();
     const stdout = captureWrites(process.stdout);

--- a/packages/cli/src/commands/status.test.ts
+++ b/packages/cli/src/commands/status.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -454,6 +454,32 @@ describe("status command", () => {
         code: "missing_repository_runtime_config",
         message:
           "No repository runtime config found. Run 'gh-symphony repo init' first.",
+      },
+    });
+  });
+
+  it("includes daemonRunning when JSON status has no snapshot", async () => {
+    const configDir = await createConfigFixture();
+    await rm(join(configDir, "status.json"));
+    const stdout = captureWrites(process.stdout);
+
+    try {
+      await statusCommand([], {
+        configDir,
+        verbose: false,
+        json: true,
+        noColor: true,
+      });
+    } finally {
+      stdout.restore();
+    }
+
+    expect(process.exitCode).toBe(1);
+    expect(JSON.parse(stdout.output())).toEqual({
+      daemonRunning: false,
+      error: {
+        code: "status_snapshot_unavailable",
+        message: "Unable to read status snapshot.",
       },
     });
   });

--- a/packages/cli/src/commands/status.test.ts
+++ b/packages/cli/src/commands/status.test.ts
@@ -461,6 +461,8 @@ describe("status command", () => {
   it("includes daemonRunning when JSON status has no snapshot", async () => {
     const configDir = await createConfigFixture();
     await rm(join(configDir, "status.json"));
+    await writeDaemonPid(configDir);
+    vi.spyOn(process, "kill").mockImplementation(() => true);
     const stdout = captureWrites(process.stdout);
 
     try {
@@ -476,12 +478,49 @@ describe("status command", () => {
 
     expect(process.exitCode).toBe(1);
     expect(JSON.parse(stdout.output())).toEqual({
-      daemonRunning: false,
+      daemonRunning: true,
       error: {
         code: "status_snapshot_unavailable",
         message: "Unable to read status snapshot.",
       },
     });
+  });
+
+  it("preserves live daemon liveness in non-TTY watch JSON without a snapshot", async () => {
+    const configDir = await createConfigFixture();
+    await rm(join(configDir, "status.json"));
+    await writeDaemonPid(configDir);
+    vi.spyOn(process, "kill").mockImplementation(() => true);
+    vi.spyOn(process, "exit").mockImplementation((() => undefined) as never);
+    const isTTYDescriptor = Object.getOwnPropertyDescriptor(
+      process.stdout,
+      "isTTY"
+    );
+    Object.defineProperty(process.stdout, "isTTY", {
+      configurable: true,
+      value: false,
+    });
+    const stdout = captureWrites(process.stdout);
+
+    try {
+      void statusCommand(["--watch"], {
+        configDir,
+        verbose: false,
+        json: false,
+        noColor: true,
+      });
+      await vi.waitFor(() => {
+        expect(JSON.parse(stdout.output())).toEqual({ daemonRunning: true });
+      });
+      process.emit("SIGTERM", "SIGTERM");
+    } finally {
+      stdout.restore();
+      if (isTTYDescriptor) {
+        Object.defineProperty(process.stdout, "isTTY", isTTYDescriptor);
+      } else {
+        delete (process.stdout as { isTTY?: boolean }).isTTY;
+      }
+    }
   });
 
   it("renders project tokens from the flat runtime status snapshot", async () => {

--- a/packages/cli/src/commands/status.test.ts
+++ b/packages/cli/src/commands/status.test.ts
@@ -224,6 +224,38 @@ describe("status command", () => {
     });
   });
 
+  it("recognizes a live foreground daemon when the PID file is malformed", async () => {
+    const configDir = await createConfigFixture();
+    await writeFile(
+      join(configDir, "projects", "tenant-a", "daemon.pid"),
+      "partially-written-pid-record\n",
+      "utf8"
+    );
+    await writeProjectLock(configDir);
+    daemonProcessMocks.getProcessIdentity.mockReturnValue(null);
+    vi.spyOn(process, "kill").mockImplementation(() => true);
+    vi.spyOn(Date, "now").mockReturnValue(
+      new Date("2026-03-30T11:00:30.000Z").getTime()
+    );
+    const stdout = captureWrites(process.stdout);
+
+    try {
+      await statusCommand([], {
+        configDir,
+        verbose: false,
+        json: true,
+        noColor: true,
+      });
+    } finally {
+      stdout.restore();
+    }
+
+    expect(JSON.parse(stdout.output())).toMatchObject({
+      health: "running",
+      daemonRunning: true,
+    });
+  });
+
   it("renders a stopped banner for a stale PID", async () => {
     const configDir = await createConfigFixture();
     await writeDaemonPid(configDir, { pid: 999_999 });

--- a/packages/cli/src/commands/status.test.ts
+++ b/packages/cli/src/commands/status.test.ts
@@ -146,6 +146,20 @@ async function writeDaemonPid(
   );
 }
 
+async function writeProjectLock(configDir: string, pid = 222): Promise<void> {
+  await writeFile(
+    join(configDir, "projects", "tenant-a", ".lock"),
+    JSON.stringify({
+      ownerToken: `${pid}:owner`,
+      pid,
+      startedAt: "2026-03-30T11:00:00.000Z",
+      heartbeatAt: "2026-03-30T11:00:00.000Z",
+      processIdentity: null,
+    }) + "\n",
+    "utf8"
+  );
+}
+
 beforeEach(() => {
   daemonProcessMocks.getProcessCwd.mockReset();
   daemonProcessMocks.getProcessIdentity.mockReset();
@@ -181,6 +195,33 @@ describe("status command", () => {
       "daemon not running — run 'gh-symphony repo start'"
     );
     expect(stdout.output()).toContain("Last known state: running");
+  });
+
+  it("recognizes a live foreground daemon from the project lock", async () => {
+    const configDir = await createConfigFixture();
+    await writeProjectLock(configDir);
+    daemonProcessMocks.getProcessIdentity.mockReturnValue(null);
+    vi.spyOn(process, "kill").mockImplementation(() => true);
+    vi.spyOn(Date, "now").mockReturnValue(
+      new Date("2026-03-30T11:00:30.000Z").getTime()
+    );
+    const stdout = captureWrites(process.stdout);
+
+    try {
+      await statusCommand([], {
+        configDir,
+        verbose: false,
+        json: true,
+        noColor: true,
+      });
+    } finally {
+      stdout.restore();
+    }
+
+    expect(JSON.parse(stdout.output())).toMatchObject({
+      health: "running",
+      daemonRunning: true,
+    });
   });
 
   it("renders a stopped banner for a stale PID", async () => {

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -60,8 +60,11 @@ type RuntimeStatus = {
 
 async function resolveStaleThresholdMs(
   workspaceDir: string,
-  rateLimits: Record<string, unknown> | null | undefined
+  snapshot: ProjectStatusSnapshot
 ): Promise<number> {
+  if (snapshot.effectivePollIntervalMs !== undefined) {
+    return snapshot.effectivePollIntervalMs * 3;
+  }
   try {
     const resolution = await workflowConfigStore.load(
       join(workspaceDir, "WORKFLOW.md")
@@ -69,14 +72,14 @@ async function resolveStaleThresholdMs(
     return (
       resolveAdaptivePollIntervalMs(
         resolution.workflow.polling.intervalMs,
-        rateLimits ?? null
+        snapshot.rateLimits ?? null
       ) * 3
     );
   } catch {
     return (
       resolveAdaptivePollIntervalMs(
         DEFAULT_POLL_INTERVAL_MS,
-        rateLimits ?? null
+        snapshot.rateLimits ?? null
       ) * 3
     );
   }
@@ -106,7 +109,7 @@ async function resolveRuntimeStatus(options: {
   }
   const staleThresholdMs = await resolveStaleThresholdMs(
     options.workspaceDir,
-    options.snapshot.rateLimits
+    options.snapshot
   );
   return {
     daemonRunning: true,

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -18,6 +18,7 @@ import { clearScreen, showCursor, hideCursor } from "../ansi.js";
 import { renderDashboard } from "../dashboard/renderer.js";
 import { formatRepositoryDisplay } from "../format/repository.js";
 import { resolveDaemonLiveness } from "../daemon-liveness.js";
+import { resolveAdaptivePollIntervalMs } from "@gh-symphony/orchestrator";
 
 const workflowConfigStore = new WorkflowConfigStore();
 
@@ -57,14 +58,27 @@ type RuntimeStatus = {
   lastTickStale: boolean;
 };
 
-async function resolveStaleThresholdMs(workspaceDir: string): Promise<number> {
+async function resolveStaleThresholdMs(
+  workspaceDir: string,
+  rateLimits: Record<string, unknown> | null | undefined
+): Promise<number> {
   try {
     const resolution = await workflowConfigStore.load(
       join(workspaceDir, "WORKFLOW.md")
     );
-    return resolution.workflow.polling.intervalMs * 3;
+    return (
+      resolveAdaptivePollIntervalMs(
+        resolution.workflow.polling.intervalMs,
+        rateLimits ?? null
+      ) * 3
+    );
   } catch {
-    return DEFAULT_POLL_INTERVAL_MS * 3;
+    return (
+      resolveAdaptivePollIntervalMs(
+        DEFAULT_POLL_INTERVAL_MS,
+        rateLimits ?? null
+      ) * 3
+    );
   }
 }
 
@@ -84,12 +98,19 @@ async function resolveRuntimeStatus(options: {
   snapshot: ProjectStatusSnapshot;
 }): Promise<RuntimeStatus> {
   const liveness = await resolveDaemonLiveness(options);
-  const staleThresholdMs = await resolveStaleThresholdMs(options.workspaceDir);
+  if (!liveness.running) {
+    return { daemonRunning: false, lastTickStale: false };
+  }
+  const staleThresholdMs = await resolveStaleThresholdMs(
+    options.workspaceDir,
+    options.snapshot.rateLimits
+  );
   return {
-    daemonRunning: liveness.running,
-    lastTickStale:
-      liveness.running &&
-      isLastTickStale(options.snapshot.lastTickAt, staleThresholdMs),
+    daemonRunning: true,
+    lastTickStale: isLastTickStale(
+      options.snapshot.lastTickAt,
+      staleThresholdMs
+    ),
   };
 }
 

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -95,10 +95,10 @@ async function resolveRuntimeStatus(options: {
   configDir: string;
   projectId: string;
   workspaceDir: string;
-  snapshot: ProjectStatusSnapshot;
+  snapshot: ProjectStatusSnapshot | null;
 }): Promise<RuntimeStatus> {
   const liveness = await resolveDaemonLiveness(options);
-  if (!liveness.running) {
+  if (!liveness.running || !options.snapshot) {
     return { daemonRunning: false, lastTickStale: false };
   }
   const staleThresholdMs = await resolveStaleThresholdMs(
@@ -354,18 +354,18 @@ const handler = async (
 
     const run = async () => {
       const snapshot = await readStatusSnapshot(runtimeRoot, projectId);
-      const runtimeStatus = snapshot
-        ? await resolveRuntimeStatus({
-            configDir: options.configDir,
-            projectId,
-            workspaceDir: projectConfig.workspaceDir,
-            snapshot,
-          })
-        : { daemonRunning: false, lastTickStale: false };
+      const runtimeStatus = await resolveRuntimeStatus({
+        configDir: options.configDir,
+        projectId,
+        workspaceDir: projectConfig.workspaceDir,
+        snapshot,
+      });
       if (options.json || !isTTY) {
         process.stdout.write(
           JSON.stringify(
-            withDaemonRunning(snapshot, runtimeStatus.daemonRunning),
+            snapshot
+              ? withDaemonRunning(snapshot, runtimeStatus.daemonRunning)
+              : { daemonRunning: runtimeStatus.daemonRunning },
             null,
             2
           ) + "\n"
@@ -446,11 +446,33 @@ const handler = async (
       );
     }
   } else {
-    writeCliError({
-      code: "status_snapshot_unavailable",
-      message: "Unable to read status snapshot.",
-      json: options.json,
+    const runtimeStatus = await resolveRuntimeStatus({
+      configDir: options.configDir,
+      projectId,
+      workspaceDir: projectConfig.workspaceDir,
+      snapshot: null,
     });
+    if (options.json) {
+      process.stdout.write(
+        JSON.stringify(
+          {
+            daemonRunning: runtimeStatus.daemonRunning,
+            error: {
+              code: "status_snapshot_unavailable",
+              message: "Unable to read status snapshot.",
+            },
+          },
+          null,
+          2
+        ) + "\n"
+      );
+      process.exitCode = 1;
+    } else {
+      writeCliError({
+        code: "status_snapshot_unavailable",
+        message: "Unable to read status snapshot.",
+      });
+    }
   }
 };
 

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -98,8 +98,11 @@ async function resolveRuntimeStatus(options: {
   snapshot: ProjectStatusSnapshot | null;
 }): Promise<RuntimeStatus> {
   const liveness = await resolveDaemonLiveness(options);
-  if (!liveness.running || !options.snapshot) {
+  if (!liveness.running) {
     return { daemonRunning: false, lastTickStale: false };
+  }
+  if (!options.snapshot) {
+    return { daemonRunning: true, lastTickStale: false };
   }
   const staleThresholdMs = await resolveStaleThresholdMs(
     options.workspaceDir,

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -1,5 +1,9 @@
 import type { GlobalOptions } from "../index.js";
-import type { ProjectStatusSnapshot } from "@gh-symphony/core";
+import {
+  DEFAULT_POLL_INTERVAL_MS,
+  WorkflowConfigStore,
+  type ProjectStatusSnapshot,
+} from "@gh-symphony/core";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { resolveRuntimeRoot } from "../orchestrator-runtime.js";
@@ -13,28 +17,87 @@ import { bold, dim, green, red, yellow, cyan, stripAnsi } from "../ansi.js";
 import { clearScreen, showCursor, hideCursor } from "../ansi.js";
 import { renderDashboard } from "../dashboard/renderer.js";
 import { formatRepositoryDisplay } from "../format/repository.js";
+import { resolveDaemonLiveness } from "../daemon-liveness.js";
 
-function healthIcon(health: "idle" | "running" | "degraded"): string {
+const workflowConfigStore = new WorkflowConfigStore();
+
+function healthIcon(
+  health: "idle" | "running" | "degraded" | "stopped"
+): string {
   switch (health) {
     case "idle":
     case "running":
       return green("●");
     case "degraded":
+    case "stopped":
       return red("●");
   }
 }
 
-function relativeTime(isoString: string): string {
-  const now = new Date();
+export function relativeTime(
+  isoString: string,
+  nowMs: number = Date.now()
+): string {
+  const now = new Date(nowMs);
   const then = new Date(isoString);
   const diffMs = now.getTime() - then.getTime();
   const diffS = Math.floor(diffMs / 1000);
   const diffM = Math.floor(diffS / 60);
   const diffH = Math.floor(diffM / 60);
+  const diffD = Math.floor(diffH / 24);
 
   if (diffS < 60) return `${diffS}s ago`;
   if (diffM < 60) return `${diffM}m ago`;
+  if (diffH >= 48) return `${diffD}d ago`;
   return `${diffH}h ago`;
+}
+
+type RuntimeStatus = {
+  daemonRunning: boolean;
+  lastTickStale: boolean;
+};
+
+async function resolveStaleThresholdMs(workspaceDir: string): Promise<number> {
+  try {
+    const resolution = await workflowConfigStore.load(
+      join(workspaceDir, "WORKFLOW.md")
+    );
+    return resolution.workflow.polling.intervalMs * 3;
+  } catch {
+    return DEFAULT_POLL_INTERVAL_MS * 3;
+  }
+}
+
+function isLastTickStale(
+  lastTickAt: string,
+  thresholdMs: number,
+  nowMs: number = Date.now()
+): boolean {
+  const lastTickMs = new Date(lastTickAt).getTime();
+  return Number.isFinite(lastTickMs) && nowMs - lastTickMs > thresholdMs;
+}
+
+async function resolveRuntimeStatus(options: {
+  configDir: string;
+  projectId: string;
+  workspaceDir: string;
+  snapshot: ProjectStatusSnapshot;
+}): Promise<RuntimeStatus> {
+  const liveness = await resolveDaemonLiveness(options);
+  const staleThresholdMs = await resolveStaleThresholdMs(options.workspaceDir);
+  return {
+    daemonRunning: liveness.running,
+    lastTickStale:
+      liveness.running &&
+      isLastTickStale(options.snapshot.lastTickAt, staleThresholdMs),
+  };
+}
+
+function withDaemonRunning(
+  snapshot: ProjectStatusSnapshot | null,
+  daemonRunning: boolean
+): (ProjectStatusSnapshot & { daemonRunning: boolean }) | null {
+  return snapshot ? { ...snapshot, daemonRunning } : null;
 }
 
 function truncate(s: string, len: number): string {
@@ -55,7 +118,8 @@ function resolveProjectTokenDelta(snapshot: ProjectStatusSnapshot): number {
 
 function renderLegacyStatus(
   snapshot: ProjectStatusSnapshot,
-  noColor: boolean
+  noColor: boolean,
+  runtimeStatus: RuntimeStatus
 ): string {
   const apply = noColor ? (s: string) => stripAnsi(s) : (s: string) => s;
 
@@ -76,13 +140,25 @@ function renderLegacyStatus(
   lines.push("");
 
   // Health and last tick
+  const renderedHealth = runtimeStatus.daemonRunning
+    ? snapshot.health
+    : "stopped";
   const healthStr = apply(
-    `${healthIcon(snapshot.health)} Health    ${snapshot.health}`
+    `${healthIcon(renderedHealth)} Health    ${renderedHealth}`
   );
+  const staleLabel = runtimeStatus.lastTickStale
+    ? apply(yellow(" (stale)"))
+    : "";
   const lastTickStr = apply(`Last tick  ${relativeTime(snapshot.lastTickAt)}`);
   lines.push(
-    `  ${healthStr}${" ".repeat(Math.max(0, 30 - stripAnsi(healthStr).length))}${lastTickStr}`
+    `  ${healthStr}${" ".repeat(Math.max(0, 30 - stripAnsi(healthStr).length))}${lastTickStr}${staleLabel}`
   );
+  if (!runtimeStatus.daemonRunning) {
+    lines.push(
+      apply(yellow("  daemon not running — run 'gh-symphony repo start'"))
+    );
+    lines.push(apply(dim(`  Last known state: ${snapshot.health}`)));
+  }
   lines.push("");
 
   // Summary stats
@@ -257,8 +333,22 @@ const handler = async (
 
     const run = async () => {
       const snapshot = await readStatusSnapshot(runtimeRoot, projectId);
+      const runtimeStatus = snapshot
+        ? await resolveRuntimeStatus({
+            configDir: options.configDir,
+            projectId,
+            workspaceDir: projectConfig.workspaceDir,
+            snapshot,
+          })
+        : { daemonRunning: false, lastTickStale: false };
       if (options.json || !isTTY) {
-        process.stdout.write(JSON.stringify(snapshot, null, 2) + "\n");
+        process.stdout.write(
+          JSON.stringify(
+            withDaemonRunning(snapshot, runtimeStatus.daemonRunning),
+            null,
+            2
+          ) + "\n"
+        );
       } else {
         if (!snapshot) {
           process.stdout.write(
@@ -271,6 +361,10 @@ const handler = async (
             renderDashboard([snapshot], {
               terminalWidth,
               noColor: options.noColor,
+              runtimeStatus: {
+                ...runtimeStatus,
+                lastTickLabel: relativeTime(snapshot.lastTickAt),
+              },
             }) +
             "\n"
         );
@@ -311,11 +405,23 @@ const handler = async (
   // Single status query
   const snapshot = await readStatusSnapshot(runtimeRoot, projectId);
   if (snapshot) {
+    const runtimeStatus = await resolveRuntimeStatus({
+      configDir: options.configDir,
+      projectId,
+      workspaceDir: projectConfig.workspaceDir,
+      snapshot,
+    });
     if (options.json) {
-      process.stdout.write(JSON.stringify(snapshot, null, 2) + "\n");
+      process.stdout.write(
+        JSON.stringify(
+          withDaemonRunning(snapshot, runtimeStatus.daemonRunning),
+          null,
+          2
+        ) + "\n"
+      );
     } else {
       process.stdout.write(
-        renderLegacyStatus(snapshot, options.noColor) + "\n"
+        renderLegacyStatus(snapshot, options.noColor, runtimeStatus) + "\n"
       );
     }
   } else {

--- a/packages/cli/src/commands/stop.ts
+++ b/packages/cli/src/commands/stop.ts
@@ -1,13 +1,13 @@
-import { readFile, rm } from "node:fs/promises";
-import { join, resolve } from "node:path";
+import { rm } from "node:fs/promises";
+import { resolve } from "node:path";
 import { getProcessCwd, getProcessIdentity } from "@gh-symphony/orchestrator";
 import type { GlobalOptions } from "../index.js";
-import { daemonPidPath, parseDaemonPidRecord } from "../config.js";
 import {
   handleMissingManagedProjectConfig,
   resolveManagedProjectConfig,
 } from "../project-selection.js";
 import { rejectRemovedProjectId } from "../removed-project-id.js";
+import { resolveDaemonLiveness } from "../daemon-liveness.js";
 
 function parseStopArgs(args: string[]): {
   force: boolean;
@@ -57,50 +57,40 @@ const handler = async (
   }
   const resolvedProjectId = projectConfig.projectId;
 
-  const pidPath = daemonPidPath(options.configDir, resolvedProjectId);
-  let pidStr: string;
-  try {
-    pidStr = await readFile(pidPath, "utf8");
-  } catch {
+  const liveness = await resolveDaemonLiveness({
+    configDir: options.configDir,
+    projectId: resolvedProjectId,
+    workspaceDir: projectConfig.workspaceDir,
+  });
+  if (!liveness.running && liveness.reason === "missing-pid") {
     process.stderr.write(
       `No running daemon found for project "${resolvedProjectId}" (PID file missing).\n`
     );
     process.exitCode = 1;
     return;
   }
-
-  const pidRecord = parseDaemonPidRecord(pidStr);
-  if (!pidRecord) {
-    process.stderr.write(`Invalid PID in ${pidPath}: ${pidStr}\n`);
+  if (!liveness.running && liveness.reason === "invalid-pid") {
+    process.stderr.write(
+      `Invalid PID in ${liveness.pidPath}: ${liveness.pidContents ?? ""}\n`
+    );
     process.exitCode = 1;
     return;
   }
-  const expectedCwd = resolve(pidRecord.cwd ?? projectConfig.workspaceDir);
-  let target = validateDaemonProcess(
-    pidRecord.pid,
-    pidRecord.processIdentity,
-    expectedCwd
-  );
-  if (!target) {
-    target = await resolveProjectLockDaemon(
-      options.configDir,
-      resolvedProjectId,
-      expectedCwd
+  if (!liveness.running) {
+    process.stderr.write(
+      `Stale daemon PID ${liveness.recordedPid} for project "${resolvedProjectId}"; no live orchestrator with repository CWD "${liveness.expectedCwd}" was found in the project lock. Cleaning up stale PID file.\n`
     );
-    if (!target) {
-      process.stderr.write(
-        `Stale daemon PID ${pidRecord.pid} for project "${resolvedProjectId}"; no live orchestrator with repository CWD "${expectedCwd}" was found in the project lock. Cleaning up stale PID file.\n`
-      );
-      await rm(pidPath, { force: true });
-      process.exitCode = 1;
-      return;
-    }
+    await rm(liveness.pidPath, { force: true });
+    process.exitCode = 1;
+    return;
+  }
+  if (liveness.source === "project-lock") {
     process.stdout.write(
-      `Recovered orchestrator PID ${target.pid} from the project lock for repository CWD "${expectedCwd}".\n`
+      `Recovered orchestrator PID ${liveness.target.pid} from the project lock for repository CWD "${liveness.expectedCwd}".\n`
     );
   }
 
-  const { pid, identity: checkedIdentity } = target;
+  const { pid, identity: checkedIdentity } = liveness.target;
 
   const signal = resolvedForce ? "SIGKILL" : "SIGTERM";
   try {
@@ -108,7 +98,7 @@ const handler = async (
     if (
       getProcessIdentity(pid) !== checkedIdentity ||
       !signalCwd ||
-      resolve(signalCwd) !== expectedCwd
+      resolve(signalCwd) !== liveness.expectedCwd
     ) {
       throw new Error("process identity changed before signal delivery");
     }
@@ -122,62 +112,8 @@ const handler = async (
     return;
   }
 
-  await rm(pidPath, { force: true });
+  await rm(liveness.pidPath, { force: true });
   process.stdout.write("Daemon stopped.\n");
 };
-
-function validateDaemonProcess(
-  pid: number,
-  recordedIdentity: string | null,
-  expectedCwd: string
-): { pid: number; identity: string } | null {
-  try {
-    process.kill(pid, 0);
-  } catch {
-    return null;
-  }
-
-  const identity = getProcessIdentity(pid);
-  const identityMatches = recordedIdentity
-    ? identity === recordedIdentity
-    : isLegacyOrchestratorIdentity(identity);
-  const cwd = getProcessCwd(pid);
-  if (!identity || !identityMatches || !cwd || resolve(cwd) !== expectedCwd) {
-    return null;
-  }
-  return { pid, identity };
-}
-
-async function resolveProjectLockDaemon(
-  configDir: string,
-  projectId: string,
-  expectedCwd: string
-): Promise<{ pid: number; identity: string } | null> {
-  try {
-    const lock = JSON.parse(
-      await readFile(join(configDir, "projects", projectId, ".lock"), "utf8")
-    ) as { pid?: unknown; processIdentity?: unknown };
-    if (!Number.isInteger(lock.pid) || (lock.pid as number) <= 0) {
-      return null;
-    }
-    const processIdentity =
-      typeof lock.processIdentity === "string" ? lock.processIdentity : null;
-    return validateDaemonProcess(
-      lock.pid as number,
-      processIdentity,
-      expectedCwd
-    );
-  } catch {
-    return null;
-  }
-}
-
-function isLegacyOrchestratorIdentity(identity: string | null): boolean {
-  return Boolean(
-    identity &&
-    /(?:gh-symphony|(?:^|\s)(?:dist\/)?index\.js)(?:\s|$)/.test(identity) &&
-    /\brepo\s+start\b/.test(identity)
-  );
-}
 
 export default handler;

--- a/packages/cli/src/commands/stop.ts
+++ b/packages/cli/src/commands/stop.ts
@@ -92,6 +92,14 @@ const handler = async (
 
   const { pid, identity: checkedIdentity } = liveness.target;
 
+  if (!liveness.target.verified) {
+    process.stderr.write(
+      `Refusing to signal PID ${pid}: process identity could not be verified.\n`
+    );
+    process.exitCode = 1;
+    return;
+  }
+
   const signal = resolvedForce ? "SIGKILL" : "SIGTERM";
   try {
     const signalCwd = getProcessCwd(pid);

--- a/packages/cli/src/daemon-liveness.ts
+++ b/packages/cli/src/daemon-liveness.ts
@@ -1,0 +1,146 @@
+import { readFile } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import { getProcessCwd, getProcessIdentity } from "@gh-symphony/orchestrator";
+import { daemonPidPath, parseDaemonPidRecord } from "./config.js";
+
+export type DaemonProcessTarget = {
+  pid: number;
+  identity: string;
+};
+
+export type DaemonLiveness =
+  | {
+      running: true;
+      target: DaemonProcessTarget;
+      source: "pid" | "project-lock";
+      expectedCwd: string;
+      pidPath: string;
+      recordedPid: number;
+    }
+  | {
+      running: false;
+      reason: "missing-pid" | "invalid-pid" | "stale-pid";
+      pidPath: string;
+      pidContents?: string;
+      recordedPid?: number;
+      expectedCwd?: string;
+    };
+
+export async function resolveDaemonLiveness(options: {
+  configDir: string;
+  projectId: string;
+  workspaceDir: string;
+}): Promise<DaemonLiveness> {
+  const pidPath = daemonPidPath(options.configDir, options.projectId);
+  let pidContents: string;
+  try {
+    pidContents = await readFile(pidPath, "utf8");
+  } catch {
+    return { running: false, reason: "missing-pid", pidPath };
+  }
+
+  const pidRecord = parseDaemonPidRecord(pidContents);
+  if (!pidRecord) {
+    return {
+      running: false,
+      reason: "invalid-pid",
+      pidPath,
+      pidContents,
+    };
+  }
+
+  const expectedCwd = resolve(pidRecord.cwd ?? options.workspaceDir);
+  const target = validateDaemonProcess(
+    pidRecord.pid,
+    pidRecord.processIdentity,
+    expectedCwd
+  );
+  if (target) {
+    return {
+      running: true,
+      target,
+      source: "pid",
+      expectedCwd,
+      pidPath,
+      recordedPid: pidRecord.pid,
+    };
+  }
+
+  const lockTarget = await resolveProjectLockDaemon(
+    options.configDir,
+    options.projectId,
+    expectedCwd
+  );
+  if (lockTarget) {
+    return {
+      running: true,
+      target: lockTarget,
+      source: "project-lock",
+      expectedCwd,
+      pidPath,
+      recordedPid: pidRecord.pid,
+    };
+  }
+
+  return {
+    running: false,
+    reason: "stale-pid",
+    pidPath,
+    recordedPid: pidRecord.pid,
+    expectedCwd,
+  };
+}
+
+export function validateDaemonProcess(
+  pid: number,
+  recordedIdentity: string | null,
+  expectedCwd: string
+): DaemonProcessTarget | null {
+  try {
+    process.kill(pid, 0);
+  } catch {
+    return null;
+  }
+
+  const identity = getProcessIdentity(pid);
+  const identityMatches = recordedIdentity
+    ? identity === recordedIdentity
+    : isLegacyOrchestratorIdentity(identity);
+  const cwd = getProcessCwd(pid);
+  if (!identity || !identityMatches || !cwd || resolve(cwd) !== expectedCwd) {
+    return null;
+  }
+  return { pid, identity };
+}
+
+async function resolveProjectLockDaemon(
+  configDir: string,
+  projectId: string,
+  expectedCwd: string
+): Promise<DaemonProcessTarget | null> {
+  try {
+    const lock = JSON.parse(
+      await readFile(join(configDir, "projects", projectId, ".lock"), "utf8")
+    ) as { pid?: unknown; processIdentity?: unknown };
+    if (!Number.isInteger(lock.pid) || (lock.pid as number) <= 0) {
+      return null;
+    }
+    const processIdentity =
+      typeof lock.processIdentity === "string" ? lock.processIdentity : null;
+    return validateDaemonProcess(
+      lock.pid as number,
+      processIdentity,
+      expectedCwd
+    );
+  } catch {
+    return null;
+  }
+}
+
+function isLegacyOrchestratorIdentity(identity: string | null): boolean {
+  return Boolean(
+    identity &&
+    /(?:gh-symphony|(?:^|\s)(?:dist\/)?index\.js)(?:\s|$)/.test(identity) &&
+    /\brepo\s+start\b/.test(identity)
+  );
+}

--- a/packages/cli/src/daemon-liveness.ts
+++ b/packages/cli/src/daemon-liveness.ts
@@ -3,9 +3,11 @@ import { join, resolve } from "node:path";
 import { getProcessCwd, getProcessIdentity } from "@gh-symphony/orchestrator";
 import { daemonPidPath, parseDaemonPidRecord } from "./config.js";
 
+const PROJECT_LOCK_HEARTBEAT_MAX_AGE_MS = 60_000;
+
 export type DaemonProcessTarget = {
   pid: number;
-  identity: string;
+  identity: string | null;
 };
 
 export type DaemonLiveness =
@@ -36,6 +38,22 @@ export async function resolveDaemonLiveness(options: {
   try {
     pidContents = await readFile(pidPath, "utf8");
   } catch {
+    const expectedCwd = resolve(options.workspaceDir);
+    const lockTarget = await resolveProjectLockDaemon(
+      options.configDir,
+      options.projectId,
+      expectedCwd
+    );
+    if (lockTarget) {
+      return {
+        running: true,
+        target: lockTarget,
+        source: "project-lock",
+        expectedCwd,
+        pidPath,
+        recordedPid: lockTarget.pid,
+      };
+    }
     return { running: false, reason: "missing-pid", pidPath };
   }
 
@@ -121,15 +139,22 @@ async function resolveProjectLockDaemon(
   try {
     const lock = JSON.parse(
       await readFile(join(configDir, "projects", projectId, ".lock"), "utf8")
-    ) as { pid?: unknown; processIdentity?: unknown };
+    ) as {
+      pid?: unknown;
+      processIdentity?: unknown;
+      heartbeatAt?: unknown;
+    };
     if (!Number.isInteger(lock.pid) || (lock.pid as number) <= 0) {
       return null;
     }
     const processIdentity =
       typeof lock.processIdentity === "string" ? lock.processIdentity : null;
-    return validateDaemonProcess(
+    const heartbeatAt =
+      typeof lock.heartbeatAt === "string" ? lock.heartbeatAt : null;
+    return validateProjectLockProcess(
       lock.pid as number,
       processIdentity,
+      heartbeatAt,
       expectedCwd
     );
   } catch {
@@ -137,10 +162,49 @@ async function resolveProjectLockDaemon(
   }
 }
 
+function validateProjectLockProcess(
+  pid: number,
+  recordedIdentity: string | null,
+  heartbeatAt: string | null,
+  expectedCwd: string
+): DaemonProcessTarget | null {
+  try {
+    process.kill(pid, 0);
+  } catch {
+    return null;
+  }
+
+  const identity = getProcessIdentity(pid);
+  const identityMatches = recordedIdentity
+    ? identity === recordedIdentity
+    : identity
+      ? isLegacyOrchestratorIdentity(identity)
+      : isFreshProjectLockHeartbeat(heartbeatAt);
+  const cwd = getProcessCwd(pid);
+  if (!identityMatches || !cwd || resolve(cwd) !== expectedCwd) {
+    return null;
+  }
+  return { pid, identity };
+}
+
+function isFreshProjectLockHeartbeat(heartbeatAt: string | null): boolean {
+  if (!heartbeatAt) {
+    return false;
+  }
+  const heartbeatAtMs = Date.parse(heartbeatAt);
+  const ageMs = Date.now() - heartbeatAtMs;
+  return (
+    Number.isFinite(heartbeatAtMs) &&
+    Math.abs(ageMs) <= PROJECT_LOCK_HEARTBEAT_MAX_AGE_MS
+  );
+}
+
 function isLegacyOrchestratorIdentity(identity: string | null): boolean {
   return Boolean(
     identity &&
-    /(?:gh-symphony|(?:^|\s)(?:dist\/)?index\.js)(?:\s|$)/.test(identity) &&
+    /(?:gh-symphony|(?:^|\s)(?:\S*\/)?(?:dist\/)?index\.js)(?:\s|$)/.test(
+      identity
+    ) &&
     /\brepo\s+start\b/.test(identity)
   );
 }

--- a/packages/cli/src/daemon-liveness.ts
+++ b/packages/cli/src/daemon-liveness.ts
@@ -8,6 +8,7 @@ const PROJECT_LOCK_HEARTBEAT_MAX_AGE_MS = 60_000;
 export type DaemonProcessTarget = {
   pid: number;
   identity: string | null;
+  verified: boolean;
 };
 
 export type DaemonLiveness =
@@ -38,20 +39,19 @@ export async function resolveDaemonLiveness(options: {
   try {
     pidContents = await readFile(pidPath, "utf8");
   } catch {
-    const expectedCwd = resolve(options.workspaceDir);
     const lockTarget = await resolveProjectLockDaemon(
       options.configDir,
       options.projectId,
-      expectedCwd
+      options.workspaceDir
     );
     if (lockTarget) {
       return {
         running: true,
-        target: lockTarget,
+        target: lockTarget.target,
         source: "project-lock",
-        expectedCwd,
+        expectedCwd: lockTarget.expectedCwd,
         pidPath,
-        recordedPid: lockTarget.pid,
+        recordedPid: lockTarget.target.pid,
       };
     }
     return { running: false, reason: "missing-pid", pidPath };
@@ -63,16 +63,16 @@ export async function resolveDaemonLiveness(options: {
     const lockTarget = await resolveProjectLockDaemon(
       options.configDir,
       options.projectId,
-      expectedCwd
+      options.workspaceDir
     );
     if (lockTarget) {
       return {
         running: true,
-        target: lockTarget,
+        target: lockTarget.target,
         source: "project-lock",
-        expectedCwd,
+        expectedCwd: lockTarget.expectedCwd,
         pidPath,
-        recordedPid: lockTarget.pid,
+        recordedPid: lockTarget.target.pid,
       };
     }
     return {
@@ -104,14 +104,14 @@ export async function resolveDaemonLiveness(options: {
   const lockTarget = await resolveProjectLockDaemon(
     options.configDir,
     options.projectId,
-    expectedCwd
+    options.workspaceDir
   );
   if (lockTarget) {
     return {
       running: true,
-      target: lockTarget,
+      target: lockTarget.target,
       source: "project-lock",
-      expectedCwd,
+      expectedCwd: lockTarget.expectedCwd,
       pidPath,
       recordedPid: pidRecord.pid,
     };
@@ -145,14 +145,14 @@ export function validateDaemonProcess(
   if (!identity || !identityMatches || !cwd || resolve(cwd) !== expectedCwd) {
     return null;
   }
-  return { pid, identity };
+  return { pid, identity, verified: true };
 }
 
 async function resolveProjectLockDaemon(
   configDir: string,
   projectId: string,
-  expectedCwd: string
-): Promise<DaemonProcessTarget | null> {
+  workspaceDir: string
+): Promise<{ target: DaemonProcessTarget; expectedCwd: string } | null> {
   try {
     const lock = JSON.parse(
       await readFile(join(configDir, "projects", projectId, ".lock"), "utf8")
@@ -160,6 +160,7 @@ async function resolveProjectLockDaemon(
       pid?: unknown;
       processIdentity?: unknown;
       heartbeatAt?: unknown;
+      cwd?: unknown;
     };
     if (!Number.isInteger(lock.pid) || (lock.pid as number) <= 0) {
       return null;
@@ -168,12 +169,16 @@ async function resolveProjectLockDaemon(
       typeof lock.processIdentity === "string" ? lock.processIdentity : null;
     const heartbeatAt =
       typeof lock.heartbeatAt === "string" ? lock.heartbeatAt : null;
-    return validateProjectLockProcess(
+    const expectedCwd = resolve(
+      typeof lock.cwd === "string" ? lock.cwd : workspaceDir
+    );
+    const target = validateProjectLockProcess(
       lock.pid as number,
       processIdentity,
       heartbeatAt,
       expectedCwd
     );
+    return target ? { target, expectedCwd } : null;
   } catch {
     return null;
   }
@@ -201,7 +206,7 @@ function validateProjectLockProcess(
   if (!identityMatches || !cwd || resolve(cwd) !== expectedCwd) {
     return null;
   }
-  return { pid, identity };
+  return { pid, identity, verified: identity !== null };
 }
 
 function isFreshProjectLockHeartbeat(heartbeatAt: string | null): boolean {
@@ -212,14 +217,15 @@ function isFreshProjectLockHeartbeat(heartbeatAt: string | null): boolean {
   const ageMs = Date.now() - heartbeatAtMs;
   return (
     Number.isFinite(heartbeatAtMs) &&
-    Math.abs(ageMs) <= PROJECT_LOCK_HEARTBEAT_MAX_AGE_MS
+    ageMs >= 0 &&
+    ageMs <= PROJECT_LOCK_HEARTBEAT_MAX_AGE_MS
   );
 }
 
 function isLegacyOrchestratorIdentity(identity: string | null): boolean {
   return Boolean(
     identity &&
-    /(?:gh-symphony|(?:^|\s)(?:\S*\/)?(?:dist\/)?index\.js)(?:\s|$)/.test(
+    /(?:gh-symphony|(?:^|\s)(?:(?:\S*\/)?dist\/)?index\.js)(?:\s|$)/.test(
       identity
     ) &&
     /\brepo\s+start\b/.test(identity)

--- a/packages/cli/src/daemon-liveness.ts
+++ b/packages/cli/src/daemon-liveness.ts
@@ -59,11 +59,28 @@ export async function resolveDaemonLiveness(options: {
 
   const pidRecord = parseDaemonPidRecord(pidContents);
   if (!pidRecord) {
+    const expectedCwd = resolve(options.workspaceDir);
+    const lockTarget = await resolveProjectLockDaemon(
+      options.configDir,
+      options.projectId,
+      expectedCwd
+    );
+    if (lockTarget) {
+      return {
+        running: true,
+        target: lockTarget,
+        source: "project-lock",
+        expectedCwd,
+        pidPath,
+        recordedPid: lockTarget.pid,
+      };
+    }
     return {
       running: false,
       reason: "invalid-pid",
       pidPath,
       pidContents,
+      expectedCwd,
     };
   }
 

--- a/packages/cli/src/dashboard/renderer.test.ts
+++ b/packages/cli/src/dashboard/renderer.test.ts
@@ -38,6 +38,43 @@ describe("renderDashboard", () => {
     expect(output).toContain("Agents");
   });
 
+  it("renders stopped daemon health and restart guidance", () => {
+    const snapshot = loadFixture("idle");
+    const output = renderDashboard([snapshot], {
+      terminalWidth: 115,
+      noColor: true,
+      now: NOW,
+      runtimeStatus: {
+        daemonRunning: false,
+        lastTickLabel: "22d ago",
+        lastTickStale: false,
+      },
+    });
+
+    expect(output).toContain("● Health  stopped");
+    expect(output).toContain(
+      "daemon not running — run 'gh-symphony repo start'"
+    );
+    expect(output).toContain(`Last known state: ${snapshot.health}`);
+  });
+
+  it("annotates stale last ticks while the daemon is live", () => {
+    const snapshot = loadFixture("idle");
+    const output = renderDashboard([snapshot], {
+      terminalWidth: 115,
+      noColor: true,
+      now: NOW,
+      runtimeStatus: {
+        daemonRunning: true,
+        lastTickLabel: "2m ago",
+        lastTickStale: true,
+      },
+    });
+
+    expect(output).toContain(`Health  ${snapshot.health}`);
+    expect(output).toContain("Last tick  2m ago (stale)");
+  });
+
   it("renders busy fixture with column headers", () => {
     const snapshot = loadFixture("busy");
     const output = renderDashboard([snapshot], {

--- a/packages/cli/src/dashboard/renderer.ts
+++ b/packages/cli/src/dashboard/renderer.ts
@@ -20,6 +20,11 @@ export type DashboardOptions = {
   terminalWidth: number;
   noColor: boolean;
   maxAgents?: number;
+  runtimeStatus?: {
+    daemonRunning: boolean;
+    lastTickLabel: string;
+    lastTickStale: boolean;
+  };
   /** Override Date.now() for deterministic testing */
   now?: number;
 };
@@ -225,6 +230,27 @@ function buildSummaryLines(
   const limitStr = hasLimits ? "active" : "standard";
   lines.push(`  ${c.dim("Rate Limits")}  ${limitStr}`);
 
+  const runtimeStatus = options.runtimeStatus;
+  const primarySnapshot = snapshots[0];
+  if (runtimeStatus && primarySnapshot) {
+    const health = runtimeStatus.daemonRunning
+      ? primarySnapshot.health
+      : "stopped";
+    const healthDot =
+      health === "degraded" || health === "stopped"
+        ? c.red("\u25CF")
+        : c.green("\u25CF");
+    const staleLabel = runtimeStatus.lastTickStale ? c.yellow(" (stale)") : "";
+    lines.push(
+      `  ${healthDot} ${c.dim("Health")}  ${c.bold(health)}     ${c.dim("Last tick")}  ${runtimeStatus.lastTickLabel}${staleLabel}`
+    );
+    if (!runtimeStatus.daemonRunning) {
+      lines.push(
+        `  ${c.yellow("daemon not running \u2014 run 'gh-symphony repo start'")}  ${c.dim(`Last known state: ${primarySnapshot.health}`)}`
+      );
+    }
+  }
+
   return lines;
 }
 
@@ -317,9 +343,7 @@ export function renderDashboard(
     const hasRetries = snap.retryQueue.length > 0;
     if (!hasActiveRuns && !hasRetries) continue;
 
-    lines.push(
-      sectionDivider(formatRepositoryDisplay(snap), width, c)
-    );
+    lines.push(sectionDivider(formatRepositoryDisplay(snap), width, c));
     if (hasActiveRuns) {
       lines.push(tableHeaderRow(c));
       for (const rawRun of snap.activeRuns) {

--- a/packages/core/src/contracts/status-surface.ts
+++ b/packages/core/src/contracts/status-surface.ts
@@ -252,6 +252,8 @@ export type ProjectStatusSnapshot = {
     secondsRunning: number;
   };
   rateLimits?: Record<string, unknown> | null;
+  /** Effective tracker reconciliation interval used for the next daemon tick. */
+  effectivePollIntervalMs?: number;
   dispatchSuppressedUntil?: string | null;
   lastError: string | null;
 };

--- a/packages/core/src/observability/snapshot-builder.ts
+++ b/packages/core/src/observability/snapshot-builder.ts
@@ -27,6 +27,7 @@ export type SnapshotInput = {
   lastTickAt: string;
   lastError: string | null;
   rateLimits?: Record<string, unknown> | null;
+  effectivePollIntervalMs?: number;
   dispatchSuppressedUntil?: string | null;
   issueWorkspaces?: readonly IssueWorkspaceRecord[];
 };
@@ -48,6 +49,7 @@ export function buildProjectSnapshot(
     lastTickAt,
     lastError,
     rateLimits,
+    effectivePollIntervalMs,
     dispatchSuppressedUntil,
     issueWorkspaces,
   } = input;
@@ -107,6 +109,9 @@ export function buildProjectSnapshot(
     lastError,
     codexTotals: aggregateTokenUsage(allRuns ?? activeRuns, lastTickAt),
     rateLimits: rateLimits ?? null,
+    ...(effectivePollIntervalMs === undefined
+      ? {}
+      : { effectivePollIntervalMs }),
     dispatchSuppressedUntil: dispatchSuppressedUntil ?? null,
   };
 }

--- a/packages/orchestrator/src/index.test.ts
+++ b/packages/orchestrator/src/index.test.ts
@@ -300,14 +300,9 @@ describe("orchestrator CLI", () => {
       }
     );
 
-    for (let attempt = 0; attempt < 20; attempt += 1) {
-      if (signalTarget.listenerCount("SIGTERM") === 1) {
-        break;
-      }
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    }
-
-    expect(signalTarget.listenerCount("SIGTERM")).toBe(1);
+    await vi.waitFor(() => {
+      expect(signalTarget.listenerCount("SIGTERM")).toBe(1);
+    });
     signalTarget.emit("SIGTERM");
     await runPromise;
 
@@ -428,9 +423,9 @@ describe("orchestrator CLI", () => {
       ["run-once", "--runtime-root", runtimeRoot, "--project-id", "tenant-1"],
       { createService: () => firstService }
     );
-    for (let attempt = 0; attempt < 20 && !finishFirst; attempt += 1) {
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    }
+    await vi.waitFor(() => {
+      expect(finishFirst).toBeTypeOf("function");
+    });
 
     const secondService = createMockService();
     await expect(

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -18,7 +18,10 @@ import {
 } from "./lock.js";
 
 export { OrchestratorService, createStore };
-export { resolveCanonicalSubjectIssues } from "./service.js";
+export {
+  resolveAdaptivePollIntervalMs,
+  resolveCanonicalSubjectIssues,
+} from "./service.js";
 export type { OrchestratorLogLevel };
 export * from "./runtime-factory.js";
 export * from "./explain.js";

--- a/packages/orchestrator/src/lock.test.ts
+++ b/packages/orchestrator/src/lock.test.ts
@@ -42,6 +42,7 @@ describe("project lock", () => {
       ownerToken: string;
       heartbeatAt: string;
       processIdentity: string;
+      cwd: string;
     };
 
     expect(contents.pid).toBe(4321);
@@ -49,6 +50,7 @@ describe("project lock", () => {
     expect(contents.ownerToken).toBe(lock.ownerToken);
     expect(contents.heartbeatAt).toBe("2026-03-16T00:00:00.000Z");
     expect(contents.processIdentity).toBe("test-process-4321");
+    expect(contents.cwd).toBe(resolve(process.cwd()));
     const projectDirStats = await stat(
       join(runtimeRoot, "projects", "project-1")
     );

--- a/packages/orchestrator/src/lock.ts
+++ b/packages/orchestrator/src/lock.ts
@@ -20,6 +20,7 @@ type ProjectLockRecord = {
   startedAt: string;
   heartbeatAt: string | null;
   processIdentity: string | null;
+  cwd?: string;
 };
 
 export type ProjectLockHandle = {
@@ -29,6 +30,7 @@ export type ProjectLockHandle = {
   startedAt: string;
   heartbeatAt: string;
   processIdentity: string | null;
+  cwd: string;
 };
 
 type LeaseLostHandler = (error: Error) => void | Promise<void>;
@@ -46,6 +48,7 @@ export async function acquireProjectLock(input: {
   now?: Date;
   isProcessRunning?: (pid: number) => boolean;
   getProcessIdentity?: (pid: number) => string | null;
+  cwd?: string;
   leaseTtlMs?: number;
   onLeaseLost?: LeaseLostHandler;
 }): Promise<ProjectLockHandle> {
@@ -54,6 +57,7 @@ export async function acquireProjectLock(input: {
   const startedAt = (input.now ?? new Date()).toISOString();
   const heartbeatAt = startedAt;
   const processIdentity = (input.getProcessIdentity ?? getProcessIdentity)(pid);
+  const cwd = resolve(input.cwd ?? process.cwd());
   const ownerToken = `${pid}:${randomUUID()}`;
   const lockPath = resolveProjectLockPath(input.runtimeRoot, input.projectId);
   const record: ProjectLockRecord = {
@@ -62,6 +66,7 @@ export async function acquireProjectLock(input: {
     startedAt,
     heartbeatAt,
     processIdentity,
+    cwd,
   };
   let invalidReadAttempts = 0;
 
@@ -84,6 +89,7 @@ export async function acquireProjectLock(input: {
         startedAt,
         heartbeatAt,
         processIdentity,
+        cwd,
       };
       startProjectLockHeartbeat(
         lock,
@@ -370,6 +376,7 @@ function parseProjectLock(raw: string): ProjectLockRecord | null {
       !Number.isInteger(parsed.pid) ||
       parsed.pid <= 0 ||
       typeof parsed.startedAt !== "string" ||
+      (parsed.cwd !== undefined && typeof parsed.cwd !== "string") ||
       (parsed.heartbeatAt !== undefined &&
         typeof parsed.heartbeatAt !== "string") ||
       (parsed.processIdentity !== undefined &&
@@ -385,6 +392,7 @@ function parseProjectLock(raw: string): ProjectLockRecord | null {
       startedAt: parsed.startedAt,
       heartbeatAt: parsed.heartbeatAt ?? null,
       processIdentity: parsed.processIdentity ?? null,
+      cwd: parsed.cwd,
     };
   } catch {
     return null;

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -4709,8 +4709,9 @@ Prefer focused changes.
     const constrainedService = await createServiceWithRemaining("constrained", {
       value: 2000,
     });
-    await constrainedService.runOnce();
+    const constrainedSnapshot = await constrainedService.runOnce();
     expect(constrainedService.getEffectivePollIntervalMs()).toBe(37_500);
+    expect(constrainedSnapshot.effectivePollIntervalMs).toBe(37_500);
 
     const lowService = await createServiceWithRemaining("low", {
       value: 500,
@@ -4724,8 +4725,9 @@ Prefer focused changes.
       exhaustedRemaining,
       60_000
     );
-    await exhaustedService.runOnce();
+    const exhaustedSnapshot = await exhaustedService.runOnce();
     expect(exhaustedService.getEffectivePollIntervalMs()).toBe(600_000);
+    expect(exhaustedSnapshot.effectivePollIntervalMs).toBe(600_000);
 
     exhaustedRemaining.value = 4000;
     await exhaustedService.runOnce();

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -1724,6 +1724,7 @@ export class OrchestratorService {
       lastTickAt: now.toISOString(),
       lastError,
       rateLimits,
+      effectivePollIntervalMs,
       dispatchSuppressedUntil: resolveDispatchSuppressedUntil(
         trackerError,
         dispatchRateLimits

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -4581,7 +4581,7 @@ function readNonNegativeNumber(value: unknown): number {
     : 0;
 }
 
-function resolveAdaptivePollIntervalMs(
+export function resolveAdaptivePollIntervalMs(
   basePollIntervalMs: number,
   rateLimits: Record<string, unknown> | null
 ): number {


### PR DESCRIPTION
## Issues — Closed #546

- Fixes #546

## TL;DR

- `repo status` verifies daemon liveness before presenting a persisted snapshot as current health.
- The implementation is rebased onto current `main`; stale warnings use the daemon's tracker-derived effective polling interval.

## 변경 지점 다이어그램

```text
tracker rate limits ─► effectivePollIntervalMs ─► status snapshot ─► stale threshold
daemon.pid / project lock ─► daemon-liveness.ts ───────────────────► repo status / repo stop
```

## 여기부터 보세요

- `packages/cli/src/daemon-liveness.ts` centralizes PID, lock, CWD, heartbeat, and identity validation.
- `packages/cli/src/commands/status.ts` renders text, watch, and JSON status from independent liveness and snapshot state.
- `packages/orchestrator/src/service.ts` persists the tracker-derived effective polling interval for the CLI stale guard.

## 위험 & 롤백

- Legacy snapshots retain rate-limit inference until a daemon writes `effectivePollIntervalMs`.
- Rollback: revert the #546 commits to restore the previous CLI status presentation.

## 변경 파일

- `.changeset/wise-dolphins-repair.md`
- CLI daemon-liveness, status, stop, dashboard, and regression tests.
- Core snapshot contract and orchestrator polling snapshot persistence.

## Evidence

- `pnpm exec vitest run packages/cli/src/commands/status.test.ts packages/orchestrator/src/service.test.ts` — passed.
- `pnpm lint && pnpm test && pnpm typecheck && pnpm build` — passed on `7cc2a4d0`.
- Docker E2E blackbox: rebuilt `symphony-e2e`; `/healthz` returned `{"ok":true}`; container and network were removed.
- GitHub CI `Test` and `Container Smoke` — passed on `7cc2a4d0`.

## 머지 후/사람 확인

- [ ] Confirm a running daemon retains the familiar idle/running presentation.
- [ ] Confirm a killed daemon shows stopped health, restart guidance, and last-known state.
- [ ] Confirm stale warnings follow a rate-limited daemon's effective polling cadence.
- [ ] Confirm `repo status --watch` remains readable at the reviewer’s terminal width.
