### PR TITLE
fix(tracker): harden advisory comment cache

### DIFF
--- a/.changeset/quiet-cats-glow.md
+++ b/.changeset/quiet-cats-glow.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Recover advisory comment reconciliation safely from corrupt cache files and preserve entries without ETags (#496).

--- a/packages/orchestrator/src/issue-comment-cache.test.ts
+++ b/packages/orchestrator/src/issue-comment-cache.test.ts
@@ -1,28 +1,39 @@
-import { mkdtemp, readFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { PersistentIssueCommentCache } from "./issue-comment-cache.js";
 
 describe("PersistentIssueCommentCache", () => {
-  it("persists comment ids and ETags in the project cache directory", async () => {
+  it("persists comment ids and nullable ETags in the project cache directory", async () => {
     const projectDirectory = await mkdtemp(
       join(tmpdir(), "orchestrator-comment-cache-")
     );
     const cacheKey = "github:acme:platform:issue-1:marker";
+    const adjacentCacheKey = "github:acme:platform:issue-2:marker";
     const firstInstance = new PersistentIssueCommentCache(projectDirectory);
 
     await firstInstance.set(cacheKey, {
       commentId: 42,
-      etag: '"comment-v1"',
+      etag: null,
       body: "marker body",
+    });
+    await firstInstance.set(adjacentCacheKey, {
+      commentId: 43,
+      etag: 'W/"comment-v1"',
+      body: "adjacent marker body",
     });
 
     const secondInstance = new PersistentIssueCommentCache(projectDirectory);
     expect(await secondInstance.get(cacheKey)).toEqual({
       commentId: 42,
-      etag: '"comment-v1"',
+      etag: null,
       body: "marker body",
+    });
+    expect(await secondInstance.get(adjacentCacheKey)).toEqual({
+      commentId: 43,
+      etag: 'W/"comment-v1"',
+      body: "adjacent marker body",
     });
 
     const persisted = JSON.parse(
@@ -33,5 +44,38 @@ describe("PersistentIssueCommentCache", () => {
     ) as { version: number; entries: Record<string, unknown> };
     expect(persisted.version).toBe(1);
     expect(persisted.entries[cacheKey]).toBeDefined();
+  });
+
+  it.each([
+    ["malformed JSON", "{ not valid json"],
+    ["an invalid cache shape", JSON.stringify({ version: 1, entries: [] })],
+    [
+      "an invalid cache entry",
+      JSON.stringify({ version: 1, entries: { broken: { commentId: "42" } } }),
+    ],
+  ])("recovers from %s as an empty cache", async (_description, contents) => {
+    const projectDirectory = await mkdtemp(
+      join(tmpdir(), "orchestrator-comment-cache-invalid-")
+    );
+    const cacheDirectory = join(projectDirectory, "cache");
+    await mkdir(cacheDirectory);
+    await writeFile(
+      join(cacheDirectory, "issue-comments.json"),
+      contents,
+      "utf8"
+    );
+
+    const warning = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+    try {
+      const cache = new PersistentIssueCommentCache(projectDirectory);
+      await expect(cache.get("missing")).resolves.toBeNull();
+      expect(warning).toHaveBeenCalledWith(
+        expect.stringContaining("Discarding issue comment cache")
+      );
+    } finally {
+      warning.mockRestore();
+    }
   });
 });

--- a/packages/orchestrator/src/issue-comment-cache.ts
+++ b/packages/orchestrator/src/issue-comment-cache.ts
@@ -52,8 +52,24 @@ export class PersistentIssueCommentCache implements IssueCommentCache {
   }
 
   private async loadFromDisk(): Promise<PersistedIssueCommentCache> {
-    const persisted = await readJsonFile<PersistedIssueCommentCache>(this.path);
-    if (!persisted || persisted.version !== 1 || !persisted.entries) {
+    let persisted: unknown;
+    try {
+      persisted = await readJsonFile<PersistedIssueCommentCache>(this.path);
+    } catch (error) {
+      if (error instanceof SyntaxError) {
+        this.warnDiscardedCache("malformed JSON");
+        return structuredClone(EMPTY_CACHE);
+      }
+
+      throw error;
+    }
+
+    if (persisted === null) {
+      return structuredClone(EMPTY_CACHE);
+    }
+
+    if (!isPersistedIssueCommentCache(persisted)) {
+      this.warnDiscardedCache("invalid shape");
       return structuredClone(EMPTY_CACHE);
     }
 
@@ -63,4 +79,30 @@ export class PersistentIssueCommentCache implements IssueCommentCache {
   private async persist(state: PersistedIssueCommentCache): Promise<void> {
     await writeFileAtomically(this.path, `${JSON.stringify(state, null, 2)}\n`);
   }
+
+  private warnDiscardedCache(reason: string): void {
+    console.warn(
+      `[orchestrator] Discarding issue comment cache at ${this.path}: ${reason}`
+    );
+  }
+}
+
+function isPersistedIssueCommentCache(
+  value: unknown
+): value is PersistedIssueCommentCache {
+  if (!isRecord(value) || value.version !== 1 || !isRecord(value.entries)) {
+    return false;
+  }
+
+  return Object.values(value.entries).every(
+    (entry) =>
+      isRecord(entry) &&
+      typeof entry.commentId === "number" &&
+      (typeof entry.etag === "string" || entry.etag === null) &&
+      typeof entry.body === "string"
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
 }

--- a/packages/tracker-github/src/adapter.ts
+++ b/packages/tracker-github/src/adapter.ts
@@ -1558,8 +1558,8 @@ async function upsertIssueCommentWithCache(
       return "updated";
     }
     if (current.status === "found") {
-      await cache.set(cacheKey, current.entry);
       if (current.entry.body === input.body) {
+        await cache.set(cacheKey, current.entry);
         return "unchanged";
       }
 
@@ -1617,8 +1617,8 @@ async function upsertIssueCommentWithCache(
     );
   }
 
-  await cache.set(cacheKey, current.entry);
   if (current.entry.body === input.body) {
+    await cache.set(cacheKey, current.entry);
     return "unchanged";
   }
 

--- a/packages/tracker-github/src/tracker-github.test.ts
+++ b/packages/tracker-github/src/tracker-github.test.ts
@@ -1267,6 +1267,121 @@ describe("resolveTrackerAdapter", () => {
     expect(mutationBody.variables.subjectId).toBe("issue-1");
   });
 
+  it("creates an advisory comment through REST and persists its ETag", async () => {
+    const adapter = resolveTrackerAdapter({
+      adapter: "github-project",
+      bindingId: "project-123",
+      settings: { projectId: "project-123" },
+    });
+    const marker = "<!-- gh-symphony:advisory -->";
+    const body = `${marker}\ncreated body`;
+    const cache: IssueCommentCache = {
+      get: vi.fn(async () => null),
+      set: vi.fn(async () => undefined),
+      delete: vi.fn(async () => undefined),
+    };
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              node: {
+                __typename: "Issue",
+                comments: {
+                  nodes: [],
+                  pageInfo: { endCursor: null, hasNextPage: false },
+                },
+              },
+            },
+          })
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ id: 42, body }), {
+          status: 201,
+          headers: { etag: '"comment-v1"' },
+        })
+      );
+
+    await expect(
+      adapter.upsertIssueComment?.(
+        makeProjectConfig(),
+        makeTrackedIssue(),
+        { marker, body },
+        { token: "test-token", fetchImpl, issueCommentCache: cache }
+      )
+    ).resolves.toMatchObject({ outcome: "created", rateLimits: null });
+
+    expect(String(fetchImpl.mock.calls[1]?.[0])).toBe(
+      "https://api.github.com/repos/acme/platform/issues/1/comments"
+    );
+    expect(fetchImpl.mock.calls[1]?.[1]).toMatchObject({
+      method: "POST",
+      body: JSON.stringify({ body }),
+    });
+    expect(cache.set).toHaveBeenCalledTimes(1);
+    expect(cache.set).toHaveBeenCalledWith(expect.any(String), {
+      commentId: 42,
+      etag: '"comment-v1"',
+      body,
+    });
+  });
+
+  it("updates a cached advisory comment through REST with one cache write", async () => {
+    const adapter = resolveTrackerAdapter({
+      adapter: "github-project",
+      bindingId: "project-123",
+      settings: { projectId: "project-123" },
+    });
+    const marker = "<!-- gh-symphony:advisory -->";
+    const body = `${marker}\nupdated body`;
+    const cache: IssueCommentCache = {
+      get: vi.fn(async () => ({
+        commentId: 42,
+        etag: '"comment-v1"',
+        body: `${marker}\nold body`,
+      })),
+      set: vi.fn(async () => undefined),
+      delete: vi.fn(async () => undefined),
+    };
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ id: 42, body: `${marker}\nold body` }), {
+          headers: { etag: '"comment-v1"' },
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ id: 42, body }), {
+          headers: { etag: '"comment-v2"' },
+        })
+      );
+
+    await expect(
+      adapter.upsertIssueComment?.(
+        makeProjectConfig(),
+        makeTrackedIssue(),
+        { marker, body },
+        { token: "test-token", fetchImpl, issueCommentCache: cache }
+      )
+    ).resolves.toMatchObject({ outcome: "updated", rateLimits: null });
+
+    expect(String(fetchImpl.mock.calls[1]?.[0])).toBe(
+      "https://api.github.com/repos/acme/platform/issues/comments/42"
+    );
+    expect(fetchImpl.mock.calls[1]?.[1]).toMatchObject({
+      method: "PATCH",
+      body: JSON.stringify({ body }),
+    });
+    expect(cache.set).toHaveBeenCalledTimes(1);
+    expect(cache.set).toHaveBeenCalledWith(expect.any(String), {
+      commentId: 42,
+      etag: '"comment-v2"',
+      body,
+    });
+  });
+
   it("does not update advisory comments when the existing body is unchanged", async () => {
     const adapter = resolveTrackerAdapter({
       adapter: "github-project",
@@ -1502,6 +1617,7 @@ describe("resolveTrackerAdapter", () => {
         body,
       })
     );
+    expect(cache.set).toHaveBeenCalledTimes(1);
   });
 
   it("re-discovers an advisory comment when the cached REST id is stale", async () => {


### PR DESCRIPTION
## TL;DR

이슈 #496의 어드바이저리 코멘트 캐시는 손상 파일을 빈 캐시로 안전하게 복구하고, REST POST/PATCH 요청과 성공 경로의 단일 디스크 쓰기를 TC로 보장합니다. 최신 `main` 리베이스 충돌도 현재 오케스트레이터 변경을 보존해 해소했습니다.

## 변경 지점 다이어그램

```text
issue-comments.json
        │ 손상/잘못된 shape
        ▼
PersistentIssueCommentCache ──► 빈 캐시 복구 + 경고
        │
        ▼
GitHub adapter ──► REST POST/PATCH ──► ETag와 최종 상태 1회 캐시 기록
```

## 여기부터 보세요

- `packages/orchestrator/src/issue-comment-cache.ts`: 손상 캐시 복구·구조 검증·nullable ETag 보존
- `packages/tracker-github/src/adapter.ts`: PATCH 성공 후 중복 `cache.set` 제거
- 관련 단위 테스트: REST 생성/수정 URL·method·body·ETag·캐시 기록 횟수와 캐시 재시작 왕복

## 위험 & 롤백

- 손상 캐시는 의도적으로 전체를 빈 캐시로 복구합니다. 다음 reconciliation에서 원격 상태를 다시 조회합니다.
- PATCH 실패 시 새 discovery 엔트리는 즉시 영속화되지 않지만, 다음 reconciliation이 안전하게 재발견합니다.
- 문제 발생 시 이 PR의 squash merge를 revert하면 기존 캐시 동작으로 되돌릴 수 있습니다.

## 변경 파일

- `.changeset/quiet-cats-glow.md`
- `packages/orchestrator/src/issue-comment-cache.ts`
- `packages/orchestrator/src/issue-comment-cache.test.ts`
- `packages/tracker-github/src/adapter.ts`
- `packages/tracker-github/src/tracker-github.test.ts`

## Issues — Closed #496

## 머지 후/사람 확인

- [ ] 손상 캐시가 있는 실제 프로젝트에서 다음 reconciliation이 정상 완료되는지 확인

## 검증

- `pnpm --filter @gh-symphony/orchestrator test -- issue-comment-cache.test.ts` — pass (4 tests)
- `pnpm --filter @gh-symphony/tracker-github test -- tracker-github.test.ts` — pass (88 tests)
- `pnpm lint` · `pnpm test` · `pnpm typecheck` · `pnpm build` — pass
- `GH_SYMPHONY_HTTP_TOKEN=e2e-http-token bash e2e/run-e2e.sh happy 45` — pass
- GitHub CI Test (1m50s) · Container Smoke (45s) — pass on `ab4a1d0`
