### PR TITLE
feat(tracker): cache project status metadata

### DIFF
--- a/.changeset/fast-status-cache.md
+++ b/.changeset/fast-status-cache.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Safely refresh cached GitHub Project Status metadata after stale field or option IDs, and support Projects whose Status field falls beyond the first 20 fields (#505).

--- a/packages/tracker-github/src/adapter.ts
+++ b/packages/tracker-github/src/adapter.ts
@@ -87,6 +87,16 @@ const cachedProjectFields = new Map<
   Promise<Array<GraphQLProjectFieldConfiguration | null>>
 >();
 
+type ProjectStatusFieldMetadata = {
+  fieldId: string;
+  options: Array<{ id: string; name: string }>;
+};
+
+const cachedProjectStatusFields = new Map<
+  string,
+  Promise<ProjectStatusFieldMetadata>
+>();
+
 type GraphQLFieldValue =
   | {
       __typename: "ProjectV2ItemFieldSingleSelectValue";
@@ -294,7 +304,7 @@ type GraphQLExactProjectItemNode = {
   id: string;
   project: { id: string } | null;
   content: { id: string } | null;
-  fieldValues: { nodes: Array<GraphQLFieldValue | null> | null } | null;
+  fieldValueByName: GraphQLFieldValue | null;
 };
 
 type GraphQLExactProjectItemResponse = {
@@ -938,21 +948,45 @@ async function executeGithubProjectItemStateRequest(
     });
   }
 
-  const statusField = await resolveStatusFieldConfiguration(
+  let statusField = await resolveStatusFieldConfiguration(
     cycleConfig,
     input.request.targetState,
     fetchImpl
   );
   latestRateLimits = statusField.rateLimits ?? latestRateLimits;
-  const mutation = await executeTransitionMutationWithRetry(
-    cycleConfig,
-    {
-      itemId: input.itemId,
-      fieldId: statusField.fieldId,
-      optionId: statusField.optionId,
-    },
-    fetchImpl
-  );
+  let mutation;
+  try {
+    mutation = await executeTransitionMutationWithRetry(
+      cycleConfig,
+      {
+        itemId: input.itemId,
+        fieldId: statusField.fieldId,
+        optionId: statusField.optionId,
+      },
+      fetchImpl
+    );
+  } catch (error) {
+    if (!isStaleStatusFieldMetadataError(error)) {
+      throw error;
+    }
+    invalidateProjectStatusFieldMetadata(cycleConfig);
+    statusField = await resolveStatusFieldConfiguration(
+      cycleConfig,
+      input.request.targetState,
+      fetchImpl,
+      { forceRefresh: true }
+    );
+    latestRateLimits = statusField.rateLimits ?? latestRateLimits;
+    mutation = await executeTransitionMutationWithRetry(
+      cycleConfig,
+      {
+        itemId: input.itemId,
+        fieldId: statusField.fieldId,
+        optionId: statusField.optionId,
+      },
+      fetchImpl
+    );
+  }
   latestRateLimits = mutation.rateLimits ?? latestRateLimits;
 
   const readback = await readExactProjectItemState(
@@ -1016,7 +1050,12 @@ async function readExactProjectItemState(
     await executeGraphQLQueryWithMetadata<GraphQLExactProjectItemResponse>(
       config,
       EXACT_PROJECT_ITEM_STATE_QUERY,
-      { itemId: input.itemId },
+      {
+        itemId: input.itemId,
+        stateFieldName:
+          config.lifecycle?.stateFieldName ??
+          DEFAULT_WORKFLOW_LIFECYCLE.stateFieldName,
+      },
       fetchImpl
     );
   const node = result.data.node;
@@ -1038,7 +1077,7 @@ async function readExactProjectItemState(
 
   return {
     state: requireProjectItemState(
-      extractFieldValues(exactNode.fieldValues?.nodes ?? []),
+      extractFieldValues([exactNode.fieldValueByName]),
       config.lifecycle ?? DEFAULT_WORKFLOW_LIFECYCLE,
       input.itemId
     ),
@@ -1049,43 +1088,125 @@ async function readExactProjectItemState(
 async function resolveStatusFieldConfiguration(
   config: GitHubTrackerConfig,
   targetState: string,
-  fetchImpl: FetchLike
+  fetchImpl: FetchLike,
+  options: { forceRefresh?: boolean } = {}
 ): Promise<{
   fieldId: string;
   optionId: string;
   rateLimits: GitHubRateLimitPayload | null;
 }> {
-  const result =
-    await executeGraphQLQueryWithMetadata<GraphQLProjectFieldsResponse>(
-      config,
-      PROJECT_FIELDS_QUERY,
-      { projectId: config.projectId },
-      fetchImpl
-    );
   const fieldName =
     config.lifecycle?.stateFieldName ??
     DEFAULT_WORKFLOW_LIFECYCLE.stateFieldName;
-  const field = (result.data.node?.fields?.nodes ?? [])
-    .filter(isSingleSelectProjectField)
-    .find((candidate) => candidate.name === fieldName);
-  if (!field || !field.id) {
-    throw new GitHubTrackerQueryError(
-      `tracker_status_field_not_found: ${fieldName}`
-    );
-  }
-  const option = (field.options ?? []).find(
+  const resolved = await getProjectStatusFieldMetadata(
+    config,
+    fieldName,
+    fetchImpl,
+    options.forceRefresh === true
+  );
+  const option = resolved.metadata.options.find(
     (candidate) => candidate && statesEqual(candidate.name, targetState)
   );
   if (!option?.id) {
+    if (!options.forceRefresh) {
+      invalidateProjectStatusFieldMetadata(config, fieldName);
+      return resolveStatusFieldConfiguration(config, targetState, fetchImpl, {
+        forceRefresh: true,
+      });
+    }
     throw new GitHubTrackerQueryError(
       `tracker_target_state_not_found: ${targetState}`
     );
   }
   return {
-    fieldId: field.id,
+    fieldId: resolved.metadata.fieldId,
     optionId: option.id,
-    rateLimits: result.rateLimits,
+    rateLimits: resolved.rateLimits,
   };
+}
+
+async function getProjectStatusFieldMetadata(
+  config: GitHubTrackerConfig,
+  fieldName: string,
+  fetchImpl: FetchLike,
+  forceRefresh: boolean
+): Promise<{
+  metadata: ProjectStatusFieldMetadata;
+  rateLimits: GitHubRateLimitPayload | null;
+}> {
+  const cacheKey = projectStatusFieldCacheKey(config, fieldName);
+  if (forceRefresh) {
+    cachedProjectStatusFields.delete(cacheKey);
+  }
+  let pending = cachedProjectStatusFields.get(cacheKey);
+  if (!pending) {
+    pending = executeGraphQLQueryWithMetadata<GraphQLProjectFieldsResponse>(
+      config,
+      PROJECT_FIELDS_QUERY,
+      { projectId: config.projectId },
+      fetchImpl
+    ).then((result) => {
+      const field = (result.data.node?.fields?.nodes ?? [])
+        .filter(isSingleSelectProjectField)
+        .find((candidate) => candidate.name === fieldName);
+      if (!field?.id) {
+        throw new GitHubTrackerQueryError(
+          `tracker_status_field_not_found: ${fieldName}`
+        );
+      }
+      return {
+        fieldId: field.id,
+        options: (field.options ?? []).flatMap((option) =>
+          option?.id && option.name ? [option] : []
+        ),
+      };
+    });
+    cachedProjectStatusFields.set(cacheKey, pending);
+  }
+  try {
+    return {
+      metadata: await pending,
+      rateLimits: null,
+    };
+  } catch (error) {
+    if (cachedProjectStatusFields.get(cacheKey) === pending) {
+      cachedProjectStatusFields.delete(cacheKey);
+    }
+    throw error;
+  }
+}
+
+function projectStatusFieldCacheKey(
+  config: GitHubTrackerConfig,
+  fieldName?: string
+): string {
+  return JSON.stringify({
+    apiUrl: config.apiUrl ?? DEFAULT_API_URL,
+    projectId: config.projectId,
+    stateFieldName:
+      fieldName ??
+      config.lifecycle?.stateFieldName ??
+      DEFAULT_WORKFLOW_LIFECYCLE.stateFieldName,
+    tokenFingerprint: fingerprintGitHubToken(config.token),
+  });
+}
+
+function invalidateProjectStatusFieldMetadata(
+  config: GitHubTrackerConfig,
+  fieldName?: string
+): void {
+  cachedProjectStatusFields.delete(
+    projectStatusFieldCacheKey(config, fieldName)
+  );
+}
+
+function isStaleStatusFieldMetadataError(error: unknown): boolean {
+  return (
+    error instanceof GitHubTrackerQueryError &&
+    /(?:field|option|single.?select).*(?:invalid|not found)|(?:invalid|not found).*(?:field|option|single.?select)/i.test(
+      error.message
+    )
+  );
 }
 
 async function executeTransitionMutationWithRetry(
@@ -2664,10 +2785,12 @@ export function resetGitHubRateLimitCacheForTests(): void {
   githubGraphQLRateLimitPolicy.reset();
   transitionQueueTails.clear();
   transitionQueueDepths.clear();
+  cachedProjectStatusFields.clear();
 }
 
 export function resetPriorityOptionOrderCacheForTests(): void {
   cachedProjectFields.clear();
+  cachedProjectStatusFields.clear();
 }
 
 const PROJECT_ITEMS_QUERY = `
@@ -2838,7 +2961,7 @@ const PROJECT_FIELDS_QUERY = `
 `;
 
 const EXACT_PROJECT_ITEM_STATE_QUERY = `
-  query ExactProjectItemState($itemId: ID!) {
+  query ExactProjectItemState($itemId: ID!, $stateFieldName: String!) {
     rateLimit {
       cost
       remaining
@@ -2859,24 +2982,22 @@ const EXACT_PROJECT_ITEM_STATE_QUERY = `
             id
           }
         }
-        fieldValues(first: 20) {
-          nodes {
-            __typename
-            ... on ProjectV2ItemFieldSingleSelectValue {
-              name
-              optionId
-              field {
-                ... on ProjectV2SingleSelectField {
-                  name
-                }
+        fieldValueByName(name: $stateFieldName) {
+          __typename
+          ... on ProjectV2ItemFieldSingleSelectValue {
+            name
+            optionId
+            field {
+              ... on ProjectV2SingleSelectField {
+                name
               }
             }
-            ... on ProjectV2ItemFieldTextValue {
-              text
-              field {
-                ... on ProjectV2FieldCommon {
-                  name
-                }
+          }
+          ... on ProjectV2ItemFieldTextValue {
+            text
+            field {
+              ... on ProjectV2FieldCommon {
+                name
               }
             }
           }

--- a/packages/tracker-github/src/adapter.ts
+++ b/packages/tracker-github/src/adapter.ts
@@ -1052,9 +1052,10 @@ async function readExactProjectItemState(
       EXACT_PROJECT_ITEM_STATE_QUERY,
       {
         itemId: input.itemId,
-        stateFieldName:
+        stateFieldName: (
           config.lifecycle?.stateFieldName ??
-          DEFAULT_WORKFLOW_LIFECYCLE.stateFieldName,
+          DEFAULT_WORKFLOW_LIFECYCLE.stateFieldName
+        ).trim(),
       },
       fetchImpl
     );
@@ -1203,7 +1204,7 @@ function invalidateProjectStatusFieldMetadata(
 function isStaleStatusFieldMetadataError(error: unknown): boolean {
   return (
     error instanceof GitHubTrackerQueryError &&
-    /(?:field|option|single.?select).*(?:invalid|not found)|(?:invalid|not found).*(?:field|option|single.?select)/i.test(
+    /(?:field|option|single.?select).*(?:invalid|not found|does not belong)|(?:invalid|not found|does not belong).*(?:field|option|single.?select)|could not resolve to a node with the global id/i.test(
       error.message
     )
   );

--- a/packages/tracker-github/src/adapter.ts
+++ b/packages/tracker-github/src/adapter.ts
@@ -953,7 +953,6 @@ async function executeGithubProjectItemStateRequest(
     input.request.targetState,
     fetchImpl
   );
-  latestRateLimits = statusField.rateLimits ?? latestRateLimits;
   let mutation;
   try {
     mutation = await executeTransitionMutationWithRetry(
@@ -976,7 +975,6 @@ async function executeGithubProjectItemStateRequest(
       fetchImpl,
       { forceRefresh: true }
     );
-    latestRateLimits = statusField.rateLimits ?? latestRateLimits;
     mutation = await executeTransitionMutationWithRetry(
       cycleConfig,
       {
@@ -1094,7 +1092,6 @@ async function resolveStatusFieldConfiguration(
 ): Promise<{
   fieldId: string;
   optionId: string;
-  rateLimits: GitHubRateLimitPayload | null;
 }> {
   const fieldName =
     config.lifecycle?.stateFieldName ??
@@ -1122,7 +1119,6 @@ async function resolveStatusFieldConfiguration(
   return {
     fieldId: resolved.metadata.fieldId,
     optionId: option.id,
-    rateLimits: resolved.rateLimits,
   };
 }
 
@@ -1133,7 +1129,6 @@ async function getProjectStatusFieldMetadata(
   forceRefresh: boolean
 ): Promise<{
   metadata: ProjectStatusFieldMetadata;
-  rateLimits: GitHubRateLimitPayload | null;
 }> {
   const cacheKey = projectStatusFieldCacheKey(config, fieldName);
   if (forceRefresh) {
@@ -1167,7 +1162,6 @@ async function getProjectStatusFieldMetadata(
   try {
     return {
       metadata: await pending,
-      rateLimits: null,
     };
   } catch (error) {
     if (cachedProjectStatusFields.get(cacheKey) === pending) {
@@ -1202,6 +1196,8 @@ function invalidateProjectStatusFieldMetadata(
 }
 
 function isStaleStatusFieldMetadataError(error: unknown): boolean {
+  // GitHub does not provide a structured stale-ID code for this mutation.
+  // Unknown errors fail normally rather than risking an extra mutation retry.
   return (
     error instanceof GitHubTrackerQueryError &&
     /(?:field|option|single.?select).*(?:invalid|not found|does not belong)|(?:invalid|not found|does not belong).*(?:field|option|single.?select)|could not resolve to a node with the global id/i.test(

--- a/packages/tracker-github/src/tracker-state.test.ts
+++ b/packages/tracker-github/src/tracker-state.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { DEFAULT_WORKFLOW_LIFECYCLE } from "@gh-symphony/core";
 import {
   requestGithubProjectItemState,
   resetGitHubRateLimitCacheForTests,
@@ -86,7 +87,7 @@ describe("requestGithubProjectItemState", () => {
     );
   });
 
-  it("reads the Status field by name when it falls after the first 20 fields", async () => {
+  it("queries the Status field by name without a field-value page limit", async () => {
     const states = new Map([["item-21", "In progress"]]);
     const fetchImpl = vi.fn(
       async (_url: string | URL | Request, init?: RequestInit) => {
@@ -118,6 +119,40 @@ describe("requestGithubProjectItemState", () => {
       outcome: "confirmed",
       state: "In progress",
     });
+  });
+
+  it("trims the configured Status field name for exact-item readback", async () => {
+    const states = new Map([["item-trimmed", "In progress"]]);
+    const fetchImpl = vi.fn(
+      async (_url: string | URL | Request, init?: RequestInit) => {
+        const body = JSON.parse(String(init?.body)) as {
+          query: string;
+          variables: Record<string, string>;
+        };
+        if (body.query.includes("query ExactProjectItemState")) {
+          expect(body.variables.stateFieldName).toBe("Status");
+        }
+        return graphqlResponse(body.query, body.variables, states);
+      }
+    ) as typeof fetch;
+
+    const result = await requestGithubProjectItemState(
+      {
+        ...config,
+        lifecycle: {
+          ...DEFAULT_WORKFLOW_LIFECYCLE,
+          stateFieldName: " Status ",
+        },
+      },
+      {
+        issueSubjectId: "issue-trimmed",
+        itemId: "item-trimmed",
+        request: { type: "state-read" },
+      },
+      fetchImpl
+    );
+
+    expect(result).toMatchObject({ ok: true, state: "In progress" });
   });
 
   it("refreshes stale cached Status metadata after an invalid option mutation", async () => {
@@ -177,6 +212,77 @@ describe("requestGithubProjectItemState", () => {
           expectedState: "In progress",
           targetState: "In review",
           reason: "refresh stale metadata",
+        },
+      },
+      fetchImpl
+    );
+
+    expect(result).toMatchObject({ ok: true, state: "In review" });
+    expect(projectFieldRequests).toBe(2);
+  });
+
+  it("refreshes stale cached Status metadata after a global-ID mutation error", async () => {
+    const states = new Map([["item-global-id", "In progress"]]);
+    let projectFieldRequests = 0;
+    const fetchImpl = vi.fn(
+      async (_url: string | URL | Request, init?: RequestInit) => {
+        const body = JSON.parse(String(init?.body)) as {
+          query: string;
+          variables: Record<string, string>;
+        };
+        if (body.query.includes("query ProjectFields")) {
+          projectFieldRequests += 1;
+          return jsonResponse({
+            data: {
+              rateLimit: rateLimit(),
+              node: {
+                __typename: "ProjectV2",
+                fields: {
+                  nodes: [
+                    {
+                      __typename: "ProjectV2SingleSelectField",
+                      id: `status-field-${projectFieldRequests}`,
+                      name: "Status",
+                      options: [
+                        {
+                          id: `in-review-${projectFieldRequests}`,
+                          name: "In review",
+                        },
+                      ],
+                    },
+                  ],
+                },
+              },
+            },
+          });
+        }
+        if (
+          body.query.includes("mutation UpdateProjectItemState") &&
+          body.variables.fieldId === "status-field-1"
+        ) {
+          return jsonResponse({
+            errors: [
+              {
+                message:
+                  "Could not resolve to a node with the global id of 'PVTSSF_stale'",
+              },
+            ],
+          });
+        }
+        return graphqlResponse(body.query, body.variables, states);
+      }
+    ) as typeof fetch;
+
+    const result = await requestGithubProjectItemState(
+      config,
+      {
+        issueSubjectId: "issue-global-id",
+        itemId: "item-global-id",
+        request: {
+          type: "transition-request",
+          expectedState: "In progress",
+          targetState: "In review",
+          reason: "refresh stale global ID metadata",
         },
       },
       fetchImpl

--- a/packages/tracker-github/src/tracker-state.test.ts
+++ b/packages/tracker-github/src/tracker-state.test.ts
@@ -68,15 +68,122 @@ describe("requestGithubProjectItemState", () => {
     expect(results).toHaveLength(5);
     expect(results.every((result) => result.ok)).toBe(true);
     expect(results.every((result) => result.state === "In review")).toBe(true);
-    expect(results.every((result) => result.rateLimits?.cycleCost === 3)).toBe(
-      true
-    );
+    expect(results.map((result) => result.rateLimits?.cycleCost)).toEqual([
+      3, 2, 2, 2, 2,
+    ]);
+    expect(results[0]?.rateLimits?.queryCosts).toEqual({
+      ExactProjectItemState: { requestCount: 2, cost: 2 },
+      ProjectFields: { requestCount: 1, cost: 1 },
+    });
+    for (const result of results.slice(1)) {
+      expect(result.rateLimits?.queryCosts).not.toHaveProperty("ProjectFields");
+    }
     expect(maxInFlight).toBe(1);
-    expect(seenQueries).toHaveLength(20);
+    expect(seenQueries).toHaveLength(16);
     expect(seenQueries.join("\n")).not.toContain("query ProjectItems");
     expect(new Set(seenItemIds)).toEqual(
       new Set(["item-1", "item-2", "item-3", "item-4", "item-5"])
     );
+  });
+
+  it("reads the Status field by name when it falls after the first 20 fields", async () => {
+    const states = new Map([["item-21", "In progress"]]);
+    const fetchImpl = vi.fn(
+      async (_url: string | URL | Request, init?: RequestInit) => {
+        const body = JSON.parse(String(init?.body)) as {
+          query: string;
+          variables: Record<string, string>;
+        };
+        if (body.query.includes("query ExactProjectItemState")) {
+          expect(body.query).toContain("fieldValueByName");
+          expect(body.query).not.toContain("fieldValues(first: 20)");
+          expect(body.variables.stateFieldName).toBe("Status");
+        }
+        return graphqlResponse(body.query, body.variables, states);
+      }
+    ) as typeof fetch;
+
+    const result = await requestGithubProjectItemState(
+      config,
+      {
+        issueSubjectId: "issue-21",
+        itemId: "item-21",
+        request: { type: "state-read" },
+      },
+      fetchImpl
+    );
+
+    expect(result).toMatchObject({
+      ok: true,
+      outcome: "confirmed",
+      state: "In progress",
+    });
+  });
+
+  it("refreshes stale cached Status metadata after an invalid option mutation", async () => {
+    const states = new Map([["item-1", "In progress"]]);
+    let projectFieldRequests = 0;
+    const fetchImpl = vi.fn(
+      async (_url: string | URL | Request, init?: RequestInit) => {
+        const body = JSON.parse(String(init?.body)) as {
+          query: string;
+          variables: Record<string, string>;
+        };
+        if (body.query.includes("query ProjectFields")) {
+          projectFieldRequests += 1;
+          return jsonResponse({
+            data: {
+              rateLimit: rateLimit(),
+              node: {
+                __typename: "ProjectV2",
+                fields: {
+                  nodes: [
+                    {
+                      __typename: "ProjectV2SingleSelectField",
+                      id: "status-field",
+                      name: "Status",
+                      options: [
+                        {
+                          id: `in-review-${projectFieldRequests}`,
+                          name: "In review",
+                        },
+                      ],
+                    },
+                  ],
+                },
+              },
+            },
+          });
+        }
+        if (
+          body.query.includes("mutation UpdateProjectItemState") &&
+          body.variables.optionId === "in-review-1"
+        ) {
+          return jsonResponse({
+            errors: [{ message: "single select option not found" }],
+          });
+        }
+        return graphqlResponse(body.query, body.variables, states);
+      }
+    ) as typeof fetch;
+
+    const result = await requestGithubProjectItemState(
+      config,
+      {
+        issueSubjectId: "issue-1",
+        itemId: "item-1",
+        request: {
+          type: "transition-request",
+          expectedState: "In progress",
+          targetState: "In review",
+          reason: "refresh stale metadata",
+        },
+      },
+      fetchImpl
+    );
+
+    expect(result).toMatchObject({ ok: true, state: "In review" });
+    expect(projectFieldRequests).toBe(2);
   });
 
   it("rejects an expected-state mismatch before mutation", async () => {
@@ -231,7 +338,7 @@ describe("requestGithubProjectItemState", () => {
               id: "item-1",
               project: { id: "project-1" },
               content: { id: "pull-request-1" },
-              fieldValues: { nodes: [statusFieldValue("In progress")] },
+              fieldValueByName: statusFieldValue("In progress"),
             },
           },
         });
@@ -302,9 +409,7 @@ function graphqlResponse(
           id: itemId,
           project: { id: "project-1" },
           content: { id: issueId },
-          fieldValues: {
-            nodes: [statusFieldValue(states.get(itemId) ?? "unknown")],
-          },
+          fieldValueByName: statusFieldValue(states.get(itemId) ?? "unknown"),
         },
       },
     });


### PR DESCRIPTION
## Issues — Closed #505

## TL;DR

- GitHub Project Status metadata를 token/project/status-field 범위로 캐시해 일반 transition의 ProjectFields 조회를 제거합니다.
- stale field/option ID는 cache 무효화·metadata refresh·1회 재시도로 복구하며, exact-item Status readback은 `fieldValueByName`으로 20개 field 제한을 제거합니다.

## 변경 지점 다이어그램

```text
cached Status metadata → transition mutation
          │                  │ stale global ID / option mismatch
          └── invalidate → refresh metadata → retry once

exact-item readback → trim Status field name → fieldValueByName
```

## 여기부터 보세요

- `packages/tracker-github/src/adapter.ts` — scoped metadata cache, bounded stale-ID invalidation/retry, exact field-name lookup, telemetry cost collection
- `packages/tracker-github/src/tracker-state.test.ts` — stale metadata, field-name trim, server-side Status lookup 및 cycle-cost TC

## 위험 & 롤백

- GitHub의 알려진 stale identifier 오류만 metadata를 한 번 새로 읽어 재시도합니다. 인증·권한·일반 mutation 오류는 정상 실패합니다.
- 문제 발생 시 cache 경로를 제거하면 요청별 metadata 조회 동작으로 되돌릴 수 있습니다.

## 변경 파일

- `.changeset/fast-status-cache.md`
- `packages/tracker-github/src/adapter.ts`
- `packages/tracker-github/src/tracker-state.test.ts`

## Evidence

- `pnpm lint` — pass
- `pnpm test` — pass
- `pnpm --filter @gh-symphony/tracker-github test -- --run` — pass (102 tests)
- `pnpm typecheck` — pass
- `pnpm build` — pass
- `GH_SYMPHONY_HTTP_TOKEN=e2e-http-token docker compose -f docker-compose.e2e.yml up -d --build` + `curl --fail http://localhost:4680/healthz` — pass (`{"ok":true}`); teardown complete
- `git merge-base --is-ancestor origin/main HEAD` — pass (`origin/main` is already the current head's ancestor after full-history fetch)

## 머지 후/사람 확인

- [ ] 실제 Status field/option 재생성 뒤 첫 transition이 metadata를 갱신하여 성공하는지 확인
- [ ] 20개 초과 필드를 가진 GitHub Project에서 Status transition을 확인
