### PR TITLE
fix: aggregate comment mutation GraphQL costs

### DIFF
--- a/.changeset/calm-pandas-observe.md
+++ b/.changeset/calm-pandas-observe.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Record GitHub comment mutation GraphQL costs in poll-cycle observability aggregates (#492).

--- a/packages/core/src/contracts/tracker-adapter.ts
+++ b/packages/core/src/contracts/tracker-adapter.ts
@@ -147,6 +147,11 @@ export type TrackerCommentWriteResult = {
   rateLimits: Record<string, unknown> | null;
 };
 
+export type TrackerIssueCommentUpsertResult = {
+  outcome: "created" | "updated" | "unchanged";
+  rateLimits: Record<string, unknown> | null;
+};
+
 export type TrackerStateResult = {
   ok: boolean;
   outcome: "confirmed" | "expected_state_mismatch" | "rejected" | "failed";
@@ -206,5 +211,5 @@ export type OrchestratorTrackerAdapter = {
       body: string;
     },
     dependencies?: OrchestratorTrackerDependencies
-  ): Promise<"created" | "updated" | "unchanged">;
+  ): Promise<TrackerIssueCommentUpsertResult>;
 };

--- a/packages/orchestrator/src/dispatch.test.ts
+++ b/packages/orchestrator/src/dispatch.test.ts
@@ -10,6 +10,7 @@ import type {
   OrchestratorRunRecord,
   OrchestratorProjectConfig,
   TrackedIssue,
+  TrackedIssueList,
   TrackedPullRequestContext,
   IssueWorkspaceRecord,
 } from "@gh-symphony/core";
@@ -1410,6 +1411,200 @@ describe("targeted canonical subject dispatch", () => {
       );
     }
   );
+
+  it("aggregates advisory GraphQL costs in a no-run poll without run events", async () => {
+    const tempRoot = await mkdtemp(
+      join(tmpdir(), "orchestrator-linked-pr-advisory-rate-limits-")
+    );
+    const repository = await createRepositoryFixture(
+      tempRoot,
+      "acme",
+      "platform"
+    );
+    const store = new OrchestratorFsStore(tempRoot);
+    const projectConfig = createProjectConfig(
+      tempRoot,
+      repository.cloneUrl,
+      repository.owner,
+      repository.name
+    );
+    await store.saveProjectConfig(projectConfig);
+    const issue = makeIssue({
+      id: "issue-9",
+      identifier: "acme/platform#9",
+      number: 9,
+      state: "In review",
+      repository,
+      metadata: {
+        contentType: "Issue",
+        linkedPullRequests: [
+          makePullRequestContext(repository, 109, "feature/pr-109"),
+        ],
+      },
+    });
+    const linkedPullRequest = makeIssue({
+      id: "pr-109",
+      identifier: "acme/platform#109",
+      number: 109,
+      state: "Todo",
+      repository,
+      metadata: {
+        contentType: "PullRequest",
+        pullRequest: makePullRequestContext(repository, 109, "feature/pr-109"),
+      },
+    });
+    const issues = [issue, linkedPullRequest] as TrackedIssueList;
+    issues.rateLimits = {
+      source: "github",
+      resource: "graphql",
+      cycleCost: 11,
+      queryCosts: { ProjectItems: { requestCount: 1, cost: 11 } },
+    };
+    const adapter = createDispatchAdapter(repository, issues);
+    adapter.upsertIssueComment = vi.fn().mockResolvedValue({
+      outcome: "created",
+      rateLimits: {
+        source: "github",
+        resource: "graphql",
+        cycleCost: 5,
+        queryCosts: {
+          IssueCommentsById: { requestCount: 1, cost: 2 },
+          AddIssueComment: { requestCount: 1, cost: 3 },
+        },
+      },
+    });
+    vi.spyOn(trackerAdapters, "resolveTrackerAdapter").mockReturnValue(adapter);
+
+    const result = await new OrchestratorService(store, projectConfig, {
+      now: () => new Date("2026-03-08T00:00:00.000Z"),
+    }).runOnce({ issueIdentifier: "acme/platform#109" });
+
+    expect(result.summary.dispatched).toBe(0);
+    expect(result.rateLimits).toMatchObject({
+      cycleCost: 16,
+      queryCosts: {
+        ProjectItems: { requestCount: 1, cost: 11 },
+        IssueCommentsById: { requestCount: 1, cost: 2 },
+        AddIssueComment: { requestCount: 1, cost: 3 },
+      },
+    });
+    expect(await store.loadAllRuns()).toEqual([]);
+  });
+
+  it("aggregates advisory costs once without adding them to an active run", async () => {
+    const tempRoot = await mkdtemp(
+      join(tmpdir(), "orchestrator-linked-pr-advisory-active-run-")
+    );
+    const repository = await createRepositoryFixture(
+      tempRoot,
+      "acme",
+      "platform"
+    );
+    const store = new OrchestratorFsStore(tempRoot);
+    const projectConfig = createProjectConfig(
+      tempRoot,
+      repository.cloneUrl,
+      repository.owner,
+      repository.name
+    );
+    await store.saveProjectConfig(projectConfig);
+    const issue = makeIssue({
+      id: "issue-9",
+      identifier: "acme/platform#9",
+      number: 9,
+      state: "In review",
+      repository,
+      metadata: {
+        contentType: "Issue",
+        linkedPullRequests: [
+          makePullRequestContext(repository, 109, "feature/pr-109"),
+        ],
+      },
+    });
+    const linkedPullRequest = makeIssue({
+      id: "pr-109",
+      identifier: "acme/platform#109",
+      number: 109,
+      state: "Todo",
+      repository,
+      metadata: {
+        contentType: "PullRequest",
+        pullRequest: makePullRequestContext(repository, 109, "feature/pr-109"),
+      },
+    });
+    const issues = [issue, linkedPullRequest] as TrackedIssueList;
+    issues.rateLimits = {
+      source: "github",
+      resource: "graphql",
+      cycleCost: 11,
+      queryCosts: { ProjectItems: { requestCount: 1, cost: 11 } },
+    };
+    const adapter = createDispatchAdapter(repository, issues);
+    adapter.upsertIssueComment = vi.fn().mockResolvedValue({
+      outcome: "updated",
+      rateLimits: {
+        source: "github",
+        resource: "graphql",
+        cycleCost: 5,
+        queryCosts: {
+          IssueCommentsById: { requestCount: 1, cost: 2 },
+          UpdateIssueComment: { requestCount: 1, cost: 3 },
+        },
+      },
+    });
+    vi.spyOn(trackerAdapters, "resolveTrackerAdapter").mockReturnValue(adapter);
+    await store.saveRun(
+      makeRun({
+        runId: "run-9",
+        issueId: issue.id,
+        issueIdentifier: issue.identifier,
+        issueState: issue.state,
+        repository,
+        processId: 5409,
+        rateLimits: {
+          source: "github",
+          resource: "graphql",
+          cycleCost: 11,
+          queryCosts: { WorkerStatus: { requestCount: 1, cost: 11 } },
+        },
+      })
+    );
+
+    const result = await new OrchestratorService(store, projectConfig, {
+      isProcessRunning: (pid) => pid === 5409,
+      now: () => new Date("2026-03-08T00:00:00.000Z"),
+    }).runOnce({ issueIdentifier: "acme/platform#109" });
+
+    expect(result.rateLimits).toMatchObject({
+      cycleCost: 16,
+      queryCosts: {
+        WorkerStatus: { requestCount: 1, cost: 11 },
+        IssueCommentsById: { requestCount: 1, cost: 2 },
+        UpdateIssueComment: { requestCount: 1, cost: 3 },
+      },
+    });
+    const events = (
+      await readFile(
+        join(store.runDir("run-9", projectConfig.projectId), "events.ndjson"),
+        "utf8"
+      )
+    )
+      .trim()
+      .split("\n")
+      .map(
+        (line) => JSON.parse(line) as { rateLimits?: Record<string, unknown> }
+      );
+    expect(events).not.toContainEqual(
+      expect.objectContaining({
+        rateLimits: expect.objectContaining({
+          cycleCost: 5,
+          queryCosts: expect.objectContaining({
+            UpdateIssueComment: expect.anything(),
+          }),
+        }),
+      })
+    );
+  });
 
   it("evaluates linked PR advisory states with each issue repository workflow", async () => {
     const tempRoot = await mkdtemp(

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -8875,9 +8875,16 @@ Prefer focused changes.
       },
     });
 
-    const fetchImpl = vi
-      .fn()
-      .mockResolvedValue(createTrackerResponseWithState(repository, "Todo"));
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ...createTrackerResponseWithState(repository, "Todo"),
+      headers: new Headers({
+        "x-ratelimit-limit": "5000",
+        "x-ratelimit-remaining": "4998",
+        "x-ratelimit-used": "2",
+        "x-ratelimit-reset": "1773892920",
+        "x-ratelimit-resource": "graphql",
+      }),
+    });
     const service = new OrchestratorService(store, projectConfig, {
       fetchImpl: fetchImpl as typeof fetch,
       spawnImpl: vi.fn().mockReturnValue({

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -1236,20 +1236,30 @@ export class OrchestratorService {
             matchesTargetIssueIdentifier(issue, issueIdentifier)
           )
         : canonicalIssues;
-      await this.publishLinkedPullRequestActiveAdvisories(
-        tenant,
-        trackerAdapter,
-        targetedIssues,
-        trackerDependencies
-      );
+      const advisoryRateLimits =
+        await this.publishLinkedPullRequestActiveAdvisories(
+          tenant,
+          trackerAdapter,
+          targetedIssues,
+          trackerDependencies
+        );
+      const pollListRateLimits =
+        getTrackedIssueListRateLimits(issues) ?? supplementalLinearRateLimits;
       rateLimits = resolveProjectRateLimits(
         syncedActiveRuns,
         trackedIssuesByIdentifier.values(),
-        getTrackedIssueListRateLimits(issues) ?? supplementalLinearRateLimits
+        pollListRateLimits
       );
+      rateLimits = isTrackerGraphqlRateLimits(rateLimits)
+        ? (mergeTrackerRateLimits(rateLimits, advisoryRateLimits) ?? rateLimits)
+        : rateLimits;
       trackerRateLimits = resolveTrackerRateLimits(
         trackedIssuesByIdentifier.values(),
-        getTrackedIssueListRateLimits(issues) ?? supplementalLinearRateLimits
+        pollListRateLimits
+      );
+      trackerRateLimits = mergeTrackerRateLimits(
+        trackerRateLimits,
+        advisoryRateLimits
       );
       this.rememberTrackerRateLimits(tenant.projectId, trackerRateLimits);
       const concurrency = await this.getProjectConcurrency(tenant);
@@ -2028,10 +2038,12 @@ export class OrchestratorService {
     trackerAdapter: OrchestratorTrackerAdapter,
     issues: readonly TrackedIssue[],
     trackerDependencies: OrchestratorTrackerDependencies
-  ): Promise<void> {
+  ): Promise<Record<string, unknown> | null> {
     if (!trackerAdapter.upsertIssueComment) {
-      return;
+      return null;
     }
+
+    let rateLimits: Record<string, unknown> | null = null;
 
     for (const issue of issues) {
       if (
@@ -2071,18 +2083,21 @@ export class OrchestratorService {
       });
 
       try {
-        await trackerAdapter.upsertIssueComment(
+        const result = await trackerAdapter.upsertIssueComment(
           tenant,
           issue,
           { marker, body },
           trackerDependencies
         );
+        rateLimits = mergeTrackerRateLimits(rateLimits, result.rateLimits);
       } catch (error) {
         this.writeStderr(
           `[orchestrator] failed to publish linked PR active advisory for ${issue.identifier}: ${this.formatErrorMessage(error)}`
         );
       }
     }
+
+    return rateLimits;
   }
 
   private async loadProjectWorkflow(
@@ -4512,6 +4527,50 @@ function resolveTrackerRateLimits(
   return isTrackerGraphqlRateLimits(fallbackRateLimits)
     ? fallbackRateLimits
     : null;
+}
+
+function mergeTrackerRateLimits(
+  ...rateLimits: Array<Record<string, unknown> | null>
+): Record<string, unknown> | null {
+  const graphqlRateLimits = rateLimits.filter(isTrackerGraphqlRateLimits);
+  if (graphqlRateLimits.length === 0) {
+    return null;
+  }
+  if (graphqlRateLimits.length === 1) {
+    return graphqlRateLimits[0] ?? null;
+  }
+
+  const queryCosts: Record<string, { requestCount: number; cost: number }> = {};
+  let cycleCost = 0;
+  for (const rateLimit of graphqlRateLimits) {
+    cycleCost += readNonNegativeNumber(rateLimit.cycleCost);
+    if (!isRecord(rateLimit.queryCosts)) {
+      continue;
+    }
+    for (const [operation, value] of Object.entries(rateLimit.queryCosts)) {
+      if (!isRecord(value)) {
+        continue;
+      }
+      const previous = queryCosts[operation] ?? { requestCount: 0, cost: 0 };
+      queryCosts[operation] = {
+        requestCount:
+          previous.requestCount + readNonNegativeNumber(value.requestCount),
+        cost: previous.cost + readNonNegativeNumber(value.cost),
+      };
+    }
+  }
+
+  return {
+    ...graphqlRateLimits.at(-1),
+    cycleCost,
+    queryCosts,
+  };
+}
+
+function readNonNegativeNumber(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0
+    ? value
+    : 0;
 }
 
 function resolveAdaptivePollIntervalMs(

--- a/packages/tracker-github/src/adapter.ts
+++ b/packages/tracker-github/src/adapter.ts
@@ -8,6 +8,7 @@ import {
   type TrackerStateRequest,
   type TrackerStateResult,
   type TrackerCommentWriteResult,
+  type TrackerIssueCommentUpsertResult,
   type WorkflowPriorityConfig,
   type WorkflowLifecycleConfig,
 } from "@gh-symphony/core";
@@ -368,12 +369,13 @@ export class GitHubTrackerQueryError extends GitHubTrackerError {}
 
 type GitHubRateLimitObservation = {
   operationName: string;
-  rateLimit: GraphQLRateLimitField;
+  cost: number;
   payload: GitHubRateLimitPayload;
 };
 
 type GitHubRateLimitCollector = {
   observations: GitHubRateLimitObservation[];
+  lastUsed: number | null;
 };
 
 const ARCHIVED_PROJECT_ITEM_STATE = "Archived";
@@ -1299,11 +1301,40 @@ async function upsertIssueComment(
   },
   fetchImpl: FetchLike = fetch,
   cache?: IssueCommentCache
-): Promise<"created" | "updated" | "unchanged"> {
-  if (cache) {
-    return upsertIssueCommentWithCache(config, issue, input, fetchImpl, cache);
-  }
+): Promise<TrackerIssueCommentUpsertResult> {
+  const cycleConfig = beginGraphQLRateLimitCycle(config);
+  const result = cache
+    ? await upsertIssueCommentWithCache(
+        cycleConfig,
+        issue,
+        input,
+        fetchImpl,
+        cache
+      )
+    : await upsertIssueCommentWithoutCache(
+        cycleConfig,
+        issue,
+        input,
+        fetchImpl
+      );
+  return {
+    outcome: result,
+    rateLimits: finalizeGraphQLRateLimitCycle(
+      null,
+      cycleConfig.rateLimitCollector
+    ),
+  };
+}
 
+async function upsertIssueCommentWithoutCache(
+  config: GitHubTrackerConfig,
+  issue: Pick<TrackedIssue, "id" | "number" | "repository">,
+  input: {
+    marker: string;
+    body: string;
+  },
+  fetchImpl: FetchLike
+): Promise<"created" | "updated" | "unchanged"> {
   const existingComment = await findIssueCommentByMarker(
     config,
     issue.id,
@@ -2574,12 +2605,18 @@ async function executeGraphQLQueryWithMetadata<TData>(
   const data = payload.data as TData;
   const fieldRateLimits = extractGraphQLRateLimitField(payload.data.rateLimit);
   const rateLimits = extractGitHubRateLimits(response.headers, fieldRateLimits);
-  if (fieldRateLimits && rateLimits) {
+  const cost =
+    fieldRateLimits?.cost ??
+    inferGraphQLHeaderCost(config.rateLimitCollector, rateLimits);
+  if (rateLimits && cost !== null) {
     config.rateLimitCollector?.observations.push({
       operationName: extractGraphQLOperationName(query),
-      rateLimit: fieldRateLimits,
+      cost,
       payload: rateLimits,
     });
+  }
+  if (rateLimits && config.rateLimitCollector) {
+    config.rateLimitCollector.lastUsed = rateLimits.used;
   }
   return {
     data,
@@ -2601,6 +2638,7 @@ function beginGraphQLRateLimitCycle(
     ...config,
     rateLimitCollector: {
       observations: [],
+      lastUsed: null,
     },
   };
 }
@@ -2623,26 +2661,34 @@ function finalizeGraphQLRateLimitCycle(
     };
     queryCosts[observation.operationName] = {
       requestCount: previous.requestCount + 1,
-      cost: previous.cost + observation.rateLimit.cost,
+      cost: previous.cost + observation.cost,
     };
-    cycleCost += observation.rateLimit.cost;
+    cycleCost += observation.cost;
   }
 
-  const latestObservation = observations.at(-1);
   return {
-    ...(latestObservation?.payload ??
-      latestRateLimits ?? {
-        source: "github",
-        limit: null,
-        remaining: latestObservation?.rateLimit.remaining ?? null,
-        used: null,
-        reset: null,
-        resetAt: latestObservation?.rateLimit.resetAt ?? null,
-        resource: "graphql",
-      }),
+    ...observations.at(-1)!.payload,
     cycleCost,
     queryCosts,
   };
+}
+
+function inferGraphQLHeaderCost(
+  collector: GitHubRateLimitCollector | undefined,
+  rateLimits: GitHubRateLimitPayload | null
+): number | null {
+  if (
+    !collector ||
+    !rateLimits ||
+    rateLimits.used === null ||
+    collector.lastUsed === null
+  ) {
+    return null;
+  }
+
+  // Header deltas are token-scoped, so concurrent requests can over-attribute cost.
+  const cost = rateLimits.used - collector.lastUsed;
+  return cost >= 0 ? cost : null;
 }
 
 function parseTimestampMs(value: string | null): number | null {

--- a/packages/tracker-github/src/tracker-github.test.ts
+++ b/packages/tracker-github/src/tracker-github.test.ts
@@ -1100,6 +1100,11 @@ describe("resolveTrackerAdapter", () => {
         new Response(
           JSON.stringify({
             data: {
+              rateLimit: {
+                cost: 2,
+                remaining: 4998,
+                resetAt: "2026-03-19T04:02:00.000Z",
+              },
               node: {
                 __typename: "Issue",
                 comments: {
@@ -1108,13 +1113,24 @@ describe("resolveTrackerAdapter", () => {
                 },
               },
             },
-          })
+          }),
+          {
+            headers: {
+              "x-ratelimit-used": "2",
+              "x-ratelimit-resource": "graphql",
+            },
+          }
         )
       )
       .mockResolvedValueOnce(
         new Response(
           JSON.stringify({
             data: {
+              rateLimit: {
+                cost: 3,
+                remaining: 4995,
+                resetAt: "2026-03-19T04:02:00.000Z",
+              },
               addComment: {
                 commentEdge: {
                   node: {
@@ -1124,7 +1140,13 @@ describe("resolveTrackerAdapter", () => {
                 },
               },
             },
-          })
+          }),
+          {
+            headers: {
+              "x-ratelimit-used": "5",
+              "x-ratelimit-resource": "graphql",
+            },
+          }
         )
       );
 
@@ -1139,7 +1161,16 @@ describe("resolveTrackerAdapter", () => {
       { token: "test-token", fetchImpl }
     );
 
-    expect(result).toBe("created");
+    expect(result).toMatchObject({
+      outcome: "created",
+      rateLimits: {
+        cycleCost: 5,
+        queryCosts: {
+          IssueCommentsById: { requestCount: 1, cost: 2 },
+          AddIssueComment: { requestCount: 1, cost: 3 },
+        },
+      },
+    });
     expect(fetchImpl).toHaveBeenCalledTimes(2);
     const queryBody = JSON.parse(
       String(fetchImpl.mock.calls[0]?.[1]?.body)
@@ -1152,8 +1183,8 @@ describe("resolveTrackerAdapter", () => {
       String(fetchImpl.mock.calls[1]?.[1]?.body)
     ) as { query: string; variables: Record<string, string> };
     expect(mutationBody.query).toContain("mutation AddIssueComment");
-    // rateLimit only exists on the Query type; selecting it in a mutation
-    // fails GitHub schema validation.
+    // GitHub exposes rateLimit on Query only; mutation cost is inferred from
+    // successive x-ratelimit-used response headers.
     expect(mutationBody.query).not.toContain("rateLimit");
     expect(mutationBody.variables.subjectId).toBe("issue-1");
   });
@@ -1173,6 +1204,11 @@ describe("resolveTrackerAdapter", () => {
       new Response(
         JSON.stringify({
           data: {
+            rateLimit: {
+              cost: 2,
+              remaining: 4998,
+              resetAt: "2026-03-19T04:02:00.000Z",
+            },
             node: {
               __typename: "Issue",
               comments: {
@@ -1192,7 +1228,15 @@ describe("resolveTrackerAdapter", () => {
       { token: "test-token", fetchImpl }
     );
 
-    expect(result).toBe("unchanged");
+    expect(result).toMatchObject({
+      outcome: "unchanged",
+      rateLimits: {
+        cycleCost: 2,
+        queryCosts: {
+          IssueCommentsById: { requestCount: 1, cost: 2 },
+        },
+      },
+    });
     expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
 
@@ -1212,6 +1256,11 @@ describe("resolveTrackerAdapter", () => {
         new Response(
           JSON.stringify({
             data: {
+              rateLimit: {
+                cost: 2,
+                remaining: 4998,
+                resetAt: "2026-03-19T04:02:00.000Z",
+              },
               node: {
                 __typename: "Issue",
                 comments: {
@@ -1220,13 +1269,24 @@ describe("resolveTrackerAdapter", () => {
                 },
               },
             },
-          })
+          }),
+          {
+            headers: {
+              "x-ratelimit-used": "2",
+              "x-ratelimit-resource": "graphql",
+            },
+          }
         )
       )
       .mockResolvedValueOnce(
         new Response(
           JSON.stringify({
             data: {
+              rateLimit: {
+                cost: 4,
+                remaining: 4994,
+                resetAt: "2026-03-19T04:02:00.000Z",
+              },
               updateIssueComment: {
                 issueComment: {
                   id: "comment-1",
@@ -1234,7 +1294,13 @@ describe("resolveTrackerAdapter", () => {
                 },
               },
             },
-          })
+          }),
+          {
+            headers: {
+              "x-ratelimit-used": "6",
+              "x-ratelimit-resource": "graphql",
+            },
+          }
         )
       );
 
@@ -1245,14 +1311,23 @@ describe("resolveTrackerAdapter", () => {
       { token: "test-token", fetchImpl }
     );
 
-    expect(result).toBe("updated");
+    expect(result).toMatchObject({
+      outcome: "updated",
+      rateLimits: {
+        cycleCost: 6,
+        queryCosts: {
+          IssueCommentsById: { requestCount: 1, cost: 2 },
+          UpdateIssueComment: { requestCount: 1, cost: 4 },
+        },
+      },
+    });
     expect(fetchImpl).toHaveBeenCalledTimes(2);
     const mutationBody = JSON.parse(
       String(fetchImpl.mock.calls[1]?.[1]?.body)
     ) as { query: string; variables: Record<string, string> };
     expect(mutationBody.query).toContain("mutation UpdateIssueComment");
-    // rateLimit only exists on the Query type; selecting it in a mutation
-    // fails GitHub schema validation.
+    // GitHub exposes rateLimit on Query only; mutation cost is inferred from
+    // successive x-ratelimit-used response headers.
     expect(mutationBody.query).not.toContain("rateLimit");
     expect(mutationBody.variables.commentId).toBe("comment-1");
   });
@@ -1326,8 +1401,8 @@ describe("resolveTrackerAdapter", () => {
       dependencies
     );
 
-    expect(first).toBe("unchanged");
-    expect(second).toBe("unchanged");
+    expect(first).toMatchObject({ outcome: "unchanged", rateLimits: null });
+    expect(second).toMatchObject({ outcome: "unchanged", rateLimits: null });
     expect(fetchImpl).toHaveBeenCalledTimes(3);
     expect(String(fetchImpl.mock.calls[0]?.[0])).toBe(
       "https://api.github.com/graphql"
@@ -1414,7 +1489,7 @@ describe("resolveTrackerAdapter", () => {
       { token: "test-token", fetchImpl, issueCommentCache: cache }
     );
 
-    expect(result).toBe("unchanged");
+    expect(result).toMatchObject({ outcome: "unchanged", rateLimits: null });
     expect(cache.delete).toHaveBeenCalledTimes(1);
     expect(entry).toEqual({
       commentId: 42,

--- a/packages/tracker-github/src/tracker-state.test.ts
+++ b/packages/tracker-github/src/tracker-state.test.ts
@@ -332,7 +332,11 @@ function graphqlResponse(
       },
     });
   }
-  if (query.includes("mutation UpdateProjectItemState")) {
+  if (
+    query.includes("mutation UpdateProjectItemState") ||
+    query.includes("mutation AddIssueComment") ||
+    query.includes("mutation UpdateIssueComment")
+  ) {
     // GitHub's schema only defines rateLimit on Query; selecting it inside a
     // mutation fails validation in production (see the v0.6.6 transition
     // outage), so the mock enforces the same rule.


### PR DESCRIPTION
## TL;DR

- linked-PR advisory의 GraphQL comment mutation 비용을 project poll-cycle aggregate에 포함합니다.
- `changeset:patch` 라벨에 맞춰 `@gh-symphony/cli` patch Changeset을 추가했습니다.

## 변경 지점 다이어그램

`IssueCommentsById field cost` + `comment mutation header delta` → `upsert aggregate` → `project poll snapshot`

`Codex run payload` ───────────────→ `snapshot.rateLimits` (보존)

## 여기부터 보세요

- `packages/tracker-github/src/adapter.ts`: header delta 기반 mutation 비용 수집
- `packages/orchestrator/src/service.ts`: project-scoped advisory 비용 병합 및 run payload 보존
- `packages/orchestrator/src/dispatch.test.ts`: active run 유무의 비용 집계·비중복 TC
- `.changeset/calm-pandas-observe.md`: `@gh-symphony/cli` patch 릴리스 메타데이터

## 위험 & 롤백

- `x-ratelimit-used` delta는 token-scoped라 동시 요청 비용을 mutation에 과다 귀속할 수 있습니다. 헤더가 없거나 단조 증가하지 않으면 mutation cost는 기록하지 않습니다.
- 문제 발생 시 이 PR을 되돌리면 기존 poll snapshot 우선순위로 복원됩니다.

## 변경 파일

- `.changeset/calm-pandas-observe.md`
- `packages/core/src/contracts/tracker-adapter.ts`
- `packages/tracker-github/src/adapter.ts`
- `packages/tracker-github/src/tracker-github.test.ts`
- `packages/tracker-github/src/tracker-state.test.ts`
- `packages/orchestrator/src/service.ts`
- `packages/orchestrator/src/service.test.ts`
- `packages/orchestrator/src/dispatch.test.ts`

## Issues — Closed #492

## Evidence

- `pnpm lint` — pass
- `pnpm test` — pass
- `pnpm typecheck` — pass
- `pnpm build` — pass
- `git diff --check` — pass
- Docker happy E2E — Cycle 4 pass: `GH_SYMPHONY_HTTP_TOKEN=e2e-http-token bash e2e/run-e2e.sh happy 45`

## 머지 후/사람 확인

- [ ] GitHub Project linked-PR advisory 발생 시 상태 API의 operation별 비용 분해를 확인
