### PR TITLE
fix(tracker-github): skip project items without Status

### DIFF
--- a/.changeset/quiet-skips-fix.md
+++ b/.changeset/quiet-skips-fix.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Keep dispatching when a GitHub Project item is missing its configured Status, and report skipped tracker items without degrading the project tick. (#549)

--- a/packages/cli/src/commands/start.test.ts
+++ b/packages/cli/src/commands/start.test.ts
@@ -848,7 +848,13 @@ describe("start command foreground locking", () => {
         tracker: { adapter: "github-project", bindingId: "project-1" },
         health: "running",
         lastTickAt: "2026-03-17T00:00:00.000Z",
-        summary: { dispatched: 1, suppressed: 0, recovered: 0, activeRuns: 1 },
+        summary: {
+          dispatched: 1,
+          suppressed: 0,
+          recovered: 0,
+          skipped: 3,
+          activeRuns: 1,
+        },
         activeRuns: [
           {
             runId: "run-1",
@@ -865,7 +871,13 @@ describe("start command foreground locking", () => {
         tracker: { adapter: "github-project", bindingId: "project-1" },
         health: "idle",
         lastTickAt: "2026-03-17T00:01:00.000Z",
-        summary: { dispatched: 1, suppressed: 0, recovered: 0, activeRuns: 0 },
+        summary: {
+          dispatched: 1,
+          suppressed: 0,
+          recovered: 0,
+          skipped: 3,
+          activeRuns: 0,
+        },
         activeRuns: [],
         retryQueue: [],
         lastError: null,
@@ -888,6 +900,7 @@ describe("start command foreground locking", () => {
 
     expect(stdout.output()).toContain("Worker stderr (acme/platform#1):");
     expect(stdout.output()).toContain("last failure");
+    expect(stdout.output()).toContain("item(s) skipped by the tracker");
     expect(exitSpy).toHaveBeenCalledWith(0);
   });
 

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -391,6 +391,13 @@ function logTickResult(
     if (snapshot.summary.activeRuns > 0) {
       logLine(cyan("\u25B8"), `${snapshot.summary.activeRuns} active run(s)`);
     }
+    const skipped = snapshot.summary.skipped ?? 0;
+    if (skipped > 0) {
+      logLine(
+        yellow("⚠"),
+        `${bold(String(skipped))} item(s) skipped by the tracker`
+      );
+    }
     return;
   }
 
@@ -457,6 +464,15 @@ function logTickResult(
     );
   }
 
+  const prevSkipped = prevSnapshot?.summary.skipped ?? 0;
+  const skipped = snapshot.summary.skipped ?? 0;
+  if (skipped !== prevSkipped) {
+    logLine(
+      yellow("⚠"),
+      `${bold(String(skipped))} item(s) skipped by the tracker`
+    );
+  }
+
   const prevRetryCount = prevSnapshot?.retryQueue.length ?? 0;
   if (snapshot.retryQueue.length > prevRetryCount) {
     const delta = snapshot.retryQueue.length - prevRetryCount;
@@ -469,6 +485,7 @@ function logTickResult(
     snapshot.summary.dispatched !== prevSnapshot?.summary.dispatched ||
     snapshot.summary.suppressed !== prevSnapshot?.summary.suppressed ||
     snapshot.summary.recovered !== prevSnapshot?.summary.recovered ||
+    (snapshot.summary.skipped ?? 0) !== (prevSnapshot?.summary.skipped ?? 0) ||
     snapshot.activeRuns.length !== (prevSnapshot?.activeRuns.length ?? 0) ||
     snapshot.retryQueue.length !== (prevSnapshot?.retryQueue.length ?? 0);
 

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -90,6 +90,7 @@ function renderLegacyStatus(
   const activeRunsStr = apply(`Active Runs  ${snapshot.summary.activeRuns}`);
   const suppressedStr = apply(`Suppressed   ${snapshot.summary.suppressed}`);
   const recoveredStr = apply(`Recovered    ${snapshot.summary.recovered}`);
+  const skippedStr = apply(`Skipped      ${snapshot.summary.skipped ?? 0}`);
 
   lines.push(
     `  ${dispatchedStr}${" ".repeat(Math.max(0, 20 - stripAnsi(dispatchedStr).length))}${activeRunsStr}`
@@ -97,6 +98,7 @@ function renderLegacyStatus(
   lines.push(
     `  ${suppressedStr}${" ".repeat(Math.max(0, 20 - stripAnsi(suppressedStr).length))}${recoveredStr}`
   );
+  lines.push(`  ${skippedStr}`);
   lines.push("");
 
   // Active runs table

--- a/packages/core/src/contracts/status-surface.ts
+++ b/packages/core/src/contracts/status-surface.ts
@@ -211,6 +211,7 @@ export type ProjectStatusSnapshot = {
     dispatched: number;
     suppressed: number;
     recovered: number;
+    skipped?: number;
     activeRuns: number;
   };
   activeRuns: Array<{

--- a/packages/core/src/contracts/tracker-adapter.ts
+++ b/packages/core/src/contracts/tracker-adapter.ts
@@ -99,6 +99,11 @@ export type TrackedIssue = {
 
 export type TrackedIssueList = TrackedIssue[] & {
   rateLimits?: Record<string, unknown> | null;
+  skippedItems?: Array<{
+    id: string;
+    identifier: string;
+    reason: string;
+  }>;
 };
 
 export type ProjectItemsCache = {

--- a/packages/core/src/observability/snapshot-builder.test.ts
+++ b/packages/core/src/observability/snapshot-builder.test.ts
@@ -338,7 +338,7 @@ describe("buildProjectSnapshot", () => {
     const input: SnapshotInput = {
       project: mockProject(),
       activeRuns: [],
-      summary: { dispatched: 5, suppressed: 2, recovered: 1 },
+      summary: { dispatched: 5, suppressed: 2, recovered: 1, skipped: 3 },
       lastTickAt: "2024-01-01T00:10:00Z",
       lastError: null,
     };
@@ -348,6 +348,7 @@ describe("buildProjectSnapshot", () => {
     expect(snapshot.summary.dispatched).toBe(5);
     expect(snapshot.summary.suppressed).toBe(2);
     expect(snapshot.summary.recovered).toBe(1);
+    expect(snapshot.summary.skipped).toBe(3);
   });
 
   it("surfaces the latest incomplete-turn dirty-workspace recovery", () => {

--- a/packages/core/src/observability/snapshot-builder.ts
+++ b/packages/core/src/observability/snapshot-builder.ts
@@ -22,6 +22,7 @@ export type SnapshotInput = {
     dispatched: number;
     suppressed: number;
     recovered: number;
+    skipped?: number;
   };
   lastTickAt: string;
   lastError: string | null;
@@ -67,6 +68,7 @@ export function buildProjectSnapshot(
       dispatched: summary.dispatched,
       suppressed: summary.suppressed,
       recovered: summary.recovered,
+      skipped: summary.skipped ?? 0,
       activeRuns: activeRuns.length,
     },
     activeRuns: activeRuns.map((run) => ({

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -762,6 +762,39 @@ describe("OrchestratorService", () => {
     );
   });
 
+  it("dispatches ready issues when a tracker item is skipped", async () => {
+    process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
+    const tempRoot = await mkdtemp(join(tmpdir(), "orchestrator-skipped-item-"));
+    const repository = await createRepositoryFixture(
+      tempRoot,
+      "acme",
+      "platform"
+    );
+    const store = new OrchestratorFsStore(tempRoot);
+    const projectConfig = createProjectConfig(tempRoot, repository);
+    await store.saveProjectConfig(projectConfig);
+    const stderr = { write: vi.fn() };
+    const service = new OrchestratorService(store, projectConfig, {
+      fetchImpl: vi.fn().mockResolvedValue(
+        createTrackerResponseWithItems(repository, [
+          { id: "issue-missing", identifier: "acme/platform#2", state: "" },
+          { id: "issue-ready", identifier: "acme/platform#1", state: "Todo" },
+        ])
+      ),
+      spawnImpl: vi.fn().mockReturnValue({ pid: 4103, unref: vi.fn() }) as never,
+      stderr: stderr as never,
+      now: () => new Date("2026-03-08T00:00:00.000Z"),
+    });
+
+    const snapshot = await service.runOnce();
+
+    expect(snapshot.health).not.toBe("degraded");
+    expect(snapshot.summary).toMatchObject({ dispatched: 1, skipped: 1 });
+    expect(stderr.write).toHaveBeenCalledWith(
+      expect.stringContaining("acme/platform#2 (missing Status)")
+    );
+  });
+
   it("preserves dirty persisted issue workspaces when dispatching a retry", async () => {
     process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
     const tempRoot = await mkdtemp(

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -1078,6 +1078,7 @@ export class OrchestratorService {
     let dispatched = 0;
     let suppressed = 0;
     let recovered = 0;
+    let skipped = 0;
     let pollIntervalMs = DEFAULT_POLL_INTERVAL_MS;
     let rateLimits: Record<string, unknown> | null = null;
     let trackerRateLimits: Record<string, unknown> | null = null;
@@ -1135,6 +1136,13 @@ export class OrchestratorService {
         tenant,
         candidateTrackerDependencies
       );
+      const skippedItems = (issues as TrackedIssueList).skippedItems ?? [];
+      skipped = skippedItems.length;
+      if (skippedItems.length > 0) {
+        this.writeStderr(
+          `[orchestrator] skipped ${skippedItems.length} item(s) for ${tenant.projectId}: ${[...new Set(skippedItems.map((item) => item.identifier))].join(", ")} (${[...new Set(skippedItems.map((item) => item.reason))].join(", ")})`
+        );
+      }
       const canonicalIssues = resolveCanonicalSubjectIssues(issues);
       // `canonicalIssues`로 맵을 무조건 시딩하므로 기존 두 번째 역순 머지
       // 루프는 불필요하다. 시딩이 조건부가 되면 우선순위를 다시 검토해야 한다.
@@ -1712,7 +1720,7 @@ export class OrchestratorService {
       project: tenant,
       activeRuns: latestRuns,
       allRuns: allTenantRuns,
-      summary: { dispatched, suppressed, recovered },
+      summary: { dispatched, suppressed, recovered, skipped },
       lastTickAt: now.toISOString(),
       lastError,
       rateLimits,

--- a/packages/tracker-github/src/adapter.ts
+++ b/packages/tracker-github/src/adapter.ts
@@ -304,7 +304,14 @@ type GraphQLExactProjectItemNode = {
   __typename: "ProjectV2Item";
   id: string;
   project: { id: string } | null;
-  content: { id: string } | null;
+  content: {
+    id: string;
+    number: number;
+    repository: {
+      name: string;
+      owner: { login: string };
+    };
+  } | null;
   fieldValueByName: GraphQLFieldValue | null;
 };
 
@@ -408,9 +415,24 @@ export function normalizeProjectItem(
 
   const fieldValues = extractFieldValues(item.fieldValues?.nodes ?? []);
   const isArchived = item.isArchived === true;
+  const issueIdentifier = projectItemIssueIdentifier(item);
+  const stateFieldName = lifecycle.stateFieldName?.trim() ?? "";
+  if (!stateFieldName && !isArchived) {
+    throw new GitHubTrackerQueryError(
+      `github_project_state_field_unconfigured: Project item ${item.id} cannot be normalized without lifecycle.stateFieldName.`
+    );
+  }
+  if (getMissingStateSkippedItem(item, lifecycle)) {
+    emitProjectItemStatusMissingEvent({
+      projectId,
+      itemId: item.id,
+      issueIdentifier,
+    });
+    return null;
+  }
   const state = isArchived
     ? ARCHIVED_PROJECT_ITEM_STATE
-    : requireProjectItemState(fieldValues, lifecycle, item.id);
+    : requireProjectItemState(fieldValues, lifecycle, item.id, issueIdentifier);
 
   if (item.content.__typename === "PullRequest") {
     return normalizePullRequestProjectItem(
@@ -561,6 +583,7 @@ export async function fetchProjectIssues(
   let excludedCount = 0;
   let repositoryExcludedCount = 0;
   let latestRateLimits: GitHubRateLimitPayload | null = null;
+  const skippedItems: NonNullable<TrackedIssueList["skippedItems"]> = [];
 
   do {
     const pageResult = await fetchProjectItemsPage(
@@ -613,6 +636,13 @@ export async function fetchProjectIssues(
         latestRateLimits
       );
       if (!normalized) {
+        const skippedItem = getMissingStateSkippedItem(
+          item,
+          config.lifecycle ?? DEFAULT_WORKFLOW_LIFECYCLE
+        );
+        if (skippedItem) {
+          skippedItems.push(skippedItem);
+        }
         return [];
       }
 
@@ -656,6 +686,7 @@ export async function fetchProjectIssues(
     cycleConfig.rateLimitCollector
   );
   (issues as TrackedIssueList).rateLimits = latestRateLimits;
+  (issues as TrackedIssueList).skippedItems = skippedItems;
 
   return issues as GitHubTrackedIssue[] & TrackedIssueList;
 }
@@ -1080,7 +1111,8 @@ async function readExactProjectItemState(
     state: requireProjectItemState(
       extractFieldValues([exactNode.fieldValueByName]),
       config.lifecycle ?? DEFAULT_WORKFLOW_LIFECYCLE,
-      input.itemId
+      input.itemId,
+      exactProjectItemIssueIdentifier(exactNode.content)
     ),
     rateLimits: result.rateLimits,
   };
@@ -2037,7 +2069,8 @@ function extractFieldValues(
 function requireProjectItemState(
   fieldValues: Record<string, string>,
   lifecycle: WorkflowLifecycleConfig,
-  itemId: string
+  itemId: string,
+  issueIdentifier?: string
 ): string {
   const stateFieldName =
     typeof lifecycle.stateFieldName === "string"
@@ -2052,11 +2085,74 @@ function requireProjectItemState(
   const state = fieldValues[stateFieldName];
   if (!state) {
     throw new GitHubTrackerQueryError(
-      `github_project_state_field_missing: Project item ${itemId} did not include configured state field "${stateFieldName}".`
+      `github_project_state_field_missing: Project item ${itemId} did not include configured state field "${stateFieldName}".` +
+        (issueIdentifier ? ` Issue: ${issueIdentifier}.` : "")
     );
   }
 
   return state;
+}
+
+function hasProjectItemState(
+  fieldValues: Record<string, string>,
+  lifecycle: WorkflowLifecycleConfig
+): boolean {
+  const stateFieldName = lifecycle.stateFieldName?.trim() ?? "";
+  return Boolean(stateFieldName && fieldValues[stateFieldName]);
+}
+
+function getMissingStateSkippedItem(
+  item: GraphQLProjectItem,
+  lifecycle: WorkflowLifecycleConfig
+): NonNullable<TrackedIssueList["skippedItems"]>[number] | null {
+  if (
+    item.isArchived === true ||
+    (item.content?.__typename !== "Issue" &&
+      item.content?.__typename !== "PullRequest")
+  ) {
+    return null;
+  }
+
+  const fieldValues = extractFieldValues(item.fieldValues?.nodes ?? []);
+  if (hasProjectItemState(fieldValues, lifecycle)) {
+    return null;
+  }
+
+  return {
+    id: item.id,
+    identifier: projectItemIssueIdentifier(item),
+    reason: `missing ${lifecycle.stateFieldName?.trim() || "configured state"}`,
+  };
+}
+
+function projectItemIssueIdentifier(item: GraphQLProjectItem): string {
+  const content = item.content;
+  if (!content) {
+    return item.id;
+  }
+
+  const repository = content.repository;
+  return `${repository.owner.login}/${repository.name}#${content.number}`;
+}
+
+function emitProjectItemStatusMissingEvent(input: {
+  projectId: string;
+  itemId: string;
+  issueIdentifier: string;
+}): void {
+  console.warn(
+    JSON.stringify({ event: "tracker-project-item-status-missing", ...input })
+  );
+}
+
+function exactProjectItemIssueIdentifier(
+  content: GraphQLExactProjectItemNode["content"]
+): string | undefined {
+  if (!content?.repository?.owner?.login || !content.repository.name) {
+    return undefined;
+  }
+
+  return `${content.repository.owner.login}/${content.repository.name}#${content.number}`;
 }
 
 function normalizeIssueStateLookupNode(
@@ -2075,11 +2171,16 @@ function normalizeIssueStateLookupNode(
 
   const fieldValues = extractFieldValues(projectItem.fieldValues?.nodes ?? []);
   const isArchived = projectItem.isArchived === true;
-  const state = isArchived
-    ? ARCHIVED_PROJECT_ITEM_STATE
-    : requireProjectItemState(fieldValues, lifecycle, projectItem.id);
   const repository = issue.repository;
   const identifier = `${repository.owner.login}/${repository.name}#${issue.number}`;
+  const state = isArchived
+    ? ARCHIVED_PROJECT_ITEM_STATE
+    : requireProjectItemState(
+        fieldValues,
+        lifecycle,
+        projectItem.id,
+        identifier
+      );
   const url =
     issue.url ??
     `${repository.url}/${issue.__typename === "PullRequest" ? "pull" : "issues"}/${issue.number}`;
@@ -3020,9 +3121,23 @@ const EXACT_PROJECT_ITEM_STATE_QUERY = `
         content {
           ... on Issue {
             id
+            number
+            repository {
+              name
+              owner {
+                login
+              }
+            }
           }
           ... on PullRequest {
             id
+            number
+            repository {
+              name
+              owner {
+                login
+              }
+            }
           }
         }
         fieldValueByName(name: $stateFieldName) {

--- a/packages/tracker-github/src/tracker-github.test.ts
+++ b/packages/tracker-github/src/tracker-github.test.ts
@@ -391,7 +391,7 @@ describe("resolveTrackerAdapter", () => {
     expect(issue?.metadata).toEqual({ Status: "Ready" });
   });
 
-  it("fails loudly when a Project item omits the configured state field", () => {
+  it("skips and emits an event when a Project item omits the configured state field", () => {
     const item = makeProjectItem({
       itemId: "item-missing-state",
       issueId: "issue-1",
@@ -401,15 +401,76 @@ describe("resolveTrackerAdapter", () => {
     });
     item.fieldValues = { nodes: [] };
 
-    expect(() =>
-      normalizeGithubProjectItem(
-        "project-123",
-        item,
-        DEFAULT_WORKFLOW_LIFECYCLE
-      )
-    ).toThrow(
-      'github_project_state_field_missing: Project item item-missing-state did not include configured state field "Status".'
-    );
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    try {
+      expect(
+        normalizeGithubProjectItem(
+          "project-123",
+          item,
+          DEFAULT_WORKFLOW_LIFECYCLE
+        )
+      ).toBeNull();
+      expect(warn).toHaveBeenCalledWith(
+        JSON.stringify({
+          event: "tracker-project-item-status-missing",
+          projectId: "project-123",
+          itemId: "item-missing-state",
+          issueIdentifier: "acme/platform#1",
+        })
+      );
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("continues listing other items when one Project item omits Status", async () => {
+    const missing = makeProjectItem({
+      itemId: "item-missing-state",
+      issueId: "issue-missing-state",
+      number: 1,
+      title: "Missing state metadata",
+      assignees: [],
+    });
+    missing.fieldValues = { nodes: [] };
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    try {
+      const adapter = resolveTrackerAdapter({
+        adapter: "github-project",
+        bindingId: "project-123",
+        settings: { projectId: "project-123" },
+      });
+      const issues = await adapter.listIssues(makeProjectConfig(), {
+        token: "dependencies-token",
+        fetchImpl: async () =>
+          makeJsonResponse(
+            makeProjectItemsPayload([
+              missing,
+              makeProjectItem({
+                itemId: "item-ready",
+                issueId: "issue-ready",
+                number: 2,
+                title: "Ready issue",
+                assignees: [],
+                state: "Ready",
+              }),
+            ])
+          ),
+      });
+
+      expect(issues.map((issue) => issue.identifier)).toEqual([
+        "acme/platform#2",
+      ]);
+      expect(issues.skippedItems).toEqual([
+        {
+          id: "item-missing-state",
+          identifier: "acme/platform#1",
+          reason: "missing Status",
+        },
+      ]);
+      expect(warn).toHaveBeenCalledTimes(1);
+    } finally {
+      warn.mockRestore();
+    }
   });
 
   it("fails loudly when lifecycle.stateFieldName is empty", () => {
@@ -428,6 +489,23 @@ describe("resolveTrackerAdapter", () => {
     ).toThrow(
       "github_project_state_field_unconfigured: Project item item-unconfigured-state cannot be normalized without lifecycle.stateFieldName."
     );
+  });
+
+  it("normalizes archived items when lifecycle.stateFieldName is empty", () => {
+    const issue = normalizeGithubProjectItem(
+      "project-123",
+      makeProjectItem({
+        itemId: "item-archived-unconfigured-state",
+        issueId: "issue-1",
+        number: 1,
+        title: "Archived unconfigured state metadata",
+        assignees: [],
+        isArchived: true,
+      }),
+      { ...DEFAULT_WORKFLOW_LIFECYCLE, stateFieldName: "" }
+    );
+
+    expect(issue?.state).toBe("Archived");
   });
 
   it("normalizes PullRequest Project item content instead of dropping it", () => {
@@ -4761,7 +4839,7 @@ describe("resolveTrackerAdapter", () => {
           }),
       })
     ).rejects.toThrow(
-      'github_project_state_field_missing: Project item item-missing-state did not include configured state field "Status".'
+      'github_project_state_field_missing: Project item item-missing-state did not include configured state field "Status". Issue: acme/platform#1.'
     );
   });
 

--- a/packages/tracker-github/src/tracker-state.test.ts
+++ b/packages/tracker-github/src/tracker-state.test.ts
@@ -497,6 +497,41 @@ describe("requestGithubProjectItemState", () => {
       )
     ).rejects.toThrow("tracker_item_authorization_mismatch");
   });
+
+  it("identifies the issue when strict exact-item state readback is missing Status", async () => {
+    const fetchImpl = vi.fn(async () =>
+      jsonResponse({
+        data: {
+          rateLimit: rateLimit(),
+          node: {
+            __typename: "ProjectV2Item",
+            id: "item-1",
+            project: { id: "project-1" },
+            content: {
+              id: "issue-1",
+              number: 1,
+              repository: { name: "platform", owner: { login: "acme" } },
+            },
+            fieldValues: { nodes: [] },
+          },
+        },
+      })
+    ) as typeof fetch;
+
+    await expect(
+      requestGithubProjectItemState(
+        config,
+        {
+          issueSubjectId: "issue-1",
+          itemId: "item-1",
+          request: { type: "state-read" },
+        },
+        fetchImpl
+      )
+    ).rejects.toThrow(
+      'github_project_state_field_missing: Project item item-1 did not include configured state field "Status". Issue: acme/platform#1.'
+    );
+  });
 });
 
 function graphqlResponse(
@@ -514,7 +549,11 @@ function graphqlResponse(
           __typename: "ProjectV2Item",
           id: itemId,
           project: { id: "project-1" },
-          content: { id: issueId },
+          content: {
+            id: issueId,
+            number: Number(itemId.replace("item-", "")),
+            repository: { name: "platform", owner: { login: "acme" } },
+          },
           fieldValueByName: statusFieldValue(states.get(itemId) ?? "unknown"),
         },
       },


### PR DESCRIPTION
## TL;DR

- GitHub Project items missing the configured Status are skipped instead of aborting the whole listing.
- Archived items retain their existing `Archived` normalization even when `lifecycle.stateFieldName` is unconfigured.
- Other Ready issues still dispatch; the tick, status snapshot, and CLI expose the skipped-item gauge.

## 변경 지점 다이어그램

`GitHub Project item` → `tracker-github` (skip + structured event / archived fallback) → tracker-neutral `skippedItems` → `orchestrator` (warning + summary) → `repo status` / `repo start`

## 여기부터 보세요

- `packages/tracker-github/src/adapter.ts`: tolerant listing, strict identifier-enriched exact reads, and archived-item state fallback.
- `packages/tracker-github/src/tracker-github.test.ts`: regression coverage for archived cards with an unconfigured state field.
- `packages/orchestrator/src/service.test.ts`: Status-less card alongside a dispatchable Ready issue.
- `packages/cli/src/commands/start.ts`: initial/current skipped gauge output.

## 위험 & 롤백

- Status-less non-archived cards remain intentionally non-dispatchable, but no longer degrade unrelated dispatch.
- The archived fallback preserves pre-existing behavior; reverting the PR restores the previous outage-prone listing behavior.

## 변경 파일

- GitHub tracker adapter and regression tests
- Core tracker contract
- Orchestrator service and tests
- CLI start warning/test
- CLI patch changeset

## Evidence

- `pnpm --filter @gh-symphony/tracker-github test -- --run src/tracker-github.test.ts` — pass (86 tests).
- `pnpm lint && pnpm test && pnpm typecheck && pnpm build` — pass.
- Docker E2E: `docker compose -f docker-compose.e2e.yml -f docker-compose.e2e.events.yml up -d`; `/healthz` returned `{"ok":true}`; cleanup completed.
- GitHub CI on `d62d379`: `Test` and `Container Smoke` — pass.

## Issues — Closed #549

## 머지 후/사람 확인

- [ ] In a GitHub Project, leave one Issue card without Status and confirm other Ready issues still dispatch.
- [ ] Confirm the daemon warning and `gh-symphony repo status` show the skipped-item gauge.
