### PR TITLE
feat(orchestrator): validate issue state transitions

### DIFF
--- a/.changeset/quiet-orchestration-transitions.md
+++ b/.changeset/quiet-orchestration-transitions.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Validate issue orchestration lifecycle transitions to expose invalid runtime state changes immediately (#553).

--- a/packages/core/src/contracts/issue-orchestration.test.ts
+++ b/packages/core/src/contracts/issue-orchestration.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import {
+  assertIssueOrchestrationTransition,
+  ISSUE_ORCHESTRATION_INITIAL_STATES,
+  ISSUE_ORCHESTRATION_TRANSITIONS,
+  type IssueOrchestrationState,
+} from "./issue-orchestration.js";
+
+describe("issue orchestration transitions", () => {
+  it("accepts every declared transition", () => {
+    for (const [from, targets] of Object.entries(
+      ISSUE_ORCHESTRATION_TRANSITIONS
+    ) as [IssueOrchestrationState, readonly IssueOrchestrationState[]][]) {
+      for (const to of targets) {
+        expect(() =>
+          assertIssueOrchestrationTransition(from, to)
+        ).not.toThrow();
+      }
+    }
+  });
+
+  it.each<[IssueOrchestrationState, IssueOrchestrationState]>([
+    ["unclaimed", "released"],
+    ["claimed", "retry_queued"],
+    ["running", "claimed"],
+    ["retry_queued", "claimed"],
+    ["released", "running"],
+  ])("rejects invalid transition %s -> %s", (from, to) => {
+    expect(() => assertIssueOrchestrationTransition(from, to)).toThrow(
+      `Invalid issue orchestration transition: ${from} -> ${to}`
+    );
+  });
+
+  it.each(ISSUE_ORCHESTRATION_INITIAL_STATES)(
+    "accepts %s when establishing a record",
+    (to) => {
+      expect(() => assertIssueOrchestrationTransition(null, to)).not.toThrow();
+    }
+  );
+
+  it("rejects an invalid initial state", () => {
+    expect(() => assertIssueOrchestrationTransition(null, "released")).toThrow(
+      "Invalid initial issue orchestration state: released"
+    );
+  });
+
+  it("reports an unknown persisted state explicitly", () => {
+    expect(() =>
+      assertIssueOrchestrationTransition(
+        "unknown" as IssueOrchestrationState,
+        "running"
+      )
+    ).toThrow("Unknown issue orchestration state: unknown");
+  });
+});

--- a/packages/core/src/contracts/issue-orchestration.ts
+++ b/packages/core/src/contracts/issue-orchestration.ts
@@ -9,6 +9,49 @@ export const ISSUE_ORCHESTRATION_STATES = [
 export type IssueOrchestrationState =
   (typeof ISSUE_ORCHESTRATION_STATES)[number];
 
+/** States that may establish a newly persisted coordination record. */
+export const ISSUE_ORCHESTRATION_INITIAL_STATES: readonly IssueOrchestrationState[] =
+  ["claimed", "running", "retry_queued"];
+
+/**
+ * Legal lifecycle changes for an orchestrator's per-issue coordination record.
+ *
+ * Self-transitions are deliberate: reconciliation may refresh a record's
+ * metadata while retaining its lifecycle state.
+ */
+export const ISSUE_ORCHESTRATION_TRANSITIONS: Record<
+  IssueOrchestrationState,
+  readonly IssueOrchestrationState[]
+> = {
+  // No orchestrator code writes this; it can appear in legacy or externally
+  // authored records and is retained for Record completeness and display-only use.
+  unclaimed: ["unclaimed", "claimed"],
+  claimed: ["claimed", "running", "released"],
+  running: ["running", "retry_queued", "released"],
+  retry_queued: ["retry_queued", "running", "released"],
+  released: ["released", "claimed"],
+};
+
+/** Throws when a coordination record attempts an invalid lifecycle change. */
+export function assertIssueOrchestrationTransition(
+  from: IssueOrchestrationState | null,
+  to: IssueOrchestrationState
+): void {
+  if (from === null) {
+    if (!ISSUE_ORCHESTRATION_INITIAL_STATES.includes(to)) {
+      throw new Error(`Invalid initial issue orchestration state: ${to}`);
+    }
+    return;
+  }
+
+  const allowed = ISSUE_ORCHESTRATION_TRANSITIONS[from];
+  if (!allowed) {
+    throw new Error(`Unknown issue orchestration state: ${from}`);
+  }
+  if (!allowed.includes(to)) {
+    throw new Error(`Invalid issue orchestration transition: ${from} -> ${to}`);
+  }
+}
 export type IssueRetryEntry = {
   attempt: number;
   dueAt: string;

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -4153,19 +4153,7 @@ Prefer focused changes.
     const store = new OrchestratorFsStore(tempRoot);
     const projectConfig = createProjectConfig(tempRoot, repository);
     await store.saveProjectConfig(projectConfig);
-    const issueRecords: IssueOrchestrationRecord[] = [
-      {
-        issueId: "issue-1",
-        identifier: "acme/platform#1",
-        workspaceKey: "acme_platform_1",
-        completedOnce: false,
-        failureRetryCount: 0,
-        state: "running",
-        currentRunId: null,
-        retryEntry: null,
-        updatedAt: "2026-03-08T00:00:00.000Z",
-      },
-    ];
+    const issueRecords: IssueOrchestrationRecord[] = [];
     await store.saveProjectIssueOrchestrations("tenant-1", issueRecords);
     const baseRun = {
       projectId: "tenant-1",
@@ -4240,6 +4228,7 @@ Prefer focused changes.
       [deadRun, liveRun],
       new Date("2026-03-08T00:01:00.000Z")
     );
+    expect(selectedRecords[0]?.state).toBe("running");
     expect(selectedRecords[0]?.currentRunId).toBe("run-z-live");
     expect(
       (await store.loadProjectIssueOrchestrations("tenant-1"))[0]?.currentRunId

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -9,6 +9,7 @@ import {
   DEFAULT_MAX_FAILURE_RETRIES,
   DEFAULT_WORKFLOW_LIFECYCLE,
   TrackerRateLimitError,
+  assertIssueOrchestrationTransition,
   attributeDirtyWorkToIssue,
   buildHookEnv,
   buildIssueIdentityHeader,
@@ -5044,19 +5045,22 @@ function upsertIssueOrchestration(
   const existingRecord =
     issueRecords.find((record) => record.issueId === nextRecord.issueId) ??
     null;
-  const remaining = issueRecords.filter(
-    (record) => record.issueId !== nextRecord.issueId
+  assertIssueOrchestrationTransition(
+    existingRecord?.state ?? null,
+    nextRecord.state
   );
-  return [
-    ...remaining,
-    {
-      ...nextRecord,
-      completedOnce:
-        nextRecord.completedOnce ?? existingRecord?.completedOnce ?? false,
-      failureRetryCount:
-        nextRecord.failureRetryCount ?? existingRecord?.failureRetryCount ?? 0,
-    },
-  ];
+  const record = {
+    ...nextRecord,
+    completedOnce:
+      nextRecord.completedOnce ?? existingRecord?.completedOnce ?? false,
+    failureRetryCount:
+      nextRecord.failureRetryCount ?? existingRecord?.failureRetryCount ?? 0,
+  };
+  return existingRecord
+    ? issueRecords.map((candidate) =>
+        candidate.issueId === nextRecord.issueId ? record : candidate
+      )
+    : [...issueRecords, record];
 }
 
 function releaseIssueOrchestration(
@@ -5064,17 +5068,19 @@ function releaseIssueOrchestration(
   issueId: string,
   now: Date
 ): IssueOrchestrationRecord[] {
-  return issueRecords.map((record) =>
-    record.issueId === issueId
-      ? {
-          ...record,
-          state: "released",
-          currentRunId: null,
-          retryEntry: null,
-          updatedAt: now.toISOString(),
-        }
-      : record
+  const record = issueRecords.find(
+    (candidate) => candidate.issueId === issueId
   );
+  if (!record) {
+    return issueRecords;
+  }
+  return upsertIssueOrchestration(issueRecords, {
+    ...record,
+    state: "released",
+    currentRunId: null,
+    retryEntry: null,
+    updatedAt: now.toISOString(),
+  });
 }
 
 function isArchivedProjectItem(issue: TrackedIssue): boolean {


### PR DESCRIPTION
## TL;DR

- IssueOrchestrationState의 허용 전이와 신규 record 생성 상태를 core 계약으로 명시하고, 잘못된 전이는 즉시 진단 가능한 오류로 노출합니다.
- orchestrator의 모든 record 갱신을 단일 관문으로 수렴해 기존 정상 dispatch·retry·release·recovery 동작을 보존합니다.
- Cycle 16에서 전체 품질 게이트와 Docker E2E를 다시 통과했습니다.

## 변경 지점 다이어그램

```text
service state update / recovery adoption
              │
              ▼
upsertIssueOrchestration ──► assertIssueOrchestrationTransition
              │                         │
              ▼                         ▼
       persisted issue record     core transition table
```

## 여기부터 보세요

- `packages/core/src/contracts/issue-orchestration.ts`: 전이 표, 생성 상태 집합, 진단 가능한 assertion
- `packages/orchestrator/src/service.ts`: 단일 갱신 관문과 release 경로
- `packages/core/src/contracts/issue-orchestration.test.ts`: 전체 허용 전이와 상태별 비허용 전이 TC
- `packages/orchestrator/src/service.test.ts`: record 없는 live run adoption 회귀 TC

## 위험 & 롤백

- 허용되지 않은 상태 변경은 이제 즉시 throw합니다. 이는 코딩 오류를 빠르게 드러내기 위한 의도된 동작입니다.
- 롤백은 이 PR의 squash revert로 이전 갱신 동작을 복원할 수 있습니다.

## 변경 파일

- `.changeset/quiet-orchestration-transitions.md`
- `packages/core/src/contracts/issue-orchestration.ts`
- `packages/core/src/contracts/issue-orchestration.test.ts`
- `packages/orchestrator/src/service.ts`
- `packages/orchestrator/src/service.test.ts`

## Issues

- Closed #553

## 검증

- `pnpm --filter @gh-symphony/core test -- issue-orchestration.test.ts` — pass (11 TC)
- `pnpm --filter @gh-symphony/orchestrator test -- service.test.ts` — pass
- `pnpm lint` — pass
- `pnpm test` — pass
- `pnpm typecheck` — pass
- `pnpm build` — pass
- Docker E2E (`docker compose -f docker-compose.e2e.yml -f docker-compose.e2e.events.yml up -d --build`) — pass; happy worker `starting` → `running` → `completed`, continuation recovery 동작 확인

## 머지 후/사람 확인

- [ ] recovery adoption이 record 없는 live run을 `running`으로 정상 생성하는지 확인
- [ ] 허용되지 않은 상태 변경이 명시적인 전이 오류로 표면화되는지 확인
