### PR TITLE
fix(orchestrator): decouple tracker-state I/O

### DIFF
--- a/.changeset/quiet-trains-switch.md
+++ b/.changeset/quiet-trains-switch.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Keep tracker-state transitions from blocking reconciliation while GitHub provider I/O waits for rate limits, and apply the transition queue backpressure limit per GitHub token (#504).

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -689,6 +689,274 @@ describe("OrchestratorService", () => {
     expect(requestState).not.toHaveBeenCalled();
   });
 
+  it("continues polling while a tracker transition comment waits on provider I/O", async () => {
+    const tempRoot = await mkdtemp(
+      join(tmpdir(), "orchestrator-tracker-state-concurrent-")
+    );
+    const store = new OrchestratorFsStore(tempRoot);
+    const repository = {
+      owner: "acme",
+      name: "platform",
+      cloneUrl: "https://github.com/acme/platform.git",
+    };
+    const projectConfig = createProjectConfig(tempRoot, repository);
+    await store.saveProjectConfig(projectConfig);
+    await store.saveProjectIssueOrchestrations(projectConfig.projectId, [
+      {
+        issueId: "issue-1",
+        identifier: "acme/platform#1",
+        workspaceKey: "issue-1",
+        completedOnce: false,
+        failureRetryCount: 0,
+        state: "running",
+        currentRunId: "run-1",
+        retryEntry: null,
+        updatedAt: "2026-07-30T13:00:00.000Z",
+      },
+    ]);
+    await store.saveRun({
+      runId: "run-1",
+      projectId: projectConfig.projectId,
+      projectSlug: projectConfig.slug,
+      issueId: "issue-1",
+      issueSubjectId: "issue-1",
+      trackerItemId: "item-1",
+      issueIdentifier: "acme/platform#1",
+      issueState: "In progress",
+      repository,
+      status: "running",
+      attempt: 1,
+      processId: null,
+      port: null,
+      workingDirectory: tempRoot,
+      issueWorkspaceKey: "issue-1",
+      workspaceRuntimeDir: join(tempRoot, "runtime"),
+      workflowPath: null,
+      retryKind: null,
+      createdAt: "2026-07-30T13:00:00.000Z",
+      updatedAt: "2026-07-30T13:00:00.000Z",
+      startedAt: "2026-07-30T13:00:00.000Z",
+      completedAt: null,
+      lastError: null,
+      nextRetryAt: null,
+    });
+    let releaseComment!: () => void;
+    const commentWait = new Promise<void>((resolve) => {
+      releaseComment = resolve;
+    });
+    const requestState = vi.fn().mockResolvedValue({
+      ok: true,
+      outcome: "confirmed" as const,
+      state: "In review",
+      expectedState: "In progress",
+      targetState: "In review",
+      reason: "handoff",
+      rateLimits: null,
+      error: null,
+    });
+    const upsertTransitionComment = vi.fn(async () => {
+      await commentWait;
+      return { outcome: "created" as const, rateLimits: null };
+    });
+    const listIssues = vi
+      .fn()
+      .mockResolvedValue(Object.assign([], { rateLimits: null }));
+    vi.spyOn(trackerAdapters, "resolveTrackerAdapter").mockReturnValue({
+      listIssues,
+      listIssuesByStates: vi.fn(),
+      fetchIssueStatesByIds: vi.fn(),
+      buildWorkerEnvironment: vi.fn(),
+      reviveIssue: vi.fn(),
+      requestState,
+      upsertTransitionComment,
+    });
+    const service = new OrchestratorService(store, projectConfig);
+
+    const transition = service.requestTrackerState({
+      runId: "run-1",
+      request: {
+        type: "transition-request",
+        expectedState: "In progress",
+        targetState: "In review",
+        reason: "handoff",
+        commentBody: "agent-authored transition body",
+      },
+    });
+    await vi.waitFor(() =>
+      expect(upsertTransitionComment).toHaveBeenCalledOnce()
+    );
+
+    await expect(service.runOnce()).resolves.toMatchObject({
+      summary: expect.objectContaining({ dispatched: 0 }),
+    });
+    expect(listIssues).toHaveBeenCalled();
+    await expect(
+      store.loadRun("run-1", projectConfig.projectId)
+    ).resolves.toMatchObject({
+      status: "retrying",
+      processId: null,
+    });
+
+    releaseComment();
+    await expect(transition).resolves.toMatchObject({
+      ok: true,
+      outcome: "confirmed",
+    });
+    await expect(
+      store.loadRun("run-1", projectConfig.projectId)
+    ).resolves.toMatchObject({
+      status: "retrying",
+      processId: null,
+    });
+  });
+
+  it("continues polling while a tracker transition waits on provider I/O", async () => {
+    const tempRoot = await mkdtemp(
+      join(tmpdir(), "orchestrator-tracker-state-request-concurrent-")
+    );
+    const store = new OrchestratorFsStore(tempRoot);
+    const repository = {
+      owner: "acme",
+      name: "platform",
+      cloneUrl: "https://github.com/acme/platform.git",
+    };
+    const projectConfig = createProjectConfig(tempRoot, repository);
+    await store.saveProjectConfig(projectConfig);
+    await store.saveProjectIssueOrchestrations(projectConfig.projectId, [
+      {
+        issueId: "issue-1",
+        identifier: "acme/platform#1",
+        workspaceKey: "issue-1",
+        completedOnce: false,
+        failureRetryCount: 0,
+        state: "running",
+        currentRunId: "run-1",
+        retryEntry: null,
+        updatedAt: "2026-07-30T13:00:00.000Z",
+      },
+    ]);
+    await store.saveRun({
+      runId: "run-1",
+      projectId: projectConfig.projectId,
+      projectSlug: projectConfig.slug,
+      issueId: "issue-1",
+      issueSubjectId: "issue-1",
+      trackerItemId: "item-1",
+      issueIdentifier: "acme/platform#1",
+      issueState: "In progress",
+      repository,
+      status: "running",
+      attempt: 1,
+      processId: null,
+      port: null,
+      workingDirectory: tempRoot,
+      issueWorkspaceKey: "issue-1",
+      workspaceRuntimeDir: join(tempRoot, "runtime"),
+      workflowPath: null,
+      retryKind: null,
+      createdAt: "2026-07-30T13:00:00.000Z",
+      updatedAt: "2026-07-30T13:00:00.000Z",
+      startedAt: "2026-07-30T13:00:00.000Z",
+      completedAt: null,
+      lastError: null,
+      nextRetryAt: null,
+    });
+    let releaseProvider!: () => void;
+    const providerWait = new Promise<void>((resolve) => {
+      releaseProvider = resolve;
+    });
+    const requestState = vi.fn(async () => {
+      await providerWait;
+      return {
+        ok: true,
+        outcome: "confirmed" as const,
+        state: "In review",
+        expectedState: "In progress",
+        targetState: "In review",
+        reason: "handoff",
+        rateLimits: null,
+        error: null,
+      };
+    });
+    const listIssues = vi
+      .fn()
+      .mockResolvedValue(Object.assign([], { rateLimits: null }));
+    vi.spyOn(trackerAdapters, "resolveTrackerAdapter").mockReturnValue({
+      listIssues,
+      listIssuesByStates: vi.fn(),
+      fetchIssueStatesByIds: vi.fn(),
+      buildWorkerEnvironment: vi.fn(),
+      reviveIssue: vi.fn(),
+      requestState,
+    });
+    const service = new OrchestratorService(store, projectConfig);
+
+    const transition = service.requestTrackerState({
+      runId: "run-1",
+      request: {
+        type: "transition-request",
+        expectedState: "In progress",
+        targetState: "In review",
+        reason: "handoff",
+      },
+    });
+    await vi.waitFor(() => expect(requestState).toHaveBeenCalledOnce());
+
+    await expect(service.runOnce()).resolves.toMatchObject({
+      summary: expect.objectContaining({ dispatched: 0 }),
+    });
+    expect(listIssues).toHaveBeenCalled();
+    await expect(
+      store.loadRun("run-1", projectConfig.projectId)
+    ).resolves.toMatchObject({ status: "retrying", processId: null });
+
+    releaseProvider();
+    await expect(transition).resolves.toMatchObject({
+      ok: true,
+      outcome: "confirmed",
+    });
+    await expect(
+      store.loadRun("run-1", projectConfig.projectId)
+    ).resolves.toMatchObject({ status: "retrying", processId: null });
+  });
+
+  it("dispatches ready issues when a tracker item is skipped", async () => {
+    process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
+    const tempRoot = await mkdtemp(
+      join(tmpdir(), "orchestrator-skipped-item-")
+    );
+    const repository = await createRepositoryFixture(
+      tempRoot,
+      "acme",
+      "platform"
+    );
+    const store = new OrchestratorFsStore(tempRoot);
+    const projectConfig = createProjectConfig(tempRoot, repository);
+    await store.saveProjectConfig(projectConfig);
+    const stderr = { write: vi.fn() };
+    const service = new OrchestratorService(store, projectConfig, {
+      fetchImpl: vi.fn().mockResolvedValue(
+        createTrackerResponseWithItems(repository, [
+          { id: "issue-missing", identifier: "acme/platform#2", state: "" },
+          { id: "issue-ready", identifier: "acme/platform#1", state: "Todo" },
+        ])
+      ),
+      spawnImpl: vi
+        .fn()
+        .mockReturnValue({ pid: 4103, unref: vi.fn() }) as never,
+      stderr: stderr as never,
+      now: () => new Date("2026-03-08T00:00:00.000Z"),
+    });
+
+    const snapshot = await service.runOnce();
+
+    expect(snapshot.health).not.toBe("degraded");
+    expect(snapshot.summary).toMatchObject({ dispatched: 1, skipped: 1 });
+    expect(stderr.write).toHaveBeenCalledWith(
+      expect.stringContaining("acme/platform#2 (missing Status)")
+    );
+  });
+
   it("dispatches actionable issues and prevents duplicate issue leases", async () => {
     process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
     const tempRoot = await mkdtemp(join(tmpdir(), "orchestrator-test-"));
@@ -759,39 +1027,6 @@ describe("OrchestratorService", () => {
           WORKSPACE_RUNTIME_DIR: expect.stringMatching(/runs\/.+/),
         }),
       })
-    );
-  });
-
-  it("dispatches ready issues when a tracker item is skipped", async () => {
-    process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
-    const tempRoot = await mkdtemp(join(tmpdir(), "orchestrator-skipped-item-"));
-    const repository = await createRepositoryFixture(
-      tempRoot,
-      "acme",
-      "platform"
-    );
-    const store = new OrchestratorFsStore(tempRoot);
-    const projectConfig = createProjectConfig(tempRoot, repository);
-    await store.saveProjectConfig(projectConfig);
-    const stderr = { write: vi.fn() };
-    const service = new OrchestratorService(store, projectConfig, {
-      fetchImpl: vi.fn().mockResolvedValue(
-        createTrackerResponseWithItems(repository, [
-          { id: "issue-missing", identifier: "acme/platform#2", state: "" },
-          { id: "issue-ready", identifier: "acme/platform#1", state: "Todo" },
-        ])
-      ),
-      spawnImpl: vi.fn().mockReturnValue({ pid: 4103, unref: vi.fn() }) as never,
-      stderr: stderr as never,
-      now: () => new Date("2026-03-08T00:00:00.000Z"),
-    });
-
-    const snapshot = await service.runOnce();
-
-    expect(snapshot.health).not.toBe("degraded");
-    expect(snapshot.summary).toMatchObject({ dispatched: 1, skipped: 1 });
-    expect(stderr.write).toHaveBeenCalledWith(
-      expect.stringContaining("acme/platform#2 (missing Status)")
     );
   });
 
@@ -7243,9 +7478,16 @@ Prefer focused changes.
     });
 
     const killImpl = vi.fn();
-    const fetchImpl = vi
-      .fn()
-      .mockResolvedValue(createTrackerResponseWithState(repository, "Todo"));
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ...createTrackerResponseWithState(repository, "Todo"),
+      headers: new Headers({
+        "x-ratelimit-limit": "5000",
+        "x-ratelimit-remaining": "4998",
+        "x-ratelimit-used": "2",
+        "x-ratelimit-reset": "1773892920",
+        "x-ratelimit-resource": "graphql",
+      }),
+    });
     const service = new OrchestratorService(store, projectConfig, {
       fetchImpl: fetchImpl as typeof fetch,
       spawnImpl: vi.fn().mockReturnValue({
@@ -8910,16 +9152,9 @@ Prefer focused changes.
       },
     });
 
-    const fetchImpl = vi.fn().mockResolvedValue({
-      ...createTrackerResponseWithState(repository, "Todo"),
-      headers: new Headers({
-        "x-ratelimit-limit": "5000",
-        "x-ratelimit-remaining": "4998",
-        "x-ratelimit-used": "2",
-        "x-ratelimit-reset": "1773892920",
-        "x-ratelimit-resource": "graphql",
-      }),
-    });
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(createTrackerResponseWithState(repository, "Todo"));
     const service = new OrchestratorService(store, projectConfig, {
       fetchImpl: fetchImpl as typeof fetch,
       spawnImpl: vi.fn().mockReturnValue({

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -363,6 +363,9 @@ export class OrchestratorService {
   private sleepTimer: ReturnType<typeof setTimeout> | null = null;
   private sleepResolver: (() => void) | null = null;
   private reconcilePromise: Promise<void> = Promise.resolve();
+  // Provider calls can wait for GraphQL rate limits. Their ordering is kept
+  // separate from reconciliation so polling and dispatch are not blocked.
+  private trackerStatePromise: Promise<void> = Promise.resolve();
   private reconcileRequested = false;
   private workerOrchestratorUrl: string | null = null;
   private workerOrchestratorToken: string | null = null;
@@ -442,7 +445,7 @@ export class OrchestratorService {
     runId: string;
     request: TrackerStateRequest;
   }): Promise<TrackerStateResult> {
-    return this.runSerialized(async () => {
+    return this.runTrackerStateSerialized(async () => {
       const rejected = (error: string): TrackerStateResult => ({
         ok: false,
         outcome: "rejected",
@@ -462,44 +465,61 @@ export class OrchestratorService {
         rateLimits: null,
         error,
       });
-      const run = await this.store.loadRun(
-        input.runId,
-        this.projectConfig.projectId
-      );
-      if (!run) {
-        return rejected("run_not_found");
+      const authorization: {
+        run?: OrchestratorRunRecord;
+        trackerAdapter?: OrchestratorTrackerAdapter;
+        result?: TrackerStateResult;
+      } = await this.runSerialized(async () => {
+        const run = await this.store.loadRun(
+          input.runId,
+          this.projectConfig.projectId
+        );
+        if (!run) return { result: rejected("run_not_found") };
+
+        const issueRecords = await this.store.loadProjectIssueOrchestrations(
+          this.projectConfig.projectId
+        );
+        const issueRecord = issueRecords.find(
+          (candidate) => candidate.issueId === run.issueId
+        );
+        if (
+          !issueRecord ||
+          issueRecord.state !== "running" ||
+          issueRecord.currentRunId !== run.runId ||
+          !isActiveRunRecordStatus(run.status)
+        ) {
+          return { run, result: rejected("run_not_current") };
+        }
+        const invalidRequest = validateTrackerStateRequest(input.request);
+        if (invalidRequest) return { run, result: rejected(invalidRequest) };
+
+        const trackerAdapter = resolveTrackerAdapter(
+          this.projectConfig.tracker
+        );
+        if (!trackerAdapter.requestState) {
+          return {
+            run,
+            result: rejected("tracker_state_requests_unsupported"),
+          };
+        }
+        return { run, trackerAdapter };
+      });
+      if (authorization.result !== undefined) {
+        if (authorization.run) {
+          await this.runSerialized(() =>
+            this.appendTrackerStateEvent(
+              authorization.run!,
+              input.request,
+              authorization.result!
+            )
+          );
+        }
+        return authorization.result;
       }
 
-      const issueRecords = await this.store.loadProjectIssueOrchestrations(
-        this.projectConfig.projectId
-      );
-      const issueRecord = issueRecords.find(
-        (candidate) => candidate.issueId === run.issueId
-      );
-      if (
-        !issueRecord ||
-        issueRecord.state !== "running" ||
-        issueRecord.currentRunId !== run.runId ||
-        !isActiveRunRecordStatus(run.status)
-      ) {
-        const result = rejected("run_not_current");
-        await this.appendTrackerStateEvent(run, input.request, result);
-        return result;
-      }
-
-      const invalidRequest = validateTrackerStateRequest(input.request);
-      if (invalidRequest) {
-        const result = rejected(invalidRequest);
-        await this.appendTrackerStateEvent(run, input.request, result);
-        return result;
-      }
-
-      const trackerAdapter = resolveTrackerAdapter(this.projectConfig.tracker);
-      if (!trackerAdapter.requestState) {
-        const result = rejected("tracker_state_requests_unsupported");
-        await this.appendTrackerStateEvent(run, input.request, result);
-        return result;
-      }
+      const run = authorization.run!;
+      const trackerAdapter = authorization.trackerAdapter!;
+      const requestState = trackerAdapter.requestState!;
 
       let canonicalItemId = run.trackerItemId?.trim() ?? "";
       try {
@@ -514,12 +534,14 @@ export class OrchestratorService {
               .itemId ?? "";
           if (!canonicalItemId) {
             const result = rejected("canonical_tracker_item_missing");
-            await this.appendTrackerStateEvent(run, input.request, result);
+            await this.runSerialized(() =>
+              this.appendTrackerStateEvent(run, input.request, result)
+            );
             return result;
           }
         }
 
-        const result = await trackerAdapter.requestState(
+        const result = await requestState(
           this.projectConfig,
           {
             issueSubjectId: run.issueSubjectId,
@@ -528,27 +550,38 @@ export class OrchestratorService {
           },
           this.createTrackerDependencies()
         );
-        const nowIso = this.now().toISOString();
-        const persistedRun: OrchestratorRunRecord = {
-          ...run,
-          trackerItemId: canonicalItemId,
-          issueState: result.state ?? run.issueState,
-          updatedAt: nowIso,
-          lastEvent:
-            input.request.type === "transition-request"
-              ? "tracker-transition"
-              : "tracker-state-read",
-          lastEventAt: nowIso,
-          rateLimits: result.rateLimits ?? run.rateLimits ?? null,
-          lastError: result.ok
-            ? run.lastError
-            : (result.error ?? run.lastError),
-        };
-        await this.persistTrackerStateDiagnostics(
-          persistedRun,
-          input.request,
-          result
-        );
+        const persistedRun = await this.runSerialized(async () => {
+          // Reconciliation may have updated this run while the provider call
+          // waited for GitHub. Preserve that newer lifecycle state and merge
+          // only the diagnostics produced by this tracker-state request.
+          const latestRun =
+            (await this.store.loadRun(
+              run.runId,
+              this.projectConfig.projectId
+            )) ?? run;
+          const nowIso = this.now().toISOString();
+          const diagnosticRun: OrchestratorRunRecord = {
+            ...latestRun,
+            trackerItemId: canonicalItemId,
+            issueState: result.state ?? latestRun.issueState,
+            updatedAt: nowIso,
+            lastEvent:
+              input.request.type === "transition-request"
+                ? "tracker-transition"
+                : "tracker-state-read",
+            lastEventAt: nowIso,
+            rateLimits: result.rateLimits ?? latestRun.rateLimits ?? null,
+            lastError: result.ok
+              ? latestRun.lastError
+              : (result.error ?? latestRun.lastError),
+          };
+          await this.persistTrackerStateDiagnostics(
+            diagnosticRun,
+            input.request,
+            result
+          );
+          return diagnosticRun;
+        });
         const transitionCommentRateLimits =
           await this.publishConfirmedTransitionComment({
             run: persistedRun,
@@ -569,21 +602,25 @@ export class OrchestratorService {
           outcome: "failed",
           rateLimits,
         };
-        const nowIso = this.now().toISOString();
-        await this.store.saveRun({
-          ...run,
-          trackerItemId: canonicalItemId,
-          updatedAt: nowIso,
-          lastEvent: "tracker-transition-failed",
-          lastEventAt: nowIso,
-          rateLimits: rateLimits ?? run.rateLimits ?? null,
-          lastError: result.error,
+        await this.runSerialized(async () => {
+          const latestRun =
+            (await this.store.loadRun(
+              run.runId,
+              this.projectConfig.projectId
+            )) ?? run;
+          const nowIso = this.now().toISOString();
+          const failedRun: OrchestratorRunRecord = {
+            ...latestRun,
+            trackerItemId: canonicalItemId,
+            updatedAt: nowIso,
+            lastEvent: "tracker-transition-failed",
+            lastEventAt: nowIso,
+            rateLimits: rateLimits ?? latestRun.rateLimits ?? null,
+            lastError: result.error,
+          };
+          await this.store.saveRun(failedRun);
+          await this.appendTrackerStateEvent(failedRun, input.request, result);
         });
-        await this.appendTrackerStateEvent(
-          { ...run, trackerItemId: canonicalItemId },
-          input.request,
-          result
-        );
         return result;
       }
     });
@@ -649,6 +686,7 @@ export class OrchestratorService {
     ) {
       return null;
     }
+    const transitionRequest = input.request;
 
     let outcome: "created" | "unchanged" | "failed" = "failed";
     let error: string | null = null;
@@ -674,54 +712,63 @@ export class OrchestratorService {
       rateLimits = extractTrackerRateLimitsFromError(cause) ?? rateLimits;
     }
 
-    const nowIso = this.now().toISOString();
-    const diagnosticRun: OrchestratorRunRecord = {
-      ...input.run,
-      updatedAt: nowIso,
-      lastEvent:
-        error === null
-          ? "tracker-transition-comment"
-          : "tracker-transition-comment-failed",
-      lastEventAt: nowIso,
-      lastError:
-        error === null
-          ? input.run.lastError
-          : `tracker_transition_comment_failed: ${error}`,
-      transitionComment: {
-        status: outcome,
+    await this.runSerialized(async () => {
+      // Comment provider I/O is deliberately outside the reconcile lock.
+      // Reload inside the lock before persisting its diagnostics so a
+      // concurrent reconciliation lifecycle update cannot be overwritten.
+      const latestRun =
+        (await this.store.loadRun(
+          input.run.runId,
+          this.projectConfig.projectId
+        )) ?? input.run;
+      const nowIso = this.now().toISOString();
+      const diagnosticRun: OrchestratorRunRecord = {
+        ...latestRun,
         updatedAt: nowIso,
-        error,
-      },
-      rateLimits,
-    };
-    try {
-      await this.store.saveRun(diagnosticRun);
-    } catch (cause) {
-      this.reportDiagnosticWriteFailure(input.run, "saveRun", cause);
-    }
-
-    try {
-      await this.store.appendRunEvent(input.run.runId, {
-        at: nowIso,
-        event: "tracker.transition-comment",
-        projectId: input.run.projectId,
-        runId: input.run.runId,
-        tracker: {
-          adapter: this.projectConfig.tracker.adapter,
+        lastEvent:
+          error === null
+            ? "tracker-transition-comment"
+            : "tracker-transition-comment-failed",
+        lastEventAt: nowIso,
+        lastError:
+          error === null
+            ? latestRun.lastError
+            : `tracker_transition_comment_failed: ${error}`,
+        transitionComment: {
+          status: outcome,
+          updatedAt: nowIso,
+          error,
         },
-        issue: {
-          identifier: input.run.issueIdentifier,
-          id: input.run.issueSubjectId,
-        },
-        expectedState: input.request.expectedState,
-        targetState: input.request.targetState,
-        outcome,
-        error,
-        rateLimits,
-      });
-    } catch (cause) {
-      this.reportDiagnosticWriteFailure(input.run, "appendRunEvent", cause);
-    }
+        rateLimits: rateLimits ?? latestRun.rateLimits ?? null,
+      };
+      try {
+        await this.store.saveRun(diagnosticRun);
+      } catch (cause) {
+        this.reportDiagnosticWriteFailure(input.run, "saveRun", cause);
+      }
+      try {
+        await this.store.appendRunEvent(input.run.runId, {
+          at: nowIso,
+          event: "tracker.transition-comment",
+          projectId: input.run.projectId,
+          runId: input.run.runId,
+          tracker: {
+            adapter: this.projectConfig.tracker.adapter,
+          },
+          issue: {
+            identifier: input.run.issueIdentifier,
+            id: input.run.issueSubjectId,
+          },
+          expectedState: transitionRequest.expectedState,
+          targetState: transitionRequest.targetState,
+          outcome,
+          error,
+          rateLimits: rateLimits ?? latestRun.rateLimits ?? null,
+        });
+      } catch (cause) {
+        this.reportDiagnosticWriteFailure(input.run, "appendRunEvent", cause);
+      }
+    });
     return rateLimits;
   }
 
@@ -1892,6 +1939,23 @@ export class OrchestratorService {
     const previous = this.reconcilePromise;
     let release!: () => void;
     this.reconcilePromise = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    await previous;
+    try {
+      return await operation();
+    } finally {
+      release();
+    }
+  }
+
+  private async runTrackerStateSerialized<T>(
+    operation: () => Promise<T>
+  ): Promise<T> {
+    const previous = this.trackerStatePromise;
+    let release!: () => void;
+    this.trackerStatePromise = new Promise<void>((resolve) => {
       release = resolve;
     });
 

--- a/packages/tracker-github/src/adapter.ts
+++ b/packages/tracker-github/src/adapter.ts
@@ -769,7 +769,8 @@ export async function requestGithubProjectItemState(
   },
   fetchImpl: FetchLike = fetch
 ): Promise<TrackerStateResult> {
-  const queueKey = `${fingerprintGitHubToken(config.token)}:${config.projectId}`;
+  // Rate-limit budget is shared by all projects using this token.
+  const queueKey = fingerprintGitHubToken(config.token);
   const depth = transitionQueueDepths.get(queueKey) ?? 0;
   if (depth >= MAX_TRANSITION_QUEUE_DEPTH) {
     return {
@@ -829,8 +830,7 @@ export async function upsertGithubTransitionComment(
   },
   fetchImpl: FetchLike = fetch
 ): Promise<TrackerCommentWriteResult> {
-  const queueKey =
-    fingerprintGitHubToken(config.token) + ":" + config.projectId;
+  const queueKey = fingerprintGitHubToken(config.token);
   const depth = transitionQueueDepths.get(queueKey) ?? 0;
   if (depth >= MAX_TRANSITION_QUEUE_DEPTH) {
     throw new GitHubTrackerQueryError("tracker_transition_queue_full");


### PR DESCRIPTION
## Issues — Closed #504

## TL;DR

- tracker-state provider I/O를 reconcile lock 밖의 token-wide transition queue로 분리해 polling/dispatch head-of-line blocking을 제거합니다.
- provider 대기 중 reconcile이 갱신한 lifecycle을 최신 run record 병합으로 보존하고, comment diagnostics 저장 실패도 event 기록을 막지 않게 했습니다.
- transition queue key를 token fingerprint로 통일해 GraphQL budget 경계와 맞췄습니다.

## 변경 지점 다이어그램

```text
tracker-state request
  ├─ reconcile lock: canonical run/item authorization, expected-state 검증
  └─ token-wide transition queue: GitHub provider I/O / rate-limit wait
       └─ diagnostics: latest run record에 병합

reconcile polling/dispatch ──> reconcile lock 즉시 획득 가능
```

## 여기부터 보세요

- `packages/orchestrator/src/service.ts`: provider I/O와 reconcile lock 분리, 최신 lifecycle 보존, comment diagnostic event persistence.
- `packages/orchestrator/src/service.test.ts`: requestState 및 transition comment I/O가 막힌 동안 polling이 진행되고 lifecycle이 보존되는 회귀 TC, main의 관련 coverage 보존.
- `packages/tracker-github/src/adapter.ts`: token-wide GraphQL budget와 동일한 transition queue key.

## 위험 & 롤백

- 같은 token의 transition 순서는 유지하지만 reconcile과 병렬 실행됩니다. 문제 발생 시 tracker-state queue 분리와 latest-record merge를 이전 직렬화 경로로 되돌릴 수 있습니다.

## 변경 파일

- `packages/orchestrator/src/service.ts`
- `packages/orchestrator/src/service.test.ts`
- `packages/tracker-github/src/adapter.ts`
- `.changeset/quiet-trains-switch.md`

## Evidence

- `pnpm --filter @gh-symphony/orchestrator test -- --run src/service.test.ts` — pass (138 tests)
- `pnpm lint` — pass
- `pnpm test` — pass
- `pnpm typecheck` — pass
- `pnpm build` — pass
- Docker E2E: compose rebuild, `/healthz`, authenticated `/api/v1/state` — pass (`health: idle`, `activeRuns: 0`, `lastError: null`)
- GitHub CI on `8dd760d`: `Test`, `Container Smoke` — pass

## 머지 후/사람 확인

- [ ] 동일 token 다중 프로젝트 배포에서 transition queue depth와 polling latency를 관찰합니다.
- [ ] `requestState` 및 transition comment provider I/O 대기 중 polling latency를 관찰합니다.
