### PR TITLE
chore(test): exclude runtime worker copies

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from "vitest/config";
+import { configDefaults, defineConfig } from "vitest/config";
 
 export default defineConfig({
   define: {
@@ -6,6 +6,7 @@ export default defineConfig({
   },
   test: {
     include: ["**/*.test.ts"],
+    exclude: [...configDefaults.exclude, ".runtime/**"],
     environment: "node",
   },
 });


### PR DESCRIPTION
## TL;DR

루트 Vitest가 워커 checkout 사본이 있는 `.runtime/**`를 수집하지 않도록 하면서 Vitest 기본 제외 패턴은 그대로 유지합니다.

## 변경 지점 다이어그램

`vitest.config.ts`
→ `configDefaults.exclude`
→ `".runtime/**"` 추가
→ 루트 단일 파일 실행이 실제 저장소 테스트만 수집

## 여기부터 보세요

- `vitest.config.ts`: Vitest 기본 제외 목록을 확장해 `.runtime/**`를 제외합니다.

## 위험 & 롤백

- 위험: 루트 실행에서 `.runtime/**`에 의도적으로 둔 테스트는 더 이상 수집되지 않습니다. 해당 디렉터리는 워커 사본이므로 이 변경의 대상입니다.
- 롤백: 이 PR의 단일 커밋을 되돌리면 기존 수집 범위로 복원됩니다.

## 변경 파일

- `vitest.config.ts`

## Issues

Closed #560

## 검증

- `pnpm exec vitest run packages/orchestrator/src/index.test.ts` — 1 file, 18 tests passed; `.runtime/**` 사본 미수집
- `pnpm lint` — passed
- `pnpm test` — passed
- `pnpm typecheck` — passed
- `pnpm build` — passed
- `git merge-base --is-ancestor origin/main HEAD` — passed after shallow checkout history normalization

## 머지 후/사람 확인

- [ ] 루트에서 `pnpm exec vitest run packages/orchestrator/src/index.test.ts`를 실행해 `.runtime/**` 사본이 수집되지 않는지 확인

