### PR TITLE
fix(runtime-claude): use resume error result

### DIFF
--- a/.changeset/quiet-resumes-dance.md
+++ b/.changeset/quiet-resumes-dance.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Use Claude stream-json results instead of stderr regex matching when a resumed session is rejected (#554).

--- a/packages/runtime-claude/src/adapter.test.ts
+++ b/packages/runtime-claude/src/adapter.test.ts
@@ -916,10 +916,10 @@ describe("ClaudePrintRuntimeAdapter", () => {
     expect(session.parentRunId).toBe("run-missing");
   });
 
-  it("falls back to a new session id and emits sessionInvalidated when resume returns 4xx", async () => {
+  it("falls back to a new session when stream-json reports a rejected resume", async () => {
     const runtimeRoot = await createTempDir();
     const calls: Array<ReadonlyArray<string>> = [];
-    const emitted: string[] = [];
+    const emitted: Array<{ name: string; reason?: string }> = [];
     const children = [createStubChild(), createStubChild(), createStubChild()];
     const spawnImpl: SpawnLike = (_command, args) => {
       const callIndex = calls.length;
@@ -927,7 +927,10 @@ describe("ClaudePrintRuntimeAdapter", () => {
       calls.push(args);
       queueMicrotask(() => {
         if (callIndex === 1) {
-          stub.stderr.write("resume failed: 401 Unauthorized\n");
+          stub.stdout.write(
+            '{"type":"result","subtype":"error_during_execution","is_error":true,"session_id":"session-fresh","errors":["No conversation found with session ID: session-fresh"]}\n'
+          );
+          stub.stderr.write("No conversation found with session ID: session-fresh\n");
           stub.stdout.end();
           stub.stderr.end();
           stub.child.emit("close", 1, null);
@@ -956,7 +959,7 @@ describe("ClaudePrintRuntimeAdapter", () => {
     await adapter.spawnTurn({ messages: [] });
     adapter.onEvent((event) => {
       if (event.name === "agent.sessionInvalidated") {
-        emitted.push(event.name);
+        emitted.push({ name: event.name, reason: event.payload.reason });
       }
     });
 
@@ -970,7 +973,13 @@ describe("ClaudePrintRuntimeAdapter", () => {
       expect.arrayContaining(["--session-id", "session-new"])
     );
     expect(calls[2]).not.toContain("--fork-session");
-    expect(emitted).toEqual(["agent.sessionInvalidated"]);
+    expect(emitted).toEqual([
+      {
+        name: "agent.sessionInvalidated",
+        reason:
+          "claude resume session was rejected because no conversation was found",
+      },
+    ]);
     const session = JSON.parse(
       await readFile(join(runtimeRoot, "runs", "run-1", "claude-session.json"), "utf8")
     ) as Record<string, unknown>;
@@ -978,7 +987,7 @@ describe("ClaudePrintRuntimeAdapter", () => {
     expect(session.protocol).toBe("claude-print");
   });
 
-  it("falls back to a new session when inter-run fork resume returns 4xx", async () => {
+  it("falls back to a new session when forked resume is rejected in stream-json", async () => {
     const runtimeRoot = await createTempDir();
     const calls: Array<ReadonlyArray<string>> = [];
     const emitted: string[] = [];
@@ -989,7 +998,10 @@ describe("ClaudePrintRuntimeAdapter", () => {
       calls.push(args);
       queueMicrotask(() => {
         if (callIndex === 1) {
-          stub.stderr.write("Claude resume failed: 401 Unauthorized\n");
+          stub.stdout.write(
+            '{"type":"result","subtype":"error_during_execution","is_error":true,"session_id":"session-prev","errors":["No conversation found with session ID: session-prev"]}\n'
+          );
+          stub.stderr.write("No conversation found with session ID: session-prev\n");
           stub.stdout.end();
           stub.stderr.end();
           stub.child.emit("close", 1, null);
@@ -1047,6 +1059,57 @@ describe("ClaudePrintRuntimeAdapter", () => {
     ) as Record<string, unknown>;
     expect(session.sessionId).toBe("session-new");
     expect(session.parentRunId).toBe("run-prev");
+  });
+
+  it("does not invalidate a resume session for an unrelated stream-json error", async () => {
+    const runtimeRoot = await createTempDir();
+    const calls: Array<ReadonlyArray<string>> = [];
+    const emitted: string[] = [];
+    const children = [createStubChild(), createStubChild()];
+    const spawnImpl: SpawnLike = (_command, args) => {
+      const stub = children[calls.length]!;
+      calls.push(args);
+      queueMicrotask(() => {
+        if (calls.length === 2) {
+          stub.stdout.write(
+            '{"type":"result","subtype":"error_during_execution","is_error":true,"session_id":"session-fresh","errors":["Request timed out"]}\n'
+          );
+          stub.stdout.end();
+          stub.stderr.end();
+          stub.child.emit("close", 1, null);
+          return;
+        }
+        stub.stdout.write('{"type":"result","subtype":"success"}\n');
+        stub.stdout.end();
+        stub.stderr.end();
+        stub.child.emit("close", 0, null);
+      });
+      return stub.child;
+    };
+    const adapter = new ClaudePrintRuntimeAdapter(
+      {
+        workingDirectory: runtimeRoot,
+        runtimeRoot,
+      },
+      {
+        spawnImpl,
+        createSessionId: () => "session-fresh",
+        now: () => new Date("2026-04-26T00:00:00.000Z"),
+      }
+    );
+    adapter.onEvent((event) => {
+      if (event.name === "agent.sessionInvalidated") {
+        emitted.push(event.name);
+      }
+    });
+
+    await adapter.prepare({ runId: "run-1" });
+    await adapter.spawnTurn({ messages: [] });
+    const result = await adapter.spawnTurn({ messages: [] });
+
+    expect(result.result).toBe("process-error");
+    expect(calls).toHaveLength(2);
+    expect(emitted).toEqual([]);
   });
 
   it("replays a prepare-time sessionInvalidated event to later subscribers with the read error", async () => {

--- a/packages/runtime-claude/src/adapter.ts
+++ b/packages/runtime-claude/src/adapter.ts
@@ -351,7 +351,7 @@ export class ClaudePrintRuntimeAdapter implements AgentRuntimeAdapter<
       runId: this.preparedSession.runId,
       sessionId: invalidatedSessionId,
       replacementSessionId,
-      reason: "claude resume session was rejected with a 4xx response",
+      reason: "claude resume session was rejected because no conversation was found",
     });
 
     const retryArgv = buildClaudePrintArgv(
@@ -465,7 +465,7 @@ export class ClaudePrintRuntimeAdapter implements AgentRuntimeAdapter<
     return (
       session === this.preparedSession?.session &&
       session?.mode === "resume" &&
-      isResumeRejectedWith4xx(result)
+      isResumeRejected(session, result)
     );
   }
 
@@ -630,17 +630,34 @@ function findSessionId(value: unknown, depth = 0): string | null {
   return null;
 }
 
-function isResumeRejectedWith4xx(result: ClaudeSpawnTurnResult): boolean {
+function isResumeRejected(
+  session: ClaudeRuntimeSessionOptions,
+  result: ClaudeSpawnTurnResult
+): boolean {
   if (result.result !== "process-error") {
     return false;
   }
 
-  // Claude print currently surfaces rejected resume sessions through stderr text
-  // rather than a structured error field, so fallback detection is intentionally
-  // constrained to resume-related lines that include an HTTP 4xx code.
+  // Claude Code 2.1.227 emits a terminal stream-json result for a missing
+  // resume session: `{ subtype: "error_during_execution", is_error: true,
+  // session_id, errors }`. Use that protocol record rather than duplicating the
+  // human-readable stderr diagnostic. `errors` identifies this as a rejected
+  // session instead of another process error that happens after --resume.
   return result.records.some((record) => {
-    const text = record.line.toLowerCase();
-    return text.includes("resume") && /\b4\d\d\b/.test(text);
+    const message = record.message;
+    const errors = message?.errors;
+    return (
+      message?.type === "result" &&
+      message.subtype === "error_during_execution" &&
+      message.is_error === true &&
+      message.session_id === session.sessionId &&
+      Array.isArray(errors) &&
+      errors.some(
+        (error) =>
+          typeof error === "string" &&
+          error.startsWith("No conversation found with session ID:")
+      )
+    );
   });
 }
 

--- a/test/e2e/claude/claude-docker.spec.ts
+++ b/test/e2e/claude/claude-docker.spec.ts
@@ -1,6 +1,8 @@
 import { randomUUID } from "node:crypto";
 import { spawn } from "node:child_process";
 import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -98,26 +100,34 @@ Worker prompt.
       "utf8"
     );
 
-    const result = await runWorkerProcess({
-      cwd: repoRoot,
-      env: {
-        ...process.env,
-        PATH: `${resolve(repoRoot, "test/e2e/stubs")}:${process.env.PATH ?? ""}`,
-        CLAUDE_STUB_LOG_DIR: logDir,
-        CLAUDE_STUB_SCENARIO: "success",
-        ANTHROPIC_API_KEY: "stub-anthropic-key",
-        GITHUB_GRAPHQL_TOKEN: "stub-token",
-        GITHUB_PROJECT_ID: "stub-project",
-        WORKING_DIRECTORY: workspace,
-        WORKSPACE_RUNTIME_DIR: runtimeRoot,
-        SYMPHONY_WORKFLOW_PATH: workflowPath,
-        SYMPHONY_RENDERED_PROMPT: "Handle worker runtime adapter issue.",
-        SYMPHONY_RUN_ID: "run-worker-claude",
-        SYMPHONY_ISSUE_ID: "issue-worker-claude",
-        SYMPHONY_ISSUE_IDENTIFIER: "test-owner/test-repo#254",
-        SYMPHONY_ISSUE_STATE: "In progress",
-      },
-    });
+    const leaseServer = await createTurnLeaseServer();
+    let result: Awaited<ReturnType<typeof runWorkerProcess>>;
+    try {
+      result = await runWorkerProcess({
+        cwd: repoRoot,
+        env: {
+          ...process.env,
+          PATH: `${resolve(repoRoot, "test/e2e/stubs")}:${process.env.PATH ?? ""}`,
+          CLAUDE_STUB_LOG_DIR: logDir,
+          CLAUDE_STUB_SCENARIO: "success",
+          ANTHROPIC_API_KEY: "stub-anthropic-key",
+          GITHUB_GRAPHQL_TOKEN: "stub-token",
+          GITHUB_PROJECT_ID: "stub-project",
+          WORKING_DIRECTORY: workspace,
+          WORKSPACE_RUNTIME_DIR: runtimeRoot,
+          SYMPHONY_WORKFLOW_PATH: workflowPath,
+          SYMPHONY_RENDERED_PROMPT: "Handle worker runtime adapter issue.",
+          SYMPHONY_RUN_ID: "run-worker-claude",
+          SYMPHONY_ISSUE_ID: "issue-worker-claude",
+          SYMPHONY_ISSUE_IDENTIFIER: "test-owner/test-repo#254",
+          SYMPHONY_ISSUE_STATE: "In progress",
+          SYMPHONY_ORCHESTRATOR_URL: leaseServer.url,
+          SYMPHONY_ORCHESTRATOR_TOKEN: "stub-orchestrator-token",
+        },
+      });
+    } finally {
+      await leaseServer.close();
+    }
 
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toContain("Claude runtime preflight");
@@ -443,6 +453,42 @@ function runWorkerProcess(options: {
       resolveResult({ exitCode, signal, stderr });
     });
   });
+}
+
+async function createTurnLeaseServer(): Promise<{
+  url: string;
+  close: () => Promise<void>;
+}> {
+  const server = createServer((request, response) => {
+    if (
+      request.method === "POST" &&
+      request.url === "/api/v1/worker-turn-lease"
+    ) {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(
+        JSON.stringify({ acquired: true, expiresAt: "2026-04-26T01:00:00.000Z" })
+      );
+      return;
+    }
+    response.writeHead(404);
+    response.end();
+  });
+  await new Promise<void>((resolveServer, rejectServer) => {
+    server.once("error", rejectServer);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", rejectServer);
+      resolveServer();
+    });
+  });
+  const address = server.address() as AddressInfo;
+
+  return {
+    url: `http://127.0.0.1:${address.port}`,
+    close: () =>
+      new Promise<void>((resolveServer, rejectServer) => {
+        server.close((error) => (error ? rejectServer(error) : resolveServer()));
+      }),
+  };
 }
 
 function valueAfter(argv: readonly string[], flag: string): string | undefined {

--- a/test/e2e/stubs/claude.sh
+++ b/test/e2e/stubs/claude.sh
@@ -13,7 +13,8 @@ set -euo pipefail
 #   retry-then-success, inter-run-recover, rate-limit, and
 #   session-invalid-on-resume.
 # - exit modes: success scenarios exit 0. CLAUDE_STUB_EXIT_MODE=process-error
-#   or the first rejected resume in session-invalid-on-resume exits non-zero.
+#   or the first rejected resume in session-invalid-on-resume emits Claude
+#   Code's terminal structured error result and exits non-zero.
 # - observability: each invocation appends argv/stdin/session metadata to
 #   ${CLAUDE_STUB_LOG_DIR:-$PWD/.claude-stub}/invocations.ndjson.
 
@@ -133,7 +134,12 @@ fs.appendFileSync(process.env.INVOCATIONS_FILE, JSON.stringify(record) + "\n");
 invalid_marker="$log_dir/session-invalid-resume-rejected"
 if [[ "$scenario" == "session-invalid-on-resume" && -n "$resume_id" && ! -f "$invalid_marker" ]]; then
   printf '1\n' > "$invalid_marker"
-  printf 'resume session %s rejected with HTTP 404\n' "$resume_id" >&2
+  # Claude Code print mode reports a rejected resume as a terminal stream-json
+  # result. Keep this fixture aligned with the observed CLI protocol so the
+  # adapter E2E exercises structured rejection detection rather than the
+  # removed stderr/HTTP-status heuristic.
+  printf '{"type":"result","subtype":"error_during_execution","is_error":true,"session_id":"%s","errors":["No conversation found with session ID: %s"]}\n' "$resume_id" "$resume_id"
+  printf 'No conversation found with session ID: %s\n' "$resume_id" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## TL;DR

Claude CLI 2.1.228의 rejected `--resume`를 terminal `stream-json` 결과로 구조화해 판정하도록 교체했습니다. stderr의 `resume`/HTTP 4xx 정규식은 제거했고, persisted resume 거부 시 fresh session 재시도 및 `agent.sessionInvalidated` 기록을 Docker E2E로 검증했습니다.

## 변경 지점 다이어그램

```text
Claude print --resume 거부
  → terminal stream-json { type, subtype, is_error, session_id, errors }
  → isResumeRejected()
  → fresh session retry + agent.sessionInvalidated
```

## 여기부터 보세요

- `packages/runtime-claude/src/adapter.ts`: 구조화 terminal result predicate 및 invalidation reason
- `packages/runtime-claude/src/adapter.test.ts`: positive/negative structured fixture TC
- `test/e2e/stubs/claude.sh`: 실제 CLI capture와 맞춘 rejected-resume E2E fixture

## 위험 & 롤백

- 현재 predicate는 캡처한 nonexistent-session `errors[]` 형태에 한정됩니다. 만료/타 계정 형태는 #575에서 조사합니다.
- CLI protocol이 변경되면 fresh-session retry가 발생하지 않을 수 있습니다. 롤백은 predicate를 제거하고 기존 동작으로 되돌리는 것입니다.

## 변경 파일

- `packages/runtime-claude/src/adapter.ts`
- `packages/runtime-claude/src/adapter.test.ts`
- `test/e2e/stubs/claude.sh`
- `.changeset/quiet-resumes-dance.md`

## Issues — Closed #554

## Evidence

- `claude --version` — `2.1.228 (Claude Code)`
- rejected `--resume` with `--output-format json` — exit `1`, empty stdout, stderr diagnostic
- rejected `--resume` with `--output-format stream-json` — exit `1`, terminal structured result with `is_error`, `subtype`, `session_id`, and `errors[]`
- `pnpm --filter @gh-symphony/runtime-claude test` — 8 files, 91 tests passed
- `pnpm e2e:claude` — Docker Claude E2E 5 scenarios passed
- `pnpm lint && pnpm test && pnpm typecheck && pnpm build` — passed at HEAD `419f5c5`

## 머지 후/사람 확인

- [ ] 만료·타 계정 resume 거부의 실제 `errors[]` 형태를 수집하고 #575 범위를 검토
- [ ] 프로덕션 호출부의 `previousRunId` 활성화는 별도 제품 결정으로 검토
