### PR TITLE
fix(orchestrator): use blobless worker checkouts

### DIFF
--- a/.changeset/blobless-worker-checkouts.md
+++ b/.changeset/blobless-worker-checkouts.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Use blobless worker checkouts and migrate legacy shallow workspaces so Land rebases retain a merge base (#559).

--- a/packages/orchestrator/src/git.test.ts
+++ b/packages/orchestrator/src/git.test.ts
@@ -427,10 +427,11 @@ describe("cloneRepositoryForRun", () => {
     ).toBe("# pull request workflow v2\n");
   });
 
-  it("skips pull request checkout when dirty recovery preserves an existing workspace", async () => {
+  it("migrates a dirty shallow workspace before preserving it for recovery", async () => {
     const tempRoot = await mkdtemp(join(tmpdir(), "orchestrator-git-pr-"));
     const repository = await createRepositoryFixture(tempRoot);
     const issueWorkspacePath = join(tempRoot, "workspaces", "acme_platform_2");
+    const repositoryDirectory = join(issueWorkspacePath, "repository");
 
     execSync(`git -C "${repository.path}" checkout -b feature/pr-branch`);
     await writeFile(
@@ -442,14 +443,10 @@ describe("cloneRepositoryForRun", () => {
     execSync(`git -C "${repository.path}" commit -m "Update PR workflow v1"`);
     execSync(`git -C "${repository.path}" push origin feature/pr-branch`);
 
-    const repositoryDirectory = await ensureIssueWorkspaceRepository({
-      repository,
-      issueWorkspacePath,
-      existingWorkspace: false,
-      pullRequestBranch: {
-        headRefName: "feature/pr-branch",
-      },
-    });
+    await mkdir(issueWorkspacePath, { recursive: true });
+    execSync(
+      `git clone --depth 1 --branch feature/pr-branch "file://${repository.cloneUrl}" "${repositoryDirectory}"`
+    );
     await writeFile(
       join(repositoryDirectory, "WORKFLOW.md"),
       "# partial recovery work\n",
@@ -478,6 +475,11 @@ describe("cloneRepositoryForRun", () => {
       })
     ).resolves.toBe(repositoryDirectory);
 
+    expect(
+      execSync(`git -C "${repositoryDirectory}" rev-parse --is-shallow-repository`, {
+        encoding: "utf8",
+      }).trim()
+    ).toBe("false");
     expect(
       await readFile(join(repositoryDirectory, "WORKFLOW.md"), "utf8")
     ).toBe("# partial recovery work\n");

--- a/packages/orchestrator/src/git.test.ts
+++ b/packages/orchestrator/src/git.test.ts
@@ -233,6 +233,99 @@ describe("cloneRepositoryForRun", () => {
     expect(
       await readFile(join(repositoryDirectory, "WORKFLOW.md"), "utf8")
     ).toBe("# pull request workflow\n");
+    expect(
+      execSync(
+        `git -C "${repositoryDirectory}" merge-base origin/main feature/pr-branch`,
+        { encoding: "utf8" }
+      ).trim()
+    ).not.toBe("");
+    expect(
+      execSync(
+        `git -C "${repositoryDirectory}" rev-parse --is-shallow-repository`,
+        { encoding: "utf8" }
+      ).trim()
+    ).toBe("false");
+  });
+
+  it("migrates a reused shallow checkout before checking out a pull request branch", async () => {
+    const tempRoot = await mkdtemp(join(tmpdir(), "orchestrator-git-pr-"));
+    const repository = await createRepositoryFixture(tempRoot);
+    const issueWorkspacePath = join(tempRoot, "workspaces", "acme_platform_2");
+    const repositoryDirectory = join(issueWorkspacePath, "repository");
+
+    execSync(`git -C "${repository.path}" checkout -b feature/pr-branch`);
+    await writeFile(join(repository.path, "feature.txt"), "feature\n", "utf8");
+    execSync(`git -C "${repository.path}" add feature.txt`);
+    execSync(`git -C "${repository.path}" commit -m "Add feature"`);
+    execSync(`git -C "${repository.path}" push origin feature/pr-branch`);
+
+    await mkdir(issueWorkspacePath, { recursive: true });
+    execSync(
+      `git clone --depth 1 "file://${repository.cloneUrl}" "${repositoryDirectory}"`
+    );
+    expect(
+      execSync(
+        `git -C "${repositoryDirectory}" rev-parse --is-shallow-repository`,
+        { encoding: "utf8" }
+      ).trim()
+    ).toBe("true");
+
+    await ensureIssueWorkspaceRepository({
+      repository,
+      issueWorkspacePath,
+      existingWorkspace: true,
+      pullRequestBranch: {
+        headRefName: "feature/pr-branch",
+      },
+    });
+
+    expect(
+      execSync(
+        `git -C "${repositoryDirectory}" rev-parse --is-shallow-repository`,
+        { encoding: "utf8" }
+      ).trim()
+    ).toBe("false");
+    expect(
+      execSync(
+        `git -C "${repositoryDirectory}" merge-base origin/main feature/pr-branch`,
+        { encoding: "utf8" }
+      ).trim()
+    ).not.toBe("");
+  });
+
+  it("rebases a pull request branch onto an advanced base without add/add conflicts", async () => {
+    const tempRoot = await mkdtemp(join(tmpdir(), "orchestrator-git-pr-"));
+    const repository = await createRepositoryFixture(tempRoot);
+    const issueWorkspacePath = join(tempRoot, "workspaces", "acme_platform_2");
+
+    execSync(`git -C "${repository.path}" checkout -b feature/pr-branch`);
+    await writeFile(join(repository.path, "feature.txt"), "feature\n", "utf8");
+    execSync(`git -C "${repository.path}" add feature.txt`);
+    execSync(`git -C "${repository.path}" commit -m "Add feature"`);
+    execSync(`git -C "${repository.path}" push origin feature/pr-branch`);
+
+    execSync(`git -C "${repository.path}" checkout main`);
+    await writeFile(join(repository.path, "base.txt"), "base\n", "utf8");
+    execSync(`git -C "${repository.path}" add base.txt`);
+    execSync(`git -C "${repository.path}" commit -m "Advance base"`);
+    execSync(`git -C "${repository.path}" push origin main`);
+
+    const repositoryDirectory = await ensureIssueWorkspaceRepository({
+      repository,
+      issueWorkspacePath,
+      existingWorkspace: false,
+      pullRequestBranch: {
+        headRefName: "feature/pr-branch",
+      },
+    });
+    execSync(`git -C "${repositoryDirectory}" config user.name "Test User"`);
+    execSync(`git -C "${repositoryDirectory}" config user.email "test@example.com"`);
+
+    expect(() =>
+      execSync(`git -C "${repositoryDirectory}" rebase origin/main`)
+    ).not.toThrow();
+    await expect(access(join(repositoryDirectory, "base.txt"))).resolves.toBeUndefined();
+    await expect(access(join(repositoryDirectory, "feature.txt"))).resolves.toBeUndefined();
   });
 
   it("keeps pull request branch workspaces reusable on the second cycle", async () => {
@@ -437,7 +530,7 @@ async function createRepositoryFixture(tempRoot: string) {
   const originPath = join(tempRoot, "origin.git");
   const workingPath = join(tempRoot, "working");
 
-  execSync(`git init --bare "${originPath}"`);
+  execSync(`git init --initial-branch=main --bare "${originPath}"`);
   execSync(`git clone "${originPath}" "${workingPath}"`);
   execSync(`git -C "${workingPath}" config user.name "Test User"`);
   execSync(`git -C "${workingPath}" config user.email "test@example.com"`);

--- a/packages/orchestrator/src/git.ts
+++ b/packages/orchestrator/src/git.ts
@@ -61,6 +61,7 @@ export async function syncRepositoryForRun(input: {
 
     if (hasGit) {
       try {
+        await migrateShallowRepository(repositoryDirectory);
         const beforeHead = await readGitHead(repositoryDirectory);
         await runCommand("git", [
           "-C",
@@ -91,8 +92,7 @@ export async function syncRepositoryForRun(input: {
     try {
       await runCommand("git", [
         "clone",
-        "--depth",
-        "1",
+        "--filter=blob:none",
         input.repository.cloneUrl,
         tempRepositoryDirectory,
       ]);
@@ -307,6 +307,15 @@ async function syncExistingIssueWorkspaceRepository(
         );
       }
 
+      try {
+        await migrateShallowRepository(repositoryDirectory);
+      } catch (error) {
+        throw createIssueWorkspacePreservedError(
+          repositoryDirectory,
+          `could not be migrated from a shallow checkout: ${formatCommandError(error, "git fetch --unshallow failed")}`
+        );
+      }
+
       if (!input.skipPull) {
         try {
           await runCommand("git", [
@@ -346,8 +355,7 @@ async function syncExistingIssueWorkspaceRepository(
     try {
       await runCommand("git", [
         "clone",
-        "--depth",
-        "1",
+        "--filter=blob:none",
         input.repository.cloneUrl,
         tempRepositoryDirectory,
       ]);
@@ -387,8 +395,7 @@ async function checkoutPullRequestBranch(
       "fetch",
       "origin",
       `+refs/heads/${branchName}:${remoteRef}`,
-      "--depth",
-      "1",
+      "--filter=blob:none",
     ]);
   } catch (error) {
     throw new Error(
@@ -440,6 +447,30 @@ async function checkoutPullRequestBranch(
       `Cannot checkout pull request branch ${branchName}: git branch --set-upstream-to failed (${formatCommandError(error, "git branch --set-upstream-to failed")}).`
     );
   }
+}
+
+async function migrateShallowRepository(
+  repositoryDirectory: string
+): Promise<void> {
+  const isShallow = await runCommandCapture("git", [
+    "-C",
+    repositoryDirectory,
+    "rev-parse",
+    "--is-shallow-repository",
+  ]);
+
+  if (isShallow.trim() !== "true") {
+    return;
+  }
+
+  await runCommand("git", [
+    "-C",
+    repositoryDirectory,
+    "fetch",
+    "--unshallow",
+    "--filter=blob:none",
+    "origin",
+  ]);
 }
 
 function createIssueWorkspacePreservedError(

--- a/packages/orchestrator/src/git.ts
+++ b/packages/orchestrator/src/git.ts
@@ -295,6 +295,15 @@ async function syncExistingIssueWorkspaceRepository(
         );
       }
 
+      try {
+        await migrateShallowRepository(repositoryDirectory);
+      } catch (error) {
+        throw createIssueWorkspacePreservedError(
+          repositoryDirectory,
+          `could not be migrated from a shallow checkout: ${formatCommandError(error, "git fetch --unshallow failed")}`
+        );
+      }
+
       if (dirtyStatus.trim() && input.allowDirty) {
         onDirtyAllowed?.(true);
         return repositoryDirectory;
@@ -304,15 +313,6 @@ async function syncExistingIssueWorkspaceRepository(
         throw createIssueWorkspacePreservedError(
           repositoryDirectory,
           `has uncommitted changes: ${summarizeGitStatus(dirtyStatus)}`
-        );
-      }
-
-      try {
-        await migrateShallowRepository(repositoryDirectory);
-      } catch (error) {
-        throw createIssueWorkspacePreservedError(
-          repositoryDirectory,
-          `could not be migrated from a shallow checkout: ${formatCommandError(error, "git fetch --unshallow failed")}`
         );
       }
 


### PR DESCRIPTION
## TL;DR

- 워커 checkout을 shallow clone 대신 blobless partial clone으로 전환했습니다.
- 재사용되는 기존 shallow workspace는 한 번 `--unshallow`하여 Land rebase의 merge-base를 복구합니다.
- dirty recovery workspace도 worktree 변경을 보존한 채 migration을 먼저 수행합니다.

## 변경 지점 다이어그램

```text
새 workspace ── git clone --filter=blob:none ──┐
기존 shallow workspace ── git fetch --unshallow ─┼─ PR branch fetch --filter=blob:none ── rebase origin/main
dirty recovery ── migration 후 worktree 보존 ────┘
                                                  └─ 공통 merge-base 유지
```

## 여기부터 보세요

- `packages/orchestrator/src/git.ts`: blobless clone/fetch 및 dirty workspace를 포함한 shallow migration
- `packages/orchestrator/src/git.test.ts`: merge-base, base 전진 rebase, dirty recovery 회귀 TC

## 위험 & 롤백

- blobless clone은 필요 시 blob을 lazy fetch하므로 Git remote와 자격증명이 워커 실행 중에도 필요합니다.
- partial clone을 지원하지 않는 remote는 Git이 filter를 무시하고 전체 clone/fetch로 안전하게 처리합니다.
- 문제 발생 시 이 변경을 되돌리면 이전 shallow checkout 동작으로 복귀합니다.

## 변경 파일

- `packages/orchestrator/src/git.ts`
- `packages/orchestrator/src/git.test.ts`
- `.changeset/blobless-worker-checkouts.md`

## Evidence

- `pnpm --filter @gh-symphony/orchestrator test -- git.test.ts` — 14 passed
- `pnpm lint && pnpm test && pnpm typecheck && pnpm build` — pass
- `./e2e/run-e2e.sh happy 45` — Docker worker dispatch·checkout blackbox pass

## Issues — Closed #559

Fixes #559

## 머지 후/사람 확인

- [ ] 실제 GitHub remote에서 Land rebase가 공통 merge-base를 사용하고 add/add 충돌 없이 진행되는지 확인
