### PR TITLE
feat(core): extend project config for standalone projects

### DIFF
--- a/.changeset/fair-otters-config.md
+++ b/.changeset/fair-otters-config.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Validate standalone project configuration consistently when CLI-managed projects are loaded or saved, including #562 workflow-source defaults.

--- a/packages/cli/src/commands/start.test.ts
+++ b/packages/cli/src/commands/start.test.ts
@@ -37,6 +37,7 @@ const loadProjectState = vi.fn();
 const startControlPlaneServer = vi.fn();
 const HTTP_API_TOKEN = "test-http-api-token";
 const serviceDependencies: Array<Record<string, unknown>> = [];
+const serviceProjectConfigs: unknown[] = [];
 const ghAuthMocks = vi.hoisted(() => ({
   resolveGitHubAuth: vi.fn(),
   runGhAuthLogin: vi.fn(),
@@ -63,9 +64,10 @@ vi.mock("@gh-symphony/orchestrator", () => ({
   OrchestratorService: class {
     constructor(
       _store: unknown,
-      _projectConfig: unknown,
+      projectConfig: unknown,
       dependencies: Record<string, unknown> = {}
     ) {
+      serviceProjectConfigs.push(projectConfig);
       serviceDependencies.push(dependencies);
     }
     run = orchestratorMocks.run;
@@ -184,6 +186,7 @@ beforeEach(() => {
   process.env.LINEAR_API_KEY = originalLinearApiKey;
   process.env.GH_SYMPHONY_HTTP_TOKEN = HTTP_API_TOKEN;
   serviceDependencies.length = 0;
+  serviceProjectConfigs.length = 0;
 });
 
 function createSpawnedChild(pid: number): EventEmitter & {
@@ -352,6 +355,36 @@ describe("start command foreground locking", () => {
     await startModule.default([], baseOptions(configDir));
 
     expect(process.env.GITHUB_GRAPHQL_TOKEN).toBe("validated-token");
+    expect(exitSpy).toHaveBeenCalledWith(0);
+  });
+
+  it("normalizes legacy project config before constructing the orchestrator", async () => {
+    const configDir = await createConfigFixture({
+      activeProject: "tenant-a",
+      projects: [createProject("tenant-a", "acme", "platform")],
+    });
+    const lock = {
+      lockPath: join(configDir, ".lock"),
+      ownerToken: "owner",
+      pid: 1234,
+      startedAt: "2026-03-17T00:00:00.000Z",
+    };
+    acquireProjectLock.mockResolvedValue(lock);
+    run.mockImplementation(async () => {
+      process.emit("SIGINT");
+    });
+    const exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation(
+        ((_code?: number) => undefined) as (code?: number) => never
+      );
+
+    await startModule.default([], baseOptions(configDir));
+
+    expect(serviceProjectConfigs.at(-1)).toMatchObject({
+      workflowSource: { type: "repo" },
+      populateStrategy: "clone",
+    });
     expect(exitSpy).toHaveBeenCalledWith(0);
   });
 

--- a/packages/cli/src/config.test.ts
+++ b/packages/cli/src/config.test.ts
@@ -13,9 +13,11 @@ import {
   DEFAULT_CONFIG_DIR,
   REPO_RUNTIME_DIR,
   loadGlobalConfig,
+  loadProjectConfig,
   parseDaemonPidRecord,
   resolveConfigDir,
   saveGlobalConfig,
+  saveProjectConfig,
   updateGlobalConfig,
 } from "./config.js";
 
@@ -76,6 +78,43 @@ describe("resolveConfigDir", () => {
 });
 
 describe("config persistence", () => {
+  it("normalizes legacy project configs and rejects invalid standalone values", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "cli-project-config-"));
+    const projectId = "project-1";
+    const projectDir = join(configDir, "projects", projectId);
+    await mkdir(projectDir, { recursive: true });
+    await writeFile(
+      join(projectDir, "project.json"),
+      JSON.stringify({
+        projectId,
+        slug: projectId,
+        workspaceDir: "/tmp/project-1",
+        tracker: { adapter: "file", bindingId: "project-1" },
+      }),
+      "utf8"
+    );
+
+    await expect(
+      loadProjectConfig(configDir, projectId)
+    ).resolves.toMatchObject({
+      workflowSource: { type: "repo" },
+      populateStrategy: "clone",
+    });
+
+    await expect(
+      saveProjectConfig(configDir, projectId, {
+        projectId,
+        slug: projectId,
+        workspaceDir: "/tmp/project-1",
+        tracker: { adapter: "file", bindingId: "project-1" },
+        workflowSource: {
+          type: "external",
+          path: "relative/WORKFLOW.md",
+        },
+      })
+    ).rejects.toThrow('Project "project-1" external workflow source path');
+  });
+
   it("serializes concurrent load-modify-save updates", async () => {
     const configDir = await mkdtemp(join(tmpdir(), "cli-config-lock-"));
     await saveGlobalConfig(configDir, {

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -13,6 +13,7 @@ import { basename, dirname, join, resolve } from "node:path";
 import { homedir } from "node:os";
 import { setTimeout as delay } from "node:timers/promises";
 import { getProcessIdentity } from "@gh-symphony/orchestrator";
+import { normalizeOrchestratorProjectConfig } from "@gh-symphony/core";
 import type {
   OrchestratorProjectConfig,
   OrchestratorTrackerSettingValue,
@@ -182,9 +183,14 @@ export async function loadProjectConfig(
   configDir: string,
   projectId: string
 ): Promise<CliProjectConfig | null> {
-  return readJsonFile<CliProjectConfig>(
+  const config = await readJsonFile<CliProjectConfig>(
     projectConfigPath(configDir, projectId)
   );
+  return config
+    ? (normalizeOrchestratorProjectConfig(
+        config as OrchestratorProjectConfig
+      ) as CliProjectConfig)
+    : null;
 }
 
 export async function saveProjectConfig(
@@ -193,7 +199,12 @@ export async function saveProjectConfig(
   config: CliProjectConfig
 ): Promise<void> {
   await withConfigLock(configDir, () =>
-    writeJsonFile(projectConfigPath(configDir, projectId), config)
+    writeJsonFile(
+      projectConfigPath(configDir, projectId),
+      normalizeOrchestratorProjectConfig(
+        config as OrchestratorProjectConfig
+      ) as CliProjectConfig
+    )
   );
 }
 

--- a/packages/core/src/contracts/status-surface.ts
+++ b/packages/core/src/contracts/status-surface.ts
@@ -24,12 +24,24 @@ export type OrchestratorTrackerConfig = {
   settings?: Record<string, OrchestratorTrackerSettingValue>;
 };
 
+export type WorkflowSource =
+  | { type: "repo" }
+  | { type: "external"; path: string };
+
+export type PopulateStrategy = "clone" | "worktree-cache";
+
 export type OrchestratorProjectConfig = {
   projectId: string;
   slug: string;
   workspaceDir: string;
   repository: RepositoryRef;
   tracker: OrchestratorTrackerConfig;
+  /** Defaults to the repository-local workflow for legacy project configs. */
+  workflowSource?: WorkflowSource;
+  /** Defaults to cloning for legacy project configs. */
+  populateStrategy?: PopulateStrategy;
+  /** Standalone project directory, when configuration is managed externally. */
+  projectDir?: string;
 };
 
 export type RetryKind = "continuation" | "failure" | "recovery";

--- a/packages/core/src/contracts/status-surface.ts
+++ b/packages/core/src/contracts/status-surface.ts
@@ -1,3 +1,4 @@
+import { isAbsolute } from "node:path";
 import type { RepositoryRef } from "../domain/workspace.js";
 import type {
   WorkflowDefinition,
@@ -43,6 +44,76 @@ export type OrchestratorProjectConfig = {
   /** Standalone project directory, when configuration is managed externally. */
   projectDir?: string;
 };
+
+/**
+ * Materializes standalone-project defaults and rejects malformed persisted
+ * configuration before it reaches an orchestrator service.
+ */
+export function normalizeOrchestratorProjectConfig(
+  config: OrchestratorProjectConfig
+): OrchestratorProjectConfig {
+  const workflowSource = normalizeWorkflowSource(config);
+  const populateStrategy = normalizePopulateStrategy(config);
+
+  return {
+    ...config,
+    workflowSource,
+    populateStrategy,
+  };
+}
+
+function normalizeWorkflowSource(
+  config: OrchestratorProjectConfig
+): WorkflowSource {
+  const workflowSource = config.workflowSource as unknown;
+  if (workflowSource === undefined) {
+    return { type: "repo" };
+  }
+  if (!isRecord(workflowSource)) {
+    throw new Error(
+      `Project ${JSON.stringify(config.projectId)} has unsupported workflow source ${JSON.stringify(workflowSource)}.`
+    );
+  }
+  if (workflowSource.type === "repo") {
+    return { type: "repo" };
+  }
+  if (workflowSource.type !== "external") {
+    throw new Error(
+      `Project ${JSON.stringify(config.projectId)} has unsupported workflow source type ${JSON.stringify(workflowSource.type)}.`
+    );
+  }
+  if (typeof workflowSource.path !== "string" || !workflowSource.path) {
+    throw new Error(
+      `Project ${JSON.stringify(config.projectId)} external workflow source requires a path.`
+    );
+  }
+  if (!isAbsolute(workflowSource.path)) {
+    throw new Error(
+      `Project ${JSON.stringify(config.projectId)} external workflow source path ${JSON.stringify(workflowSource.path)} must be absolute.`
+    );
+  }
+
+  return { type: "external", path: workflowSource.path };
+}
+
+function normalizePopulateStrategy(
+  config: OrchestratorProjectConfig
+): PopulateStrategy {
+  const populateStrategy = config.populateStrategy;
+  if (populateStrategy === undefined) {
+    return "clone";
+  }
+  if (populateStrategy === "clone" || populateStrategy === "worktree-cache") {
+    return populateStrategy;
+  }
+  throw new Error(
+    `Project ${JSON.stringify(config.projectId)} has unsupported populate strategy ${JSON.stringify(populateStrategy)}.`
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
 
 export type RetryKind = "continuation" | "failure" | "recovery";
 

--- a/packages/orchestrator/src/fs-store.test.ts
+++ b/packages/orchestrator/src/fs-store.test.ts
@@ -57,6 +57,72 @@ describe("OrchestratorFsStore.loadRecentRunEvents", () => {
     }
   });
 
+  it("defaults legacy project configs to repository workflows and cloning", async () => {
+    const runtimeRoot = await mkdtemp(join(tmpdir(), "orchestrator-store-"));
+    const store = new OrchestratorFsStore(runtimeRoot);
+    const projectDir = store.projectDir("project-1");
+    await mkdir(projectDir, { recursive: true });
+    await writeFile(
+      join(projectDir, "project.json"),
+      JSON.stringify({
+        projectId: "project-1",
+        slug: "project-1",
+        workspaceDir: "/tmp/workspaces/project-1",
+        repository: { owner: "acme", name: "repo" },
+        tracker: { adapter: "file", bindingId: "file-project-1" },
+      }),
+      "utf8"
+    );
+
+    await expect(store.loadProjectConfig("project-1")).resolves.toEqual(
+      expect.objectContaining({
+        workflowSource: { type: "repo" },
+        populateStrategy: "clone",
+      })
+    );
+  });
+
+  it("round-trips standalone project configuration", async () => {
+    const runtimeRoot = await mkdtemp(join(tmpdir(), "orchestrator-store-"));
+    const store = new OrchestratorFsStore(runtimeRoot);
+    const config = {
+      projectId: "project-1",
+      slug: "project-1",
+      workspaceDir: "/tmp/workspaces/project-1",
+      repository: { owner: "acme", name: "repo" },
+      tracker: { adapter: "file" as const, bindingId: "file-project-1" },
+      workflowSource: {
+        type: "external" as const,
+        path: "/projects/project-1/WORKFLOW.md",
+      },
+      populateStrategy: "worktree-cache" as const,
+      projectDir: "/projects/project-1",
+    };
+
+    await store.saveProjectConfig(config);
+
+    await expect(store.loadProjectConfig("project-1")).resolves.toEqual(config);
+  });
+
+  it.each([
+    [{ type: "external" }],
+    [{ type: "external", path: "projects/project-1/WORKFLOW.md" }],
+  ])("rejects invalid external workflow source %j", async (workflowSource) => {
+    const runtimeRoot = await mkdtemp(join(tmpdir(), "orchestrator-store-"));
+    const store = new OrchestratorFsStore(runtimeRoot);
+
+    await expect(
+      store.saveProjectConfig({
+        projectId: "project-1",
+        slug: "project-1",
+        workspaceDir: "/tmp/workspaces/project-1",
+        repository: { owner: "acme", name: "repo" },
+        tracker: { adapter: "file", bindingId: "file-project-1" },
+        workflowSource: workflowSource as never,
+      })
+    ).rejects.toThrow("External workflow source");
+  });
+
   it("loads only issue workspace directories from the project runtime root", async () => {
     const runtimeRoot = await mkdtemp(join(tmpdir(), "orchestrator-store-"));
     const store = new OrchestratorFsStore(runtimeRoot);

--- a/packages/orchestrator/src/fs-store.test.ts
+++ b/packages/orchestrator/src/fs-store.test.ts
@@ -120,7 +120,28 @@ describe("OrchestratorFsStore.loadRecentRunEvents", () => {
         tracker: { adapter: "file", bindingId: "file-project-1" },
         workflowSource: workflowSource as never,
       })
-    ).rejects.toThrow("External workflow source");
+    ).rejects.toThrow("external workflow source");
+  });
+
+  it.each([
+    ["workflow source type", { type: "externel" }],
+    ["populate strategy", "copy"],
+  ])("rejects an unsupported %s", async (_label, value) => {
+    const runtimeRoot = await mkdtemp(join(tmpdir(), "orchestrator-store-"));
+    const store = new OrchestratorFsStore(runtimeRoot);
+
+    await expect(
+      store.saveProjectConfig({
+        projectId: "project-1",
+        slug: "project-1",
+        workspaceDir: "/tmp/workspaces/project-1",
+        repository: { owner: "acme", name: "repo" },
+        tracker: { adapter: "file", bindingId: "file-project-1" },
+        ...(typeof value === "string"
+          ? { populateStrategy: value as never }
+          : { workflowSource: value as never }),
+      })
+    ).rejects.toThrow("project-1");
   });
 
   it("loads only issue workspace directories from the project runtime root", async () => {

--- a/packages/orchestrator/src/fs-store.ts
+++ b/packages/orchestrator/src/fs-store.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import { chmod, mkdir, open, rm, stat } from "node:fs/promises";
-import { isAbsolute, join, relative, resolve } from "node:path";
+import { join, relative, resolve } from "node:path";
 import {
   deriveIssueWorkspaceKeyFromIdentifier,
   isFileMissing,
@@ -11,6 +11,7 @@ import {
   type OrchestratorRunRecord,
   type OrchestratorStateStore,
   type OrchestratorProjectConfig,
+  normalizeOrchestratorProjectConfig,
   parseRecentEvents,
   redactObservabilitySecrets,
   type ProjectStatusSnapshot,
@@ -81,14 +82,14 @@ export class OrchestratorFsStore implements OrchestratorStateStore {
           )
         : null);
 
-    return config ? normalizeProjectConfig(config) : null;
+    return config ? normalizeOrchestratorProjectConfig(config) : null;
   }
 
   async saveProjectConfig(config: OrchestratorProjectConfig): Promise<void> {
     await this.ensureProjectDirectory(config.projectId);
     await writeJsonFile(
       join(this.projectDir(config.projectId), "project.json"),
-      normalizeProjectConfig(config)
+      normalizeOrchestratorProjectConfig(config)
     );
   }
 
@@ -505,27 +506,6 @@ export class OrchestratorFsStore implements OrchestratorStateStore {
     const mirrorPath = join(this.resolvedEventsMirrorRoot, relativePath);
     return mirrorPath === primaryPath ? null : mirrorPath;
   }
-}
-
-function normalizeProjectConfig(
-  config: OrchestratorProjectConfig
-): OrchestratorProjectConfig {
-  const workflowSource = config.workflowSource ?? { type: "repo" };
-
-  if (workflowSource.type === "external") {
-    if (!workflowSource.path) {
-      throw new Error("External workflow source requires a path.");
-    }
-    if (!isAbsolute(workflowSource.path)) {
-      throw new Error("External workflow source path must be absolute.");
-    }
-  }
-
-  return {
-    ...config,
-    workflowSource,
-    populateStrategy: config.populateStrategy ?? "clone",
-  };
 }
 
 async function writeJsonFile(path: string, value: unknown): Promise<void> {

--- a/packages/orchestrator/src/fs-store.ts
+++ b/packages/orchestrator/src/fs-store.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import { chmod, mkdir, open, rm, stat } from "node:fs/promises";
-import { join, relative, resolve } from "node:path";
+import { isAbsolute, join, relative, resolve } from "node:path";
 import {
   deriveIssueWorkspaceKeyFromIdentifier,
   isFileMissing,
@@ -71,7 +71,7 @@ export class OrchestratorFsStore implements OrchestratorStateStore {
   async loadProjectConfig(
     projectId?: string
   ): Promise<OrchestratorProjectConfig | null> {
-    return (
+    const config =
       (await readJsonFile<OrchestratorProjectConfig>(
         join(this.projectDir(projectId), "project.json")
       )) ??
@@ -79,15 +79,16 @@ export class OrchestratorFsStore implements OrchestratorStateStore {
         ? await readJsonFile<OrchestratorProjectConfig>(
             join(this.legacyProjectDir(), "project.json")
           )
-        : null)
-    );
+        : null);
+
+    return config ? normalizeProjectConfig(config) : null;
   }
 
   async saveProjectConfig(config: OrchestratorProjectConfig): Promise<void> {
     await this.ensureProjectDirectory(config.projectId);
     await writeJsonFile(
       join(this.projectDir(config.projectId), "project.json"),
-      config
+      normalizeProjectConfig(config)
     );
   }
 
@@ -504,6 +505,27 @@ export class OrchestratorFsStore implements OrchestratorStateStore {
     const mirrorPath = join(this.resolvedEventsMirrorRoot, relativePath);
     return mirrorPath === primaryPath ? null : mirrorPath;
   }
+}
+
+function normalizeProjectConfig(
+  config: OrchestratorProjectConfig
+): OrchestratorProjectConfig {
+  const workflowSource = config.workflowSource ?? { type: "repo" };
+
+  if (workflowSource.type === "external") {
+    if (!workflowSource.path) {
+      throw new Error("External workflow source requires a path.");
+    }
+    if (!isAbsolute(workflowSource.path)) {
+      throw new Error("External workflow source path must be absolute.");
+    }
+  }
+
+  return {
+    ...config,
+    workflowSource,
+    populateStrategy: config.populateStrategy ?? "clone",
+  };
 }
 
 async function writeJsonFile(path: string, value: unknown): Promise<void> {


### PR DESCRIPTION
## Issues — Closed #562

## TL;DR

Standalone project configuration now normalizes consistently at CLI and fs-store boundaries: legacy configs receive `repo`/`clone` defaults, external workflows require absolute paths, and invalid strategy/source values fail closed.

## 변경 지점 다이어그램

`project.json` → `normalizeOrchestratorProjectConfig` (core) → CLI `repo start` / `OrchestratorFsStore` → `OrchestratorService`

## 여기부터 보세요

- `packages/core/src/contracts/status-surface.ts` — shared defaults and runtime validation.
- `packages/cli/src/config.ts` — applies normalization on managed-config load/save.
- `packages/orchestrator/src/fs-store.ts` — reuses the shared normalization for persistence.
- `packages/cli/src/commands/start.test.ts` — verifies legacy config reaches the service with materialized defaults.

## 위험 & 롤백

- Invalid persisted standalone config now fails at the CLI/config boundary instead of silently reaching the runtime.
- Rollback is a revert of this PR; legacy `project.json` remains supported by the defaulting behavior.

## 변경 파일

- `.changeset/fair-otters-config.md`
- `packages/core/src/contracts/status-surface.ts`
- `packages/cli/src/config.ts`
- `packages/cli/src/config.test.ts`
- `packages/cli/src/commands/start.test.ts`
- `packages/orchestrator/src/fs-store.ts`
- `packages/orchestrator/src/fs-store.test.ts`

## Evidence

- `pnpm lint` — pass
- `pnpm test` — pass
- `pnpm typecheck` — pass
- `pnpm build` — pass

## 머지 후/사람 확인

- [ ] Confirm the standalone workflow-loader slice consumes the normalized external workflow path.
- [ ] Confirm `projectDir` absolute-path policy with the standalone project-directory creation/lookup slice.
