### PR TITLE
feat(orchestrator): resolve declared workflow source

### DIFF
--- a/.changeset/fresh-workflows-resolve.md
+++ b/.changeset/fresh-workflows-resolve.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Resolve declared external workflow sources without loading repository policy, and surface a warning when an external workflow shadows the checkout `WORKFLOW.md` (#563).

--- a/packages/core/src/contracts/status-surface.ts
+++ b/packages/core/src/contracts/status-surface.ts
@@ -289,6 +289,8 @@ export type ProjectStatusSnapshot = {
     settings?: Record<string, OrchestratorTrackerSettingValue>;
   };
   lastTickAt: string;
+  /** Non-fatal configuration conditions that operators should review. */
+  warnings?: string[];
   health: "idle" | "running" | "degraded";
   summary: {
     dispatched: number;

--- a/packages/core/src/observability/snapshot-builder.ts
+++ b/packages/core/src/observability/snapshot-builder.ts
@@ -30,6 +30,7 @@ export type SnapshotInput = {
   effectivePollIntervalMs?: number;
   dispatchSuppressedUntil?: string | null;
   issueWorkspaces?: readonly IssueWorkspaceRecord[];
+  warnings?: string[];
 };
 
 /**
@@ -52,6 +53,7 @@ export function buildProjectSnapshot(
     effectivePollIntervalMs,
     dispatchSuppressedUntil,
     issueWorkspaces,
+    warnings,
   } = input;
   const cumulativeTokenUsageByIssue = aggregateTokenUsageByIssue(
     allRuns ?? activeRuns
@@ -65,6 +67,7 @@ export function buildProjectSnapshot(
       settings: project.tracker.settings,
     },
     lastTickAt,
+    warnings: warnings ?? [],
     health: lastError ? "degraded" : activeRuns.length > 0 ? "running" : "idle",
     summary: {
       dispatched: summary.dispatched,

--- a/packages/core/src/workflow-loader.test.ts
+++ b/packages/core/src/workflow-loader.test.ts
@@ -50,6 +50,10 @@ codex:
   turn_timeout_ms: 3600000
 custom_extension:
   enabled: true
+repository:
+  owner: acme
+  name: platform
+  extension_flag: true
 ---
 Prefer focused changes.
 `;
@@ -73,6 +77,11 @@ describe("parseWorkflowMarkdown", () => {
     expect(workflow.lifecycle.blockerCheckStates).toEqual([]);
     expect(workflow.lifecycle.planningStates).toEqual([]);
     expect(workflow.polling.intervalMs).toBe(30000);
+    expect(workflow.repository).toEqual({
+      owner: "acme",
+      name: "platform",
+      extension_flag: true,
+    });
     expect(workflow.agent.maxFailureRetries).toBe(6);
     expect(workflow.agent.maxConcurrentAgentsByState).toEqual({ Todo: 1 });
   });

--- a/packages/core/src/workflow/config.ts
+++ b/packages/core/src/workflow/config.ts
@@ -50,6 +50,12 @@ export type WorkflowWorkspaceConfig = {
   root: string | null;
 };
 
+/**
+ * Repository-specific front matter is an optional extension. Its schema is
+ * owned by the extension consumer, so core preserves the decoded object.
+ */
+export type WorkflowRepositoryExtension = Record<string, unknown> | null;
+
 export type WorkflowAgentConfig = {
   maxConcurrentAgents: number;
   maxRetryBackoffMs: number;
@@ -115,6 +121,7 @@ export type WorkflowDefinition = {
   polling: {
     intervalMs: number;
   };
+  repository: WorkflowRepositoryExtension;
   workspace: WorkflowWorkspaceConfig;
   hooks: WorkflowHooksConfig;
   agent: WorkflowAgentConfig;
@@ -204,6 +211,7 @@ export const DEFAULT_WORKFLOW_DEFINITION: ParsedWorkflow = {
   polling: {
     intervalMs: DEFAULT_POLL_INTERVAL_MS,
   },
+  repository: null,
   workspace: DEFAULT_WORKFLOW_WORKSPACE,
   hooks: DEFAULT_WORKFLOW_HOOKS,
   agent: DEFAULT_WORKFLOW_AGENT,

--- a/packages/core/src/workflow/parser.ts
+++ b/packages/core/src/workflow/parser.ts
@@ -135,6 +135,7 @@ export function parseWorkflowMarkdown(
         readOptionalIntegerLike(polling, "interval_ms") ??
         DEFAULT_POLL_INTERVAL_MS,
     },
+    repository: readOptionalExtensionObject(frontMatter, "repository"),
     workspace: {
       root: readOptionalString(workspace, "root", env),
     },
@@ -705,6 +706,16 @@ function readOptionalRuntimeObject(
     return null;
   }
   return readObject(input, "runtime");
+}
+
+function readOptionalExtensionObject(
+  input: Record<string, WorkflowFrontMatterNode>,
+  key: string
+): Record<string, unknown> | null {
+  if (input[key] === undefined || input[key] === null) {
+    return null;
+  }
+  return readObject(input, key) as Record<string, unknown>;
 }
 
 function readRequiredObject(

--- a/packages/orchestrator/src/git.ts
+++ b/packages/orchestrator/src/git.ts
@@ -211,8 +211,13 @@ export async function loadRepositoryWorkflow(
   repositoryDirectory: string,
   _repository: RepositoryRef
 ): Promise<WorkflowResolution> {
-  const workflowPath = join(repositoryDirectory, "WORKFLOW.md");
+  return loadWorkflowFile(join(repositoryDirectory, "WORKFLOW.md"));
+}
 
+/** Load a workflow from an explicitly selected file without repository lookup. */
+export async function loadWorkflowFile(
+  workflowPath: string
+): Promise<WorkflowResolution> {
   try {
     return await workflowConfigStore.load(workflowPath);
   } catch (error) {

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -11373,6 +11373,157 @@ Workspace prompt.
     expect(spawnImpl).not.toHaveBeenCalled();
   });
 
+  it("loads only an external workflow and warns when it shadows the repository workflow", async () => {
+    process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
+    const tempRoot = await mkdtemp(
+      join(tmpdir(), "orchestrator-external-workflow-")
+    );
+    const repository = await createRepositoryFixture(
+      tempRoot,
+      "acme",
+      "platform"
+    );
+    const store = new OrchestratorFsStore(tempRoot);
+    const externalWorkflowPath = join(
+      store.projectDir("tenant-1"),
+      "WORKFLOW.md"
+    );
+    const projectConfig = {
+      ...createProjectConfig(tempRoot, repository),
+      workflowSource: { type: "external" as const, path: externalWorkflowPath },
+    };
+    await store.saveProjectConfig(projectConfig);
+    await writeFile(
+      externalWorkflowPath,
+      await readFile(join(repository.path, "WORKFLOW.md"), "utf8"),
+      "utf8"
+    );
+    await writeFile(
+      join(repository.path, "WORKFLOW.md"),
+      "---\ninvalid: [\n---\n",
+      "utf8"
+    );
+
+    const spawnImpl = vi.fn().mockReturnValue({
+      pid: 4309,
+      unref: vi.fn(),
+    });
+    const service = new OrchestratorService(store, projectConfig, {
+      fetchImpl: vi.fn().mockResolvedValue(createTrackerResponse(repository)),
+      spawnImpl: spawnImpl as never,
+      now: () => new Date("2026-03-08T00:00:00.000Z"),
+    });
+
+    const snapshot = await service.runOnce();
+    const workerEnv = spawnImpl.mock.calls[0]?.[2]?.env as
+      | Record<string, string>
+      | undefined;
+
+    expect(snapshot.summary.dispatched).toBe(1);
+    expect(workerEnv?.SYMPHONY_WORKFLOW_PATH).toBe(externalWorkflowPath);
+    expect(snapshot.warnings).toEqual([
+      `External workflow source ${externalWorkflowPath} shadows repository WORKFLOW.md at ${join(repository.path, "WORKFLOW.md")}.`,
+    ]);
+  });
+
+  it("reloads the configured external workflow and preserves repo mode behavior", async () => {
+    process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
+    const tempRoot = await mkdtemp(
+      join(tmpdir(), "orchestrator-external-workflow-reload-")
+    );
+    const repository = await createRepositoryFixture(
+      tempRoot,
+      "acme",
+      "platform",
+      { codexCommand: "codex --model repo" }
+    );
+    const store = new OrchestratorFsStore(tempRoot);
+    const externalWorkflowPath = join(
+      store.projectDir("tenant-1"),
+      "WORKFLOW.md"
+    );
+    const projectConfig = {
+      ...createProjectConfig(tempRoot, repository),
+      workflowSource: { type: "external" as const, path: externalWorkflowPath },
+    };
+    await store.saveProjectConfig(projectConfig);
+    await writeFile(
+      externalWorkflowPath,
+      await readFile(join(repository.path, "WORKFLOW.md"), "utf8"),
+      "utf8"
+    );
+    const service = new OrchestratorService(store, projectConfig);
+    const loadWorkflow = (
+      service as unknown as {
+        loadProjectWorkflow: (
+          tenant: OrchestratorProjectConfig,
+          repository: RepositoryRef
+        ) => Promise<WorkflowResolution>;
+      }
+    ).loadProjectWorkflow.bind(service);
+
+    await expect(
+      loadWorkflow(projectConfig, repository)
+    ).resolves.toMatchObject({
+      workflowPath: externalWorkflowPath,
+      agentCommand: "codex --model repo",
+    });
+    await writeFile(
+      externalWorkflowPath,
+      (await readFile(externalWorkflowPath, "utf8")).replace(
+        "codex --model repo",
+        "codex --model external-reloaded"
+      ),
+      "utf8"
+    );
+
+    await expect(
+      loadWorkflow(projectConfig, repository)
+    ).resolves.toMatchObject({
+      workflowPath: externalWorkflowPath,
+      agentCommand: "codex --model external-reloaded",
+    });
+  });
+
+  it("reports missing_workflow_file for a missing external workflow", async () => {
+    process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
+    const tempRoot = await mkdtemp(
+      join(tmpdir(), "orchestrator-external-workflow-missing-")
+    );
+    const repository = await createRepositoryFixture(
+      tempRoot,
+      "acme",
+      "platform"
+    );
+    const store = new OrchestratorFsStore(tempRoot);
+    const externalWorkflowPath = join(
+      store.projectDir("tenant-1"),
+      "WORKFLOW.md"
+    );
+    const projectConfig = {
+      ...createProjectConfig(tempRoot, repository),
+      workflowSource: { type: "external" as const, path: externalWorkflowPath },
+    };
+    await store.saveProjectConfig(projectConfig);
+    const service = new OrchestratorService(store, projectConfig);
+    const loadWorkflow = (
+      service as unknown as {
+        loadProjectWorkflow: (
+          tenant: OrchestratorProjectConfig,
+          repository: RepositoryRef
+        ) => Promise<WorkflowResolution>;
+      }
+    ).loadProjectWorkflow.bind(service);
+
+    await expect(
+      loadWorkflow(projectConfig, repository)
+    ).resolves.toMatchObject({
+      workflowPath: null,
+      isValid: false,
+      validationError: "missing_workflow_file",
+    });
+  });
+
   it("uses repo WORKFLOW.md when it is valid", async () => {
     process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
     const tempRoot = await mkdtemp(join(tmpdir(), "orchestrator-repo-wf-"));
@@ -11400,6 +11551,7 @@ Workspace prompt.
     // Repo WORKFLOW.md defines Todo as active, issue is in "Todo" → dispatched
     expect(result.summary.dispatched).toBe(1);
     expect(spawnImpl).toHaveBeenCalledTimes(1);
+    expect(result.warnings).toEqual([]);
   });
 
   it("loads project .env for repository script hooks during workspace creation", async () => {

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { access, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { createWriteStream, mkdirSync } from "node:fs";
 import { spawn } from "node:child_process";
 import type { ChildProcess, SpawnOptions } from "node:child_process";
@@ -58,6 +58,7 @@ import {
 import {
   ensureIssueWorkspaceRepository,
   inspectIssueWorkspaceDirtyStatus,
+  loadWorkflowFile,
   loadRepositoryWorkflow,
   quarantineIssueWorkspace,
   readGitCurrentBranch,
@@ -1778,6 +1779,7 @@ export class OrchestratorService {
         dispatchRateLimits
       ),
       issueWorkspaces,
+      warnings: await this.resolveWorkflowWarnings(tenant),
     });
     await this.store.saveProjectStatus({
       ...status,
@@ -2207,13 +2209,35 @@ export class OrchestratorService {
       repository.owner,
       repository.name
     );
-    const repositoryDirectory =
-      this.resolveWorkflowRepositoryDirectory(repository);
-    const resolution = await loadRepositoryWorkflow(
-      repositoryDirectory,
-      repository
-    );
+    const resolution =
+      tenant.workflowSource?.type === "external"
+        ? await loadWorkflowFile(tenant.workflowSource.path)
+        : await loadRepositoryWorkflow(
+            this.resolveWorkflowRepositoryDirectory(repository),
+            repository
+          );
     return this.resolveWorkflowResolution(repository, cacheRoot, resolution);
+  }
+
+  private async resolveWorkflowWarnings(
+    tenant: OrchestratorProjectConfig
+  ): Promise<string[]> {
+    if (tenant.workflowSource?.type !== "external") {
+      return [];
+    }
+
+    const repositoryWorkflowPath = join(
+      this.resolveWorkflowRepositoryDirectory(tenant.repository),
+      "WORKFLOW.md"
+    );
+    try {
+      await access(repositoryWorkflowPath);
+      return [
+        `External workflow source ${tenant.workflowSource.path} shadows repository WORKFLOW.md at ${repositoryWorkflowPath}.`,
+      ];
+    } catch {
+      return [];
+    }
   }
 
   private async startRun(


### PR DESCRIPTION
## TL;DR

- `workflowSource.type`에 따라 저장소 또는 명시된 외부 `WORKFLOW.md`만 해석합니다.
- 외부 소스가 checkout의 `WORKFLOW.md`를 가릴 때 status surface에 경고를 노출합니다.

## 변경 지점 다이어그램

```text
project config.workflowSource
  ├─ repo     → checkout/WORKFLOW.md
  └─ external → projectDir/WORKFLOW.md
                    └─ checkout WORKFLOW.md 존재 시 status warning
```

## 여기부터 보세요

- `packages/orchestrator/src/service.ts`의 워크플로우 해석 및 status warning 경로
- `packages/orchestrator/src/service.test.ts`의 external/repo 회귀 TC
- `packages/core/src/workflow/parser.ts`의 `repository` 확장 키 보존

## 위험 & 롤백

- external 설정의 잘못된 파일 경로는 기존 로더 규약대로 `missing_workflow_file`로 관찰됩니다.
- 롤백은 이 PR을 되돌리면 기존 checkout 기반 해석으로 복원됩니다.

## 변경 파일

- `packages/orchestrator/src/git.ts` — 명시 파일 로더
- `packages/orchestrator/src/service.ts` — 모드 분기 및 shadow warning
- `packages/orchestrator/src/service.test.ts` — external/repo/dynamic reload/missing-file TC
- `packages/core/src/workflow/{config,parser}.ts` — `repository` 확장 키 보존
- `.changeset/fresh-workflows-resolve.md`

## Evidence

- `pnpm lint`
- `pnpm test`
- `pnpm typecheck`
- `pnpm build`
- Docker E2E happy path: authenticated status API에서 dispatch 및 worker `completed` 이벤트 확인

## Issues — Closed #563

## 머지 후/사람 확인

- [ ] external 모드 운영 프로젝트에서 상태 표면의 shadow warning을 확인합니다.
