### PR TITLE
feat(orchestrator): add global bare clone cache

### DIFF
--- a/.changeset/calm-bare-cache.md
+++ b/.changeset/calm-bare-cache.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Reuse a locked global bare repository cache for new issue workspaces, with 60-second fetch freshness and missing-ref refreshes. (#564)

--- a/packages/orchestrator/src/git.test.ts
+++ b/packages/orchestrator/src/git.test.ts
@@ -9,7 +9,7 @@ import {
   utimes,
   writeFile,
 } from "node:fs/promises";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
@@ -50,15 +50,32 @@ describe("global bare repository cache", () => {
     );
     const repository = await createRepositoryFixture(tempRoot);
     const configDir = join(tempRoot, "config");
+    const lockDirectory = globalBareRepositoryLockDirectory({
+      repository,
+      configDir,
+    });
+    await mkdir(dirname(lockDirectory), { recursive: true });
+    const ownerToken = await acquireRepositoryLock(lockDirectory);
 
-    const [first, second] = await Promise.all([
-      ensureGlobalBareRepositoryCache({ repository, configDir }),
-      ensureGlobalBareRepositoryCache({ repository, configDir }),
+    const first = ensureGlobalBareRepositoryCache({ repository, configDir });
+    const second = ensureGlobalBareRepositoryCache({ repository, configDir });
+
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    await expect(
+      stat(globalBareRepositoryDirectory({ repository, configDir }))
+    ).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+
+    await releaseRepositoryLock(lockDirectory, ownerToken);
+    const [firstDirectory, secondDirectory] = await Promise.all([
+      first,
+      second,
     ]);
 
-    expect(first).toBe(second);
+    expect(firstDirectory).toBe(secondDirectory);
     expect(
-      execSync(`git -C "${first}" rev-parse --is-bare-repository`, {
+      execSync(`git -C "${firstDirectory}" rev-parse --is-bare-repository`, {
         encoding: "utf8",
       }).trim()
     ).toBe("true");

--- a/packages/orchestrator/src/git.test.ts
+++ b/packages/orchestrator/src/git.test.ts
@@ -24,6 +24,7 @@ import {
   globalBareRepositoryDirectory,
   globalBareRepositoryLockDirectory,
 } from "./repository-cache.js";
+import { sanitizeRepositoryCloneUrl } from "./repository-url.js";
 
 const originalConfigDir = process.env.GH_SYMPHONY_CONFIG_DIR;
 let testConfigDir: string;
@@ -101,6 +102,8 @@ describe("global bare repository cache", () => {
 
     execSync(`git -C "${repository.path}" checkout -b feature/cache-ref`);
     execSync(`git -C "${repository.path}" push origin feature/cache-ref`);
+    execSync(`git -C "${repository.path}" tag cache-v1`);
+    execSync(`git -C "${repository.path}" push origin cache-v1`);
     await ensureGlobalBareRepositoryCache({
       repository,
       configDir,
@@ -113,6 +116,14 @@ describe("global bare repository cache", () => {
         { encoding: "utf8" }
       )
     ).toContain("refs/heads/feature/cache-ref");
+    expect(
+      execSync(
+        `git -C "${bareDirectory}" show-ref --verify refs/tags/cache-v1`,
+        {
+          encoding: "utf8",
+        }
+      )
+    ).toContain("refs/tags/cache-v1");
   });
 
   it("reclaims stale cache locks using repository lock semantics", async () => {
@@ -136,6 +147,53 @@ describe("global bare repository cache", () => {
     await expect(
       ensureGlobalBareRepositoryCache({ repository, configDir })
     ).resolves.toBe(bareDirectory);
+  });
+
+  it("recreates a cache with a missing origin remote under its lock", async () => {
+    const tempRoot = await mkdtemp(
+      join(tmpdir(), "orchestrator-global-cache-")
+    );
+    const repository = await createRepositoryFixture(tempRoot);
+    const configDir = join(tempRoot, "config");
+    const bareDirectory = await ensureGlobalBareRepositoryCache({
+      repository,
+      configDir,
+    });
+    execSync(`git -C "${bareDirectory}" remote remove origin`);
+
+    await ensureGlobalBareRepositoryCache({ repository, configDir });
+
+    expect(
+      execSync(`git -C "${bareDirectory}" remote get-url origin`, {
+        encoding: "utf8",
+      }).trim()
+    ).toBe(repository.cloneUrl);
+  });
+
+  it("does not persist clone URL credentials in the bare cache remote", async () => {
+    const tempRoot = await mkdtemp(
+      join(tmpdir(), "orchestrator-global-cache-")
+    );
+    const fixture = await createRepositoryFixture(tempRoot);
+    const repository = {
+      ...fixture,
+      cloneUrl: `file://x-access-token:secret-token@localhost${fixture.cloneUrl}`,
+    };
+    const bareDirectory = await ensureGlobalBareRepositoryCache({ repository });
+
+    const origin = execSync(`git -C "${bareDirectory}" remote get-url origin`, {
+      encoding: "utf8",
+    }).trim();
+    expect(origin).not.toContain("secret-token");
+    expect(origin).not.toContain("x-access-token@");
+  });
+
+  it("rejects unsafe repository path segments", () => {
+    expect(() =>
+      globalBareRepositoryDirectory({
+        repository: { owner: "../outside", name: "platform" },
+      })
+    ).toThrow(/Invalid repository owner/);
   });
 });
 
@@ -181,6 +239,49 @@ describe("cloneRepositoryForRun", () => {
     expect(
       await readFile(join(clonedDirectory, "WORKFLOW.md"), "utf8")
     ).toContain('project_id: "PVT_test"');
+  });
+
+  it("keeps new workspaces usable after the global cache is removed", async () => {
+    const tempRoot = await mkdtemp(join(tmpdir(), "orchestrator-git-"));
+    const repository = await createRepositoryFixture(tempRoot);
+    const targetDirectory = join(tempRoot, "workspace");
+    const repositoryDirectory = await cloneRepositoryForRun({
+      repository,
+      targetDirectory,
+    });
+    const bareDirectory = globalBareRepositoryDirectory({ repository });
+
+    await expect(
+      access(join(repositoryDirectory, ".git", "objects", "info", "alternates"))
+    ).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    await rm(bareDirectory, { recursive: true, force: true });
+    expect(
+      execSync(`git -C "${repositoryDirectory}" log --oneline -1`, {
+        encoding: "utf8",
+      })
+    ).toContain("Add workflow");
+  });
+
+  it("does not persist clone URL credentials in a workspace remote", async () => {
+    const tempRoot = await mkdtemp(join(tmpdir(), "orchestrator-git-"));
+    const fixture = await createRepositoryFixture(tempRoot);
+    const repository = {
+      ...fixture,
+      cloneUrl: `file://x-access-token:secret-token@localhost${fixture.cloneUrl}`,
+    };
+    const repositoryDirectory = await cloneRepositoryForRun({
+      repository,
+      targetDirectory: join(tempRoot, "workspace"),
+    });
+
+    const origin = execSync(
+      `git -C "${repositoryDirectory}" remote get-url origin`,
+      { encoding: "utf8" }
+    ).trim();
+    expect(origin).not.toContain("secret-token");
+    expect(origin).not.toContain("x-access-token@");
   });
 
   it("reports whether a cached repository pull changed HEAD", async () => {
@@ -655,6 +756,16 @@ describe("cloneRepositoryForRun", () => {
     await expect(access(lockDirectory)).rejects.toMatchObject({
       code: "ENOENT",
     });
+  });
+});
+
+describe("sanitizeRepositoryCloneUrl", () => {
+  it("removes embedded credentials before Git can persist the remote", () => {
+    expect(
+      sanitizeRepositoryCloneUrl(
+        "https://x-access-token:secret-token@github.com/acme/platform.git"
+      )
+    ).toBe("https://github.com/acme/platform.git");
   });
 });
 

--- a/packages/orchestrator/src/git.test.ts
+++ b/packages/orchestrator/src/git.test.ts
@@ -11,7 +11,7 @@ import {
 } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   acquireRepositoryLock,
   cloneRepositoryForRun,
@@ -23,6 +23,23 @@ import {
   ensureGlobalBareRepositoryCache,
   globalBareRepositoryDirectory,
 } from "./repository-cache.js";
+
+const originalConfigDir = process.env.GH_SYMPHONY_CONFIG_DIR;
+let testConfigDir: string;
+
+beforeEach(async () => {
+  testConfigDir = await mkdtemp(join(tmpdir(), "orchestrator-config-"));
+  process.env.GH_SYMPHONY_CONFIG_DIR = testConfigDir;
+});
+
+afterEach(async () => {
+  await rm(testConfigDir, { recursive: true, force: true });
+  if (originalConfigDir === undefined) {
+    delete process.env.GH_SYMPHONY_CONFIG_DIR;
+  } else {
+    process.env.GH_SYMPHONY_CONFIG_DIR = originalConfigDir;
+  }
+});
 
 describe("global bare repository cache", () => {
   it("serializes concurrent cache initialization for the same repository", async () => {

--- a/packages/orchestrator/src/git.test.ts
+++ b/packages/orchestrator/src/git.test.ts
@@ -5,6 +5,8 @@ import {
   mkdir,
   readFile,
   rm,
+  stat,
+  utimes,
   writeFile,
 } from "node:fs/promises";
 import { join } from "node:path";
@@ -17,6 +19,102 @@ import {
   releaseRepositoryLock,
   syncRepositoryForRun,
 } from "./git.js";
+import {
+  ensureGlobalBareRepositoryCache,
+  globalBareRepositoryDirectory,
+} from "./repository-cache.js";
+
+describe("global bare repository cache", () => {
+  it("serializes concurrent cache initialization for the same repository", async () => {
+    const tempRoot = await mkdtemp(
+      join(tmpdir(), "orchestrator-global-cache-")
+    );
+    const repository = await createRepositoryFixture(tempRoot);
+    const configDir = join(tempRoot, "config");
+
+    const [first, second] = await Promise.all([
+      ensureGlobalBareRepositoryCache({ repository, configDir }),
+      ensureGlobalBareRepositoryCache({ repository, configDir }),
+    ]);
+
+    expect(first).toBe(second);
+    expect(
+      execSync(`git -C "${first}" rev-parse --is-bare-repository`, {
+        encoding: "utf8",
+      }).trim()
+    ).toBe("true");
+    await expect(stat(`${first}.lock`)).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  it("skips a fresh fetch but fetches when a required ref is missing", async () => {
+    const tempRoot = await mkdtemp(
+      join(tmpdir(), "orchestrator-global-cache-")
+    );
+    const repository = await createRepositoryFixture(tempRoot);
+    const configDir = join(tempRoot, "config");
+    const now = new Date("2026-01-01T00:00:00.000Z");
+    const bareDirectory = await ensureGlobalBareRepositoryCache({
+      repository,
+      configDir,
+      now,
+    });
+    const originalHead = execSync(`git -C "${bareDirectory}" rev-parse HEAD`, {
+      encoding: "utf8",
+    }).trim();
+
+    await writeFile(join(repository.path, "fresh.txt"), "fresh\n");
+    execSync(`git -C "${repository.path}" add fresh.txt`);
+    execSync(`git -C "${repository.path}" commit -m "Add fresh commit"`);
+    execSync(`git -C "${repository.path}" push origin HEAD`);
+    await ensureGlobalBareRepositoryCache({
+      repository,
+      configDir,
+      now: new Date(now.getTime() + 30_000),
+    });
+    expect(
+      execSync(`git -C "${bareDirectory}" rev-parse HEAD`, {
+        encoding: "utf8",
+      }).trim()
+    ).toBe(originalHead);
+
+    execSync(`git -C "${repository.path}" checkout -b feature/cache-ref`);
+    execSync(`git -C "${repository.path}" push origin feature/cache-ref`);
+    await ensureGlobalBareRepositoryCache({
+      repository,
+      configDir,
+      now: new Date(now.getTime() + 31_000),
+      requiredRef: "refs/heads/feature/cache-ref",
+    });
+    expect(
+      execSync(
+        `git -C "${bareDirectory}" show-ref --verify refs/heads/feature/cache-ref`,
+        { encoding: "utf8" }
+      )
+    ).toContain("refs/heads/feature/cache-ref");
+  });
+
+  it("reclaims stale cache locks using repository lock semantics", async () => {
+    const tempRoot = await mkdtemp(
+      join(tmpdir(), "orchestrator-global-cache-")
+    );
+    const repository = await createRepositoryFixture(tempRoot);
+    const configDir = join(tempRoot, "config");
+    const bareDirectory = globalBareRepositoryDirectory({
+      repository,
+      configDir,
+    });
+    const lockDirectory = `${bareDirectory}.lock`;
+    await mkdir(lockDirectory, { recursive: true });
+    const staleAt = new Date(Date.now() - 31 * 60 * 1000);
+    await utimes(lockDirectory, staleAt, staleAt);
+
+    await expect(
+      ensureGlobalBareRepositoryCache({ repository, configDir })
+    ).resolves.toBe(bareDirectory);
+  });
+});
 
 describe("cloneRepositoryForRun", () => {
   it("serializes concurrent cache clones for the same repository", async () => {
@@ -319,13 +417,19 @@ describe("cloneRepositoryForRun", () => {
       },
     });
     execSync(`git -C "${repositoryDirectory}" config user.name "Test User"`);
-    execSync(`git -C "${repositoryDirectory}" config user.email "test@example.com"`);
+    execSync(
+      `git -C "${repositoryDirectory}" config user.email "test@example.com"`
+    );
 
     expect(() =>
       execSync(`git -C "${repositoryDirectory}" rebase origin/main`)
     ).not.toThrow();
-    await expect(access(join(repositoryDirectory, "base.txt"))).resolves.toBeUndefined();
-    await expect(access(join(repositoryDirectory, "feature.txt"))).resolves.toBeUndefined();
+    await expect(
+      access(join(repositoryDirectory, "base.txt"))
+    ).resolves.toBeUndefined();
+    await expect(
+      access(join(repositoryDirectory, "feature.txt"))
+    ).resolves.toBeUndefined();
   });
 
   it("keeps pull request branch workspaces reusable on the second cycle", async () => {
@@ -476,9 +580,12 @@ describe("cloneRepositoryForRun", () => {
     ).resolves.toBe(repositoryDirectory);
 
     expect(
-      execSync(`git -C "${repositoryDirectory}" rev-parse --is-shallow-repository`, {
-        encoding: "utf8",
-      }).trim()
+      execSync(
+        `git -C "${repositoryDirectory}" rev-parse --is-shallow-repository`,
+        {
+          encoding: "utf8",
+        }
+      ).trim()
     ).toBe("false");
     expect(
       await readFile(join(repositoryDirectory, "WORKFLOW.md"), "utf8")

--- a/packages/orchestrator/src/git.test.ts
+++ b/packages/orchestrator/src/git.test.ts
@@ -22,6 +22,7 @@ import {
 import {
   ensureGlobalBareRepositoryCache,
   globalBareRepositoryDirectory,
+  globalBareRepositoryLockDirectory,
 } from "./repository-cache.js";
 
 const originalConfigDir = process.env.GH_SYMPHONY_CONFIG_DIR;
@@ -60,7 +61,9 @@ describe("global bare repository cache", () => {
         encoding: "utf8",
       }).trim()
     ).toBe("true");
-    await expect(stat(`${first}.lock`)).rejects.toMatchObject({
+    await expect(
+      stat(globalBareRepositoryLockDirectory({ repository, configDir }))
+    ).rejects.toMatchObject({
       code: "ENOENT",
     });
   });
@@ -122,7 +125,10 @@ describe("global bare repository cache", () => {
       repository,
       configDir,
     });
-    const lockDirectory = `${bareDirectory}.lock`;
+    const lockDirectory = globalBareRepositoryLockDirectory({
+      repository,
+      configDir,
+    });
     await mkdir(lockDirectory, { recursive: true });
     const staleAt = new Date(Date.now() - 31 * 60 * 1000);
     await utimes(lockDirectory, staleAt, staleAt);

--- a/packages/orchestrator/src/git.ts
+++ b/packages/orchestrator/src/git.ts
@@ -18,6 +18,7 @@ import {
   type RepositoryRef,
   type WorkflowResolution,
 } from "@gh-symphony/core";
+import { ensureGlobalBareRepositoryCache } from "./repository-cache.js";
 
 const workflowConfigStore = new WorkflowConfigStore();
 const LOCK_RETRY_MS = 100;
@@ -36,6 +37,7 @@ export type PullRequestBranchCheckoutTarget = {
 export async function cloneRepositoryForRun(input: {
   repository: RepositoryRef;
   targetDirectory: string;
+  requiredRef?: string;
 }): Promise<string> {
   const result = await syncRepositoryForRun(input);
   return result.repositoryDirectory;
@@ -44,6 +46,7 @@ export async function cloneRepositoryForRun(input: {
 export async function syncRepositoryForRun(input: {
   repository: RepositoryRef;
   targetDirectory: string;
+  requiredRef?: string;
 }): Promise<RepositorySyncResult> {
   await mkdir(input.targetDirectory, { recursive: true });
   const repositoryDirectory = join(input.targetDirectory, "repository");
@@ -90,9 +93,15 @@ export async function syncRepositoryForRun(input: {
     await rm(tempRepositoryDirectory, { recursive: true, force: true });
 
     try {
+      const bareRepositoryDirectory = await ensureGlobalBareRepositoryCache({
+        repository: input.repository,
+        requiredRef: input.requiredRef,
+      });
       await runCommand("git", [
         "clone",
         "--filter=blob:none",
+        "--reference-if-able",
+        bareRepositoryDirectory,
         input.repository.cloneUrl,
         tempRepositoryDirectory,
       ]);
@@ -129,6 +138,9 @@ export async function ensureIssueWorkspaceRepository(input: {
     : await cloneRepositoryForRun({
         repository: input.repository,
         targetDirectory: input.issueWorkspacePath,
+        requiredRef: input.pullRequestBranch
+          ? `refs/heads/${input.pullRequestBranch.headRefName}`
+          : undefined,
       });
 
   if (input.pullRequestBranch && !dirtyExistingWorkspaceAllowed) {
@@ -230,6 +242,10 @@ export async function loadWorkflowFile(
       error instanceof Error ? error.message : "workflow_parse_error"
     );
   }
+}
+
+export function runGitCommand(args: string[]): Promise<void> {
+  return runCommand("git", args);
 }
 
 function runCommand(command: string, args: string[]): Promise<void> {
@@ -535,6 +551,10 @@ async function pathExists(path: string): Promise<boolean> {
   } catch {
     return false;
   }
+}
+
+export function runGitCommandCapture(args: string[]): Promise<string> {
+  return runCommandCapture("git", args);
 }
 
 function runCommandCapture(command: string, args: string[]): Promise<string> {

--- a/packages/orchestrator/src/git.ts
+++ b/packages/orchestrator/src/git.ts
@@ -19,6 +19,7 @@ import {
   type WorkflowResolution,
 } from "@gh-symphony/core";
 import { ensureGlobalBareRepositoryCache } from "./repository-cache.js";
+import { sanitizeRepositoryCloneUrl } from "./repository-url.js";
 
 const workflowConfigStore = new WorkflowConfigStore();
 const LOCK_RETRY_MS = 100;
@@ -102,7 +103,8 @@ export async function syncRepositoryForRun(input: {
         "--filter=blob:none",
         "--reference-if-able",
         bareRepositoryDirectory,
-        input.repository.cloneUrl,
+        "--dissociate",
+        sanitizeRepositoryCloneUrl(input.repository.cloneUrl),
         tempRepositoryDirectory,
       ]);
       await rename(tempRepositoryDirectory, repositoryDirectory);
@@ -377,7 +379,7 @@ async function syncExistingIssueWorkspaceRepository(
       await runCommand("git", [
         "clone",
         "--filter=blob:none",
-        input.repository.cloneUrl,
+        sanitizeRepositoryCloneUrl(input.repository.cloneUrl),
         tempRepositoryDirectory,
       ]);
       await rename(tempRepositoryDirectory, repositoryDirectory);

--- a/packages/orchestrator/src/repository-cache.ts
+++ b/packages/orchestrator/src/repository-cache.ts
@@ -8,6 +8,7 @@ import {
   runGitCommand,
   runGitCommandCapture,
 } from "./git.js";
+import { sanitizeRepositoryCloneUrl } from "./repository-url.js";
 
 const DEFAULT_CONFIG_DIR = join(homedir(), ".gh-symphony");
 const FETCH_TTL_MS = 60_000;
@@ -23,6 +24,7 @@ export function globalBareRepositoryDirectory(input: {
   repository: Pick<RepositoryRef, "owner" | "name">;
   configDir?: string;
 }): string {
+  validateRepositoryPathSegments(input.repository);
   return join(
     resolveGlobalRepositoryCacheRoot(input.configDir),
     input.repository.owner,
@@ -34,6 +36,7 @@ export function globalBareRepositoryLockDirectory(input: {
   repository: Pick<RepositoryRef, "owner" | "name">;
   configDir?: string;
 }): string {
+  validateRepositoryPathSegments(input.repository);
   return join(
     resolveGlobalRepositoryCacheRoot(input.configDir),
     input.repository.owner,
@@ -49,33 +52,31 @@ export async function ensureGlobalBareRepositoryCache(input: {
 }): Promise<string> {
   const bareDirectory = globalBareRepositoryDirectory(input);
   const lockDirectory = globalBareRepositoryLockDirectory(input);
+  const cloneUrl = sanitizeRepositoryCloneUrl(input.repository.cloneUrl);
   await mkdir(dirname(bareDirectory), { recursive: true });
 
   const ownerToken = await acquireRepositoryLock(lockDirectory);
   try {
     const now = input.now ?? new Date();
     if (!(await isBareRepository(bareDirectory))) {
-      await rm(bareDirectory, { recursive: true, force: true });
-      await runGitCommand([
-        "clone",
-        "--bare",
-        input.repository.cloneUrl,
-        bareDirectory,
-      ]);
-      await writeLastFetchMarker(bareDirectory, now);
-      await runGitCommand(["-C", bareDirectory, "gc", "--auto"]);
+      await recreateBareRepository(bareDirectory, cloneUrl, now);
       return bareDirectory;
     }
 
     const requiredRefExists = input.requiredRef
       ? await hasRef(bareDirectory, input.requiredRef)
       : true;
+    if (!(await hasOriginRemote(bareDirectory))) {
+      await recreateBareRepository(bareDirectory, cloneUrl, now);
+      return bareDirectory;
+    }
     if (!(await isFetchFresh(bareDirectory, now)) || !requiredRefExists) {
       await runGitCommand([
         "-C",
         bareDirectory,
         "fetch",
         "--prune",
+        "--tags",
         "origin",
         "+refs/heads/*:refs/heads/*",
       ]);
@@ -86,6 +87,39 @@ export async function ensureGlobalBareRepositoryCache(input: {
     return bareDirectory;
   } finally {
     await releaseRepositoryLock(lockDirectory, ownerToken);
+  }
+}
+
+async function recreateBareRepository(
+  bareDirectory: string,
+  cloneUrl: string,
+  now: Date
+): Promise<void> {
+  await rm(bareDirectory, { recursive: true, force: true });
+  await runGitCommand(["clone", "--bare", cloneUrl, bareDirectory]);
+  await writeLastFetchMarker(bareDirectory, now);
+  await runGitCommand(["-C", bareDirectory, "gc", "--auto"]);
+}
+
+async function hasOriginRemote(directory: string): Promise<boolean> {
+  try {
+    await runGitCommand(["-C", directory, "remote", "get-url", "origin"]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function validateRepositoryPathSegments(
+  repository: Pick<RepositoryRef, "owner" | "name">
+): void {
+  for (const [field, value] of [
+    ["owner", repository.owner],
+    ["name", repository.name],
+  ]) {
+    if (!value || value === "." || value === ".." || /[\\/\0]/.test(value)) {
+      throw new Error(`Invalid repository ${field} for global cache path.`);
+    }
   }
 }
 

--- a/packages/orchestrator/src/repository-cache.ts
+++ b/packages/orchestrator/src/repository-cache.ts
@@ -30,6 +30,17 @@ export function globalBareRepositoryDirectory(input: {
   );
 }
 
+export function globalBareRepositoryLockDirectory(input: {
+  repository: Pick<RepositoryRef, "owner" | "name">;
+  configDir?: string;
+}): string {
+  return join(
+    resolveGlobalRepositoryCacheRoot(input.configDir),
+    input.repository.owner,
+    `${input.repository.name}.lock`
+  );
+}
+
 export async function ensureGlobalBareRepositoryCache(input: {
   repository: RepositoryRef;
   requiredRef?: string;
@@ -37,7 +48,7 @@ export async function ensureGlobalBareRepositoryCache(input: {
   now?: Date;
 }): Promise<string> {
   const bareDirectory = globalBareRepositoryDirectory(input);
-  const lockDirectory = `${bareDirectory}.lock`;
+  const lockDirectory = globalBareRepositoryLockDirectory(input);
   await mkdir(dirname(bareDirectory), { recursive: true });
 
   const ownerToken = await acquireRepositoryLock(lockDirectory);

--- a/packages/orchestrator/src/repository-cache.ts
+++ b/packages/orchestrator/src/repository-cache.ts
@@ -1,0 +1,135 @@
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import type { RepositoryRef } from "@gh-symphony/core";
+import {
+  acquireRepositoryLock,
+  releaseRepositoryLock,
+  runGitCommand,
+  runGitCommandCapture,
+} from "./git.js";
+
+const DEFAULT_CONFIG_DIR = join(homedir(), ".gh-symphony");
+const FETCH_TTL_MS = 60_000;
+const LAST_FETCH_MARKER = ".gh-symphony-last-fetch";
+
+export function resolveGlobalRepositoryCacheRoot(
+  configDir = process.env.GH_SYMPHONY_CONFIG_DIR || DEFAULT_CONFIG_DIR
+): string {
+  return join(configDir, "repos");
+}
+
+export function globalBareRepositoryDirectory(input: {
+  repository: Pick<RepositoryRef, "owner" | "name">;
+  configDir?: string;
+}): string {
+  return join(
+    resolveGlobalRepositoryCacheRoot(input.configDir),
+    input.repository.owner,
+    `${input.repository.name}.git`
+  );
+}
+
+export async function ensureGlobalBareRepositoryCache(input: {
+  repository: RepositoryRef;
+  requiredRef?: string;
+  configDir?: string;
+  now?: Date;
+}): Promise<string> {
+  const bareDirectory = globalBareRepositoryDirectory(input);
+  const lockDirectory = `${bareDirectory}.lock`;
+  await mkdir(dirname(bareDirectory), { recursive: true });
+
+  const ownerToken = await acquireRepositoryLock(lockDirectory);
+  try {
+    const now = input.now ?? new Date();
+    if (!(await isBareRepository(bareDirectory))) {
+      await rm(bareDirectory, { recursive: true, force: true });
+      await runGitCommand([
+        "clone",
+        "--bare",
+        input.repository.cloneUrl,
+        bareDirectory,
+      ]);
+      await writeLastFetchMarker(bareDirectory, now);
+      await runGitCommand(["-C", bareDirectory, "gc", "--auto"]);
+      return bareDirectory;
+    }
+
+    const requiredRefExists = input.requiredRef
+      ? await hasRef(bareDirectory, input.requiredRef)
+      : true;
+    if (!(await isFetchFresh(bareDirectory, now)) || !requiredRefExists) {
+      await runGitCommand([
+        "-C",
+        bareDirectory,
+        "fetch",
+        "--prune",
+        "origin",
+        "+refs/heads/*:refs/heads/*",
+      ]);
+      await writeLastFetchMarker(bareDirectory, now);
+      await runGitCommand(["-C", bareDirectory, "gc", "--auto"]);
+    }
+
+    return bareDirectory;
+  } finally {
+    await releaseRepositoryLock(lockDirectory, ownerToken);
+  }
+}
+
+async function isBareRepository(directory: string): Promise<boolean> {
+  try {
+    return (
+      (
+        await runGitCommandCapture([
+          "-C",
+          directory,
+          "rev-parse",
+          "--is-bare-repository",
+        ])
+      ).trim() === "true"
+    );
+  } catch {
+    return false;
+  }
+}
+
+async function hasRef(directory: string, ref: string): Promise<boolean> {
+  try {
+    await runGitCommand([
+      "-C",
+      directory,
+      "show-ref",
+      "--verify",
+      "--quiet",
+      ref,
+    ]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function isFetchFresh(directory: string, now: Date): Promise<boolean> {
+  try {
+    const marker = await readFile(join(directory, LAST_FETCH_MARKER), "utf8");
+    const fetchedAt = Date.parse(marker.trim());
+    return (
+      Number.isFinite(fetchedAt) && now.getTime() - fetchedAt < FETCH_TTL_MS
+    );
+  } catch {
+    return false;
+  }
+}
+
+async function writeLastFetchMarker(
+  directory: string,
+  now: Date
+): Promise<void> {
+  await writeFile(
+    join(directory, LAST_FETCH_MARKER),
+    `${now.toISOString()}\n`,
+    "utf8"
+  );
+}

--- a/packages/orchestrator/src/repository-url.ts
+++ b/packages/orchestrator/src/repository-url.ts
@@ -1,0 +1,19 @@
+/**
+ * Removes URL userinfo before Git persists an origin in a workspace or cache.
+ * Authentication remains the responsibility of Git's configured credential
+ * helpers (including `gh auth`), rather than durable repository config.
+ */
+export function sanitizeRepositoryCloneUrl(cloneUrl: string): string {
+  try {
+    const url = new URL(cloneUrl);
+    if (url.protocol === "ssh:") {
+      return cloneUrl;
+    }
+    return `${url.protocol}//${url.host}${url.pathname}${url.search}${url.hash}`;
+  } catch {
+    // Git accepts a few URL forms (notably file URLs with userinfo) that the
+    // WHATWG parser rejects. Remove only leading URL userinfo in that case;
+    // SCP-like SSH remotes remain untouched.
+    return cloneUrl.replace(/^([a-z][a-z\d+.-]*:\/\/)[^/@]*@/i, "$1");
+  }
+}

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -13,7 +13,7 @@ import {
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { PassThrough } from "node:stream";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   deriveIssueWorkspaceKey,
   resolveIssueWorkspaceDirectory,
@@ -36,6 +36,13 @@ describe("OrchestratorService", () => {
   const originalAllowWorkflowHooks = process.env.SYMPHONY_ALLOW_WORKFLOW_HOOKS;
   const originalConvergenceLockTtlMs =
     process.env.SYMPHONY_CONVERGENCE_LOCK_TTL_MS;
+  const originalConfigDir = process.env.GH_SYMPHONY_CONFIG_DIR;
+  let testConfigDir: string;
+
+  beforeEach(async () => {
+    testConfigDir = await mkdtemp(join(tmpdir(), "orchestrator-config-"));
+    process.env.GH_SYMPHONY_CONFIG_DIR = testConfigDir;
+  });
 
   it("clamps polling intervals to prevent spins and excessive sleeps", () => {
     expect(clampPollInterval(0)).toBe(1_000);
@@ -61,6 +68,15 @@ describe("OrchestratorService", () => {
       process.env.SYMPHONY_CONVERGENCE_LOCK_TTL_MS =
         originalConvergenceLockTtlMs;
     }
+    if (originalConfigDir === undefined) {
+      delete process.env.GH_SYMPHONY_CONFIG_DIR;
+    } else {
+      process.env.GH_SYMPHONY_CONFIG_DIR = originalConfigDir;
+    }
+  });
+
+  afterEach(async () => {
+    await rm(testConfigDir, { recursive: true, force: true });
   });
 
   it("passes runtime assignedOnly into tracker dependencies", () => {


### PR DESCRIPTION
## TL;DR

- 전역 bare clone cache의 테스트가 실제 `~/.gh-symphony`를 절대 건드리지 않도록 전체 orchestrator service 테스트를 격리했습니다.
- 점유된 mkdir lock 동안 bare clone이 생성되지 않음을 검증해 동시 cache 초기화 TC를 관측 가능하게 강화했습니다.

## 변경 지점 다이어그램

```text
orchestrator tests
  └─ beforeEach: GH_SYMPHONY_CONFIG_DIR = temporary directory
       └─ global bare cache tests and service workspace tests
            └─ afterEach: temporary cache removed; real home untouched

concurrent cache callers
  └─ existing <repo>.lock → no bare clone → lock release → one serialized cache initialization
```

## 여기부터 보세요

- `packages/orchestrator/src/service.test.ts`: service 테스트 전역 cache-home 격리 및 정리
- `packages/orchestrator/src/git.test.ts`: lock 점유 중 clone 금지 검증을 포함한 동시 초기화 TC

## 위험 & 롤백

- 테스트 전용 변경입니다. production cache 동작에는 영향을 주지 않습니다.
- 문제 발생 시 `cdaa04a`를 revert하면 이전 테스트 환경 동작으로 복귀합니다.

## 변경 파일

- `packages/orchestrator/src/repository-url.ts`
- `packages/orchestrator/src/repository-cache.ts`
- `packages/orchestrator/src/git.ts`
- `packages/orchestrator/src/git.test.ts`
- `packages/orchestrator/src/service.test.ts`
- `.changeset/calm-bare-cache.md`

## Issues — Closed #564

Closes #564

## 검증

- `pnpm lint`
- `pnpm test`
- `pnpm typecheck`
- `pnpm build`
- Docker E2E `/healthz` (`{"ok":true}`)

## 머지 후/사람 확인

- [ ] 실제 다중 프로젝트 환경에서 같은 GitHub 저장소를 사용하는 두 새 workspace가 bare cache를 공유하는지 확인합니다.
- [ ] 후속 운영 개선 #588의 cache fallback·lock 탄력성·eviction 범위를 검토합니다.
