### PR TITLE
feat(orchestrator): resolve project env in workflows

### DIFF
--- a/.changeset/quiet-project-envs.md
+++ b/.changeset/quiet-project-envs.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Resolve standalone project workflow environment variables from the project's `.env` file (#566).

--- a/packages/core/src/workflow/loader.ts
+++ b/packages/core/src/workflow/loader.ts
@@ -7,6 +7,7 @@ import type { WorkflowResolution } from "../contracts/status-surface.js";
 
 type WorkflowCacheEntry = {
   fingerprint: string;
+  envSignature: string;
   workflow: ParsedWorkflow;
   loadedAt: string;
 };
@@ -25,8 +26,17 @@ export class WorkflowConfigStore {
     const fingerprint = `${fileStat.mtimeMs}:${fileStat.size}:${createHash("sha256")
       .update(markdown)
       .digest("hex")}`;
+    const envSignature = JSON.stringify(
+      Object.entries(env).filter(
+        (entry): entry is [string, string] => typeof entry[1] === "string"
+      )
+    );
 
-    if (cached && cached.fingerprint === fingerprint) {
+    if (
+      cached &&
+      cached.fingerprint === fingerprint &&
+      cached.envSignature === envSignature
+    ) {
       return toWorkflowResolution(workflowPath, cached.workflow, {
         isValid: true,
         usedLastKnownGood: false,
@@ -38,6 +48,7 @@ export class WorkflowConfigStore {
       const workflow = parseWorkflowMarkdown(markdown, env);
       this.cache.set(workflowPath, {
         fingerprint,
+        envSignature,
         workflow,
         loadedAt: new Date().toISOString(),
       });

--- a/packages/orchestrator/src/git.ts
+++ b/packages/orchestrator/src/git.ts
@@ -223,17 +223,19 @@ export async function quarantineIssueWorkspace(
 
 export async function loadRepositoryWorkflow(
   repositoryDirectory: string,
-  _repository: RepositoryRef
+  _repository: RepositoryRef,
+  env: NodeJS.ProcessEnv = process.env
 ): Promise<WorkflowResolution> {
-  return loadWorkflowFile(join(repositoryDirectory, "WORKFLOW.md"));
+  return loadWorkflowFile(join(repositoryDirectory, "WORKFLOW.md"), env);
 }
 
 /** Load a workflow from an explicitly selected file without repository lookup. */
 export async function loadWorkflowFile(
-  workflowPath: string
+  workflowPath: string,
+  env: NodeJS.ProcessEnv = process.env
 ): Promise<WorkflowResolution> {
   try {
-    return await workflowConfigStore.load(workflowPath);
+    return await workflowConfigStore.load(workflowPath, env);
   } catch (error) {
     if (isMissingFileError(error)) {
       return createDefaultWorkflowResolution();

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -11712,7 +11712,7 @@ Prefer focused changes.
       await store.saveProjectConfig(projectConfig);
       await writeFile(
         join(store.projectDir(projectConfig.projectId), ".env"),
-        "PROJECT_ENV_WORKFLOW_ID=project-env-id\\n",
+        "PROJECT_ENV_WORKFLOW_ID=project-env-id\n",
         "utf8"
       );
 
@@ -11757,7 +11757,7 @@ Prefer focused changes.
     const projectConfig = createProjectConfig(tempRoot, repository);
     await store.saveProjectConfig(projectConfig);
     const envPath = join(store.projectDir(projectConfig.projectId), ".env");
-    await writeFile(envPath, "PROJECT_ENV_VALUE=loaded\\n", "utf8");
+    await writeFile(envPath, "PROJECT_ENV_VALUE=loaded\n", "utf8");
     await chmod(envPath, 0o644);
     const stderr = { write: vi.fn().mockReturnValue(true) };
     const service = new OrchestratorService(store, projectConfig, { stderr });

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -11664,7 +11664,7 @@ Prefer focused changes.
     ).resolves.toBe("from-project-env\n");
   });
 
-  it("resolves workflow $VAR values from project .env with host precedence", async () => {
+  it("resolves standalone project .env $VAR values with host precedence", async () => {
     process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
     const originalProjectId = process.env.PROJECT_ENV_WORKFLOW_ID;
     process.env.PROJECT_ENV_WORKFLOW_ID = "host-project-id";
@@ -11708,10 +11708,16 @@ Prefer focused changes.
         }
       );
       const store = new OrchestratorFsStore(tempRoot);
-      const projectConfig = createProjectConfig(tempRoot, repository);
+      const standaloneProjectDir = await mkdtemp(
+        join(tmpdir(), "orchestrator-standalone-project-env-")
+      );
+      const projectConfig = {
+        ...createProjectConfig(tempRoot, repository),
+        projectDir: standaloneProjectDir,
+      };
       await store.saveProjectConfig(projectConfig);
       await writeFile(
-        join(store.projectDir(projectConfig.projectId), ".env"),
+        join(standaloneProjectDir, ".env"),
         "PROJECT_ENV_WORKFLOW_ID=project-env-id\n",
         "utf8"
       );
@@ -11764,9 +11770,11 @@ Prefer focused changes.
 
     const environment = (
       service as unknown as {
-        resolveProjectEnvironment(projectId: string): NodeJS.ProcessEnv;
+        resolveProjectEnvironment(
+          tenant: OrchestratorProjectConfig
+        ): NodeJS.ProcessEnv;
       }
-    ).resolveProjectEnvironment(projectConfig.projectId);
+    ).resolveProjectEnvironment(projectConfig);
 
     expect(environment.PROJECT_ENV_VALUE).toBe("loaded");
     expect(stderr.write).toHaveBeenCalledWith(

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -11664,6 +11664,116 @@ Prefer focused changes.
     ).resolves.toBe("from-project-env\n");
   });
 
+  it("resolves workflow $VAR values from project .env with host precedence", async () => {
+    process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
+    const originalProjectId = process.env.PROJECT_ENV_WORKFLOW_ID;
+    process.env.PROJECT_ENV_WORKFLOW_ID = "host-project-id";
+
+    try {
+      const tempRoot = await mkdtemp(
+        join(tmpdir(), "orchestrator-workflow-project-env-")
+      );
+      const repository = await createRepositoryFixture(
+        tempRoot,
+        "acme",
+        "platform",
+        {
+          rawWorkflow: `---
+tracker:
+  kind: github-project
+  project_id: $PROJECT_ENV_WORKFLOW_ID
+  state_field: Status
+  active_states:
+    - Todo
+  terminal_states:
+    - Done
+  blocker_check_states:
+    - Todo
+polling:
+  interval_ms: 30000
+workspace:
+  root: .runtime/symphony-workspaces
+agent:
+  max_concurrent_agents: 10
+  max_retry_backoff_ms: 30000
+  retry_base_delay_ms: 1000
+codex:
+  command: codex app-server
+  read_timeout_ms: 5000
+  stall_timeout_ms: 300000
+  turn_timeout_ms: 3600000
+---
+Prefer focused changes.
+`,
+        }
+      );
+      const store = new OrchestratorFsStore(tempRoot);
+      const projectConfig = createProjectConfig(tempRoot, repository);
+      await store.saveProjectConfig(projectConfig);
+      await writeFile(
+        join(store.projectDir(projectConfig.projectId), ".env"),
+        "PROJECT_ENV_WORKFLOW_ID=project-env-id\\n",
+        "utf8"
+      );
+
+      const service = new OrchestratorService(store, projectConfig);
+      const resolution = await (
+        service as unknown as {
+          loadProjectWorkflowUncached(
+            tenant: OrchestratorProjectConfig,
+            repository: RepositoryRef
+          ): Promise<WorkflowResolution>;
+        }
+      ).loadProjectWorkflowUncached(projectConfig, repository);
+
+      expect(resolution.workflow.tracker.projectId).toBe("host-project-id");
+
+      delete process.env.PROJECT_ENV_WORKFLOW_ID;
+      const projectResolution = await (
+        service as unknown as {
+          loadProjectWorkflowUncached(
+            tenant: OrchestratorProjectConfig,
+            repository: RepositoryRef
+          ): Promise<WorkflowResolution>;
+        }
+      ).loadProjectWorkflowUncached(projectConfig, repository);
+      expect(projectResolution.workflow.tracker.projectId).toBe("project-env-id");
+    } finally {
+      if (originalProjectId === undefined) {
+        delete process.env.PROJECT_ENV_WORKFLOW_ID;
+      } else {
+        process.env.PROJECT_ENV_WORKFLOW_ID = originalProjectId;
+      }
+    }
+  });
+
+  it("warns for project .env permissions other than 0600 without rejecting it", async () => {
+    process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
+    const tempRoot = await mkdtemp(
+      join(tmpdir(), "orchestrator-project-env-permissions-")
+    );
+    const repository = await createRepositoryFixture(tempRoot, "acme", "platform");
+    const store = new OrchestratorFsStore(tempRoot);
+    const projectConfig = createProjectConfig(tempRoot, repository);
+    await store.saveProjectConfig(projectConfig);
+    const envPath = join(store.projectDir(projectConfig.projectId), ".env");
+    await writeFile(envPath, "PROJECT_ENV_VALUE=loaded\\n", "utf8");
+    await chmod(envPath, 0o644);
+    const stderr = { write: vi.fn().mockReturnValue(true) };
+    const service = new OrchestratorService(store, projectConfig, { stderr });
+
+    const environment = (
+      service as unknown as {
+        resolveProjectEnvironment(projectId: string): NodeJS.ProcessEnv;
+      }
+    ).resolveProjectEnvironment(projectConfig.projectId);
+
+    expect(environment.PROJECT_ENV_VALUE).toBe("loaded");
+    expect(stderr.write).toHaveBeenCalledWith(
+      expect.stringContaining("should use 0600 permissions")
+    );
+  });
+
   it("applies allowlisted project .env to approved script hooks, with symphony context precedence", async () => {
     process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
     const originalStagingApiHost = process.env.STAGING_API_HOST;

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -11743,7 +11743,9 @@ Prefer focused changes.
           ): Promise<WorkflowResolution>;
         }
       ).loadProjectWorkflowUncached(projectConfig, repository);
-      expect(projectResolution.workflow.tracker.projectId).toBe("project-env-id");
+      expect(projectResolution.workflow.tracker.projectId).toBe(
+        "project-env-id"
+      );
     } finally {
       if (originalProjectId === undefined) {
         delete process.env.PROJECT_ENV_WORKFLOW_ID;
@@ -11753,12 +11755,56 @@ Prefer focused changes.
     }
   });
 
-  it("warns for project .env permissions other than 0600 without rejecting it", async () => {
+  it("warns once for group-readable project .env files without rejecting them", async () => {
     process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
     const tempRoot = await mkdtemp(
       join(tmpdir(), "orchestrator-project-env-permissions-")
     );
-    const repository = await createRepositoryFixture(tempRoot, "acme", "platform");
+    const repository = await createRepositoryFixture(
+      tempRoot,
+      "acme",
+      "platform"
+    );
+    const store = new OrchestratorFsStore(tempRoot);
+    const projectConfig = createProjectConfig(tempRoot, repository);
+    await store.saveProjectConfig(projectConfig);
+    const envPath = join(store.projectDir(projectConfig.projectId), ".env");
+    await writeFile(envPath, "PROJECT_ENV_VALUE=loaded\n", "utf8");
+    await chmod(envPath, 0o644);
+    const stderr = { write: vi.fn().mockReturnValue(true) };
+    const service = new OrchestratorService(store, projectConfig, { stderr });
+
+    const resolveProjectEnvironment = (
+      service as unknown as {
+        resolveProjectEnvironment(
+          tenant: OrchestratorProjectConfig
+        ): NodeJS.ProcessEnv;
+      }
+    ).resolveProjectEnvironment.bind(service);
+    const environment = resolveProjectEnvironment(projectConfig);
+    resolveProjectEnvironment(projectConfig);
+
+    expect(environment.PROJECT_ENV_VALUE).toBe("loaded");
+    expect(stderr.write).toHaveBeenCalledTimes(1);
+    expect(stderr.write).toHaveBeenCalledWith(
+      expect.stringContaining("should use 0600 permissions")
+    );
+
+    await chmod(envPath, 0o400);
+    resolveProjectEnvironment(projectConfig);
+    expect(stderr.write).toHaveBeenCalledTimes(1);
+  });
+
+  it("reads project .env once when building worker execution env", async () => {
+    process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
+    const tempRoot = await mkdtemp(
+      join(tmpdir(), "orchestrator-project-env-execution-")
+    );
+    const repository = await createRepositoryFixture(
+      tempRoot,
+      "acme",
+      "platform"
+    );
     const store = new OrchestratorFsStore(tempRoot);
     const projectConfig = createProjectConfig(tempRoot, repository);
     await store.saveProjectConfig(projectConfig);
@@ -11770,16 +11816,15 @@ Prefer focused changes.
 
     const environment = (
       service as unknown as {
-        resolveProjectEnvironment(
-          tenant: OrchestratorProjectConfig
-        ): NodeJS.ProcessEnv;
+        buildProjectExecutionEnv(
+          tenant: OrchestratorProjectConfig,
+          env: Record<string, string | undefined>
+        ): Record<string, string>;
       }
-    ).resolveProjectEnvironment(projectConfig);
+    ).buildProjectExecutionEnv(projectConfig, {});
 
     expect(environment.PROJECT_ENV_VALUE).toBe("loaded");
-    expect(stderr.write).toHaveBeenCalledWith(
-      expect.stringContaining("should use 0600 permissions")
-    );
+    expect(stderr.write).toHaveBeenCalledTimes(1);
   });
 
   it("applies allowlisted project .env to approved script hooks, with symphony context precedence", async () => {

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -1,5 +1,5 @@
 import { access, mkdir, readFile, rm, writeFile } from "node:fs/promises";
-import { createWriteStream, mkdirSync } from "node:fs";
+import { createWriteStream, existsSync, mkdirSync, statSync } from "node:fs";
 import { spawn } from "node:child_process";
 import type { ChildProcess, SpawnOptions } from "node:child_process";
 import { isAbsolute, join } from "node:path";
@@ -2209,12 +2209,14 @@ export class OrchestratorService {
       repository.owner,
       repository.name
     );
+    const environment = this.resolveProjectEnvironment(tenant);
     const resolution =
       tenant.workflowSource?.type === "external"
-        ? await loadWorkflowFile(tenant.workflowSource.path)
+        ? await loadWorkflowFile(tenant.workflowSource.path, environment)
         : await loadRepositoryWorkflow(
             this.resolveWorkflowRepositoryDirectory(repository),
-            repository
+            repository,
+            environment
           );
     return this.resolveWorkflowResolution(repository, cacheRoot, resolution);
   }
@@ -2508,7 +2510,7 @@ export class OrchestratorService {
       ["-lc", resolveWorkerCommand()],
       {
         cwd: process.cwd(),
-        env: this.buildProjectExecutionEnv(tenant.projectId, {
+        env: this.buildProjectExecutionEnv(tenant, {
           CODEX_PROJECT_ID: tenant.projectId,
           PROJECT_ID: tenant.projectId,
           WORKING_DIRECTORY: repositoryDirectory,
@@ -3750,10 +3752,7 @@ export class OrchestratorService {
             "Repository WORKFLOW.md could not be loaded.",
         };
       } else {
-        const hookEnv = this.buildProjectExecutionEnv(
-          tenant.projectId,
-          buildHookEnv(context)
-        );
+        const hookEnv = this.buildProjectExecutionEnv(tenant, buildHookEnv(context));
         result = await executeWorkspaceHook({
           kind,
           hooks: workflowResolution.workflow.hooks,
@@ -3801,26 +3800,44 @@ export class OrchestratorService {
     return result;
   }
 
-  private readProjectEnv(projectId: string): Record<string, string> {
-    const envPath = join(this.store.projectDir(projectId), ".env");
+  private readProjectEnv(
+    tenant: OrchestratorProjectConfig
+  ): Record<string, string> {
+    const projectDirectory = tenant.projectDir ?? this.store.projectDir(tenant.projectId);
+    const envPath = join(projectDirectory, ".env");
     try {
+      if (existsSync(envPath) && (statSync(envPath).mode & 0o777) !== 0o600) {
+        (this.dependencies.stderr ?? process.stderr).write(
+          `[warn] Project env for ${tenant.projectId} at ${envPath} should use 0600 permissions.\n`
+        );
+      }
       return readEnvFile(envPath);
     } catch (error) {
       const message =
         error instanceof Error ? error.message : "Unknown error occurred.";
       (this.dependencies.stderr ?? process.stderr).write(
-        `[warn] Failed to load project env for ${projectId} from ${envPath}: ${message}\n`
+        `[warn] Failed to load project env for ${tenant.projectId} from ${envPath}: ${message}\n`
       );
       return {};
     }
   }
 
+  private resolveProjectEnvironment(
+    tenant: OrchestratorProjectConfig
+  ): NodeJS.ProcessEnv {
+    return {
+      ...this.readProjectEnv(tenant),
+      ...process.env,
+    };
+  }
+
   private buildProjectExecutionEnv(
-    projectId: string,
+    tenant: OrchestratorProjectConfig,
     env: Record<string, string | undefined>
   ): Record<string, string> {
+    const projectEnvironment = this.resolveProjectEnvironment(tenant);
     const inheritedEnv = Object.fromEntries(
-      Object.entries(process.env).filter(
+      Object.entries(projectEnvironment).filter(
         (entry): entry is [string, string] =>
           typeof entry[1] === "string" && shouldInheritProcessEnvKey(entry[0])
       )
@@ -3832,7 +3849,7 @@ export class OrchestratorService {
     );
 
     return {
-      ...this.readProjectEnv(projectId),
+      ...this.readProjectEnv(tenant),
       ...inheritedEnv,
       ...explicitEnv,
     };

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -1,5 +1,5 @@
 import { access, mkdir, readFile, rm, writeFile } from "node:fs/promises";
-import { createWriteStream, existsSync, mkdirSync, statSync } from "node:fs";
+import { createWriteStream, mkdirSync, statSync } from "node:fs";
 import { spawn } from "node:child_process";
 import type { ChildProcess, SpawnOptions } from "node:child_process";
 import { isAbsolute, join } from "node:path";
@@ -355,6 +355,7 @@ export class OrchestratorService {
     Record<string, unknown>
   >();
   private readonly issueCommentCaches = new Map<string, IssueCommentCache>();
+  private readonly warnedProjectEnvPermissions = new Map<string, number>();
   private workflowResolutionCache: Map<
     string,
     Promise<WorkflowResolution>
@@ -3752,7 +3753,10 @@ export class OrchestratorService {
             "Repository WORKFLOW.md could not be loaded.",
         };
       } else {
-        const hookEnv = this.buildProjectExecutionEnv(tenant, buildHookEnv(context));
+        const hookEnv = this.buildProjectExecutionEnv(
+          tenant,
+          buildHookEnv(context)
+        );
         result = await executeWorkspaceHook({
           kind,
           hooks: workflowResolution.workflow.hooks,
@@ -3803,10 +3807,19 @@ export class OrchestratorService {
   private readProjectEnv(
     tenant: OrchestratorProjectConfig
   ): Record<string, string> {
-    const projectDirectory = tenant.projectDir ?? this.store.projectDir(tenant.projectId);
+    const projectDirectory =
+      tenant.projectDir ?? this.store.projectDir(tenant.projectId);
     const envPath = join(projectDirectory, ".env");
     try {
-      if (existsSync(envPath) && (statSync(envPath).mode & 0o777) !== 0o600) {
+      const envStat = statSync(envPath, { throwIfNoEntry: false });
+      const mode =
+        envStat?.mode === undefined ? undefined : envStat.mode & 0o777;
+      if (
+        mode !== undefined &&
+        (mode & 0o077) !== 0 &&
+        this.warnedProjectEnvPermissions.get(envPath) !== mode
+      ) {
+        this.warnedProjectEnvPermissions.set(envPath, mode);
         (this.dependencies.stderr ?? process.stderr).write(
           `[warn] Project env for ${tenant.projectId} at ${envPath} should use 0600 permissions.\n`
         );
@@ -3835,9 +3848,9 @@ export class OrchestratorService {
     tenant: OrchestratorProjectConfig,
     env: Record<string, string | undefined>
   ): Record<string, string> {
-    const projectEnvironment = this.resolveProjectEnvironment(tenant);
+    const projectEnv = this.readProjectEnv(tenant);
     const inheritedEnv = Object.fromEntries(
-      Object.entries(projectEnvironment).filter(
+      Object.entries(process.env).filter(
         (entry): entry is [string, string] =>
           typeof entry[1] === "string" && shouldInheritProcessEnvKey(entry[0])
       )
@@ -3849,7 +3862,7 @@ export class OrchestratorService {
     );
 
     return {
-      ...this.readProjectEnv(tenant),
+      ...projectEnv,
       ...inheritedEnv,
       ...explicitEnv,
     };


### PR DESCRIPTION
## TL;DR

Standalone project workflows resolve `$VAR` from `<projectDir>/.env`, with host process values taking precedence. Project env files are read once per execution-env build; unsafe group/other permissions produce one non-blocking warning per path and mode.

## 변경 지점 다이어그램

`tenant.projectDir/.env` → workflow environment (`project .env` → `process.env`) → repository/external workflow parsing → front matter and MCP composition `$VAR`

`tenant.projectDir/.env` → project env → allowlisted host env → explicit env → worker/hook env

Worker startup still uses the existing allowlisted runtime environment path; `SAFE_RUNTIME_ENV_KEYS` is unchanged.

## 여기부터 보세요

- `packages/orchestrator/src/service.ts`: standalone directory selection, workflow resolution, worker env 구성, 권한 경고 억제.
- `packages/orchestrator/src/service.test.ts`: host precedence, project-only env 격리, 권한 경고, 단일 읽기 회귀 TC.
- `.changeset/quiet-project-envs.md`: CLI patch release note.

## 위험 & 롤백

The change affects workflow-time variable resolution and non-blocking warning frequency only. Reverting `231ce4d`, `60bb23b`, and `4968c0d` restores the former behavior.

## 변경 파일

- `.changeset/quiet-project-envs.md`
- `packages/core/src/workflow/loader.ts`
- `packages/orchestrator/src/git.ts`
- `packages/orchestrator/src/service.ts`
- `packages/orchestrator/src/service.test.ts`

## Evidence

- `pnpm lint && pnpm test && pnpm typecheck && pnpm build` — pass
- `pnpm exec vitest run packages/orchestrator/src/service.test.ts` — pass
- Docker E2E: `docker compose -f docker-compose.e2e.yml up -d --build`; `/healthz` returned `{"ok":true}` and authenticated `/api/v1/state` returned `health: "idle"`, `lastError: null`.
- All six inline review threads have replies and are resolved. P3 follow-ups are tracked in #591.

## Issues — Closed #566

## 머지 후/사람 확인

- [ ] standalone project 설정에서 `<projectDir>/.env` 권한을 0600으로 확인
- [ ] standalone workflow와 MCP 설정의 `$VAR`가 기대한 값으로 해석되는지 확인
