### PR TITLE
feat(core): compose layered MCP configs

### DIFF
--- a/.changeset/fresh-mice-compose.md
+++ b/.changeset/fresh-mice-compose.md
@@ -3,3 +3,9 @@
 ---
 
 Compose layered MCP sidecars safely for Claude and Codex runtimes (#568).
+
+When `runtime.isolation.trust_repo_config` is `false` (the default), Claude
+disables MCP auto-discovery to prevent untrusted repository commands from
+running. Move trusted user-wide servers to `~/.gh-symphony/mcp.json`, or set
+`runtime.isolation.trust_repo_config: true` to explicitly load a repository
+sidecar.

--- a/.changeset/fresh-mice-compose.md
+++ b/.changeset/fresh-mice-compose.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Compose layered MCP sidecars safely for Claude and Codex runtimes (#568).

--- a/packages/core/src/runtime/index.ts
+++ b/packages/core/src/runtime/index.ts
@@ -1,3 +1,4 @@
 export * from "./adapter.js";
 export * from "./credentials.js";
 export * from "./events.js";
+export * from "./mcp-compose.js";

--- a/packages/core/src/runtime/mcp-compose.test.ts
+++ b/packages/core/src/runtime/mcp-compose.test.ts
@@ -1,0 +1,133 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, describe, expect, it } from "vitest";
+import { composeMcpServers, McpConfigError } from "./mcp-compose.js";
+
+const roots: string[] = [];
+
+async function fixture(): Promise<{
+  root: string;
+  repo: string;
+  project: string;
+  home: string;
+}> {
+  const root = await mkdtemp(join(tmpdir(), "mcp-compose-"));
+  roots.push(root);
+  const repo = join(root, "repo");
+  const project = join(root, "project");
+  const home = join(root, "home");
+  await Promise.all([mkdir(repo), mkdir(project), mkdir(home)]);
+  await mkdir(join(home, ".gh-symphony"));
+  return { root, repo, project, home };
+}
+
+afterEach(async () =>
+  Promise.all(
+    roots.splice(0).map((root) => rm(root, { recursive: true, force: true }))
+  )
+);
+
+describe("composeMcpServers", () => {
+  it("orders repo, global, project, then immutable builtins", async () => {
+    const { repo, project, home } = await fixture();
+    await writeFile(
+      join(repo, ".mcp.json"),
+      JSON.stringify({
+        mcpServers: {
+          shared: { command: "repo" },
+          repo: { command: "repo" },
+          github_graphql: { command: "repo" },
+        },
+      })
+    );
+    await writeFile(
+      join(home, ".gh-symphony", "mcp.json"),
+      JSON.stringify({
+        mcpServers: {
+          shared: { command: "global" },
+          global: { command: "global" },
+        },
+      })
+    );
+    await writeFile(
+      join(project, ".mcp.json"),
+      JSON.stringify({
+        mcpServers: {
+          shared: { command: "project" },
+          project: { command: "project" },
+          github_graphql: { command: "project" },
+        },
+      })
+    );
+    expect(
+      composeMcpServers({
+        repositoryDir: repo,
+        projectDir: project,
+        homeDir: home,
+        trustRepoConfig: true,
+        builtins: { github_graphql: { command: "builtin" } },
+      })
+    ).toMatchObject({
+      shared: { command: "project" },
+      repo: { command: "repo" },
+      global: { command: "global" },
+      project: { command: "project" },
+      github_graphql: { command: "builtin" },
+    });
+  });
+
+  it("does not load the repository sidecar without explicit trust", async () => {
+    const { repo, home } = await fixture();
+    await writeFile(
+      join(repo, ".mcp.json"),
+      JSON.stringify({ mcpServers: { repo: { command: "repo" } } })
+    );
+    expect(
+      composeMcpServers({ repositoryDir: repo, homeDir: home })
+    ).not.toHaveProperty("repo");
+    expect(
+      composeMcpServers({
+        repositoryDir: repo,
+        homeDir: home,
+        trustRepoConfig: true,
+      })
+    ).toMatchObject({ repo: { command: "repo" } });
+  });
+
+  it("rejects literal sidecar env values and resolves $VAR from project .env", async () => {
+    const { repo, project, home } = await fixture();
+    await writeFile(join(project, ".env"), "SIDE_TOKEN=from-project\n");
+    await writeFile(
+      join(project, ".mcp.json"),
+      JSON.stringify({
+        mcpServers: {
+          valid: { command: "tool", env: { TOKEN: "$SIDE_TOKEN" } },
+          invalid: { command: "tool", env: { TOKEN: "secret" } },
+        },
+      })
+    );
+    expect(() =>
+      composeMcpServers({
+        repositoryDir: repo,
+        projectDir: project,
+        homeDir: home,
+      })
+    ).toThrow(McpConfigError);
+    await writeFile(
+      join(project, ".mcp.json"),
+      JSON.stringify({
+        mcpServers: {
+          valid: { command: "tool", env: { TOKEN: "$SIDE_TOKEN" } },
+        },
+      })
+    );
+    expect(
+      composeMcpServers({
+        repositoryDir: repo,
+        projectDir: project,
+        homeDir: home,
+      })
+    ).toMatchObject({ valid: { env: { TOKEN: "from-project" } } });
+  });
+});

--- a/packages/core/src/runtime/mcp-compose.test.ts
+++ b/packages/core/src/runtime/mcp-compose.test.ts
@@ -130,4 +130,66 @@ describe("composeMcpServers", () => {
       })
     ).toMatchObject({ valid: { env: { TOKEN: "from-project" } } });
   });
+
+  it("resolves host environment values even with caller-provided env", async () => {
+    const { repo, project, home } = await fixture();
+    await writeFile(
+      join(project, ".mcp.json"),
+      JSON.stringify({
+        mcpServers: {
+          host: { command: "tool", env: { TOKEN: "$MCP_HOST_TOKEN" } },
+          mixed: { command: "tool", env: { TOKEN: "${mcpMixedToken}" } },
+        },
+      })
+    );
+    process.env.MCP_HOST_TOKEN = "from-host";
+    process.env.mcpMixedToken = "from-mixed-host";
+    try {
+      expect(
+        composeMcpServers({
+          repositoryDir: repo,
+          projectDir: project,
+          homeDir: home,
+          env: { CODEX_HOME: "/tmp/codex" },
+        })
+      ).toMatchObject({
+        host: { env: { TOKEN: "from-host" } },
+        mixed: { env: { TOKEN: "from-mixed-host" } },
+      });
+    } finally {
+      delete process.env.MCP_HOST_TOKEN;
+      delete process.env.mcpMixedToken;
+    }
+  });
+
+  it("rejects malformed server args and env shapes", async () => {
+    const { repo, project, home } = await fixture();
+    await writeFile(
+      join(project, ".mcp.json"),
+      JSON.stringify({
+        mcpServers: { invalid: { command: "tool", args: "--serve" } },
+      })
+    );
+    expect(() =>
+      composeMcpServers({
+        repositoryDir: repo,
+        projectDir: project,
+        homeDir: home,
+      })
+    ).toThrow("args as an array of strings");
+
+    await writeFile(
+      join(project, ".mcp.json"),
+      JSON.stringify({
+        mcpServers: { invalid: { command: "tool", env: "TOKEN=value" } },
+      })
+    );
+    expect(() =>
+      composeMcpServers({
+        repositoryDir: repo,
+        projectDir: project,
+        homeDir: home,
+      })
+    ).toThrow("env as an object");
+  });
 });

--- a/packages/core/src/runtime/mcp-compose.ts
+++ b/packages/core/src/runtime/mcp-compose.ts
@@ -27,7 +27,8 @@ export function composeMcpServers(
 ): Record<string, McpServerDefinition> {
   const projectDir = options.projectDir;
   const env = {
-    ...(options.env ?? process.env),
+    ...process.env,
+    ...options.env,
     ...(projectDir ? readEnvFile(join(projectDir, ".env")) : {}),
   };
   const layers = [
@@ -48,6 +49,20 @@ function readMcpServers(
   path: string,
   env: Record<string, string | undefined>
 ): Record<string, McpServerDefinition> {
+  const config = readMcpConfig(path);
+  if (config === undefined) return {};
+  const servers = isRecord(config.mcpServers) ? config.mcpServers : {};
+  return Object.fromEntries(
+    Object.entries(servers).map(([name, value]) => [
+      name,
+      resolveServer(name, value, env, path),
+    ])
+  );
+}
+
+export function readMcpConfig(
+  path: string
+): Record<string, unknown> | undefined {
   let raw: string;
   try {
     raw = readFileSync(path, "utf8");
@@ -61,14 +76,7 @@ function readMcpServers(
   } catch {
     throw new McpConfigError(`Invalid MCP config JSON: ${path}`);
   }
-  const servers =
-    isRecord(parsed) && isRecord(parsed.mcpServers) ? parsed.mcpServers : {};
-  return Object.fromEntries(
-    Object.entries(servers).map(([name, value]) => [
-      name,
-      resolveServer(name, value, env, path),
-    ])
-  );
+  return isRecord(parsed) ? parsed : {};
 }
 
 function resolveServer(
@@ -81,18 +89,35 @@ function resolveServer(
     throw new McpConfigError(`Invalid MCP server "${name}" in ${path}`);
   }
   const server = { ...value } as McpServerDefinition;
-  if (!isRecord(server.env)) return server;
+  if (
+    server.args !== undefined &&
+    (!Array.isArray(server.args) ||
+      !server.args.every((arg) => typeof arg === "string"))
+  ) {
+    throw new McpConfigError(
+      `MCP server "${name}" in ${path} must define args as an array of strings.`
+    );
+  }
+  if (server.env === undefined) return server;
+  if (!isRecord(server.env)) {
+    throw new McpConfigError(
+      `MCP server "${name}" in ${path} must define env as an object.`
+    );
+  }
   server.env = Object.fromEntries(
     Object.entries(server.env).map(([key, variable]) => {
       if (
         typeof variable !== "string" ||
-        !/^\$[A-Z_][A-Z0-9_]*$/.test(variable)
+        !/^\$\{?[A-Za-z_][A-Za-z0-9_]*\}?$/.test(variable)
       ) {
         throw new McpConfigError(
           `MCP server "${name}" in ${path} must reference env.${key} as $VAR; literal values are not allowed.`
         );
       }
-      const resolved = env[variable.slice(1)];
+      const variableName = variable.startsWith("${")
+        ? variable.slice(2, -1)
+        : variable.slice(1);
+      const resolved = env[variableName];
       if (resolved === undefined)
         throw new McpConfigError(
           `MCP server "${name}" in ${path} references unset environment variable ${variable}.`

--- a/packages/core/src/runtime/mcp-compose.ts
+++ b/packages/core/src/runtime/mcp-compose.ts
@@ -1,0 +1,112 @@
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { readEnvFile } from "../workspace/env-file.js";
+
+export type McpServerDefinition = {
+  command: string;
+  args?: string[];
+  env?: Record<string, string>;
+  [key: string]: unknown;
+};
+
+export type McpCompositionOptions = {
+  repositoryDir: string;
+  projectDir?: string;
+  trustRepoConfig?: boolean;
+  builtins?: Record<string, McpServerDefinition>;
+  env?: NodeJS.ProcessEnv;
+  homeDir?: string;
+};
+
+export class McpConfigError extends Error {}
+
+/** Combines trusted MCP declarations without allowing a sidecar to replace builtins. */
+export function composeMcpServers(
+  options: McpCompositionOptions
+): Record<string, McpServerDefinition> {
+  const projectDir = options.projectDir;
+  const env = {
+    ...(options.env ?? process.env),
+    ...(projectDir ? readEnvFile(join(projectDir, ".env")) : {}),
+  };
+  const layers = [
+    options.trustRepoConfig
+      ? readMcpServers(join(options.repositoryDir, ".mcp.json"), env)
+      : {},
+    readMcpServers(
+      join(options.homeDir ?? homedir(), ".gh-symphony", "mcp.json"),
+      env
+    ),
+    projectDir ? readMcpServers(join(projectDir, ".mcp.json"), env) : {},
+  ];
+
+  return { ...layers[0], ...layers[1], ...layers[2], ...options.builtins };
+}
+
+function readMcpServers(
+  path: string,
+  env: Record<string, string | undefined>
+): Record<string, McpServerDefinition> {
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf8");
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") return {};
+    throw error;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new McpConfigError(`Invalid MCP config JSON: ${path}`);
+  }
+  const servers =
+    isRecord(parsed) && isRecord(parsed.mcpServers) ? parsed.mcpServers : {};
+  return Object.fromEntries(
+    Object.entries(servers).map(([name, value]) => [
+      name,
+      resolveServer(name, value, env, path),
+    ])
+  );
+}
+
+function resolveServer(
+  name: string,
+  value: unknown,
+  env: Record<string, string | undefined>,
+  path: string
+): McpServerDefinition {
+  if (!isRecord(value) || typeof value.command !== "string") {
+    throw new McpConfigError(`Invalid MCP server "${name}" in ${path}`);
+  }
+  const server = { ...value } as McpServerDefinition;
+  if (!isRecord(server.env)) return server;
+  server.env = Object.fromEntries(
+    Object.entries(server.env).map(([key, variable]) => {
+      if (
+        typeof variable !== "string" ||
+        !/^\$[A-Z_][A-Z0-9_]*$/.test(variable)
+      ) {
+        throw new McpConfigError(
+          `MCP server "${name}" in ${path} must reference env.${key} as $VAR; literal values are not allowed.`
+        );
+      }
+      const resolved = env[variable.slice(1)];
+      if (resolved === undefined)
+        throw new McpConfigError(
+          `MCP server "${name}" in ${path} references unset environment variable ${variable}.`
+        );
+      return [key, resolved];
+    })
+  );
+  return server;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value != null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
+}

--- a/packages/core/src/workflow-loader.test.ts
+++ b/packages/core/src/workflow-loader.test.ts
@@ -544,6 +544,7 @@ Prompt body.
       isolation: {
         bare: true,
         strictMcpConfig: true,
+        trustRepoConfig: false,
       },
       auth: {
         env: "ANTHROPIC_API_KEY",

--- a/packages/core/src/workflow/config.ts
+++ b/packages/core/src/workflow/config.ts
@@ -88,6 +88,7 @@ export type WorkflowRuntimeKind =
 export type WorkflowRuntimeIsolationConfig = {
   bare: boolean;
   strictMcpConfig: boolean;
+  trustRepoConfig: boolean;
 };
 
 export type WorkflowRuntimeAuthConfig = {

--- a/packages/core/src/workflow/parser.ts
+++ b/packages/core/src/workflow/parser.ts
@@ -638,6 +638,12 @@ function parseRuntimeConfig(
           "strict_mcp_config",
           "runtime.isolation.strict_mcp_config"
         ) ?? false,
+      trustRepoConfig:
+        readOptionalBoolean(
+          isolation,
+          "trust_repo_config",
+          "runtime.isolation.trust_repo_config"
+        ) ?? false,
     },
     auth: {
       env: readOptionalString(auth, "env", env),

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -2513,6 +2513,10 @@ export class OrchestratorService {
           PROJECT_ID: tenant.projectId,
           WORKING_DIRECTORY: repositoryDirectory,
           WORKSPACE_RUNTIME_DIR: workspaceRuntimeDir,
+          SYMPHONY_PROJECT_DIR: this.store.projectDir(tenant.projectId),
+          SYMPHONY_TRUST_REPO_CONFIG: String(
+            workflow.workflow.runtime?.isolation.trustRepoConfig === true
+          ),
           SYMPHONY_RUN_ID: runId,
           SYMPHONY_ISSUE_STATE: issue.state,
           SYMPHONY_ISSUE_ID: issue.id,

--- a/packages/runtime-claude/src/adapter.test.ts
+++ b/packages/runtime-claude/src/adapter.test.ts
@@ -419,7 +419,7 @@ describe("ClaudePrintRuntimeAdapter", () => {
     });
   });
 
-  it("prepares non-strict MCP config argv without writing workspace .mcp.json", async () => {
+  it("enforces strict MCP config for an untrusted workspace sidecar", async () => {
     const workspaceRoot = await mkdtemp(join(tmpdir(), "claude-adapter-"));
     const runtimeRoot = join(workspaceRoot, "runtime");
     tempRoots.push(workspaceRoot);
@@ -459,7 +459,7 @@ describe("ClaudePrintRuntimeAdapter", () => {
     const mcpConfigPath = join(runtimeRoot, "mcp.json");
     expect(calls[0]?.args).toContain("--mcp-config");
     expect(calls[0]?.args).toContain(mcpConfigPath);
-    expect(calls[0]?.args).not.toContain("--strict-mcp-config");
+    expect(calls[0]?.args).toContain("--strict-mcp-config");
     expect(await readFile(mcpConfigPath, "utf8")).toContain("github_graphql");
     await expect(
       readFile(join(workspaceRoot, ".mcp.json"), "utf8")

--- a/packages/runtime-claude/src/adapter.ts
+++ b/packages/runtime-claude/src/adapter.ts
@@ -351,7 +351,8 @@ export class ClaudePrintRuntimeAdapter implements AgentRuntimeAdapter<
       runId: this.preparedSession.runId,
       sessionId: invalidatedSessionId,
       replacementSessionId,
-      reason: "claude resume session was rejected because no conversation was found",
+      reason:
+        "claude resume session was rejected because no conversation was found",
     });
 
     const retryArgv = buildClaudePrintArgv(
@@ -693,6 +694,8 @@ function buildClaudeMcpTokenEnvironment(options: {
     LINEAR_AUTHORIZATION: source.LINEAR_AUTHORIZATION,
     LINEAR_GRAPHQL_URL: source.LINEAR_GRAPHQL_URL,
     SYMPHONY_TRACKER_KIND: source.SYMPHONY_TRACKER_KIND,
+    SYMPHONY_PROJECT_DIR: source.SYMPHONY_PROJECT_DIR,
+    SYMPHONY_TRUST_REPO_CONFIG: source.SYMPHONY_TRUST_REPO_CONFIG,
     WORKSPACE_RUNTIME_DIR:
       options.runtimeDirectory ?? source.WORKSPACE_RUNTIME_DIR,
   };

--- a/packages/runtime-claude/src/mcp-compose.test.ts
+++ b/packages/runtime-claude/src/mcp-compose.test.ts
@@ -49,7 +49,11 @@ describe("composeClaudeMcpConfig", () => {
 
     expect(result).toEqual({
       finalPath: join(runtimeRoot, "mcp.json"),
-      extraArgv: ["--mcp-config", join(runtimeRoot, "mcp.json")],
+      extraArgv: [
+        "--strict-mcp-config",
+        "--mcp-config",
+        join(runtimeRoot, "mcp.json"),
+      ],
       cleanupPath: join(runtimeRoot, "mcp.json"),
     });
     expect(await readJson(result.finalPath)).toEqual({
@@ -127,6 +131,7 @@ describe("composeClaudeMcpConfig", () => {
     });
     expect(await readFile(workspaceMcpPath, "utf8")).toBe(originalConfig);
     expect(await readJson(result.finalPath)).toEqual({
+      customTopLevel: true,
       mcpServers: {
         user_server: {
           command: "node",
@@ -285,6 +290,56 @@ describe("composeClaudeMcpConfig", () => {
         },
       },
     });
+  });
+
+  it("enforces strict MCP config when repository sidecars are untrusted", async () => {
+    const workspaceRoot = await createTempWorkspace();
+    const runtimeRoot = join(workspaceRoot, "runtime");
+    await writeFile(
+      join(workspaceRoot, ".mcp.json"),
+      JSON.stringify({ mcpServers: { untrusted: { command: "unsafe" } } })
+    );
+
+    const result = await composeClaudeMcpConfig(workspaceRoot, false, {
+      WORKSPACE_RUNTIME_DIR: runtimeRoot,
+    });
+
+    expect(result.extraArgv).toEqual([
+      "--strict-mcp-config",
+      "--mcp-config",
+      join(runtimeRoot, "mcp.json"),
+    ]);
+    expect(await readJson(result.finalPath)).toEqual({
+      mcpServers: {
+        github_graphql: expect.any(Object),
+      },
+    });
+  });
+
+  it("resolves project sidecar env from the host environment", async () => {
+    const workspaceRoot = await createTempWorkspace();
+    const projectRoot = await createTempWorkspace();
+    const runtimeRoot = join(workspaceRoot, "runtime");
+    await writeFile(
+      join(projectRoot, ".mcp.json"),
+      JSON.stringify({
+        mcpServers: {
+          vendor: { command: "vendor-mcp", env: { TOKEN: "$MCP_HOST_TOKEN" } },
+        },
+      })
+    );
+    process.env.MCP_HOST_TOKEN = "host-secret";
+    try {
+      const result = await composeClaudeMcpConfig(workspaceRoot, false, {
+        SYMPHONY_PROJECT_DIR: projectRoot,
+        WORKSPACE_RUNTIME_DIR: runtimeRoot,
+      });
+      expect(await readJson(result.finalPath)).toMatchObject({
+        mcpServers: { vendor: { env: { TOKEN: "host-secret" } } },
+      });
+    } finally {
+      delete process.env.MCP_HOST_TOKEN;
+    }
   });
 
   it("throws when the workspace .mcp.json contains invalid JSON", async () => {

--- a/packages/runtime-claude/src/mcp-compose.test.ts
+++ b/packages/runtime-claude/src/mcp-compose.test.ts
@@ -102,7 +102,7 @@ describe("composeClaudeMcpConfig", () => {
             github_graphql: {
               command: "old",
               env: {
-                GITHUB_GRAPHQL_TOKEN: "old-token",
+                GITHUB_GRAPHQL_TOKEN: "$OLD_TOKEN",
               },
             },
           },
@@ -114,8 +114,10 @@ describe("composeClaudeMcpConfig", () => {
 
     const result = await composeClaudeMcpConfig(workspaceRoot, false, {
       GITHUB_GRAPHQL_TOKEN: "token-2",
+      OLD_TOKEN: "old-token",
       GITHUB_PROJECT_ID: "project-1",
       WORKSPACE_RUNTIME_DIR: runtimeRoot,
+      SYMPHONY_TRUST_REPO_CONFIG: "true",
     });
 
     expect(result).toEqual({
@@ -125,7 +127,6 @@ describe("composeClaudeMcpConfig", () => {
     });
     expect(await readFile(workspaceMcpPath, "utf8")).toBe(originalConfig);
     expect(await readJson(result.finalPath)).toEqual({
-      customTopLevel: true,
       mcpServers: {
         user_server: {
           command: "node",
@@ -203,7 +204,7 @@ describe("composeClaudeMcpConfig", () => {
           linear_graphql: {
             command: "old",
             env: {
-              LINEAR_API_KEY: "old-secret",
+              LINEAR_API_KEY: "$OLD_LINEAR_TOKEN",
             },
           },
         },
@@ -211,7 +212,10 @@ describe("composeClaudeMcpConfig", () => {
       "utf8"
     );
 
-    const result = await composeClaudeMcpConfig(workspaceRoot, false, {});
+    const result = await composeClaudeMcpConfig(workspaceRoot, false, {
+      SYMPHONY_TRUST_REPO_CONFIG: "true",
+      OLD_LINEAR_TOKEN: "old-secret",
+    });
     const config = await readJson(result.finalPath);
 
     expect(config.mcpServers).toEqual({
@@ -252,6 +256,7 @@ describe("composeClaudeMcpConfig", () => {
     const result = await composeClaudeMcpConfig(workspaceRoot, true, {
       GITHUB_GRAPHQL_TOKEN: "token-3",
       WORKSPACE_RUNTIME_DIR: runtimeRoot,
+      SYMPHONY_TRUST_REPO_CONFIG: "true",
     });
 
     expect(result).toEqual({
@@ -287,8 +292,10 @@ describe("composeClaudeMcpConfig", () => {
     await writeFile(join(workspaceRoot, ".mcp.json"), "{ invalid", "utf8");
 
     await expect(
-      composeClaudeMcpConfig(workspaceRoot, false, {})
-    ).rejects.toThrow(SyntaxError);
+      composeClaudeMcpConfig(workspaceRoot, false, {
+        SYMPHONY_TRUST_REPO_CONFIG: "true",
+      })
+    ).rejects.toThrow("Invalid MCP config JSON");
   });
 
   it("treats a non-object mcpServers value as empty", async () => {
@@ -359,6 +366,7 @@ describe("composeClaudeMcpConfig", () => {
     const result = await composeClaudeMcpConfig(workspaceRoot, false, {
       GITHUB_GRAPHQL_TOKEN: "token-clean",
       WORKSPACE_RUNTIME_DIR: runtimeRoot,
+      SYMPHONY_TRUST_REPO_CONFIG: "true",
     });
     const { stdout } = await execFileAsync("git", ["status", "--porcelain"], {
       cwd: workspaceRoot,

--- a/packages/runtime-claude/src/mcp-compose.ts
+++ b/packages/runtime-claude/src/mcp-compose.ts
@@ -3,10 +3,9 @@ import { tmpdir } from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
 import { createGitHubGraphQLMcpServerEntry } from "@gh-symphony/tool-github-graphql";
 import { createLinearGraphQLMcpServerEntry } from "@gh-symphony/tool-linear-graphql";
-import { composeMcpServers } from "@gh-symphony/core";
+import { composeMcpServers, readMcpConfig } from "@gh-symphony/core";
 
 export type ClaudeMcpTokenEnvironment = {
-  [key: string]: string | undefined;
   GITHUB_GRAPHQL_TOKEN?: string;
   GITHUB_GRAPHQL_API_URL?: string;
   GITHUB_TOKEN_BROKER_URL?: string;
@@ -37,17 +36,22 @@ export async function composeClaudeMcpConfig(
     workspaceRoot,
     symphonyTokenEnv
   );
+  const trustRepoConfig =
+    symphonyTokenEnv.SYMPHONY_TRUST_REPO_CONFIG === "true";
   const mcpServers = composeMcpServers({
     repositoryDir: workspaceRoot,
     projectDir: symphonyTokenEnv.SYMPHONY_PROJECT_DIR,
-    trustRepoConfig: symphonyTokenEnv.SYMPHONY_TRUST_REPO_CONFIG === "true",
+    trustRepoConfig,
     env: symphonyTokenEnv,
     builtins: createSymphonyMcpServers(symphonyTokenEnv),
   });
   if (symphonyTokenEnv.SYMPHONY_TRACKER_KIND !== "linear") {
     delete mcpServers.linear_graphql;
   }
-  const mergedConfig = { mcpServers };
+  const repositoryConfig = trustRepoConfig
+    ? readMcpConfig(join(workspaceRoot, ".mcp.json"))
+    : undefined;
+  const mergedConfig = { ...repositoryConfig, mcpServers };
 
   await ensureSecureConfigParent(dirname(finalPath));
   await chmodExistingSecretFile(finalPath);
@@ -59,9 +63,10 @@ export async function composeClaudeMcpConfig(
 
   return {
     finalPath,
-    extraArgv: strictMode
-      ? ["--strict-mcp-config", "--mcp-config", finalPath]
-      : ["--mcp-config", finalPath],
+    extraArgv:
+      strictMode || !trustRepoConfig
+        ? ["--strict-mcp-config", "--mcp-config", finalPath]
+        : ["--mcp-config", finalPath],
     cleanupPath: finalPath,
   };
 }

--- a/packages/runtime-claude/src/mcp-compose.ts
+++ b/packages/runtime-claude/src/mcp-compose.ts
@@ -1,10 +1,12 @@
-import { chmod, mkdir, readFile, writeFile } from "node:fs/promises";
+import { chmod, mkdir, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
 import { createGitHubGraphQLMcpServerEntry } from "@gh-symphony/tool-github-graphql";
 import { createLinearGraphQLMcpServerEntry } from "@gh-symphony/tool-linear-graphql";
+import { composeMcpServers } from "@gh-symphony/core";
 
 export type ClaudeMcpTokenEnvironment = {
+  [key: string]: string | undefined;
   GITHUB_GRAPHQL_TOKEN?: string;
   GITHUB_GRAPHQL_API_URL?: string;
   GITHUB_TOKEN_BROKER_URL?: string;
@@ -16,6 +18,8 @@ export type ClaudeMcpTokenEnvironment = {
   LINEAR_GRAPHQL_URL?: string;
   SYMPHONY_TRACKER_KIND?: string;
   WORKSPACE_RUNTIME_DIR?: string;
+  SYMPHONY_PROJECT_DIR?: string;
+  SYMPHONY_TRUST_REPO_CONFIG?: string;
 };
 
 export type ClaudeMcpCompositionResult = {
@@ -24,22 +28,26 @@ export type ClaudeMcpCompositionResult = {
   cleanupPath?: string;
 };
 
-type McpConfig = Record<string, unknown> & {
-  mcpServers?: Record<string, unknown>;
-};
-
 export async function composeClaudeMcpConfig(
   workspaceRoot: string,
   strictMode: boolean,
   symphonyTokenEnv: ClaudeMcpTokenEnvironment = {}
 ): Promise<ClaudeMcpCompositionResult> {
-  const workspaceMcpPath = join(workspaceRoot, ".mcp.json");
   const finalPath = resolveRuntimeMcpConfigPath(
     workspaceRoot,
     symphonyTokenEnv
   );
-  const baseConfig = await readBaseMcpConfig(workspaceMcpPath);
-  const mergedConfig = mergeSymphonyMcpServers(baseConfig, symphonyTokenEnv);
+  const mcpServers = composeMcpServers({
+    repositoryDir: workspaceRoot,
+    projectDir: symphonyTokenEnv.SYMPHONY_PROJECT_DIR,
+    trustRepoConfig: symphonyTokenEnv.SYMPHONY_TRUST_REPO_CONFIG === "true",
+    env: symphonyTokenEnv,
+    builtins: createSymphonyMcpServers(symphonyTokenEnv),
+  });
+  if (symphonyTokenEnv.SYMPHONY_TRACKER_KIND !== "linear") {
+    delete mcpServers.linear_graphql;
+  }
+  const mergedConfig = { mcpServers };
 
   await ensureSecureConfigParent(dirname(finalPath));
   await chmodExistingSecretFile(finalPath);
@@ -93,30 +101,16 @@ async function chmodExistingSecretFile(path: string): Promise<void> {
   }
 }
 
-async function readBaseMcpConfig(workspaceMcpPath: string): Promise<McpConfig> {
-  try {
-    const raw = await readFile(workspaceMcpPath, "utf8");
-    const parsed = JSON.parse(raw) as unknown;
-    return isRecord(parsed) ? parsed : { mcpServers: {} };
-  } catch (error) {
-    if (isNodeError(error) && error.code === "ENOENT") {
-      return { mcpServers: {} };
-    }
-
-    throw error;
-  }
-}
-
-function mergeSymphonyMcpServers(
-  baseConfig: McpConfig,
+function createSymphonyMcpServers(
   env: ClaudeMcpTokenEnvironment
-): McpConfig {
-  const mcpServers = isRecord(baseConfig.mcpServers)
-    ? baseConfig.mcpServers
-    : {};
-
-  const mergedServers: Record<string, unknown> = {
-    ...mcpServers,
+): Record<
+  string,
+  { command: string; args: string[]; env: Record<string, string> }
+> {
+  const mergedServers: Record<
+    string,
+    { command: string; args: string[]; env: Record<string, string> }
+  > = {
     github_graphql: createGitHubGraphQLMcpServerEntry({
       githubToken: env.GITHUB_GRAPHQL_TOKEN,
       githubGraphqlApiUrl: env.GITHUB_GRAPHQL_API_URL,
@@ -135,10 +129,7 @@ function mergeSymphonyMcpServers(
     delete mergedServers.linear_graphql;
   }
 
-  return {
-    ...baseConfig,
-    mcpServers: mergedServers,
-  };
+  return mergedServers;
 }
 
 function resolveRuntimeMcpConfigPath(
@@ -157,10 +148,6 @@ function resolveRuntimeMcpConfigPath(
     );
 
   return join(runtimeDir, "mcp.json");
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value != null && typeof value === "object" && !Array.isArray(value);
 }
 
 function isNodeError(error: unknown): error is NodeJS.ErrnoException {

--- a/packages/runtime-codex/src/launcher.ts
+++ b/packages/runtime-codex/src/launcher.ts
@@ -28,6 +28,8 @@ export function resolveLocalRuntimeLaunchConfig(
   return {
     projectId,
     workingDirectory,
+    projectDirectory: env.SYMPHONY_PROJECT_DIR,
+    trustRepoConfig: env.SYMPHONY_TRUST_REPO_CONFIG === "true",
     githubToken: env.GITHUB_GRAPHQL_TOKEN,
     githubTokenBrokerUrl: env.GITHUB_TOKEN_BROKER_URL,
     githubTokenBrokerSecret: env.GITHUB_TOKEN_BROKER_SECRET,

--- a/packages/runtime-codex/src/runtime.test.ts
+++ b/packages/runtime-codex/src/runtime.test.ts
@@ -1,4 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   AgentRuntimeResolutionError,
   CODEX_PROTOCOL_EVENT_NAMES,
@@ -145,6 +148,49 @@ describe("buildCodexRuntimePlan", () => {
       expect(plan.env.GITHUB_GRAPHQL_TOKEN).toBeUndefined();
     } finally {
       delete process.env.GITHUB_GRAPHQL_TOKEN;
+    }
+  });
+
+  it("preserves builtin schemas and isolates sidecar env from the agent", async () => {
+    const root = await mkdtemp(join(tmpdir(), "codex-mcp-sidecar-"));
+    const workspace = join(root, "workspace");
+    const project = join(root, "project");
+    await Promise.all([mkdir(workspace), mkdir(project)]);
+    await writeFile(
+      join(project, ".mcp.json"),
+      JSON.stringify({
+        mcpServers: {
+          vendor_api: {
+            command: "vendor-mcp",
+            args: ["--serve"],
+            env: { VENDOR_SECRET: "$MCP_VENDOR_SECRET" },
+          },
+          github_graphql: { command: "replacement" },
+        },
+      })
+    );
+    process.env.MCP_VENDOR_SECRET = "vendor-secret";
+    try {
+      const plan = buildCodexRuntimePlan({
+        projectId: "workspace-123",
+        workingDirectory: workspace,
+        projectDirectory: project,
+        extraEnv: { CODEX_HOME: "/tmp/codex" },
+      });
+      const githubTool = plan.tools.find(
+        (tool) => tool.name === "github_graphql"
+      );
+      const vendorTool = plan.tools.find((tool) => tool.name === "vendor_api");
+      expect(githubTool?.inputSchema.properties).toHaveProperty("query");
+      expect(vendorTool).toMatchObject({
+        command: "vendor-mcp",
+        args: ["--serve"],
+        env: { VENDOR_SECRET: "vendor-secret" },
+      });
+      expect(plan.env.VENDOR_SECRET).toBeUndefined();
+    } finally {
+      delete process.env.MCP_VENDOR_SECRET;
+      await rm(root, { recursive: true, force: true });
     }
   });
 

--- a/packages/runtime-codex/src/runtime.ts
+++ b/packages/runtime-codex/src/runtime.ts
@@ -557,8 +557,11 @@ export function buildCodexRuntimePlan(
         linearGraphqlUrl: config.linearGraphqlUrl ?? DEFAULT_LINEAR_GRAPHQL_URL,
       })
     : undefined;
+  const builtinTools = [githubTool, linearTool].filter(
+    (tool): tool is RuntimeToolDefinition => tool !== undefined
+  );
   const builtins = Object.fromEntries(
-    [githubTool, linearTool]
+    builtinTools
       .filter((tool): tool is RuntimeToolDefinition => tool !== undefined)
       .map((tool) => [tool.name, tool])
   );
@@ -572,8 +575,8 @@ export function buildCodexRuntimePlan(
   if (!config.enableLinearGraphqlTool) {
     delete servers.linear_graphql;
   }
-  const tools = Object.entries(servers).map(([name, server]) =>
-    createMcpToolDefinition(name, server)
+  const tools = Object.entries(servers).map(
+    ([name, server]) => builtins[name] ?? createMcpToolDefinition(name, server)
   );
   const gitCredentialHelper = createGitCredentialHelperEnvironment(config);
 
@@ -634,7 +637,7 @@ export function buildCodexRuntimePlan(
       ...orchestratorRunEnv,
       ...agentEnv,
       ...gitCredentialHelper,
-      ...Object.assign({}, ...tools.map((tool) => tool.env)),
+      ...Object.assign({}, ...builtinTools.map((tool) => tool.env)),
     },
     tools,
   };

--- a/packages/runtime-codex/src/runtime.ts
+++ b/packages/runtime-codex/src/runtime.ts
@@ -8,6 +8,7 @@ import {
   readAgentCredentialCache,
   shouldReuseAgentCredentialCache,
   writeAgentCredentialCache,
+  composeMcpServers,
   type AgentRuntimeAdapter,
   type AgentRuntimeCredentialBrokerResponse,
   type AgentEvent,
@@ -29,7 +30,7 @@ const DIRECT_AGENT_ENV_KEYS = [
 ] as const;
 
 export type RuntimeToolDefinition = {
-  name: "github_graphql" | "linear_graphql";
+  name: string;
   description: string;
   command: string;
   args: string[];
@@ -66,6 +67,8 @@ export type CodexRuntimeConfig = {
   orchestratorUrl?: string;
   orchestratorRunId?: string;
   orchestratorToken?: string;
+  projectDirectory?: string;
+  trustRepoConfig?: boolean;
 };
 
 export type CodexRuntimePlan = {
@@ -218,6 +221,25 @@ export function createLinearGraphQLToolDefinition(
       },
       required: ["query"],
       additionalProperties: false,
+    },
+  };
+}
+
+export function createMcpToolDefinition(
+  name: string,
+  server: { command: string; args?: string[]; env?: Record<string, string> }
+): RuntimeToolDefinition {
+  return {
+    name,
+    description: `Execute the configured ${name} MCP server.`,
+    command: server.command,
+    args: server.args ?? [],
+    env: server.env ?? {},
+    inputSchema: {
+      type: "object",
+      properties: {},
+      required: [],
+      additionalProperties: true,
     },
   };
 }
@@ -530,17 +552,29 @@ export function buildCodexRuntimePlan(
   config: CodexRuntimeConfig
 ): CodexRuntimePlan {
   const githubTool = createGitHubGraphQLToolDefinition(config);
-  const tools = [
-    githubTool,
-    ...(config.enableLinearGraphqlTool
-      ? [
-          createLinearGraphQLToolDefinition({
-            linearGraphqlUrl:
-              config.linearGraphqlUrl ?? DEFAULT_LINEAR_GRAPHQL_URL,
-          }),
-        ]
-      : []),
-  ];
+  const linearTool = config.enableLinearGraphqlTool
+    ? createLinearGraphQLToolDefinition({
+        linearGraphqlUrl: config.linearGraphqlUrl ?? DEFAULT_LINEAR_GRAPHQL_URL,
+      })
+    : undefined;
+  const builtins = Object.fromEntries(
+    [githubTool, linearTool]
+      .filter((tool): tool is RuntimeToolDefinition => tool !== undefined)
+      .map((tool) => [tool.name, tool])
+  );
+  const servers = composeMcpServers({
+    repositoryDir: config.workingDirectory,
+    projectDir: config.projectDirectory,
+    trustRepoConfig: config.trustRepoConfig,
+    env: config.extraEnv,
+    builtins,
+  });
+  if (!config.enableLinearGraphqlTool) {
+    delete servers.linear_graphql;
+  }
+  const tools = Object.entries(servers).map(([name, server]) =>
+    createMcpToolDefinition(name, server)
+  );
   const gitCredentialHelper = createGitCredentialHelperEnvironment(config);
 
   const agentCommand = parseAgentCommand(


### PR DESCRIPTION
## TL;DR

- MCP sidecar 계층 합성과 보안 검증을 Claude·Codex 런타임에 적용했습니다.
- `trust_repo_config: false` 기본값에서는 Claude MCP auto-discovery를 차단해 신뢰하지 않은 repository command 실행을 막습니다.

## 변경 지점 다이어그램

`repository/global/project .mcp.json` → `core layer merge + $VAR resolution` → `Claude secure config` / `Codex per-server tools`

## 여기부터 보세요

- `packages/core/src/runtime/mcp-compose.ts`
- `packages/runtime-claude/src/mcp-compose.ts`
- `packages/runtime-codex/src/runtime.ts`
- `.changeset/fresh-mice-compose.md`

## 위험 & 롤백

- 기본 설정에서 Claude MCP auto-discovery가 차단됩니다. 기존 `~/.claude` 또는 repository MCP 설정은 `~/.gh-symphony/mcp.json`으로 옮기거나 `runtime.isolation.trust_repo_config: true`로 명시 opt-in할 수 있습니다.
- Sidecar secret은 Codex agent process 환경이 아니라 해당 MCP server 정의에만 유지됩니다.

## 변경 파일

- Core MCP sidecar validation, layered precedence, `$VAR` environment resolution
- Claude secure config composition and untrusted repository discovery isolation
- Codex MCP tool translation with builtin schema and secret isolation
- Release migration guidance

## Issues — Closed #568

## Evidence

- `pnpm lint` — pass
- `pnpm test` — pass
- `pnpm typecheck` — pass
- `pnpm build` — pass
- CI: `Test`, `Container Smoke` — success

## 머지 후/사람 확인

- [ ] 기존 `~/.claude` 또는 repository `.mcp.json` 사용자가 `~/.gh-symphony/mcp.json` 이전 또는 `trust_repo_config` opt-in 경로를 이해하는지 확인
- [ ] `trust_repo_config: false` 환경에서 Claude가 repository `.mcp.json`을 자동 로드하지 않는지 확인
- [ ] 프로젝트/전역 sidecar의 `$VAR`가 호스트 env 및 프로젝트 `.env`에서 해석되는지 확인
- [ ] Codex agent process 환경에 sidecar 전용 secret이 노출되지 않는지 확인
