### PR TITLE
feat(cli): add standalone project startup

### DIFF
--- a/.changeset/tidy-doors-build.md
+++ b/.changeset/tidy-doors-build.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Add standalone project registration and project-directory daemon startup for #569.

--- a/packages/cli/src/commands/lifecycle.test.ts
+++ b/packages/cli/src/commands/lifecycle.test.ts
@@ -235,7 +235,7 @@ describe("lifecycle command integration", () => {
     );
   });
 
-  it("prompts for project selection when run omits --project-id in interactive multi-project mode", async () => {
+  it("uses the active project when run omits --project-id in multi-project mode", async () => {
     const configDir = await createConfigFixture({
       activeProject: "tenant-a",
       projects: [
@@ -243,26 +243,25 @@ describe("lifecycle command integration", () => {
         createTenant("tenant-b", "beta", "api"),
       ],
     });
-    selectMock.mockResolvedValue("tenant-b");
-    setTty(true, true);
+    setTty(false, false);
 
-    await runModule.default(["beta/api#42"], baseOptions(configDir));
+    await runModule.default(["acme/platform#42"], baseOptions(configDir));
 
-    expect(selectMock).toHaveBeenCalled();
+    expect(selectMock).not.toHaveBeenCalled();
     expect(orchestratorRunCli).toHaveBeenCalledWith([
       "run-issue",
       "--runtime-root",
       configDir,
       "--project-id",
-      "tenant-b",
+      "tenant-a",
       "--issue",
-      "beta/api#42",
+      "acme/platform#42",
     ]);
   });
 
-  it("preserves the cancel exit code when interactive project selection is aborted", async () => {
+  it("preserves the cancel exit code when no active project selection is aborted", async () => {
     const configDir = await createConfigFixture({
-      activeProject: "tenant-a",
+      activeProject: null,
       projects: [
         createTenant("tenant-a", "acme", "platform"),
         createTenant("tenant-b", "beta", "api"),
@@ -286,7 +285,7 @@ describe("lifecycle command integration", () => {
     expect(process.exitCode).toBe(130);
   });
 
-  it("requires explicit --project-id in non-interactive multi-project mode", async () => {
+  it("uses the active project in non-interactive multi-project mode", async () => {
     const configDir = await createConfigFixture({
       activeProject: "tenant-a",
       projects: [
@@ -295,18 +294,18 @@ describe("lifecycle command integration", () => {
       ],
     });
     setTty(false, false);
-    const stderr = vi
-      .spyOn(process.stderr, "write")
-      .mockImplementation(() => true);
-
     await runModule.default(["acme/platform#7"], baseOptions(configDir));
 
-    expect(orchestratorRunCli).not.toHaveBeenCalled();
-    const output = stderr.mock.calls.map((call) => String(call[0])).join("");
-    expect(output).toContain(
-      "Multiple repository runtime configs are present. Run 'gh-symphony repo init' from the target repository to refresh the cwd runtime."
-    );
-    expect(process.exitCode).toBe(1);
+    expect(orchestratorRunCli).toHaveBeenCalledWith([
+      "run-issue",
+      "--runtime-root",
+      configDir,
+      "--project-id",
+      "tenant-a",
+      "--issue",
+      "acme/platform#7",
+    ]);
+    expect(process.exitCode).toBeUndefined();
   });
 
   it("rejects removed project selection flags in daemon mode", async () => {
@@ -635,7 +634,7 @@ function createTenant(
 }
 
 async function createConfigFixture(input: {
-  activeProject: string;
+  activeProject: string | null;
   projects: CliProjectConfig[];
 }): Promise<string> {
   const configDir = await mkdtemp(join(tmpdir(), "cli-lifecycle-"));
@@ -644,7 +643,7 @@ async function createConfigFixture(input: {
     JSON.stringify(
       {
         activeProject: input.activeProject,
-        token: `${input.activeProject}-token`,
+        token: input.activeProject ? `${input.activeProject}-token` : undefined,
         projects: input.projects.map((project) => project.projectId),
       },
       null,

--- a/packages/cli/src/commands/project-lifecycle.test.ts
+++ b/packages/cli/src/commands/project-lifecycle.test.ts
@@ -1,0 +1,76 @@
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const startMock = vi.fn();
+const statusMock = vi.fn();
+const stopMock = vi.fn();
+
+vi.mock("./start.js", () => ({ default: startMock }));
+vi.mock("./status.js", () => ({ default: statusMock }));
+vi.mock("./stop.js", () => ({ default: stopMock }));
+
+const { default: projectCommand } = await import("./project.js");
+
+const workflow = `---
+tracker:
+  kind: github-project
+  project_id: PVT_example
+codex:
+  command: codex app-server
+repository:
+  slug: acme/platform
+---
+Implement the issue.`;
+
+const baseOptions = (configDir: string) => ({
+  configDir,
+  verbose: false,
+  json: false,
+  noColor: true,
+});
+
+afterEach(() => {
+  startMock.mockReset();
+  statusMock.mockReset();
+  stopMock.mockReset();
+  vi.restoreAllMocks();
+  process.exitCode = undefined;
+});
+
+describe("standalone project lifecycle command", () => {
+  it("round-trips add, list, start, status, and stop through one registry", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "cli-project-config-"));
+    const projectDir = await mkdtemp(join(tmpdir(), "cli-project-dir-"));
+    await writeFile(join(projectDir, "WORKFLOW.md"), workflow, "utf8");
+    const stdout = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+
+    await projectCommand(["add", projectDir], baseOptions(configDir));
+    await projectCommand(["list"], {
+      ...baseOptions(configDir),
+      json: true,
+    });
+    await projectCommand(["start", "--daemon"], baseOptions(configDir));
+    await projectCommand(["status"], baseOptions(configDir));
+    await projectCommand(["stop"], baseOptions(configDir));
+
+    expect(
+      stdout.mock.calls.map(([chunk]) => String(chunk)).join("")
+    ).toContain(projectDir);
+    expect(startMock).toHaveBeenCalledWith(
+      ["--daemon"],
+      expect.objectContaining({ configDir, invocation: "project" })
+    );
+    expect(statusMock).toHaveBeenCalledWith(
+      [],
+      expect.objectContaining({ configDir })
+    );
+    expect(stopMock).toHaveBeenCalledWith(
+      [],
+      expect.objectContaining({ configDir })
+    );
+  });
+});

--- a/packages/cli/src/commands/project.test.ts
+++ b/packages/cli/src/commands/project.test.ts
@@ -19,6 +19,21 @@ workspace:
 ---
 Implement the issue.`;
 
+const linearWorkflow = `---
+tracker:
+  kind: linear
+  project_slug: symphony
+  active_states: [" Todo "]
+  pickup_labels:
+    include: [team-a]
+    exclude: [skip]
+codex:
+  command: codex app-server
+repository:
+  slug: acme/platform
+---
+Implement the issue.`;
+
 describe("registerStandaloneProject", () => {
   it("persists an external workflow project and makes it active", async () => {
     const configDir = await mkdtemp(join(tmpdir(), "cli-standalone-config-"));
@@ -27,9 +42,14 @@ describe("registerStandaloneProject", () => {
 
     const project = await registerStandaloneProject(projectDir, { configDir });
 
-    await expect(loadProjectConfig(configDir, project.projectId)).resolves.toMatchObject({
+    await expect(
+      loadProjectConfig(configDir, project.projectId)
+    ).resolves.toMatchObject({
       repository: { owner: "acme", name: "platform" },
-      workflowSource: { type: "external", path: join(projectDir, "WORKFLOW.md") },
+      workflowSource: {
+        type: "external",
+        path: join(projectDir, "WORKFLOW.md"),
+      },
       projectDir,
       workspaceDir: join(projectDir, ".runners"),
       populateStrategy: "worktree-cache",
@@ -51,9 +71,38 @@ describe("registerStandaloneProject", () => {
     ]);
     await registerStandaloneProject(first, { configDir });
 
-    await expect(registerStandaloneProject(second, { configDir })).rejects.toThrow(
-      "Tracker mapping overlaps registered project(s)"
-    );
+    await expect(
+      registerStandaloneProject(second, { configDir })
+    ).rejects.toThrow("Tracker mapping overlaps registered project(s)");
+  });
+
+  it("preserves Linear label filters and normalizes overlapping states", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "cli-standalone-config-"));
+    const first = await mkdtemp(join(tmpdir(), "cli-standalone-project-"));
+    const second = await mkdtemp(join(tmpdir(), "cli-standalone-project-"));
+    await Promise.all([
+      writeFile(join(first, "WORKFLOW.md"), linearWorkflow, "utf8"),
+      writeFile(
+        join(second, "WORKFLOW.md"),
+        linearWorkflow.replace(" Todo ", "todo"),
+        "utf8"
+      ),
+    ]);
+
+    const project = await registerStandaloneProject(first, { configDir });
+
+    await expect(
+      loadProjectConfig(configDir, project.projectId)
+    ).resolves.toMatchObject({
+      tracker: {
+        settings: {
+          pickupLabels: { include: ["team-a"], exclude: ["skip"] },
+        },
+      },
+    });
+    await expect(
+      registerStandaloneProject(second, { configDir })
+    ).rejects.toThrow("Tracker mapping overlaps registered project(s)");
   });
 
   it("lists registered standalone projects", async () => {
@@ -62,10 +111,12 @@ describe("registerStandaloneProject", () => {
     await writeFile(join(projectDir, "WORKFLOW.md"), workflow, "utf8");
     const project = await registerStandaloneProject(projectDir, { configDir });
     const writes: string[] = [];
-    const spy = vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
-      writes.push(String(chunk));
-      return true;
-    });
+    const spy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation((chunk) => {
+        writes.push(String(chunk));
+        return true;
+      });
 
     await projectCommand(["list"], {
       configDir,

--- a/packages/cli/src/commands/project.test.ts
+++ b/packages/cli/src/commands/project.test.ts
@@ -1,0 +1,57 @@
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { loadGlobalConfig, loadProjectConfig } from "../config.js";
+import { registerStandaloneProject } from "./project.js";
+
+const workflow = `---
+tracker:
+  kind: github-project
+  project_id: PVT_example
+codex:
+  command: codex app-server
+repository:
+  slug: acme/platform
+workspace:
+  root: .runners
+---
+Implement the issue.`;
+
+describe("registerStandaloneProject", () => {
+  it("persists an external workflow project and makes it active", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "cli-standalone-config-"));
+    const projectDir = await mkdtemp(join(tmpdir(), "cli-standalone-project-"));
+    await writeFile(join(projectDir, "WORKFLOW.md"), workflow, "utf8");
+
+    const project = await registerStandaloneProject(projectDir, { configDir });
+
+    await expect(loadProjectConfig(configDir, project.projectId)).resolves.toMatchObject({
+      repository: { owner: "acme", name: "platform" },
+      workflowSource: { type: "external", path: join(projectDir, "WORKFLOW.md") },
+      projectDir,
+      workspaceDir: join(projectDir, ".runners"),
+      populateStrategy: "worktree-cache",
+    });
+    await expect(loadGlobalConfig(configDir)).resolves.toEqual({
+      activeProject: project.projectId,
+      projects: [project.projectId],
+    });
+  });
+
+  it("rejects an overlapping mapping without interactive confirmation", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "cli-standalone-config-"));
+    const first = await mkdtemp(join(tmpdir(), "cli-standalone-project-"));
+    const second = await mkdtemp(join(tmpdir(), "cli-standalone-project-"));
+    await Promise.all([
+      writeFile(join(first, "WORKFLOW.md"), workflow, "utf8"),
+      writeFile(join(second, "WORKFLOW.md"), workflow, "utf8"),
+      mkdir(join(first, ".runners"), { recursive: true }),
+    ]);
+    await registerStandaloneProject(first, { configDir });
+
+    await expect(registerStandaloneProject(second, { configDir })).rejects.toThrow(
+      "Tracker mapping overlaps registered project(s)"
+    );
+  });
+});

--- a/packages/cli/src/commands/project.test.ts
+++ b/packages/cli/src/commands/project.test.ts
@@ -1,9 +1,10 @@
 import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { loadGlobalConfig, loadProjectConfig } from "../config.js";
 import { registerStandaloneProject } from "./project.js";
+import projectCommand from "./project.js";
 
 const workflow = `---
 tracker:
@@ -53,5 +54,30 @@ describe("registerStandaloneProject", () => {
     await expect(registerStandaloneProject(second, { configDir })).rejects.toThrow(
       "Tracker mapping overlaps registered project(s)"
     );
+  });
+
+  it("lists registered standalone projects", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "cli-standalone-config-"));
+    const projectDir = await mkdtemp(join(tmpdir(), "cli-standalone-project-"));
+    await writeFile(join(projectDir, "WORKFLOW.md"), workflow, "utf8");
+    const project = await registerStandaloneProject(projectDir, { configDir });
+    const writes: string[] = [];
+    const spy = vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
+      writes.push(String(chunk));
+      return true;
+    });
+
+    await projectCommand(["list"], {
+      configDir,
+      configDirOverride: true,
+      verbose: false,
+      json: true,
+      noColor: true,
+    });
+
+    spy.mockRestore();
+    expect(JSON.parse(writes.join(""))).toEqual([
+      expect.objectContaining({ projectId: project.projectId, projectDir }),
+    ]);
   });
 });

--- a/packages/cli/src/commands/project.ts
+++ b/packages/cli/src/commands/project.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import { basename, resolve } from "node:path";
+import * as p from "@clack/prompts";
 import {
   parseWorkflowMarkdown,
   type OrchestratorTrackerSettingValue,
@@ -61,9 +62,13 @@ export async function registerStandaloneProject(
     );
   }
   if (overlap.length > 0) {
-    process.stderr.write(
-      `Warning: tracker mapping overlaps registered project(s): ${overlap.join(", ")}.\n`
-    );
+    const confirmed = await p.confirm({
+      message: `Tracker mapping overlaps registered project(s): ${overlap.join(", ")}. Register anyway?`,
+      initialValue: false,
+    });
+    if (p.isCancel(confirmed) || !confirmed) {
+      throw new Error("Standalone project registration cancelled because tracker mappings overlap.");
+    }
   }
 
   await saveProjectConfig(options.configDir, projectId, config);
@@ -94,7 +99,9 @@ function mappingFor(config: CliProjectConfig): Mapping {
     adapter: config.tracker.adapter,
     bindingId: config.tracker.bindingId,
     states: (config.tracker.settings?.activeStates as string | undefined)?.split("\n").filter(Boolean) ?? [],
-    labels: Array.isArray(labels) ? labels.filter((value): value is string => typeof value === "string") : [],
+    labels: Array.isArray(labels)
+      ? labels.filter((value): value is string => typeof value === "string")
+      : [],
   };
 }
 
@@ -112,6 +119,9 @@ function trackerSettings(workflow: ReturnType<typeof parseWorkflowMarkdown>, rep
     ...(workflow.tracker.projectId ? { projectId: workflow.tracker.projectId } : {}),
     ...(workflow.tracker.projectSlug ? { projectSlug: workflow.tracker.projectSlug } : {}),
     ...(workflow.tracker.kind === "linear" ? { activeStates: workflow.tracker.activeStates.join("\n") } : {}),
+    ...(workflow.tracker.pickupLabels.include.length > 0
+      ? { pickupLabels: workflow.tracker.pickupLabels.include }
+      : {}),
     repository: `${repository.owner}/${repository.name}`,
   };
 }

--- a/packages/cli/src/commands/project.ts
+++ b/packages/cli/src/commands/project.ts
@@ -263,7 +263,7 @@ const handler = async (
     return;
   }
   if (subcommand === "start") {
-    await startCommand(args.slice(1), options);
+    await startCommand(args.slice(1), { ...options, invocation: "project" });
     return;
   }
   if (subcommand === "status") {

--- a/packages/cli/src/commands/project.ts
+++ b/packages/cli/src/commands/project.ts
@@ -19,7 +19,14 @@ import {
   type CliProjectConfig,
 } from "../config.js";
 
-type Mapping = { adapter: string; bindingId: string; states: string[]; labels: string[] };
+type PickupLabels = { include: string[]; exclude: string[] };
+
+type Mapping = {
+  adapter: string;
+  bindingId: string;
+  states: string[];
+  labels: PickupLabels;
+};
 
 export async function registerStandaloneProject(
   projectDirInput: string,
@@ -30,9 +37,12 @@ export async function registerStandaloneProject(
   const workflow = parseWorkflowMarkdown(await readFile(workflowPath, "utf8"));
   const repository = parseRepository(workflow.repository);
   const adapter = workflow.tracker.kind ?? "github-project";
-  const bindingId = workflow.tracker.projectId ?? workflow.tracker.projectSlug ?? "";
+  const bindingId =
+    workflow.tracker.projectId ?? workflow.tracker.projectSlug ?? "";
   if (!bindingId) {
-    throw new Error("WORKFLOW.md tracker configuration requires project_id or project_slug.");
+    throw new Error(
+      "WORKFLOW.md tracker configuration requires project_id or project_slug."
+    );
   }
   const projectId = projectIdentifier(projectDir);
   const config: CliProjectConfig = {
@@ -49,7 +59,9 @@ export async function registerStandaloneProject(
     tracker: {
       adapter,
       bindingId,
-      ...(workflow.tracker.endpoint ? { apiUrl: workflow.tracker.endpoint } : {}),
+      ...(workflow.tracker.endpoint
+        ? { apiUrl: workflow.tracker.endpoint }
+        : {}),
       priority: workflow.tracker.priority,
       settings: trackerSettings(workflow, repository),
     },
@@ -67,7 +79,9 @@ export async function registerStandaloneProject(
       initialValue: false,
     });
     if (p.isCancel(confirmed) || !confirmed) {
-      throw new Error("Standalone project registration cancelled because tracker mappings overlap.");
+      throw new Error(
+        "Standalone project registration cancelled because tracker mappings overlap."
+      );
     }
   }
 
@@ -80,15 +94,23 @@ export async function registerStandaloneProject(
   return config;
 }
 
-async function findOverlappingProjects(configDir: string, candidate: CliProjectConfig): Promise<string[]> {
+async function findOverlappingProjects(
+  configDir: string,
+  candidate: CliProjectConfig
+): Promise<string[]> {
   const global = await loadGlobalConfig(configDir);
   const candidateMapping = mappingFor(candidate);
   const overlaps: string[] = [];
   for (const id of global?.projects ?? []) {
     const existing = await loadProjectConfig(configDir, id);
     if (!existing || existing.projectId === candidate.projectId) continue;
-    if (existing.repository?.owner !== candidate.repository?.owner || existing.repository?.name !== candidate.repository?.name) continue;
-    if (mappingsOverlap(candidateMapping, mappingFor(existing))) overlaps.push(id);
+    if (
+      existing.repository?.owner !== candidate.repository?.owner ||
+      existing.repository?.name !== candidate.repository?.name
+    )
+      continue;
+    if (mappingsOverlap(candidateMapping, mappingFor(existing)))
+      overlaps.push(id);
   }
   return overlaps;
 }
@@ -98,39 +120,109 @@ function mappingFor(config: CliProjectConfig): Mapping {
   return {
     adapter: config.tracker.adapter,
     bindingId: config.tracker.bindingId,
-    states: (config.tracker.settings?.activeStates as string | undefined)?.split("\n").filter(Boolean) ?? [],
-    labels: Array.isArray(labels)
-      ? labels.filter((value): value is string => typeof value === "string")
-      : [],
+    states: normalizeStates(config.tracker.settings?.activeStates),
+    labels: normalizePickupLabels(labels),
   };
 }
 
 function mappingsOverlap(left: Mapping, right: Mapping): boolean {
-  if (left.adapter !== right.adapter || left.bindingId !== right.bindingId) return false;
-  return intersects(left.states, right.states) && intersects(left.labels, right.labels);
+  if (left.adapter !== right.adapter || left.bindingId !== right.bindingId)
+    return false;
+  return (
+    intersects(left.states, right.states) &&
+    pickupLabelsMayOverlap(left.labels, right.labels)
+  );
 }
 
 function intersects(left: string[], right: string[]): boolean {
-  return left.length === 0 || right.length === 0 || left.some((value) => right.includes(value));
+  return (
+    left.length === 0 ||
+    right.length === 0 ||
+    left.some((value) => right.includes(value))
+  );
 }
 
-function trackerSettings(workflow: ReturnType<typeof parseWorkflowMarkdown>, repository: RepositoryRef): Record<string, OrchestratorTrackerSettingValue> {
+function normalizeStates(
+  value: OrchestratorTrackerSettingValue | undefined
+): string[] {
+  if (typeof value !== "string") return [];
+  return value
+    .split("\n")
+    .map((state) => state.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+function normalizePickupLabels(
+  value: OrchestratorTrackerSettingValue | undefined
+): PickupLabels {
+  if (!value || Array.isArray(value) || typeof value !== "object") {
+    return { include: [], exclude: [] };
+  }
+  const labels = value as Record<string, OrchestratorTrackerSettingValue>;
   return {
-    ...(workflow.tracker.projectId ? { projectId: workflow.tracker.projectId } : {}),
-    ...(workflow.tracker.projectSlug ? { projectSlug: workflow.tracker.projectSlug } : {}),
-    ...(workflow.tracker.kind === "linear" ? { activeStates: workflow.tracker.activeStates.join("\n") } : {}),
-    ...(workflow.tracker.pickupLabels.include.length > 0
-      ? { pickupLabels: workflow.tracker.pickupLabels.include }
+    include: normalizeLabelList(labels.include),
+    exclude: normalizeLabelList(labels.exclude),
+  };
+}
+
+function normalizeLabelList(
+  value: OrchestratorTrackerSettingValue | undefined
+): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((label): label is string => typeof label === "string");
+}
+
+/** Returns false only when the two label predicates are provably disjoint. */
+function pickupLabelsMayOverlap(
+  left: PickupLabels,
+  right: PickupLabels
+): boolean {
+  const leftCandidates = left.include.length > 0 ? left.include : [undefined];
+  const rightCandidates =
+    right.include.length > 0 ? right.include : [undefined];
+  return leftCandidates.some(
+    (leftLabel) =>
+      !right.exclude.includes(leftLabel ?? "") &&
+      rightCandidates.some(
+        (rightLabel) => !left.exclude.includes(rightLabel ?? "")
+      )
+  );
+}
+
+function trackerSettings(
+  workflow: ReturnType<typeof parseWorkflowMarkdown>,
+  repository: RepositoryRef
+): Record<string, OrchestratorTrackerSettingValue> {
+  return {
+    ...(workflow.tracker.projectId
+      ? { projectId: workflow.tracker.projectId }
+      : {}),
+    ...(workflow.tracker.projectSlug
+      ? { projectSlug: workflow.tracker.projectSlug }
+      : {}),
+    ...(workflow.tracker.kind === "linear"
+      ? { activeStates: workflow.tracker.activeStates.join("\n") }
+      : {}),
+    ...(workflow.tracker.pickupLabels.include.length > 0 ||
+    workflow.tracker.pickupLabels.exclude.length > 0
+      ? { pickupLabels: workflow.tracker.pickupLabels }
       : {}),
     repository: `${repository.owner}/${repository.name}`,
   };
 }
 
 function parseRepository(value: Record<string, unknown> | null): RepositoryRef {
-  const spec = typeof value?.slug === "string" ? value.slug : typeof value?.repository === "string" ? value.repository : null;
+  const spec =
+    typeof value?.slug === "string"
+      ? value.slug
+      : typeof value?.repository === "string"
+        ? value.repository
+        : null;
   const [owner, name] = spec?.split("/") ?? [];
   if (!owner || !name || name.includes("/")) {
-    throw new Error('WORKFLOW.md repository extension requires "slug: owner/name".');
+    throw new Error(
+      'WORKFLOW.md repository extension requires "slug: owner/name".'
+    );
   }
   return { owner, name, cloneUrl: `https://github.com/${owner}/${name}.git` };
 }
@@ -140,20 +232,34 @@ function projectIdentifier(projectDir: string): string {
 }
 
 function slugify(value: string): string {
-  return value.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
 }
 
-const handler = async (args: string[], options: GlobalOptions): Promise<void> => {
+const handler = async (
+  args: string[],
+  options: GlobalOptions
+): Promise<void> => {
   const [subcommand, projectDir] = args;
   if (subcommand === "add" && projectDir && args.length === 2) {
     const project = await registerStandaloneProject(projectDir, options);
-    process.stdout.write(`Standalone project registered: ${project.projectId}\n`);
+    process.stdout.write(
+      `Standalone project registered: ${project.projectId}\n`
+    );
     return;
   }
   if (subcommand === "list" && args.length === 1) {
     const global = await loadGlobalConfig(options.configDir);
-    const projects = await Promise.all((global?.projects ?? []).map((id) => loadProjectConfig(options.configDir, id)));
-    process.stdout.write(JSON.stringify(projects.filter(Boolean), null, 2) + "\n");
+    const projects = await Promise.all(
+      (global?.projects ?? []).map((id) =>
+        loadProjectConfig(options.configDir, id)
+      )
+    );
+    process.stdout.write(
+      JSON.stringify(projects.filter(Boolean), null, 2) + "\n"
+    );
     return;
   }
   if (subcommand === "start") {
@@ -168,7 +274,9 @@ const handler = async (args: string[], options: GlobalOptions): Promise<void> =>
     await stopCommand(args.slice(1), options);
     return;
   }
-  process.stderr.write("Usage: gh-symphony project <add <projectDir>|list|start|status|stop>\n");
+  process.stderr.write(
+    "Usage: gh-symphony project <add <projectDir>|list|start|status|stop>\n"
+  );
   process.exitCode = 2;
 };
 

--- a/packages/cli/src/commands/project.ts
+++ b/packages/cli/src/commands/project.ts
@@ -1,0 +1,165 @@
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { basename, resolve } from "node:path";
+import {
+  parseWorkflowMarkdown,
+  type OrchestratorTrackerSettingValue,
+  type RepositoryRef,
+} from "@gh-symphony/core";
+import type { GlobalOptions } from "../index.js";
+import startCommand from "./start.js";
+import statusCommand from "./status.js";
+import stopCommand from "./stop.js";
+import {
+  loadGlobalConfig,
+  loadProjectConfig,
+  saveGlobalConfig,
+  saveProjectConfig,
+  type CliProjectConfig,
+} from "../config.js";
+
+type Mapping = { adapter: string; bindingId: string; states: string[]; labels: string[] };
+
+export async function registerStandaloneProject(
+  projectDirInput: string,
+  options: Pick<GlobalOptions, "configDir">
+): Promise<CliProjectConfig> {
+  const projectDir = resolve(projectDirInput);
+  const workflowPath = resolve(projectDir, "WORKFLOW.md");
+  const workflow = parseWorkflowMarkdown(await readFile(workflowPath, "utf8"));
+  const repository = parseRepository(workflow.repository);
+  const adapter = workflow.tracker.kind ?? "github-project";
+  const bindingId = workflow.tracker.projectId ?? workflow.tracker.projectSlug ?? "";
+  if (!bindingId) {
+    throw new Error("WORKFLOW.md tracker configuration requires project_id or project_slug.");
+  }
+  const projectId = projectIdentifier(projectDir);
+  const config: CliProjectConfig = {
+    projectId,
+    slug: slugify(basename(projectDir)) || projectId,
+    displayName: basename(projectDir) || projectId,
+    projectDir,
+    workspaceDir: workflow.workspace.root
+      ? resolve(projectDir, workflow.workspace.root)
+      : resolve(projectDir, ".runtime", "workspaces"),
+    repository,
+    workflowSource: { type: "external", path: workflowPath },
+    populateStrategy: "worktree-cache",
+    tracker: {
+      adapter,
+      bindingId,
+      ...(workflow.tracker.endpoint ? { apiUrl: workflow.tracker.endpoint } : {}),
+      priority: workflow.tracker.priority,
+      settings: trackerSettings(workflow, repository),
+    },
+  };
+
+  const overlap = await findOverlappingProjects(options.configDir, config);
+  if (overlap.length > 0 && !process.stdin.isTTY) {
+    throw new Error(
+      `Tracker mapping overlaps registered project(s): ${overlap.join(", ")}. Re-run interactively to confirm.`
+    );
+  }
+  if (overlap.length > 0) {
+    process.stderr.write(
+      `Warning: tracker mapping overlaps registered project(s): ${overlap.join(", ")}.\n`
+    );
+  }
+
+  await saveProjectConfig(options.configDir, projectId, config);
+  const global = await loadGlobalConfig(options.configDir);
+  await saveGlobalConfig(options.configDir, {
+    activeProject: projectId,
+    projects: [...new Set([...(global?.projects ?? []), projectId])],
+  });
+  return config;
+}
+
+async function findOverlappingProjects(configDir: string, candidate: CliProjectConfig): Promise<string[]> {
+  const global = await loadGlobalConfig(configDir);
+  const candidateMapping = mappingFor(candidate);
+  const overlaps: string[] = [];
+  for (const id of global?.projects ?? []) {
+    const existing = await loadProjectConfig(configDir, id);
+    if (!existing || existing.projectId === candidate.projectId) continue;
+    if (existing.repository?.owner !== candidate.repository?.owner || existing.repository?.name !== candidate.repository?.name) continue;
+    if (mappingsOverlap(candidateMapping, mappingFor(existing))) overlaps.push(id);
+  }
+  return overlaps;
+}
+
+function mappingFor(config: CliProjectConfig): Mapping {
+  const labels = config.tracker.settings?.pickupLabels;
+  return {
+    adapter: config.tracker.adapter,
+    bindingId: config.tracker.bindingId,
+    states: (config.tracker.settings?.activeStates as string | undefined)?.split("\n").filter(Boolean) ?? [],
+    labels: Array.isArray(labels) ? labels.filter((value): value is string => typeof value === "string") : [],
+  };
+}
+
+function mappingsOverlap(left: Mapping, right: Mapping): boolean {
+  if (left.adapter !== right.adapter || left.bindingId !== right.bindingId) return false;
+  return intersects(left.states, right.states) && intersects(left.labels, right.labels);
+}
+
+function intersects(left: string[], right: string[]): boolean {
+  return left.length === 0 || right.length === 0 || left.some((value) => right.includes(value));
+}
+
+function trackerSettings(workflow: ReturnType<typeof parseWorkflowMarkdown>, repository: RepositoryRef): Record<string, OrchestratorTrackerSettingValue> {
+  return {
+    ...(workflow.tracker.projectId ? { projectId: workflow.tracker.projectId } : {}),
+    ...(workflow.tracker.projectSlug ? { projectSlug: workflow.tracker.projectSlug } : {}),
+    ...(workflow.tracker.kind === "linear" ? { activeStates: workflow.tracker.activeStates.join("\n") } : {}),
+    repository: `${repository.owner}/${repository.name}`,
+  };
+}
+
+function parseRepository(value: Record<string, unknown> | null): RepositoryRef {
+  const spec = typeof value?.slug === "string" ? value.slug : typeof value?.repository === "string" ? value.repository : null;
+  const [owner, name] = spec?.split("/") ?? [];
+  if (!owner || !name || name.includes("/")) {
+    throw new Error('WORKFLOW.md repository extension requires "slug: owner/name".');
+  }
+  return { owner, name, cloneUrl: `https://github.com/${owner}/${name}.git` };
+}
+
+function projectIdentifier(projectDir: string): string {
+  return `${slugify(basename(projectDir)) || "project"}-${createHash("sha256").update(projectDir).digest("hex").slice(0, 8)}`;
+}
+
+function slugify(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+}
+
+const handler = async (args: string[], options: GlobalOptions): Promise<void> => {
+  const [subcommand, projectDir] = args;
+  if (subcommand === "add" && projectDir && args.length === 2) {
+    const project = await registerStandaloneProject(projectDir, options);
+    process.stdout.write(`Standalone project registered: ${project.projectId}\n`);
+    return;
+  }
+  if (subcommand === "list" && args.length === 1) {
+    const global = await loadGlobalConfig(options.configDir);
+    const projects = await Promise.all((global?.projects ?? []).map((id) => loadProjectConfig(options.configDir, id)));
+    process.stdout.write(JSON.stringify(projects.filter(Boolean), null, 2) + "\n");
+    return;
+  }
+  if (subcommand === "start") {
+    await startCommand(args.slice(1), options);
+    return;
+  }
+  if (subcommand === "status") {
+    await statusCommand(args.slice(1), options);
+    return;
+  }
+  if (subcommand === "stop") {
+    await stopCommand(args.slice(1), options);
+    return;
+  }
+  process.stderr.write("Usage: gh-symphony project <add <projectDir>|list|start|status|stop>\n");
+  process.exitCode = 2;
+};
+
+export default handler;

--- a/packages/cli/src/commands/start.test.ts
+++ b/packages/cli/src/commands/start.test.ts
@@ -816,7 +816,7 @@ describe("start command foreground locking", () => {
     expect(Date.parse(pidRecord.startedAt)).not.toBeNaN();
   });
 
-  it("starts an external project daemon from its project directory", async () => {
+  it("starts the active external project daemon from its project directory", async () => {
     const configDir = await createConfigFixture({
       activeProject: "standalone",
       projects: [
@@ -828,6 +828,7 @@ describe("start command foreground locking", () => {
             path: "/tmp/standalone-project/WORKFLOW.md",
           },
         },
+        createProject("other-project", "beta", "api"),
       ],
     });
 

--- a/packages/cli/src/commands/start.test.ts
+++ b/packages/cli/src/commands/start.test.ts
@@ -816,6 +816,35 @@ describe("start command foreground locking", () => {
     expect(Date.parse(pidRecord.startedAt)).not.toBeNaN();
   });
 
+  it("starts an external project daemon from its project directory", async () => {
+    const configDir = await createConfigFixture({
+      activeProject: "standalone",
+      projects: [
+        {
+          ...createProject("standalone", "acme", "platform"),
+          projectDir: "/tmp/standalone-project",
+          workflowSource: {
+            type: "external",
+            path: "/tmp/standalone-project/WORKFLOW.md",
+          },
+        },
+      ],
+    });
+
+    await startModule.default(["--daemon"], baseOptions(configDir));
+
+    expect(childProcessMocks.spawn.mock.calls[0]?.[2]).toMatchObject({
+      cwd: "/tmp/standalone-project",
+    });
+    const pidRecord = JSON.parse(
+      await readFile(
+        join(configDir, "projects", "standalone", "daemon.pid"),
+        "utf8"
+      )
+    ) as { cwd: string };
+    expect(pidRecord.cwd).toBe("/tmp/standalone-project");
+  });
+
   it("does not leave a PID file when daemon spawn fails", async () => {
     const configDir = await mkdtemp(join(tmpdir(), "cli-start-spawn-"));
     await configModule.saveGlobalConfig(configDir, {

--- a/packages/cli/src/commands/start.test.ts
+++ b/packages/cli/src/commands/start.test.ts
@@ -2,7 +2,7 @@ import { createServer } from "node:http";
 import { EventEmitter } from "node:events";
 import { mkdtemp, mkdir, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { CliProjectConfig } from "../config.js";
 import * as configModule from "../config.js";
@@ -835,6 +835,10 @@ describe("start command foreground locking", () => {
 
     expect(childProcessMocks.spawn.mock.calls[0]?.[2]).toMatchObject({
       cwd: "/tmp/standalone-project",
+      env: expect.objectContaining({
+        GH_SYMPHONY_CONFIG_DIR: resolve(configDir),
+        GH_SYMPHONY_DAEMON_PROJECT_ID: "standalone",
+      }),
     });
     const pidRecord = JSON.parse(
       await readFile(

--- a/packages/cli/src/commands/start.test.ts
+++ b/packages/cli/src/commands/start.test.ts
@@ -832,7 +832,15 @@ describe("start command foreground locking", () => {
       ],
     });
 
-    await startModule.default(["--daemon"], baseOptions(configDir));
+    const stdout = captureWrites(process.stdout);
+    try {
+      await startModule.default(["--daemon"], {
+        ...baseOptions(configDir),
+        invocation: "project",
+      });
+    } finally {
+      stdout.restore();
+    }
 
     expect(childProcessMocks.spawn.mock.calls[0]?.[2]).toMatchObject({
       cwd: "/tmp/standalone-project",
@@ -848,6 +856,7 @@ describe("start command foreground locking", () => {
       )
     ) as { cwd: string };
     expect(pidRecord.cwd).toBe("/tmp/standalone-project");
+    expect(stdout.output()).toContain("Stop with: gh-symphony project stop");
   });
 
   it("does not leave a PID file when daemon spawn fails", async () => {

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -1403,7 +1403,7 @@ async function startDaemon(
   process.stdout.write(
     `Orchestrator started in background (PID: ${child.pid}).\n` +
       `Logs: ${logPath}\n` +
-      "Stop with: gh-symphony repo stop\n"
+      `Stop with: ${options.invocation === "project" ? "gh-symphony project stop" : "gh-symphony repo stop"}\n`
   );
   if (httpPort !== undefined || webPort !== undefined) {
     process.stdout.write(`HTTP API bearer token: ${httpApiToken}\n`);

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -1,6 +1,6 @@
 import { mkdir, readFile, rm } from "node:fs/promises";
 import { randomBytes, timingSafeEqual } from "node:crypto";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { spawn, type ChildProcess } from "node:child_process";
 import {
   createServer,
@@ -69,6 +69,7 @@ function logLine(icon: string, msg: string): void {
 }
 
 const REPO_START_COMMAND = "gh-symphony repo start";
+const DAEMON_PROJECT_ID_ENV = "GH_SYMPHONY_DAEMON_PROJECT_ID";
 
 type RepoStartAuthPreflightResult =
   | { ok: true; githubAuthSource?: GitHubAuthSource }
@@ -903,7 +904,7 @@ const handler = async (
   }
   const projectConfig = await resolveManagedProjectConfig({
     configDir: options.configDir,
-    requestedProjectId: undefined,
+    requestedProjectId: process.env[DAEMON_PROJECT_ID_ENV],
   });
   if (!projectConfig) {
     handleMissingManagedProjectConfig();
@@ -952,7 +953,8 @@ const handler = async (
       parsed.assignedOnly === true,
       parsed.bindAll,
       httpApiToken,
-      projectConfig.projectDir
+      projectConfig.projectDir,
+      projectId
     );
     return;
   }
@@ -1324,7 +1326,8 @@ async function startDaemon(
   assignedOnly = false,
   bindAll = false,
   httpApiToken = resolveHttpApiToken(),
-  projectDir?: string
+  projectDir?: string,
+  selectedProjectId?: string
 ): Promise<void> {
   const logPath = orchestratorLogPath(options.configDir, projectId);
   await mkdir(dirname(logPath), { recursive: true });
@@ -1349,7 +1352,10 @@ async function startDaemon(
       cwd: projectDir ?? process.cwd(),
       env: {
         ...process.env,
-        GH_SYMPHONY_CONFIG_DIR: options.configDir,
+        GH_SYMPHONY_CONFIG_DIR: resolve(options.configDir),
+        ...(selectedProjectId
+          ? { [DAEMON_PROJECT_ID_ENV]: selectedProjectId }
+          : {}),
         [HTTP_API_TOKEN_ENV]: httpApiToken,
       },
       detached: true,

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -79,9 +79,12 @@ function isInteractiveTerminal(): boolean {
   return process.stdin.isTTY === true && process.stdout.isTTY === true;
 }
 
-function displayGhAuthError(error: GitHubAuthError): void {
+function displayGhAuthError(
+  error: GitHubAuthError,
+  retryCommand = REPO_START_COMMAND
+): void {
   const remediation = formatGhAuthRemediation(error, {
-    retryCommand: REPO_START_COMMAND,
+    retryCommand,
   });
   process.stderr.write(`${remediation.title}: ${remediation.message}\n`);
   process.stderr.write(`${remediation.hint}\n`);
@@ -108,6 +111,7 @@ function displayGitHubAuthSuccess(auth: {
 
 async function resolveRepoStartGitHubAuth(input: {
   allowInteractiveRemediation: boolean;
+  retryCommand: string;
 }): Promise<RepoStartAuthPreflightResult> {
   try {
     const auth = await resolveGitHubAuth();
@@ -119,10 +123,10 @@ async function resolveRepoStartGitHubAuth(input: {
       throw error;
     }
 
-    displayGhAuthError(error);
+    displayGhAuthError(error, input.retryCommand);
 
     const remediation = formatGhAuthRemediation(error, {
-      retryCommand: REPO_START_COMMAND,
+      retryCommand: input.retryCommand,
     });
     const canRemediate =
       input.allowInteractiveRemediation &&
@@ -160,7 +164,7 @@ async function resolveRepoStartGitHubAuth(input: {
       return { ok: true, githubAuthSource: auth.source };
     } catch (retryError) {
       if (retryError instanceof GitHubAuthError) {
-        displayGhAuthError(retryError);
+        displayGhAuthError(retryError, input.retryCommand);
         process.exitCode = 1;
         return { ok: false };
       }
@@ -171,11 +175,12 @@ async function resolveRepoStartGitHubAuth(input: {
 
 async function preflightRepoStartAuth(
   projectConfig: OrchestratorProjectConfig,
-  input: { daemon: boolean }
+  input: { daemon: boolean; retryCommand: string }
 ): Promise<RepoStartAuthPreflightResult> {
   if (projectConfig.tracker.adapter === "github-project") {
     return resolveRepoStartGitHubAuth({
       allowInteractiveRemediation: !input.daemon,
+      retryCommand: input.retryCommand,
     });
   }
 
@@ -184,7 +189,7 @@ async function preflightRepoStartAuth(
       return { ok: true };
     }
     process.stderr.write(
-      "Linear authentication is required. Set LINEAR_API_KEY in the environment before running 'gh-symphony repo start'.\n"
+      `Linear authentication is required. Set LINEAR_API_KEY in the environment before running '${input.retryCommand}'.\n`
     );
     process.exitCode = 1;
     return { ok: false };
@@ -936,6 +941,10 @@ const handler = async (
 
   const authPreflight = await preflightRepoStartAuth(projectConfig, {
     daemon: parsed.daemon,
+    retryCommand:
+      options.invocation === "project"
+        ? "gh-symphony project start"
+        : REPO_START_COMMAND,
   });
   if (!authPreflight.ok) {
     return;

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -951,7 +951,8 @@ const handler = async (
       parsed.webPort,
       parsed.assignedOnly === true,
       parsed.bindAll,
-      httpApiToken
+      httpApiToken,
+      projectConfig.projectDir
     );
     return;
   }
@@ -1322,7 +1323,8 @@ async function startDaemon(
   webPort?: number,
   assignedOnly = false,
   bindAll = false,
-  httpApiToken = resolveHttpApiToken()
+  httpApiToken = resolveHttpApiToken(),
+  projectDir?: string
 ): Promise<void> {
   const logPath = orchestratorLogPath(options.configDir, projectId);
   await mkdir(dirname(logPath), { recursive: true });
@@ -1344,7 +1346,7 @@ async function startDaemon(
       ...(logLevel ? ["--log-level", logLevel] : []),
     ],
     {
-      cwd: process.cwd(),
+      cwd: projectDir ?? process.cwd(),
       env: {
         ...process.env,
         GH_SYMPHONY_CONFIG_DIR: options.configDir,
@@ -1366,7 +1368,7 @@ async function startDaemon(
       pid: child.pid,
       startedAt: new Date().toISOString(),
       processIdentity: getProcessIdentity(child.pid),
-      cwd: process.cwd(),
+      cwd: projectDir ?? process.cwd(),
     });
     child.unref();
   } catch (error) {

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -267,6 +267,13 @@ function renderLegacyStatus(
     lines.push("");
   }
 
+  for (const warning of snapshot.warnings ?? []) {
+    lines.push(apply(yellow(`  ⚠ ${warning}`)));
+  }
+  if ((snapshot.warnings?.length ?? 0) > 0) {
+    lines.push("");
+  }
+
   // Token usage
   if (snapshot.codexTotals) {
     const tokenDelta = resolveProjectTokenDelta(snapshot);

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -350,10 +350,7 @@ describe("Commander CLI entrypoint", () => {
   );
 
   it.each([
-    [
-      ["repo", "run", "--json", "--watch"],
-      "Issue identifier argument missing",
-    ],
+    [["repo", "run", "--json", "--watch"], "Issue identifier argument missing"],
     [["repo", "explain", "--json"], "Issue identifier argument missing"],
   ])("prints JSON for missing issue in %s", async (argv, message) => {
     const stdout = captureWrites(process.stdout);
@@ -397,28 +394,29 @@ describe("Commander CLI entrypoint", () => {
     ["--json", "repo", "badcmd"],
     ["repo", "--json", "badcmd"],
     ["repo", "badcmd", "--json"],
-  ])("prints JSON for unknown repo subcommands with globals in %s", async (
-    ...argv
-  ) => {
-    const stdout = captureWrites(process.stdout);
-    const stderr = captureWrites(process.stderr);
+  ])(
+    "prints JSON for unknown repo subcommands with globals in %s",
+    async (...argv) => {
+      const stdout = captureWrites(process.stdout);
+      const stderr = captureWrites(process.stderr);
 
-    try {
-      await runCli(argv);
-    } finally {
-      stdout.restore();
-      stderr.restore();
+      try {
+        await runCli(argv);
+      } finally {
+        stdout.restore();
+        stderr.restore();
+      }
+
+      expect(process.exitCode).toBe(1);
+      expect(stderr.output()).toBe("");
+      expect(JSON.parse(stdout.output())).toEqual({
+        error: {
+          code: "unknown_command",
+          message: "error: unknown command 'badcmd' for 'repo'",
+        },
+      });
     }
-
-    expect(process.exitCode).toBe(1);
-    expect(stderr.output()).toBe("");
-    expect(JSON.parse(stdout.output())).toEqual({
-      error: {
-        code: "unknown_command",
-        message: "error: unknown command 'badcmd' for 'repo'",
-      },
-    });
-  });
+  );
 
   it("does not treat inherited property names as namespace commands", async () => {
     const stderr = captureWrites(process.stderr);
@@ -433,23 +431,28 @@ describe("Commander CLI entrypoint", () => {
     expect(stderr.output()).toContain("unknown command 'toString'");
   });
 
-  it.each([["project"], ["project", "add", "--non-interactive"]])(
-    "prints the removed project namespace message for %s",
-    async (...argv) => {
-      const stderr = captureWrites(process.stderr);
+  it.each([
+    [["project"], undefined, undefined],
+    [["project", "add", "--non-interactive"], "stderr", "unknown option"],
+  ])("reports project command usage for %s", async (argv, stream, message) => {
+    const stdout = captureWrites(process.stdout);
+    const stderr = captureWrites(process.stderr);
 
-      try {
-        await runCli(argv);
-      } finally {
-        stderr.restore();
-      }
-
-      expect(process.exitCode).toBe(2);
-      expect(stderr.output()).toContain("The 'project' command was removed.");
-      expect(stderr.output()).toContain("gh-symphony repo init");
-      process.exitCode = undefined;
+    try {
+      await runCli(argv);
+    } finally {
+      stdout.restore();
+      stderr.restore();
     }
-  );
+
+    expect(process.exitCode).toBe(1);
+    if (stream && message) {
+      expect(stream === "stdout" ? stdout.output() : stderr.output()).toContain(
+        message
+      );
+    }
+    process.exitCode = undefined;
+  });
 
   it("shows doctor remediation help", async () => {
     const stdout = captureWrites(process.stdout);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -21,6 +21,7 @@ export type GlobalOptions = {
   verbose: boolean;
   json: boolean;
   noColor: boolean;
+  invocation?: "project";
 };
 
 export type CommandHandler = (
@@ -514,19 +515,42 @@ function createProgram(): { program: Command; wasInvoked: () => boolean } {
     markInvoked
   );
 
-  const project = addGlobalOptions(program.command("project").description("Manage standalone projects"));
-  addGlobalOptions(project.command("add").argument("<projectDir>", "Standalone project directory").allowExcessArguments(false)).action(async function (this: Command, projectDir: string) {
+  const project = addGlobalOptions(
+    program.command("project").description("Manage standalone projects")
+  );
+  addGlobalOptions(
+    project
+      .command("add")
+      .argument("<projectDir>", "Standalone project directory")
+      .allowExcessArguments(false)
+  ).action(async function (this: Command, projectDir: string) {
     markInvoked();
-    await invokeHandler("project", ["add", projectDir], this.optsWithGlobals<CliOptionValues>());
+    await invokeHandler(
+      "project",
+      ["add", projectDir],
+      this.optsWithGlobals<CliOptionValues>()
+    );
   });
-  addGlobalOptions(project.command("list").allowExcessArguments(false)).action(async function (this: Command) {
-    markInvoked();
-    await invokeHandler("project", ["list"], this.optsWithGlobals<CliOptionValues>());
-  });
-  for (const name of ["start", "status", "stop"] as const) {
-    addGlobalOptions(project.command(name).allowUnknownOption(true).allowExcessArguments(true)).action(async function (this: Command) {
+  addGlobalOptions(project.command("list").allowExcessArguments(false)).action(
+    async function (this: Command) {
       markInvoked();
-      await invokeHandler("project", [name, ...this.args], this.optsWithGlobals<CliOptionValues>());
+      await invokeHandler(
+        "project",
+        ["list"],
+        this.optsWithGlobals<CliOptionValues>()
+      );
+    }
+  );
+  for (const name of ["start", "status", "stop"] as const) {
+    addGlobalOptions(
+      project.command(name).allowUnknownOption(true).allowExcessArguments(true)
+    ).action(async function (this: Command) {
+      markInvoked();
+      await invokeHandler(
+        "project",
+        [name, ...this.args],
+        this.optsWithGlobals<CliOptionValues>()
+      );
     });
   }
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -34,6 +34,7 @@ type LoaderKey =
   | "doctor"
   | "upgrade"
   | "repo"
+  | "project"
   | "config"
   | "version";
 
@@ -84,6 +85,7 @@ const COMMANDS: Record<LoaderKey, () => Promise<{ default: CommandHandler }>> =
     doctor: () => import("./commands/doctor.js"),
     upgrade: () => import("./commands/upgrade.js"),
     repo: () => import("./commands/repo.js"),
+    project: () => import("./commands/project.js"),
     config: () => import("./commands/config-cmd.js"),
     version: () => import("./commands/version.js"),
   };
@@ -512,19 +514,21 @@ function createProgram(): { program: Command; wasInvoked: () => boolean } {
     markInvoked
   );
 
-  addGlobalOptions(
-    program
-      .command("project")
-      .description("Removed project namespace")
-      .argument("[args...]", "Removed project command arguments")
-      .allowUnknownOption(true)
-      .allowExcessArguments(true)
-  ).action(async function (this: Command) {
+  const project = addGlobalOptions(program.command("project").description("Manage standalone projects"));
+  addGlobalOptions(project.command("add").argument("<projectDir>", "Standalone project directory").allowExcessArguments(false)).action(async function (this: Command, projectDir: string) {
     markInvoked();
-    await createRemovedCommandHandler(
-      "The 'project' command was removed. The orchestrator is now per-repository. Run 'gh-symphony repo init' in the target repository."
-    )([], resolveGlobalOptions(this.optsWithGlobals<CliOptionValues>()));
+    await invokeHandler("project", ["add", projectDir], this.optsWithGlobals<CliOptionValues>());
   });
+  addGlobalOptions(project.command("list").allowExcessArguments(false)).action(async function (this: Command) {
+    markInvoked();
+    await invokeHandler("project", ["list"], this.optsWithGlobals<CliOptionValues>());
+  });
+  for (const name of ["start", "status", "stop"] as const) {
+    addGlobalOptions(project.command(name).allowUnknownOption(true).allowExcessArguments(true)).action(async function (this: Command) {
+      markInvoked();
+      await invokeHandler("project", [name, ...this.args], this.optsWithGlobals<CliOptionValues>());
+    });
+  }
 
   const repo = addGlobalOptions(
     program

--- a/packages/cli/src/project-selection.test.ts
+++ b/packages/cli/src/project-selection.test.ts
@@ -84,7 +84,20 @@ describe("resolveManagedProjectConfig", () => {
     expect(selectMock).not.toHaveBeenCalled();
   });
 
-  it("requires explicit project selection in non-interactive multi-project mode", async () => {
+  it("uses the active project in non-interactive multi-project mode", async () => {
+    const configDir = await createConfigFixture([
+      createProject("tenant-a"),
+      createProject("tenant-b"),
+    ], "tenant-b");
+    setTty(false, false);
+
+    const project = await resolveManagedProjectConfig({ configDir });
+
+    expect(project?.projectId).toBe("tenant-b");
+    expect(selectMock).not.toHaveBeenCalled();
+  });
+
+  it("requires interactive selection when multiple projects have no active project", async () => {
     const configDir = await createConfigFixture([
       createProject("tenant-a"),
       createProject("tenant-b"),
@@ -108,8 +121,7 @@ describe("resolveManagedProjectConfig", () => {
       [
         createProject("tenant-a", "Alpha"),
         createProject("tenant-b", "Beta"),
-      ],
-      "tenant-a"
+      ]
     );
     setTty(true, true);
     selectMock.mockResolvedValue("tenant-b");
@@ -122,7 +134,6 @@ describe("resolveManagedProjectConfig", () => {
         options: expect.arrayContaining([
           expect.objectContaining({
             value: "tenant-a",
-            hint: "current",
           }),
           expect.objectContaining({
             value: "tenant-b",

--- a/packages/cli/src/project-selection.test.ts
+++ b/packages/cli/src/project-selection.test.ts
@@ -10,6 +10,14 @@ import {
 
 const selectMock = vi.fn();
 const cancelMock = vi.fn();
+const originalStdinIsTty = Object.getOwnPropertyDescriptor(
+  process.stdin,
+  "isTTY"
+);
+const originalStdoutIsTty = Object.getOwnPropertyDescriptor(
+  process.stdout,
+  "isTTY"
+);
 
 vi.mock("@clack/prompts", async () => {
   const actual =
@@ -28,7 +36,10 @@ const {
   resolveManagedProjectConfig,
 } = await import("./project-selection.js");
 
-function createProject(projectId: string, displayName?: string): CliProjectConfig {
+function createProject(
+  projectId: string,
+  displayName?: string
+): CliProjectConfig {
   return {
     projectId,
     slug: projectId,
@@ -71,6 +82,12 @@ afterEach(() => {
   selectMock.mockReset();
   cancelMock.mockReset();
   vi.restoreAllMocks();
+  if (originalStdinIsTty) {
+    Object.defineProperty(process.stdin, "isTTY", originalStdinIsTty);
+  }
+  if (originalStdoutIsTty) {
+    Object.defineProperty(process.stdout, "isTTY", originalStdoutIsTty);
+  }
   process.exitCode = undefined;
 });
 
@@ -85,10 +102,10 @@ describe("resolveManagedProjectConfig", () => {
   });
 
   it("uses the active project in non-interactive multi-project mode", async () => {
-    const configDir = await createConfigFixture([
-      createProject("tenant-a"),
-      createProject("tenant-b"),
-    ], "tenant-b");
+    const configDir = await createConfigFixture(
+      [createProject("tenant-a"), createProject("tenant-b")],
+      "tenant-b"
+    );
     setTty(false, false);
 
     const project = await resolveManagedProjectConfig({ configDir });
@@ -117,12 +134,10 @@ describe("resolveManagedProjectConfig", () => {
   });
 
   it("prompts and resolves the selected project in interactive multi-project mode", async () => {
-    const configDir = await createConfigFixture(
-      [
-        createProject("tenant-a", "Alpha"),
-        createProject("tenant-b", "Beta"),
-      ]
-    );
+    const configDir = await createConfigFixture([
+      createProject("tenant-a", "Alpha"),
+      createProject("tenant-b", "Beta"),
+    ]);
     setTty(true, true);
     selectMock.mockResolvedValue("tenant-b");
 

--- a/packages/cli/src/project-selection.ts
+++ b/packages/cli/src/project-selection.ts
@@ -149,6 +149,10 @@ export async function resolveManagedProjectConfig(
     return loadProjectConfig(input.configDir, projectIds[0]!);
   }
 
+  if (global?.activeProject) {
+    return loadProjectConfig(input.configDir, global.activeProject);
+  }
+
   if (!isInteractiveTerminal()) {
     writeCliError({
       code: "missing_repository_runtime_config",

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -11442,6 +11442,38 @@ Workspace prompt.
     ]);
   });
 
+  it("does not warn when an external workflow is the resolved repository workflow", async () => {
+    process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
+    const tempRoot = await mkdtemp(
+      join(tmpdir(), "orchestrator-external-workflow-same-path-")
+    );
+    const repository = await createRepositoryFixture(
+      tempRoot,
+      "acme",
+      "platform"
+    );
+    const store = new OrchestratorFsStore(tempRoot);
+    const externalWorkflowPath = join(process.cwd(), "WORKFLOW.md");
+    const projectConfig = {
+      ...createProjectConfig(tempRoot, {
+        ...repository,
+        path: undefined,
+        cloneUrl: "https://github.com/acme/platform.git",
+      }),
+      workflowSource: { type: "external" as const, path: externalWorkflowPath },
+    };
+    await store.saveProjectConfig(projectConfig);
+
+    const service = new OrchestratorService(store, projectConfig, {
+      fetchImpl: vi.fn().mockResolvedValue(createTrackerResponse(repository)),
+      now: () => new Date("2026-03-08T00:00:00.000Z"),
+    });
+
+    const snapshot = await service.runOnce();
+
+    expect(snapshot.warnings).toEqual([]);
+  });
+
   it("reloads the configured external workflow and preserves repo mode behavior", async () => {
     process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
     const tempRoot = await mkdtemp(

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -2,7 +2,7 @@ import { access, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { createWriteStream, mkdirSync, statSync } from "node:fs";
 import { spawn } from "node:child_process";
 import type { ChildProcess, SpawnOptions } from "node:child_process";
-import { isAbsolute, join } from "node:path";
+import { isAbsolute, join, resolve } from "node:path";
 import { StringDecoder } from "node:string_decoder";
 import { fileURLToPath } from "node:url";
 import {
@@ -2233,6 +2233,11 @@ export class OrchestratorService {
       this.resolveWorkflowRepositoryDirectory(tenant.repository),
       "WORKFLOW.md"
     );
+    if (
+      resolve(tenant.workflowSource.path) === resolve(repositoryWorkflowPath)
+    ) {
+      return [];
+    }
     try {
       await access(repositoryWorkflowPath);
       return [


### PR DESCRIPTION
## Issues — Closed #569

## TL;DR

- `gh-symphony project add <projectDir>`로 external `WORKFLOW.md` 기반 standalone 프로젝트를 등록·기동합니다.
- standalone 상태에서 자기 자신을 가리키는 shadow 경고를 제거하고 `project start --daemon`의 종료 안내를 일치시켰습니다.

## 변경 지점 다이어그램

```text
external WORKFLOW.md
  └─ daemon cwd = projectDir
       ├─ resolved repository WORKFLOW.md와 같으면 shadow warning 생략
       └─ project start --daemon → project stop 안내
```

## 여기부터 보세요

- `packages/orchestrator/src/service.ts` — 동일 workflow 경로의 shadow-warning guard
- `packages/cli/src/commands/start.ts` — invocation-aware daemon stop 안내
- 회귀 TC: `service.test.ts`, `start.test.ts`

## 위험 & 롤백

- 서로 다른 external/repository workflow 경로의 기존 shadow 경고는 유지됩니다.
- 롤백은 PR revert로 가능합니다.

## 변경 파일

- `packages/orchestrator/src/service.ts`
- `packages/orchestrator/src/service.test.ts`
- `packages/cli/src/commands/start.ts`
- `packages/cli/src/commands/start.test.ts`

## Evidence

- `pnpm lint` — pass
- `pnpm test` — pass
- `pnpm typecheck` — pass
- `pnpm build` — pass
- Docker E2E image build + `/healthz` — pass; prior cycle의 repo init→start→dispatch→worker completed TC 유지

## 머지 후/사람 확인

- [ ] 실제 standalone project directory에서 GitHub/Linear tracker 인증과 daemon lifecycle을 확인합니다.
