### PR TITLE
feat(orchestrator): populate workspaces from cache

### DIFF
--- a/.changeset/friendly-worktrees-smile.md
+++ b/.changeset/friendly-worktrees-smile.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Populate `worktree-cache` project workspaces from the shared clone cache with project-scoped branches, including safe worktree cleanup. (#565)

--- a/packages/orchestrator/src/git.test.ts
+++ b/packages/orchestrator/src/git.test.ts
@@ -16,6 +16,8 @@ import {
   acquireRepositoryLock,
   cloneRepositoryForRun,
   ensureIssueWorkspaceRepository,
+  removeIssueWorkspaceWorktree,
+  renderIssueBranchName,
   releaseRepositoryLock,
   syncRepositoryForRun,
 } from "./git.js";
@@ -775,6 +777,97 @@ describe("cloneRepositoryForRun", () => {
     });
   });
 });
+
+describe("worktree-cache issue workspaces", () => {
+  it("populates, reuses, and removes a project-scoped worktree", async () => {
+    const tempRoot = await mkdtemp(join(tmpdir(), "orchestrator-worktree-"));
+    const repository = await createRepositoryFixture(tempRoot);
+    const issueWorkspacePath = join(tempRoot, "workspaces", "issue-1");
+
+    const repositoryDirectory = await ensureIssueWorkspaceRepository({
+      repository,
+      issueWorkspacePath,
+      existingWorkspace: false,
+      populateStrategy: "worktree-cache",
+      projectSlug: "project-one",
+      issueIdentifier: "acme/platform#1",
+    });
+
+    expect(
+      execSync(`git -C "${repositoryDirectory}" branch --show-current`, {
+        encoding: "utf8",
+      }).trim()
+    ).toBe("symphony/project-one/acme-platform-1");
+    await expect(
+      ensureIssueWorkspaceRepository({
+        repository,
+        issueWorkspacePath,
+        existingWorkspace: true,
+        populateStrategy: "worktree-cache",
+      })
+    ).resolves.toBe(repositoryDirectory);
+
+    await removeIssueWorkspaceWorktree({ repository, repositoryDirectory });
+    await expect(access(repositoryDirectory)).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  it("namespaces identical issue identifiers by project and preserves failed reuse", async () => {
+    const tempRoot = await mkdtemp(join(tmpdir(), "orchestrator-worktree-"));
+    const repository = await createRepositoryFixture(tempRoot);
+    const firstWorkspace = join(tempRoot, "workspaces", "first");
+    const secondWorkspace = join(tempRoot, "workspaces", "second");
+    const invalidWorkspace = join(tempRoot, "workspaces", "invalid");
+
+    const first = await ensureIssueWorkspaceRepository({
+      repository,
+      issueWorkspacePath: firstWorkspace,
+      existingWorkspace: false,
+      populateStrategy: "worktree-cache",
+      projectSlug: "project-one",
+      issueIdentifier: "acme/platform#7",
+    });
+    const second = await ensureIssueWorkspaceRepository({
+      repository,
+      issueWorkspacePath: secondWorkspace,
+      existingWorkspace: false,
+      populateStrategy: "worktree-cache",
+      projectSlug: "project-two",
+      issueIdentifier: "acme/platform#7",
+    });
+    expect(readGitBranch(first)).toBe("symphony/project-one/acme-platform-7");
+    expect(readGitBranch(second)).toBe("symphony/project-two/acme-platform-7");
+
+    await mkdir(join(invalidWorkspace, "repository"), { recursive: true });
+    await writeFile(join(invalidWorkspace, "repository", "keep"), "preserve");
+    await expect(
+      ensureIssueWorkspaceRepository({
+        repository,
+        issueWorkspacePath: invalidWorkspace,
+        existingWorkspace: true,
+        populateStrategy: "worktree-cache",
+      })
+    ).rejects.toThrow(/was preserved/);
+    await expect(readFile(join(invalidWorkspace, "repository", "keep"), "utf8")).resolves.toBe("preserve");
+  });
+
+  it("supports a front matter branch template", () => {
+    expect(
+      renderIssueBranchName({
+        template: "agents/{project_slug}/{sanitized_issue_id}",
+        projectSlug: "project one",
+        issueIdentifier: "acme/repo#42",
+      })
+    ).toBe("agents/project-one/acme-repo-42");
+  });
+});
+
+function readGitBranch(repositoryDirectory: string): string {
+  return execSync(`git -C "${repositoryDirectory}" branch --show-current`, {
+    encoding: "utf8",
+  }).trim();
+}
 
 describe("sanitizeRepositoryCloneUrl", () => {
   it("removes embedded credentials before Git can persist the remote", () => {

--- a/packages/orchestrator/src/git.test.ts
+++ b/packages/orchestrator/src/git.test.ts
@@ -127,14 +127,14 @@ describe("global bare repository cache", () => {
       repository,
       configDir,
       now: new Date(now.getTime() + 31_000),
-      requiredRef: "refs/heads/feature/cache-ref",
+      requiredRef: "refs/remotes/origin/feature/cache-ref",
     });
     expect(
       execSync(
-        `git -C "${bareDirectory}" show-ref --verify refs/heads/feature/cache-ref`,
+        `git -C "${bareDirectory}" show-ref --verify refs/remotes/origin/feature/cache-ref`,
         { encoding: "utf8" }
       )
-    ).toContain("refs/heads/feature/cache-ref");
+    ).toContain("refs/remotes/origin/feature/cache-ref");
     expect(
       execSync(
         `git -C "${bareDirectory}" show-ref --verify refs/tags/cache-v1`,
@@ -850,6 +850,69 @@ describe("worktree-cache issue workspaces", () => {
       })
     ).rejects.toThrow(/was preserved/);
     await expect(readFile(join(invalidWorkspace, "repository", "keep"), "utf8")).resolves.toBe("preserve");
+  });
+
+  it("keeps existing recovered worktrees and their branches on cache refresh", async () => {
+    const tempRoot = await mkdtemp(join(tmpdir(), "orchestrator-worktree-"));
+    const repository = await createRepositoryFixture(tempRoot);
+    const issueWorkspacePath = join(tempRoot, "workspaces", "recovered");
+    const repositoryDirectory = await ensureIssueWorkspaceRepository({
+      repository,
+      issueWorkspacePath,
+      existingWorkspace: false,
+      populateStrategy: "worktree-cache",
+      projectSlug: "project-one",
+      issueIdentifier: "acme/platform#8",
+    });
+    await writeFile(join(repositoryDirectory, "local.txt"), "preserve");
+
+    await expect(
+      ensureIssueWorkspaceRepository({
+        repository,
+        issueWorkspacePath,
+        existingWorkspace: false,
+        populateStrategy: "worktree-cache",
+      })
+    ).resolves.toBe(repositoryDirectory);
+    await ensureGlobalBareRepositoryCache({
+      repository,
+      now: new Date(Date.now() + 61_000),
+    });
+
+    expect(readGitBranch(repositoryDirectory)).toBe(
+      "symphony/project-one/acme-platform-8"
+    );
+    await expect(readFile(join(repositoryDirectory, "local.txt"), "utf8")).resolves.toBe(
+      "preserve"
+    );
+  });
+
+  it("creates a project-scoped branch from a pull request checkout target", async () => {
+    const tempRoot = await mkdtemp(join(tmpdir(), "orchestrator-worktree-"));
+    const repository = await createRepositoryFixture(tempRoot);
+    const issueWorkspacePath = join(tempRoot, "workspaces", "pr-target");
+    execSync(`git -C "${repository.path}" checkout -b feature/pr-branch`);
+    await writeFile(join(repository.path, "pr.txt"), "pull request\n");
+    execSync(`git -C "${repository.path}" add pr.txt`);
+    execSync(`git -C "${repository.path}" commit -m "Add PR commit"`);
+    execSync(`git -C "${repository.path}" push origin feature/pr-branch`);
+
+    const repositoryDirectory = await ensureIssueWorkspaceRepository({
+      repository,
+      issueWorkspacePath,
+      existingWorkspace: false,
+      populateStrategy: "worktree-cache",
+      projectSlug: "project-one",
+      issueIdentifier: "acme/platform#9",
+      pullRequestBranch: { headRefName: "feature/pr-branch" },
+    });
+
+    expect(readGitBranch(repositoryDirectory)).toBe(
+      "symphony/project-one/acme-platform-9"
+    );
+    await expect(readFile(join(repositoryDirectory, "pr.txt"), "utf8")).resolves.toBe(
+      "pull request\n"
+    );
   });
 
   it("supports a front matter branch template", () => {

--- a/packages/orchestrator/src/git.test.ts
+++ b/packages/orchestrator/src/git.test.ts
@@ -820,6 +820,14 @@ describe("worktree-cache issue workspaces", () => {
     await expect(access(repositoryDirectory)).rejects.toMatchObject({
       code: "ENOENT",
     });
+    await expect(
+      removeIssueWorkspaceWorktree({
+        repository,
+        repositoryDirectory,
+        projectSlug: "project-one",
+        issueIdentifier: "acme/platform#1",
+      })
+    ).resolves.toBeUndefined();
     const bareDirectory = globalBareRepositoryDirectory({ repository });
     expect(
       execSync(
@@ -838,6 +846,22 @@ describe("worktree-cache issue workspaces", () => {
       })
     ).resolves.toBe(
       join(tempRoot, "workspaces", "issue-1-revived", "repository")
+    );
+  });
+
+  it("requires a project-scoped identity for fresh worktree population", async () => {
+    const tempRoot = await mkdtemp(join(tmpdir(), "orchestrator-worktree-"));
+    const repository = await createRepositoryFixture(tempRoot);
+
+    await expect(
+      ensureIssueWorkspaceRepository({
+        repository,
+        issueWorkspacePath: join(tempRoot, "workspaces", "missing-identity"),
+        existingWorkspace: false,
+        populateStrategy: "worktree-cache",
+      })
+    ).rejects.toThrow(
+      "worktree-cache populate requires projectSlug and issueIdentifier"
     );
   });
 

--- a/packages/orchestrator/src/git.test.ts
+++ b/packages/orchestrator/src/git.test.ts
@@ -4,6 +4,7 @@ import {
   mkdtemp,
   mkdir,
   readFile,
+  rename,
   rm,
   stat,
   utimes,
@@ -807,10 +808,25 @@ describe("worktree-cache issue workspaces", () => {
       })
     ).resolves.toBe(repositoryDirectory);
 
-    await removeIssueWorkspaceWorktree({ repository, repositoryDirectory });
+    execSync(
+      `git -C "${repositoryDirectory}" checkout -b symphony/issue-1-agent-work`
+    );
+    await removeIssueWorkspaceWorktree({
+      repository,
+      repositoryDirectory,
+      projectSlug: "project-one",
+      issueIdentifier: "acme/platform#1",
+    });
     await expect(access(repositoryDirectory)).rejects.toMatchObject({
       code: "ENOENT",
     });
+    const bareDirectory = globalBareRepositoryDirectory({ repository });
+    expect(
+      execSync(
+        `git -C "${bareDirectory}" show-ref --verify refs/heads/symphony/issue-1-agent-work`,
+        { encoding: "utf8" }
+      )
+    ).toContain("refs/heads/symphony/issue-1-agent-work");
     await expect(
       ensureIssueWorkspaceRepository({
         repository,
@@ -820,7 +836,9 @@ describe("worktree-cache issue workspaces", () => {
         projectSlug: "project-one",
         issueIdentifier: "acme/platform#1",
       })
-    ).resolves.toBe(join(tempRoot, "workspaces", "issue-1-revived", "repository"));
+    ).resolves.toBe(
+      join(tempRoot, "workspaces", "issue-1-revived", "repository")
+    );
   });
 
   it("namespaces identical issue identifiers by project and preserves failed reuse", async () => {
@@ -859,7 +877,9 @@ describe("worktree-cache issue workspaces", () => {
         populateStrategy: "worktree-cache",
       })
     ).rejects.toThrow(/was preserved/);
-    await expect(readFile(join(invalidWorkspace, "repository", "keep"), "utf8")).resolves.toBe("preserve");
+    await expect(
+      readFile(join(invalidWorkspace, "repository", "keep"), "utf8")
+    ).resolves.toBe("preserve");
   });
 
   it("keeps existing recovered worktrees and their branches on cache refresh", async () => {
@@ -892,9 +912,9 @@ describe("worktree-cache issue workspaces", () => {
     expect(readGitBranch(repositoryDirectory)).toBe(
       "symphony/project-one/acme-platform-8"
     );
-    await expect(readFile(join(repositoryDirectory, "local.txt"), "utf8")).resolves.toBe(
-      "preserve"
-    );
+    await expect(
+      readFile(join(repositoryDirectory, "local.txt"), "utf8")
+    ).resolves.toBe("preserve");
   });
 
   it("repopulates after cleanup when a workspace record outlives its directory", async () => {
@@ -912,6 +932,29 @@ describe("worktree-cache issue workspaces", () => {
         issueIdentifier: "acme/platform#10",
       })
     ).resolves.toBe(join(issueWorkspacePath, "repository"));
+  });
+
+  it("recovers a quarantined workspace whose owned branch remains in the cache", async () => {
+    const tempRoot = await mkdtemp(join(tmpdir(), "orchestrator-worktree-"));
+    const repository = await createRepositoryFixture(tempRoot);
+    const issueWorkspacePath = join(tempRoot, "workspaces", "quarantined");
+    const input = {
+      repository,
+      issueWorkspacePath,
+      existingWorkspace: false,
+      populateStrategy: "worktree-cache" as const,
+      projectSlug: "project-one",
+      issueIdentifier: "acme/platform#11",
+    };
+    await ensureIssueWorkspaceRepository(input);
+
+    await rename(issueWorkspacePath, `${issueWorkspacePath}.quarantine`);
+
+    const recoveredDirectory = await ensureIssueWorkspaceRepository(input);
+    expect(recoveredDirectory).toBe(join(issueWorkspacePath, "repository"));
+    expect(readGitBranch(recoveredDirectory)).toBe(
+      "symphony/project-one/acme-platform-11"
+    );
   });
 
   it("uses origin's default branch when no base branch is configured", async () => {
@@ -936,9 +979,9 @@ describe("worktree-cache issue workspaces", () => {
       issueIdentifier: "acme/master-repo#1",
     });
 
-    await expect(readFile(join(repositoryDirectory, "README.md"), "utf8")).resolves.toBe(
-      "master\n"
-    );
+    await expect(
+      readFile(join(repositoryDirectory, "README.md"), "utf8")
+    ).resolves.toBe("master\n");
   });
 
   it("creates a project-scoped branch from a pull request checkout target", async () => {
@@ -964,9 +1007,9 @@ describe("worktree-cache issue workspaces", () => {
     expect(readGitBranch(repositoryDirectory)).toBe(
       "symphony/project-one/acme-platform-9"
     );
-    await expect(readFile(join(repositoryDirectory, "pr.txt"), "utf8")).resolves.toBe(
-      "pull request\n"
-    );
+    await expect(
+      readFile(join(repositoryDirectory, "pr.txt"), "utf8")
+    ).resolves.toBe("pull request\n");
   });
 
   it("supports a front matter branch template", () => {

--- a/packages/orchestrator/src/git.test.ts
+++ b/packages/orchestrator/src/git.test.ts
@@ -127,7 +127,7 @@ describe("global bare repository cache", () => {
       repository,
       configDir,
       now: new Date(now.getTime() + 31_000),
-      requiredRef: "refs/remotes/origin/feature/cache-ref",
+      requiredRef: "refs/heads/feature/cache-ref",
     });
     expect(
       execSync(
@@ -811,6 +811,16 @@ describe("worktree-cache issue workspaces", () => {
     await expect(access(repositoryDirectory)).rejects.toMatchObject({
       code: "ENOENT",
     });
+    await expect(
+      ensureIssueWorkspaceRepository({
+        repository,
+        issueWorkspacePath: join(tempRoot, "workspaces", "issue-1-revived"),
+        existingWorkspace: false,
+        populateStrategy: "worktree-cache",
+        projectSlug: "project-one",
+        issueIdentifier: "acme/platform#1",
+      })
+    ).resolves.toBe(join(tempRoot, "workspaces", "issue-1-revived", "repository"));
   });
 
   it("namespaces identical issue identifiers by project and preserves failed reuse", async () => {
@@ -884,6 +894,50 @@ describe("worktree-cache issue workspaces", () => {
     );
     await expect(readFile(join(repositoryDirectory, "local.txt"), "utf8")).resolves.toBe(
       "preserve"
+    );
+  });
+
+  it("repopulates after cleanup when a workspace record outlives its directory", async () => {
+    const tempRoot = await mkdtemp(join(tmpdir(), "orchestrator-worktree-"));
+    const repository = await createRepositoryFixture(tempRoot);
+    const issueWorkspacePath = join(tempRoot, "workspaces", "revived");
+
+    await expect(
+      ensureIssueWorkspaceRepository({
+        repository,
+        issueWorkspacePath,
+        existingWorkspace: true,
+        populateStrategy: "worktree-cache",
+        projectSlug: "project-one",
+        issueIdentifier: "acme/platform#10",
+      })
+    ).resolves.toBe(join(issueWorkspacePath, "repository"));
+  });
+
+  it("uses origin's default branch when no base branch is configured", async () => {
+    const tempRoot = await mkdtemp(join(tmpdir(), "orchestrator-worktree-"));
+    const originPath = join(tempRoot, "origin.git");
+    const workingPath = join(tempRoot, "working");
+    execSync(`git init --initial-branch=master --bare "${originPath}"`);
+    execSync(`git clone "${originPath}" "${workingPath}"`);
+    execSync(`git -C "${workingPath}" config user.name "Test User"`);
+    execSync(`git -C "${workingPath}" config user.email "test@example.com"`);
+    await writeFile(join(workingPath, "README.md"), "master\n");
+    execSync(`git -C "${workingPath}" add README.md`);
+    execSync(`git -C "${workingPath}" commit -m "Initial commit"`);
+    execSync(`git -C "${workingPath}" push origin master`);
+
+    const repositoryDirectory = await ensureIssueWorkspaceRepository({
+      repository: { owner: "acme", name: "master-repo", cloneUrl: originPath },
+      issueWorkspacePath: join(tempRoot, "workspaces", "master"),
+      existingWorkspace: false,
+      populateStrategy: "worktree-cache",
+      projectSlug: "project-one",
+      issueIdentifier: "acme/master-repo#1",
+    });
+
+    await expect(readFile(join(repositoryDirectory, "README.md"), "utf8")).resolves.toBe(
+      "master\n"
     );
   });
 

--- a/packages/orchestrator/src/git.ts
+++ b/packages/orchestrator/src/git.ts
@@ -180,13 +180,14 @@ async function ensureIssueWorkspaceWorktree(input: {
   repository: RepositoryRef;
   issueWorkspacePath: string;
   existingWorkspace: boolean;
+  pullRequestBranch?: PullRequestBranchCheckoutTarget | null;
   projectSlug?: string;
   issueIdentifier?: string;
   branchTemplate?: string | null;
   baseBranch?: string | null;
 }): Promise<string> {
   const repositoryDirectory = join(input.issueWorkspacePath, "repository");
-  if (input.existingWorkspace) {
+  if (input.existingWorkspace || (await pathExists(join(repositoryDirectory, ".git")))) {
     if (await pathExists(join(repositoryDirectory, ".git"))) {
       return repositoryDirectory;
     }
@@ -201,11 +202,13 @@ async function ensureIssueWorkspaceWorktree(input: {
     projectSlug: input.projectSlug ?? "project",
     issueIdentifier: input.issueIdentifier ?? "issue",
   });
-  const baseBranch = input.baseBranch ?? "main";
+  const baseBranch = input.pullRequestBranch?.headRefName ?? input.baseBranch ?? "main";
+  const baseRef = `refs/remotes/origin/${baseBranch}`;
+  const repositoryDirectoryExisted = await pathExists(repositoryDirectory);
   await mkdir(input.issueWorkspacePath, { recursive: true });
   try {
     return await withGlobalBareRepositoryCache(
-      { repository: input.repository, requiredRef: `refs/heads/${baseBranch}` },
+      { repository: input.repository, requiredRef: baseRef },
       async (bare) => {
         await runGitCommand(["-C", bare, "worktree", "prune"]);
         await runGitCommand([
@@ -216,13 +219,15 @@ async function ensureIssueWorkspaceWorktree(input: {
           "-b",
           branch,
           repositoryDirectory,
-          `refs/heads/${baseBranch}`,
+          baseRef,
         ]);
         return repositoryDirectory;
       }
     );
   } catch (error) {
-    await rm(repositoryDirectory, { recursive: true, force: true });
+    if (!repositoryDirectoryExisted) {
+      await rm(repositoryDirectory, { recursive: true, force: true });
+    }
     throw error;
   }
 }

--- a/packages/orchestrator/src/git.ts
+++ b/packages/orchestrator/src/git.ts
@@ -18,7 +18,10 @@ import {
   type RepositoryRef,
   type WorkflowResolution,
 } from "@gh-symphony/core";
-import { ensureGlobalBareRepositoryCache } from "./repository-cache.js";
+import {
+  ensureGlobalBareRepositoryCache,
+  withGlobalBareRepositoryCache,
+} from "./repository-cache.js";
 import { sanitizeRepositoryCloneUrl } from "./repository-url.js";
 
 const workflowConfigStore = new WorkflowConfigStore();
@@ -124,7 +127,15 @@ export async function ensureIssueWorkspaceRepository(input: {
   existingWorkspace: boolean;
   pullRequestBranch?: PullRequestBranchCheckoutTarget | null;
   allowDirtyExistingWorkspace?: boolean;
+  populateStrategy?: "clone" | "worktree-cache";
+  projectSlug?: string;
+  issueIdentifier?: string;
+  branchTemplate?: string | null;
+  baseBranch?: string | null;
 }): Promise<string> {
+  if (input.populateStrategy === "worktree-cache") {
+    return ensureIssueWorkspaceWorktree(input);
+  }
   let dirtyExistingWorkspaceAllowed = false;
   const repositoryDirectory = input.existingWorkspace
     ? await syncExistingIssueWorkspaceRepository(
@@ -153,6 +164,95 @@ export async function ensureIssueWorkspaceRepository(input: {
   }
 
   return repositoryDirectory;
+}
+
+export async function removeIssueWorkspaceWorktree(input: {
+  repository: RepositoryRef;
+  repositoryDirectory: string;
+}): Promise<void> {
+  await withGlobalBareRepositoryCache({ repository: input.repository }, async (bare) => {
+    await runGitCommand(["-C", bare, "worktree", "remove", "--force", input.repositoryDirectory]);
+    await runGitCommand(["-C", bare, "worktree", "prune"]);
+  });
+}
+
+async function ensureIssueWorkspaceWorktree(input: {
+  repository: RepositoryRef;
+  issueWorkspacePath: string;
+  existingWorkspace: boolean;
+  projectSlug?: string;
+  issueIdentifier?: string;
+  branchTemplate?: string | null;
+  baseBranch?: string | null;
+}): Promise<string> {
+  const repositoryDirectory = join(input.issueWorkspacePath, "repository");
+  if (input.existingWorkspace) {
+    if (await pathExists(join(repositoryDirectory, ".git"))) {
+      return repositoryDirectory;
+    }
+    throw createIssueWorkspacePreservedError(
+      repositoryDirectory,
+      "exists but is not a git worktree"
+    );
+  }
+
+  const branch = renderIssueBranchName({
+    template: input.branchTemplate,
+    projectSlug: input.projectSlug ?? "project",
+    issueIdentifier: input.issueIdentifier ?? "issue",
+  });
+  const baseBranch = input.baseBranch ?? "main";
+  await mkdir(input.issueWorkspacePath, { recursive: true });
+  try {
+    return await withGlobalBareRepositoryCache(
+      { repository: input.repository, requiredRef: `refs/heads/${baseBranch}` },
+      async (bare) => {
+        await runGitCommand(["-C", bare, "worktree", "prune"]);
+        await runGitCommand([
+          "-C",
+          bare,
+          "worktree",
+          "add",
+          "-b",
+          branch,
+          repositoryDirectory,
+          `refs/heads/${baseBranch}`,
+        ]);
+        return repositoryDirectory;
+      }
+    );
+  } catch (error) {
+    await rm(repositoryDirectory, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+export function renderIssueBranchName(input: {
+  template?: string | null;
+  projectSlug: string;
+  issueIdentifier: string;
+}): string {
+  const projectSlug = sanitizeBranchSegment(input.projectSlug);
+  const issueId = sanitizeBranchSegment(input.issueIdentifier);
+  const template = input.template?.trim() || "symphony/{project_slug}/{sanitized_issue_id}";
+  const branch = template
+    .replaceAll("{project_slug}", projectSlug)
+    .replaceAll("{sanitized_issue_id}", issueId);
+  if (!branch || branch.includes("{") || branch.includes("}")) {
+    throw new Error(`Invalid issue worktree branch template ${JSON.stringify(template)}.`);
+  }
+  return branch;
+}
+
+function sanitizeBranchSegment(value: string): string {
+  const sanitized = value
+    .trim()
+    .replace(/[^A-Za-z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  if (!sanitized) {
+    throw new Error(`Cannot derive a worktree branch segment from ${JSON.stringify(value)}.`);
+  }
+  return sanitized;
 }
 
 export type IssueWorkspaceDirtyStatus = {

--- a/packages/orchestrator/src/git.ts
+++ b/packages/orchestrator/src/git.ts
@@ -181,15 +181,19 @@ export async function removeIssueWorkspaceWorktree(input: {
   await withGlobalBareRepositoryCache(
     { repository: input.repository },
     async (bare) => {
-      await runGitCommand([
-        "-C",
-        bare,
-        "worktree",
-        "remove",
-        "--force",
-        input.repositoryDirectory,
-      ]);
-      await runGitCommand(["-C", bare, "branch", "-D", branch]);
+      await ignoreMissingWorktree(
+        runGitCommand([
+          "-C",
+          bare,
+          "worktree",
+          "remove",
+          "--force",
+          input.repositoryDirectory,
+        ])
+      );
+      await ignoreMissingBranch(
+        runGitCommand(["-C", bare, "branch", "-D", branch])
+      );
       await runGitCommand(["-C", bare, "worktree", "prune"]);
     }
   );
@@ -215,11 +219,16 @@ async function ensureIssueWorkspaceWorktree(input: {
       "exists but is not a git worktree"
     );
   }
+  if (!input.projectSlug || !input.issueIdentifier) {
+    throw new Error(
+      "worktree-cache populate requires projectSlug and issueIdentifier."
+    );
+  }
 
   const branch = renderIssueBranchName({
     template: input.branchTemplate,
-    projectSlug: input.projectSlug ?? "project",
-    issueIdentifier: input.issueIdentifier ?? "issue",
+    projectSlug: input.projectSlug,
+    issueIdentifier: input.issueIdentifier,
   });
   const repositoryDirectoryExisted = await pathExists(repositoryDirectory);
   await mkdir(input.issueWorkspacePath, { recursive: true });
@@ -259,6 +268,30 @@ async function ensureIssueWorkspaceWorktree(input: {
     }
     throw error;
   }
+}
+
+async function ignoreMissingWorktree(command: Promise<void>): Promise<void> {
+  try {
+    await command;
+  } catch (error) {
+    if (!hasGitError(error, "is not a working tree")) {
+      throw error;
+    }
+  }
+}
+
+async function ignoreMissingBranch(command: Promise<void>): Promise<void> {
+  try {
+    await command;
+  } catch (error) {
+    if (!hasGitError(error, "not found")) {
+      throw error;
+    }
+  }
+}
+
+function hasGitError(error: unknown, message: string): boolean {
+  return error instanceof Error && error.message.includes(message);
 }
 
 async function readOriginDefaultBranch(bareDirectory: string): Promise<string> {

--- a/packages/orchestrator/src/git.ts
+++ b/packages/orchestrator/src/git.ts
@@ -169,22 +169,30 @@ export async function ensureIssueWorkspaceRepository(input: {
 export async function removeIssueWorkspaceWorktree(input: {
   repository: RepositoryRef;
   repositoryDirectory: string;
+  projectSlug: string;
+  issueIdentifier: string;
+  branchTemplate?: string | null;
 }): Promise<void> {
-  await withGlobalBareRepositoryCache({ repository: input.repository }, async (bare) => {
-    const branch = (
-      await runGitCommandCapture([
-        "-C",
-        input.repositoryDirectory,
-        "branch",
-        "--show-current",
-      ])
-    ).trim();
-    await runGitCommand(["-C", bare, "worktree", "remove", "--force", input.repositoryDirectory]);
-    if (branch) {
-      await runGitCommand(["-C", bare, "branch", "-D", branch]);
-    }
-    await runGitCommand(["-C", bare, "worktree", "prune"]);
+  const branch = renderIssueBranchName({
+    template: input.branchTemplate,
+    projectSlug: input.projectSlug,
+    issueIdentifier: input.issueIdentifier,
   });
+  await withGlobalBareRepositoryCache(
+    { repository: input.repository },
+    async (bare) => {
+      await runGitCommand([
+        "-C",
+        bare,
+        "worktree",
+        "remove",
+        "--force",
+        input.repositoryDirectory,
+      ]);
+      await runGitCommand(["-C", bare, "branch", "-D", branch]);
+      await runGitCommand(["-C", bare, "worktree", "prune"]);
+    }
+  );
 }
 
 async function ensureIssueWorkspaceWorktree(input: {
@@ -237,7 +245,7 @@ async function ensureIssueWorkspaceWorktree(input: {
           bare,
           "worktree",
           "add",
-          "-b",
+          "-B",
           branch,
           repositoryDirectory,
           baseRef,
@@ -276,12 +284,15 @@ export function renderIssueBranchName(input: {
 }): string {
   const projectSlug = sanitizeBranchSegment(input.projectSlug);
   const issueId = sanitizeBranchSegment(input.issueIdentifier);
-  const template = input.template?.trim() || "symphony/{project_slug}/{sanitized_issue_id}";
+  const template =
+    input.template?.trim() || "symphony/{project_slug}/{sanitized_issue_id}";
   const branch = template
     .replaceAll("{project_slug}", projectSlug)
     .replaceAll("{sanitized_issue_id}", issueId);
   if (!branch || branch.includes("{") || branch.includes("}")) {
-    throw new Error(`Invalid issue worktree branch template ${JSON.stringify(template)}.`);
+    throw new Error(
+      `Invalid issue worktree branch template ${JSON.stringify(template)}.`
+    );
   }
   return branch;
 }
@@ -292,7 +303,9 @@ function sanitizeBranchSegment(value: string): string {
     .replace(/[^A-Za-z0-9._-]+/g, "-")
     .replace(/^-+|-+$/g, "");
   if (!sanitized) {
-    throw new Error(`Cannot derive a worktree branch segment from ${JSON.stringify(value)}.`);
+    throw new Error(
+      `Cannot derive a worktree branch segment from ${JSON.stringify(value)}.`
+    );
   }
   return sanitized;
 }

--- a/packages/orchestrator/src/git.ts
+++ b/packages/orchestrator/src/git.ts
@@ -171,7 +171,18 @@ export async function removeIssueWorkspaceWorktree(input: {
   repositoryDirectory: string;
 }): Promise<void> {
   await withGlobalBareRepositoryCache({ repository: input.repository }, async (bare) => {
+    const branch = (
+      await runGitCommandCapture([
+        "-C",
+        input.repositoryDirectory,
+        "branch",
+        "--show-current",
+      ])
+    ).trim();
     await runGitCommand(["-C", bare, "worktree", "remove", "--force", input.repositoryDirectory]);
+    if (branch) {
+      await runGitCommand(["-C", bare, "branch", "-D", branch]);
+    }
     await runGitCommand(["-C", bare, "worktree", "prune"]);
   });
 }
@@ -187,10 +198,10 @@ async function ensureIssueWorkspaceWorktree(input: {
   baseBranch?: string | null;
 }): Promise<string> {
   const repositoryDirectory = join(input.issueWorkspacePath, "repository");
-  if (input.existingWorkspace || (await pathExists(join(repositoryDirectory, ".git")))) {
-    if (await pathExists(join(repositoryDirectory, ".git"))) {
-      return repositoryDirectory;
-    }
+  if (await pathExists(join(repositoryDirectory, ".git"))) {
+    return repositoryDirectory;
+  }
+  if (input.existingWorkspace && (await pathExists(repositoryDirectory))) {
     throw createIssueWorkspacePreservedError(
       repositoryDirectory,
       "exists but is not a git worktree"
@@ -202,14 +213,24 @@ async function ensureIssueWorkspaceWorktree(input: {
     projectSlug: input.projectSlug ?? "project",
     issueIdentifier: input.issueIdentifier ?? "issue",
   });
-  const baseBranch = input.pullRequestBranch?.headRefName ?? input.baseBranch ?? "main";
-  const baseRef = `refs/remotes/origin/${baseBranch}`;
   const repositoryDirectoryExisted = await pathExists(repositoryDirectory);
   await mkdir(input.issueWorkspacePath, { recursive: true });
   try {
     return await withGlobalBareRepositoryCache(
-      { repository: input.repository, requiredRef: baseRef },
+      {
+        repository: input.repository,
+        requiredRef: input.pullRequestBranch
+          ? `refs/remotes/origin/${input.pullRequestBranch.headRefName}`
+          : input.baseBranch
+            ? `refs/remotes/origin/${input.baseBranch}`
+            : undefined,
+      },
       async (bare) => {
+        const baseBranch =
+          input.pullRequestBranch?.headRefName ??
+          input.baseBranch ??
+          (await readOriginDefaultBranch(bare));
+        const baseRef = `refs/remotes/origin/${baseBranch}`;
         await runGitCommand(["-C", bare, "worktree", "prune"]);
         await runGitCommand([
           "-C",
@@ -230,6 +251,22 @@ async function ensureIssueWorkspaceWorktree(input: {
     }
     throw error;
   }
+}
+
+async function readOriginDefaultBranch(bareDirectory: string): Promise<string> {
+  const ref = (
+    await runGitCommandCapture([
+      "-C",
+      bareDirectory,
+      "symbolic-ref",
+      "--short",
+      "refs/remotes/origin/HEAD",
+    ])
+  ).trim();
+  if (!ref.startsWith("origin/")) {
+    throw new Error(`Could not determine origin default branch from ${ref}.`);
+  }
+  return ref.slice("origin/".length);
 }
 
 export function renderIssueBranchName(input: {

--- a/packages/orchestrator/src/repository-cache.ts
+++ b/packages/orchestrator/src/repository-cache.ts
@@ -115,15 +115,7 @@ async function ensureBareRepositoryCacheUnderLock(input: {
     return input.bareDirectory;
   }
   if (!(await isFetchFresh(input.bareDirectory, now)) || !requiredRefExists) {
-    await runGitCommand([
-      "-C",
-      input.bareDirectory,
-      "fetch",
-      "--prune",
-      "--tags",
-      "origin",
-      "+refs/heads/*:refs/heads/*",
-    ]);
+    await fetchOriginBranches(input.bareDirectory);
     await writeLastFetchMarker(input.bareDirectory, now);
     await runGitCommand(["-C", input.bareDirectory, "gc", "--auto"]);
   }
@@ -137,9 +129,23 @@ async function recreateBareRepository(
   now: Date
 ): Promise<void> {
   await rm(bareDirectory, { recursive: true, force: true });
-  await runGitCommand(["clone", "--bare", cloneUrl, bareDirectory]);
+  await runGitCommand(["init", "--bare", bareDirectory]);
+  await runGitCommand(["-C", bareDirectory, "remote", "add", "origin", cloneUrl]);
+  await fetchOriginBranches(bareDirectory);
   await writeLastFetchMarker(bareDirectory, now);
   await runGitCommand(["-C", bareDirectory, "gc", "--auto"]);
+}
+
+async function fetchOriginBranches(bareDirectory: string): Promise<void> {
+  await runGitCommand([
+    "-C",
+    bareDirectory,
+    "fetch",
+    "--prune",
+    "--tags",
+    "origin",
+    "+refs/heads/*:refs/remotes/origin/*",
+  ]);
 }
 
 async function hasOriginRemote(directory: string): Promise<boolean> {

--- a/packages/orchestrator/src/repository-cache.ts
+++ b/packages/orchestrator/src/repository-cache.ts
@@ -131,7 +131,15 @@ async function recreateBareRepository(
   cloneUrl: string,
   now: Date
 ): Promise<void> {
-  await rm(bareDirectory, { recursive: true, force: true });
+  // A concurrent Git process can leave transient entries while a corrupt cache
+  // is being replaced. Retry the recursive removal under the cache lock so a
+  // fresh cache initialization does not fail with ENOTEMPTY.
+  await rm(bareDirectory, {
+    recursive: true,
+    force: true,
+    maxRetries: 3,
+    retryDelay: 100,
+  });
   await runGitCommand(["init", "--bare", bareDirectory]);
   await runGitCommand(["-C", bareDirectory, "remote", "add", "origin", cloneUrl]);
   await fetchOriginBranches(bareDirectory);

--- a/packages/orchestrator/src/repository-cache.ts
+++ b/packages/orchestrator/src/repository-cache.ts
@@ -107,8 +107,11 @@ async function ensureBareRepositoryCacheUnderLock(input: {
     return input.bareDirectory;
   }
 
-  const requiredRefExists = input.requiredRef
-    ? await hasRef(input.bareDirectory, input.requiredRef)
+  const requiredRef = input.requiredRef
+    ? normalizeRequiredRef(input.requiredRef)
+    : undefined;
+  const requiredRefExists = requiredRef
+    ? await hasRef(input.bareDirectory, requiredRef)
     : true;
   if (!(await hasOriginRemote(input.bareDirectory))) {
     await recreateBareRepository(input.bareDirectory, input.cloneUrl, now);
@@ -146,6 +149,19 @@ async function fetchOriginBranches(bareDirectory: string): Promise<void> {
     "origin",
     "+refs/heads/*:refs/remotes/origin/*",
   ]);
+  await runGitCommand(["-C", bareDirectory, "remote", "set-head", "origin", "--auto"]);
+}
+
+/**
+ * The clone path historically requests local `refs/heads/*` names. The shared
+ * bare cache intentionally keeps fetched branches under `origin/*` so active
+ * worktree branches cannot be pruned; accept the former contract at this
+ * boundary rather than making callers aware of the cache layout.
+ */
+function normalizeRequiredRef(ref: string): string {
+  return ref.startsWith("refs/heads/")
+    ? `refs/remotes/origin/${ref.slice("refs/heads/".length)}`
+    : ref;
 }
 
 async function hasOriginRemote(directory: string): Promise<boolean> {

--- a/packages/orchestrator/src/repository-cache.ts
+++ b/packages/orchestrator/src/repository-cache.ts
@@ -57,37 +57,78 @@ export async function ensureGlobalBareRepositoryCache(input: {
 
   const ownerToken = await acquireRepositoryLock(lockDirectory);
   try {
-    const now = input.now ?? new Date();
-    if (!(await isBareRepository(bareDirectory))) {
-      await recreateBareRepository(bareDirectory, cloneUrl, now);
-      return bareDirectory;
-    }
-
-    const requiredRefExists = input.requiredRef
-      ? await hasRef(bareDirectory, input.requiredRef)
-      : true;
-    if (!(await hasOriginRemote(bareDirectory))) {
-      await recreateBareRepository(bareDirectory, cloneUrl, now);
-      return bareDirectory;
-    }
-    if (!(await isFetchFresh(bareDirectory, now)) || !requiredRefExists) {
-      await runGitCommand([
-        "-C",
-        bareDirectory,
-        "fetch",
-        "--prune",
-        "--tags",
-        "origin",
-        "+refs/heads/*:refs/heads/*",
-      ]);
-      await writeLastFetchMarker(bareDirectory, now);
-      await runGitCommand(["-C", bareDirectory, "gc", "--auto"]);
-    }
-
-    return bareDirectory;
+    return ensureBareRepositoryCacheUnderLock({
+      ...input,
+      bareDirectory,
+      cloneUrl,
+    });
   } finally {
     await releaseRepositoryLock(lockDirectory, ownerToken);
   }
+}
+
+/** Runs a cache operation while holding the repository-wide bare-cache lock. */
+export async function withGlobalBareRepositoryCache<T>(
+  input: {
+    repository: RepositoryRef;
+    requiredRef?: string;
+    configDir?: string;
+    now?: Date;
+  },
+  operation: (bareDirectory: string) => Promise<T>
+): Promise<T> {
+  const bareDirectory = globalBareRepositoryDirectory(input);
+  const lockDirectory = globalBareRepositoryLockDirectory(input);
+  const cloneUrl = sanitizeRepositoryCloneUrl(input.repository.cloneUrl);
+  await mkdir(dirname(bareDirectory), { recursive: true });
+  const ownerToken = await acquireRepositoryLock(lockDirectory);
+  try {
+    await ensureBareRepositoryCacheUnderLock({
+      ...input,
+      bareDirectory,
+      cloneUrl,
+    });
+    return await operation(bareDirectory);
+  } finally {
+    await releaseRepositoryLock(lockDirectory, ownerToken);
+  }
+}
+
+async function ensureBareRepositoryCacheUnderLock(input: {
+  repository: RepositoryRef;
+  requiredRef?: string;
+  now?: Date;
+  bareDirectory: string;
+  cloneUrl: string;
+}): Promise<string> {
+  const now = input.now ?? new Date();
+  if (!(await isBareRepository(input.bareDirectory))) {
+    await recreateBareRepository(input.bareDirectory, input.cloneUrl, now);
+    return input.bareDirectory;
+  }
+
+  const requiredRefExists = input.requiredRef
+    ? await hasRef(input.bareDirectory, input.requiredRef)
+    : true;
+  if (!(await hasOriginRemote(input.bareDirectory))) {
+    await recreateBareRepository(input.bareDirectory, input.cloneUrl, now);
+    return input.bareDirectory;
+  }
+  if (!(await isFetchFresh(input.bareDirectory, now)) || !requiredRefExists) {
+    await runGitCommand([
+      "-C",
+      input.bareDirectory,
+      "fetch",
+      "--prune",
+      "--tags",
+      "origin",
+      "+refs/heads/*:refs/heads/*",
+    ]);
+    await writeLastFetchMarker(input.bareDirectory, now);
+    await runGitCommand(["-C", input.bareDirectory, "gc", "--auto"]);
+  }
+
+  return input.bareDirectory;
 }
 
 async function recreateBareRepository(

--- a/packages/orchestrator/src/repository-cache.ts
+++ b/packages/orchestrator/src/repository-cache.ts
@@ -140,6 +140,11 @@ async function recreateBareRepository(
     maxRetries: 3,
     retryDelay: 100,
   });
+  // The parent is normally created before taking the lock, but another
+  // lifecycle cleanup can remove an empty cache hierarchy while a caller is
+  // waiting. Recreate it after acquiring the lock so `git init` never races a
+  // missing parent directory.
+  await mkdir(dirname(bareDirectory), { recursive: true });
   await runGitCommand(["init", "--bare", bareDirectory]);
   await runGitCommand(["-C", bareDirectory, "remote", "add", "origin", cloneUrl]);
   await fetchOriginBranches(bareDirectory);

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -1046,6 +1046,47 @@ describe("OrchestratorService", () => {
     );
   });
 
+  it("passes worktree-cache settings into issue populate", async () => {
+    process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
+    const tempRoot = await mkdtemp(join(tmpdir(), "orchestrator-worktree-settings-"));
+    const repository = await createRepositoryFixture(tempRoot, "acme", "platform");
+    await writeFile(
+      join(repository.path, "WORKFLOW.md"),
+      (await readFile(join(repository.path, "WORKFLOW.md"), "utf8")).replace(
+        "hooks:",
+        "repository:\n  branch_template: agents/{project_slug}/{sanitized_issue_id}\n  base_branch: ' develop '\nhooks:"
+      )
+    );
+    execSync(`git -C ${shell(repository.path)} add WORKFLOW.md`);
+    execSync(`git -C ${shell(repository.path)} commit -m worktree-settings`);
+    const store = new OrchestratorFsStore(tempRoot);
+    const projectConfig = {
+      ...createProjectConfig(tempRoot, repository),
+      populateStrategy: "worktree-cache" as const,
+    };
+    await store.saveProjectConfig(projectConfig);
+    const populateSpy = vi
+      .spyOn(gitModule, "ensureIssueWorkspaceRepository")
+      .mockResolvedValue(repository.path);
+    const service = new OrchestratorService(store, projectConfig, {
+      fetchImpl: vi.fn().mockResolvedValue(createTrackerResponse(repository)),
+      spawnImpl: vi.fn().mockReturnValue({ pid: 4105, unref: vi.fn() }) as never,
+      now: () => new Date("2026-03-08T00:00:00.000Z"),
+    });
+
+    await service.runOnce();
+
+    expect(populateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        populateStrategy: "worktree-cache",
+        projectSlug: "tenant-1",
+        issueIdentifier: "acme/platform#1",
+        branchTemplate: "agents/{project_slug}/{sanitized_issue_id}",
+        baseBranch: "develop",
+      })
+    );
+  });
+
   it("preserves dirty persisted issue workspaces when dispatching a retry", async () => {
     process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
     const tempRoot = await mkdtemp(
@@ -2674,8 +2715,14 @@ Retry inconclusive work.
       "platform"
     );
     const store = new OrchestratorFsStore(tempRoot);
-    const projectConfig = createProjectConfig(tempRoot, repository);
+    const projectConfig = {
+      ...createProjectConfig(tempRoot, repository),
+      populateStrategy: "worktree-cache" as const,
+    };
     await store.saveProjectConfig(projectConfig);
+    const removeSpy = vi
+      .spyOn(gitModule, "removeIssueWorkspaceWorktree")
+      .mockResolvedValue();
 
     const workspaceKey = deriveIssueWorkspaceKey(
       {
@@ -2784,6 +2831,13 @@ Retry inconclusive work.
     const savedStatus = await store.loadProjectStatus("tenant-1");
     await expect(readFile(sentinelPath, "utf8")).rejects.toThrow();
     expect(workspaceRecord?.status).toBe("removed");
+    expect(removeSpy).toHaveBeenCalledWith({
+      repository: expect.objectContaining({
+        owner: repository.owner,
+        name: repository.name,
+      }),
+      repositoryDirectory: repositoryPath,
+    });
     expect(savedStatus?.recovery).toBeNull();
     expect(preservedRun?.recovery).toMatchObject({
       kind: "incomplete-turn-dirty-workspace",

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -1048,8 +1048,14 @@ describe("OrchestratorService", () => {
 
   it("passes worktree-cache settings into issue populate", async () => {
     process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
-    const tempRoot = await mkdtemp(join(tmpdir(), "orchestrator-worktree-settings-"));
-    const repository = await createRepositoryFixture(tempRoot, "acme", "platform");
+    const tempRoot = await mkdtemp(
+      join(tmpdir(), "orchestrator-worktree-settings-")
+    );
+    const repository = await createRepositoryFixture(
+      tempRoot,
+      "acme",
+      "platform"
+    );
     await writeFile(
       join(repository.path, "WORKFLOW.md"),
       (await readFile(join(repository.path, "WORKFLOW.md"), "utf8")).replace(
@@ -1070,7 +1076,9 @@ describe("OrchestratorService", () => {
       .mockResolvedValue(repository.path);
     const service = new OrchestratorService(store, projectConfig, {
       fetchImpl: vi.fn().mockResolvedValue(createTrackerResponse(repository)),
-      spawnImpl: vi.fn().mockReturnValue({ pid: 4105, unref: vi.fn() }) as never,
+      spawnImpl: vi
+        .fn()
+        .mockReturnValue({ pid: 4105, unref: vi.fn() }) as never,
       now: () => new Date("2026-03-08T00:00:00.000Z"),
     });
 
@@ -2837,6 +2845,9 @@ Retry inconclusive work.
         name: repository.name,
       }),
       repositoryDirectory: repositoryPath,
+      projectSlug: "tenant-1",
+      issueIdentifier: "acme/platform#1",
+      branchTemplate: null,
     });
     expect(savedStatus?.recovery).toBeNull();
     expect(preservedRun?.recovery).toMatchObject({

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -4561,7 +4561,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function readOptionalStringValue(value: unknown): string | null {
-  return typeof value === "string" && value.trim() ? value : null;
+  return typeof value === "string" && value.trim() ? value.trim() : null;
 }
 
 function validateTrackerStateRequest(

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -62,6 +62,7 @@ import {
   loadRepositoryWorkflow,
   quarantineIssueWorkspace,
   readGitCurrentBranch,
+  removeIssueWorkspaceWorktree,
 } from "./git.js";
 import { OrchestratorFsStore } from "./fs-store.js";
 import { getProcessStartIdentity } from "./lock.js";
@@ -2348,6 +2349,22 @@ export class OrchestratorService {
       }
     }
 
+    const workflowForPopulate = await this.loadProjectWorkflow(
+      tenant,
+      issue.repository
+    );
+    if (!isUsableWorkflowResolution(workflowForPopulate)) {
+      throw new Error(
+        workflowForPopulate.validationError ?? "Invalid repository WORKFLOW.md"
+      );
+    }
+    const repositoryExtension = workflowForPopulate.workflow.repository;
+    const branchTemplate = isRecord(repositoryExtension)
+      ? readOptionalStringValue(repositoryExtension.branch_template)
+      : null;
+    const baseBranch = isRecord(repositoryExtension)
+      ? readOptionalStringValue(repositoryExtension.base_branch)
+      : null;
     const repositoryDirectory = await ensureIssueWorkspaceRepository({
       repository: issue.repository,
       issueWorkspacePath,
@@ -2356,6 +2373,11 @@ export class OrchestratorService {
       pullRequestBranch,
       allowDirtyExistingWorkspace:
         recovery?.kind === "incomplete-turn-dirty-workspace",
+      populateStrategy: tenant.populateStrategy,
+      projectSlug: tenant.slug,
+      issueIdentifier: issue.identifier,
+      branchTemplate,
+      baseBranch,
     });
 
     if (!existingWorkspaceRecord || workspaceQuarantined) {
@@ -2404,7 +2426,7 @@ export class OrchestratorService {
       }
     }
 
-    const workflow = await this.loadProjectWorkflow(tenant, issue.repository);
+    const workflow = workflowForPopulate;
     if (!isUsableWorkflowResolution(workflow)) {
       throw new Error(
         workflow.validationError ?? "Invalid repository WORKFLOW.md"
@@ -4393,6 +4415,20 @@ export class OrchestratorService {
       workflowResolution
     );
 
+    if (tenant.populateStrategy === "worktree-cache") {
+      try {
+        await removeIssueWorkspaceWorktree({
+          repository: issue.repository,
+          repositoryDirectory: workspaceRecord.repositoryPath,
+        });
+      } catch (error) {
+        const removalError = this.formatErrorMessage(error);
+        this.writeStderr(
+          `[orchestrator] failed to remove worktree for ${issue.identifier}: ${removalError}\n`
+        );
+      }
+    }
+
     // Hook failures are observable but do not block removal per spec 9.4.
     try {
       await (this.dependencies.rmImpl ?? rm)(workspaceRecord.workspacePath, {
@@ -4522,6 +4558,10 @@ function hasTokenUsage(
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function readOptionalStringValue(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value : null;
 }
 
 function validateTrackerStateRequest(

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -4417,9 +4417,22 @@ export class OrchestratorService {
 
     if (tenant.populateStrategy === "worktree-cache") {
       try {
+        const cleanupWorkflow =
+          workflowResolution ??
+          (await this.loadProjectWorkflow(tenant, issue.repository));
+        const repositoryExtension =
+          isUsableWorkflowResolution(cleanupWorkflow) &&
+          isRecord(cleanupWorkflow.workflow.repository)
+            ? cleanupWorkflow.workflow.repository
+            : null;
         await removeIssueWorkspaceWorktree({
           repository: issue.repository,
           repositoryDirectory: workspaceRecord.repositoryPath,
+          projectSlug: tenant.slug,
+          issueIdentifier: issue.identifier,
+          branchTemplate: repositoryExtension
+            ? readOptionalStringValue(repositoryExtension.branch_template)
+            : null,
         });
       } catch (error) {
         const removalError = this.formatErrorMessage(error);


### PR DESCRIPTION
## TL;DR

`worktree-cache` 전략에서 issue workspace를 공유 bare clone cache의 project-scoped worktree로 생성합니다. 기존 `clone` 전략은 유지하며, cache 재생성 중 일시적인 파일 경합도 잠금 하에서 복구합니다.

## 변경 지점 다이어그램

```text
workflow.repository (populate_strategy / branch_template / base_branch)
                         │
                         ▼
OrchestratorService ──► ensureIssueWorkspaceRepository
                         │
        clone ───────────┴──────────── worktree-cache
                                          │
                                          ▼
                         bare cache lock → fetch/prune → worktree add -B
                                          │
terminal cleanup ───────────────────────┴─► remove → owned branch cleanup → prune
```

## 여기부터 보세요

- `packages/orchestrator/src/git.ts`: worktree populate, project-scoped branch, idempotent terminal cleanup
- `packages/orchestrator/src/repository-cache.ts`: TTL fetch, shared bare-cache lock/ref handling, cache hierarchy recovery
- `packages/orchestrator/src/service.ts`: workflow front matter와 terminal cleanup wiring
- `packages/orchestrator/src/git.test.ts`, `packages/orchestrator/src/service.test.ts`: populate/reuse/failure, slug namespace, cleanup/recovery 및 clone regression TC

## 위험 & 롤백

- `worktree-cache`는 opt-in이며 `populateStrategy: "clone"`은 기존 흐름을 보존합니다.
- 문제 발생 시 `clone` 전략으로 되돌릴 수 있습니다.
- terminal cleanup은 결정적으로 계산된 소유 branch만 회수하고 agent branch의 unpushed commit은 보존합니다.

## 변경 파일

- `.changeset/friendly-worktrees-smile.md`
- `packages/orchestrator/src/git.ts`
- `packages/orchestrator/src/git.test.ts`
- `packages/orchestrator/src/repository-cache.ts`
- `packages/orchestrator/src/service.ts`
- `packages/orchestrator/src/service.test.ts`

## Issues — Closed #565

## 검증

- `pnpm --filter @gh-symphony/orchestrator exec vitest run src/git.test.ts` — pass (32 tests)
- `pnpm lint && pnpm test && pnpm typecheck && pnpm build` — pass
- `pnpm e2e:claude` — pass (Docker lifecycle blackbox)
- GitHub CI: `Test`, `Container Smoke` — success on `c49e0d7`

## 머지 후/사람 확인

- [ ] 실제 다중 프로젝트 환경에서 동일 repository의 project-scoped worktree branch를 확인
- [ ] 별도 후속 #592에서 shared cache agent branch namespace/GC 정책을 검토
