### PR TITLE
feat(worker): layered skill injection into worktrees

### DIFF
--- a/.changeset/layered-worker-skills.md
+++ b/.changeset/layered-worker-skills.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Inject layered global and project skills into each worker worktree attempt (#567).

--- a/packages/cli/src/commands/workflow-init.test.ts
+++ b/packages/cli/src/commands/workflow-init.test.ts
@@ -330,9 +330,9 @@ describe("init command config output", () => {
     );
 
     expect(process.exitCode).toBeUndefined();
-    expect(stdout.mock.calls.map(([chunk]) => String(chunk)).join("")).toContain(
-      '"projectId":"symphony-0c79b11b75ea"'
-    );
+    expect(
+      stdout.mock.calls.map(([chunk]) => String(chunk)).join("")
+    ).toContain('"projectId":"symphony-0c79b11b75ea"');
     expect(p.log.info).toHaveBeenCalledWith(
       expect.stringContaining("Claude runtime preflight")
     );
@@ -375,12 +375,7 @@ describe("init command config output", () => {
     vi.mocked(p.select).mockClear();
 
     await initCommand(
-      [
-        "--tracker",
-        "linear",
-        "--linear-project-slug",
-        "symphony-0c79b11b75ea",
-      ],
+      ["--tracker", "linear", "--linear-project-slug", "symphony-0c79b11b75ea"],
       {
         configDir: await mkdtemp(join(tmpdir(), "cli-init-linear-int-")),
         verbose: false,
@@ -1118,7 +1113,7 @@ describe("init ecosystem generation", () => {
     const referenceWorkflow = await readFile(
       join(
         cwd,
-        ".codex",
+        ".agent",
         "skills",
         "gh-symphony",
         "references",
@@ -1127,13 +1122,13 @@ describe("init ecosystem generation", () => {
       "utf8"
     );
     const skill = await readFile(
-      join(cwd, ".codex", "skills", "gh-symphony", "SKILL.md"),
+      join(cwd, ".agent", "skills", "gh-symphony", "SKILL.md"),
       "utf8"
     );
     const implementPosture = await readFile(
       join(
         cwd,
-        ".codex",
+        ".agent",
         "skills",
         "gh-symphony",
         "references",
@@ -1404,7 +1399,7 @@ describe("init ecosystem generation", () => {
     });
 
     const skill = await readFile(
-      join(cwd, ".codex", "skills", "gh-symphony", "SKILL.md"),
+      join(cwd, ".agent", "skills", "gh-symphony", "SKILL.md"),
       "utf8"
     );
     expect(skill.startsWith("---\n")).toBe(true);
@@ -1413,7 +1408,7 @@ describe("init ecosystem generation", () => {
     expect(skill).toContain("gh-symphony");
     await expect(
       readFile(
-        join(cwd, ".codex", "skills", "gh-symphony", "references", "README.md"),
+        join(cwd, ".agent", "skills", "gh-symphony", "references", "README.md"),
         "utf8"
       )
     ).resolves.toContain("# /gh-symphony references");
@@ -1461,7 +1456,7 @@ describe("init ecosystem generation", () => {
 
     for (const skillName of skillNames) {
       const skill = await readFile(
-        join(cwd, ".codex", "skills", skillName, "SKILL.md"),
+        join(cwd, ".agent", "skills", skillName, "SKILL.md"),
         "utf8"
       );
       expect(skill.startsWith("---\n")).toBe(true);
@@ -1483,7 +1478,7 @@ describe("init ecosystem generation", () => {
         readFile(
           join(
             cwd,
-            ".codex",
+            ".agent",
             "skills",
             "gh-symphony",
             "references",
@@ -1509,7 +1504,7 @@ describe("init ecosystem generation", () => {
     });
 
     await expect(
-      readFile(join(cwd, ".codex", "skills", "gh-symphony", "SKILL.md"), "utf8")
+      readFile(join(cwd, ".agent", "skills", "gh-symphony", "SKILL.md"), "utf8")
     ).rejects.toThrow();
 
     expect(result.skillsDir).toBeNull();

--- a/packages/cli/src/skills/skill-writer.test.ts
+++ b/packages/cli/src/skills/skill-writer.test.ts
@@ -26,34 +26,34 @@ function createSkillTemplate(name: string, content: string): SkillTemplate {
 
 describe("skill-writer", () => {
   describe("resolveSkillsDir", () => {
-    it("resolves claude-code runtime to .claude/skills", () => {
+    it("resolves claude-code runtime to the project skill layer", () => {
       const result = resolveSkillsDir("/repo", "claude-code");
-      expect(result).toBe(join("/repo", ".claude", "skills"));
+      expect(result).toBe(join("/repo", ".agent", "skills"));
     });
 
-    it("resolves claude-print runtime to .claude/skills", () => {
+    it("resolves claude-print runtime to the project skill layer", () => {
       const result = resolveSkillsDir("/repo", "claude-print");
-      expect(result).toBe(join("/repo", ".claude", "skills"));
+      expect(result).toBe(join("/repo", ".agent", "skills"));
     });
 
-    it("resolves codex runtime to .codex/skills", () => {
+    it("resolves codex runtime to the project skill layer", () => {
       const result = resolveSkillsDir("/repo", "codex");
-      expect(result).toBe(join("/repo", ".codex", "skills"));
+      expect(result).toBe(join("/repo", ".agent", "skills"));
     });
 
-    it("resolves codex-app-server runtime to .codex/skills", () => {
+    it("resolves codex-app-server runtime to the project skill layer", () => {
       const result = resolveSkillsDir("/repo", "codex-app-server");
-      expect(result).toBe(join("/repo", ".codex", "skills"));
+      expect(result).toBe(join("/repo", ".agent", "skills"));
     });
 
-    it("resolves codex agent command to .codex/skills", () => {
+    it("resolves codex agent command to the project skill layer", () => {
       const result = resolveSkillsDir("/repo", "bash -lc codex app-server");
-      expect(result).toBe(join("/repo", ".codex", "skills"));
+      expect(result).toBe(join("/repo", ".agent", "skills"));
     });
 
-    it("resolves claude-code agent command to .claude/skills", () => {
+    it("resolves claude-code agent command to the project skill layer", () => {
       const result = resolveSkillsDir("/repo", "bash -lc claude-code");
-      expect(result).toBe(join("/repo", ".claude", "skills"));
+      expect(result).toBe(join("/repo", ".agent", "skills"));
     });
 
     it("does not resolve substring-only runtime names to skill dirs", () => {
@@ -272,7 +272,7 @@ describe("skill-writer", () => {
       const result = await writeAllSkills(tempDir, "codex", templates, context);
 
       expect(result.written).toHaveLength(1);
-      expect(result.written[0]).toContain(".codex/skills");
+      expect(result.written[0]).toContain(".agent/skills");
     });
 
     it("returns empty arrays for unknown runtime", async () => {
@@ -369,7 +369,7 @@ describe("skill-writer", () => {
       expect(generate).toHaveBeenCalledTimes(1);
       await expect(
         readFile(
-          join(tempDir, ".codex", "skills", "sample", "SKILL.md"),
+          join(tempDir, ".agent", "skills", "sample", "SKILL.md"),
           "utf8"
         )
       ).resolves.toContain("name: sample");

--- a/packages/cli/src/skills/skill-writer.ts
+++ b/packages/cli/src/skills/skill-writer.ts
@@ -27,12 +27,8 @@ export function resolveSkillsDir(
   repoRoot: string,
   runtime: string
 ): string | null {
-  const normalizedRuntime = normalizeRuntimeForSkills(runtime);
-  if (normalizedRuntime === "claude-code") {
-    return join(repoRoot, ".claude", "skills");
-  }
-  if (normalizedRuntime === "codex") {
-    return join(repoRoot, ".codex", "skills");
+  if (normalizeRuntimeForSkills(runtime)) {
+    return join(repoRoot, ".agent", "skills");
   }
   return null;
 }

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -64,6 +64,7 @@ import {
   readGitCurrentBranch,
   removeIssueWorkspaceWorktree,
 } from "./git.js";
+import { excludeRuntimeSkillsFromGit, injectLayeredSkills } from "./skills.js";
 import { OrchestratorFsStore } from "./fs-store.js";
 import { getProcessStartIdentity } from "./lock.js";
 import { PersistentIssueCommentCache } from "./issue-comment-cache.js";
@@ -2379,6 +2380,10 @@ export class OrchestratorService {
       branchTemplate,
       baseBranch,
     });
+    const agentCommand = resolveWorkflowRuntimeCommand(
+      workflowForPopulate.workflow
+    );
+    await excludeRuntimeSkillsFromGit(repositoryDirectory, agentCommand);
 
     if (!existingWorkspaceRecord || workspaceQuarantined) {
       const workspaceRecord: IssueWorkspaceRecord = {
@@ -2444,6 +2449,11 @@ export class OrchestratorService {
     );
 
     // Run before_run hook before spawning the worker
+    await injectLayeredSkills({
+      projectDirectory: this.store.projectDir(tenant.projectId),
+      repositoryDirectory,
+      agentCommand,
+    });
     await this.runHook(
       "before_run",
       tenant,

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -2450,7 +2450,8 @@ export class OrchestratorService {
 
     // Run before_run hook before spawning the worker
     await injectLayeredSkills({
-      projectDirectory: this.store.projectDir(tenant.projectId),
+      projectDirectory:
+        tenant.projectDir ?? this.store.projectDir(tenant.projectId),
       repositoryDirectory,
       agentCommand,
     });

--- a/packages/orchestrator/src/skills.test.ts
+++ b/packages/orchestrator/src/skills.test.ts
@@ -1,0 +1,127 @@
+import { execFile } from "node:child_process";
+import { mkdtemp, mkdir, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  excludeRuntimeSkillsFromGit,
+  injectLayeredSkills,
+  resolveRuntimeSkillsDirectory,
+} from "./skills.js";
+
+const execFileAsync = promisify(execFile);
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    roots.splice(0).map((root) => execFileAsync("rm", ["-rf", root]))
+  );
+});
+
+async function createRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "orchestrator-skills-"));
+  roots.push(root);
+  return root;
+}
+
+async function writeSkill(root: string, name: string, content: string) {
+  const path = join(root, name, "SKILL.md");
+  await mkdir(join(root, name), { recursive: true });
+  await writeFile(path, content, "utf8");
+}
+
+describe("layered runtime skills", () => {
+  it("copies global and project skills, with the project layer winning collisions", async () => {
+    const root = await createRoot();
+    const global = join(root, "global");
+    const project = join(root, "project");
+    const repository = join(root, "repository");
+    await writeSkill(global, "global-only", "global");
+    await writeSkill(global, "shared", "global version");
+    await writeSkill(
+      join(project, ".agent", "skills"),
+      "project-only",
+      "project"
+    );
+    await writeSkill(
+      join(project, ".agent", "skills"),
+      "shared",
+      "project version"
+    );
+
+    await injectLayeredSkills({
+      globalSkillsDirectory: global,
+      projectDirectory: project,
+      repositoryDirectory: repository,
+      agentCommand: "codex app-server",
+    });
+
+    expect(
+      await readFile(
+        join(repository, ".codex", "skills", "global-only", "SKILL.md"),
+        "utf8"
+      )
+    ).toBe("global");
+    expect(
+      await readFile(
+        join(repository, ".codex", "skills", "project-only", "SKILL.md"),
+        "utf8"
+      )
+    ).toBe("project");
+    expect(
+      await readFile(
+        join(repository, ".codex", "skills", "shared", "SKILL.md"),
+        "utf8"
+      )
+    ).toBe("project version");
+  });
+
+  it("repopulates the destination on every attempt", async () => {
+    const root = await createRoot();
+    const global = join(root, "global");
+    const project = join(root, "project");
+    const repository = join(root, "repository");
+    await writeSkill(global, "shared", "first");
+    const input = {
+      globalSkillsDirectory: global,
+      projectDirectory: project,
+      repositoryDirectory: repository,
+      agentCommand: "codex app-server",
+    };
+    await injectLayeredSkills(input);
+    await writeSkill(global, "shared", "second");
+    await injectLayeredSkills(input);
+
+    expect(
+      await readFile(
+        join(repository, ".codex", "skills", "shared", "SKILL.md"),
+        "utf8"
+      )
+    ).toBe("second");
+  });
+
+  it("uses cwd-native runtime skill directories", () => {
+    expect(resolveRuntimeSkillsDirectory("/worktree", "codex app-server")).toBe(
+      "/worktree/.codex/skills"
+    );
+    expect(resolveRuntimeSkillsDirectory("/worktree", "claude -p")).toBe(
+      "/worktree/.claude/skills"
+    );
+  });
+
+  it("excludes injected runtime skills from the worktree git status", async () => {
+    const root = await createRoot();
+    await execFileAsync("git", ["init", root]);
+    await excludeRuntimeSkillsFromGit(root, "codex app-server");
+    await writeSkill(join(root, ".codex", "skills"), "injected", "skill");
+
+    const { stdout } = await execFileAsync("git", [
+      "-C",
+      root,
+      "status",
+      "--short",
+    ]);
+    expect(stdout).toBe("");
+  });
+});

--- a/packages/orchestrator/src/skills.test.ts
+++ b/packages/orchestrator/src/skills.test.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { mkdtemp, mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
@@ -15,7 +15,7 @@ const roots: string[] = [];
 
 afterEach(async () => {
   await Promise.all(
-    roots.splice(0).map((root) => execFileAsync("rm", ["-rf", root]))
+    roots.splice(0).map((root) => rm(root, { recursive: true, force: true }))
   );
 });
 

--- a/packages/orchestrator/src/skills.test.ts
+++ b/packages/orchestrator/src/skills.test.ts
@@ -108,17 +108,81 @@ describe("layered runtime skills", () => {
     expect(resolveRuntimeSkillsDirectory("/worktree", "claude -p")).toBe(
       "/worktree/.claude/skills"
     );
+    expect(
+      resolveRuntimeSkillsDirectory("/worktree", "/usr/local/bin/codex app-server")
+    ).toBe("/worktree/.codex/skills");
   });
 
-  it("excludes injected runtime skills from the worktree git status", async () => {
+  it("excludes injected runtime skills from a linked worktree git status", async () => {
     const root = await createRoot();
-    await execFileAsync("git", ["init", root]);
-    await excludeRuntimeSkillsFromGit(root, "codex app-server");
-    await writeSkill(join(root, ".codex", "skills"), "injected", "skill");
+    const bare = join(root, "cache.git");
+    const seed = join(root, "seed");
+    const worktree = join(root, "worktree");
+    await execFileAsync("git", ["init", "-q", "-b", "main", seed]);
+    await execFileAsync("git", ["-C", seed, "config", "user.email", "test@example.com"]);
+    await execFileAsync("git", ["-C", seed, "config", "user.name", "Test User"]);
+    await writeFile(join(seed, "README.md"), "seed", "utf8");
+    await execFileAsync("git", ["-C", seed, "add", "README.md"]);
+    await execFileAsync("git", ["-C", seed, "commit", "-qm", "seed"]);
+    await execFileAsync("git", ["init", "-q", "--bare", bare]);
+    await execFileAsync("git", ["-C", seed, "remote", "add", "origin", bare]);
+    await execFileAsync("git", ["-C", seed, "push", "-q", "origin", "main"]);
+    await execFileAsync("git", ["--git-dir", bare, "worktree", "add", "-q", worktree, "main"]);
+    await excludeRuntimeSkillsFromGit(worktree, "codex app-server");
+    await writeSkill(join(worktree, ".codex", "skills"), "injected", "skill");
 
     const { stdout } = await execFileAsync("git", [
       "-C",
-      root,
+      worktree,
+      "status",
+      "--short",
+    ]);
+    expect(stdout).toBe("");
+  });
+
+  it("preserves tracked runtime skills while refreshing injected skills", async () => {
+    const root = await createRoot();
+    const global = join(root, "global");
+    const project = join(root, "project");
+    const repository = join(root, "repository");
+    await execFileAsync("git", ["init", "-q", repository]);
+    await execFileAsync("git", ["-C", repository, "config", "user.email", "test@example.com"]);
+    await execFileAsync("git", ["-C", repository, "config", "user.name", "Test User"]);
+    await writeSkill(
+      join(repository, ".codex", "skills"),
+      "committed",
+      "repository skill"
+    );
+    await execFileAsync("git", ["-C", repository, "add", "."]);
+    await execFileAsync("git", ["-C", repository, "commit", "-qm", "skills"]);
+    await writeSkill(global, "injected", "first");
+    await excludeRuntimeSkillsFromGit(repository, "codex app-server");
+
+    const input = {
+      globalSkillsDirectory: global,
+      projectDirectory: project,
+      repositoryDirectory: repository,
+      agentCommand: "codex app-server",
+    };
+    await injectLayeredSkills(input);
+    await writeSkill(global, "injected", "second");
+    await injectLayeredSkills(input);
+
+    await expect(
+      readFile(
+        join(repository, ".codex", "skills", "committed", "SKILL.md"),
+        "utf8"
+      )
+    ).resolves.toBe("repository skill");
+    await expect(
+      readFile(
+        join(repository, ".codex", "skills", "injected", "SKILL.md"),
+        "utf8"
+      )
+    ).resolves.toBe("second");
+    const { stdout } = await execFileAsync("git", [
+      "-C",
+      repository,
       "status",
       "--short",
     ]);

--- a/packages/orchestrator/src/skills.ts
+++ b/packages/orchestrator/src/skills.ts
@@ -1,0 +1,117 @@
+import { cp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, isAbsolute, join, resolve } from "node:path";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const GLOBAL_SKILLS_DIRECTORY = join(homedir(), ".gh-symphony", "skills");
+const PROJECT_SKILLS_DIRECTORY = join(".agent", "skills");
+
+function containsRuntimeToken(command: string, token: string): boolean {
+  const escaped = token.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`(^|[\\s"'\\\`])${escaped}(?=$|[\\s"'\\\`])`).test(command);
+}
+
+export function resolveRuntimeSkillsDirectory(
+  repositoryDirectory: string,
+  agentCommand: string
+): string | null {
+  if (
+    containsRuntimeToken(agentCommand, "codex") ||
+    containsRuntimeToken(agentCommand, "codex-app-server")
+  ) {
+    return join(repositoryDirectory, ".codex", "skills");
+  }
+  if (
+    containsRuntimeToken(agentCommand, "claude") ||
+    containsRuntimeToken(agentCommand, "claude-code") ||
+    containsRuntimeToken(agentCommand, "claude-print")
+  ) {
+    return join(repositoryDirectory, ".claude", "skills");
+  }
+  return null;
+}
+
+export async function injectLayeredSkills(input: {
+  projectDirectory: string;
+  repositoryDirectory: string;
+  agentCommand: string;
+  globalSkillsDirectory?: string;
+}): Promise<string | null> {
+  const destination = resolveRuntimeSkillsDirectory(
+    input.repositoryDirectory,
+    input.agentCommand
+  );
+  if (!destination) {
+    return null;
+  }
+
+  // Start every attempt from an empty destination so removed or changed skills
+  // are reflected. Project skills are copied last and therefore take precedence.
+  await rm(destination, { recursive: true, force: true });
+  await mkdir(destination, { recursive: true });
+  for (const source of [
+    input.globalSkillsDirectory ?? GLOBAL_SKILLS_DIRECTORY,
+    join(input.projectDirectory, PROJECT_SKILLS_DIRECTORY),
+  ]) {
+    try {
+      await cp(source, destination, {
+        recursive: true,
+        dereference: true,
+        force: true,
+      });
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw error;
+      }
+    }
+  }
+  return destination;
+}
+
+export async function excludeRuntimeSkillsFromGit(
+  repositoryDirectory: string,
+  agentCommand: string
+): Promise<void> {
+  const skillsDirectory = resolveRuntimeSkillsDirectory(
+    repositoryDirectory,
+    agentCommand
+  );
+  if (!skillsDirectory) {
+    return;
+  }
+  const relativePath = `${skillsDirectory
+    .slice(resolve(repositoryDirectory).length + 1)
+    .replaceAll("\\", "/")}/`;
+  const { stdout } = await execFileAsync(
+    "git",
+    ["-C", repositoryDirectory, "rev-parse", "--git-dir"],
+    { encoding: "utf8" }
+  );
+  const gitDirectory = stdout.trim();
+  const excludePath = join(
+    isAbsolute(gitDirectory)
+      ? gitDirectory
+      : resolve(repositoryDirectory, gitDirectory),
+    "info",
+    "exclude"
+  );
+  let existing = "";
+  try {
+    existing = await readFile(excludePath, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw error;
+    }
+  }
+  if (existing.split(/\r?\n/).includes(relativePath)) {
+    return;
+  }
+  await mkdir(dirname(excludePath), { recursive: true });
+  await writeFile(
+    excludePath,
+    `${existing}${existing && !existing.endsWith("\n") ? "\n" : ""}${relativePath}\n`,
+    "utf8"
+  );
+}

--- a/packages/orchestrator/src/skills.ts
+++ b/packages/orchestrator/src/skills.ts
@@ -1,16 +1,64 @@
-import { cp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { cp, mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
-import { dirname, isAbsolute, join, resolve } from "node:path";
+import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
 const GLOBAL_SKILLS_DIRECTORY = join(homedir(), ".gh-symphony", "skills");
 const PROJECT_SKILLS_DIRECTORY = join(".agent", "skills");
+const INJECTED_SKILLS_MANIFEST = ".gh-symphony-injected-skills.json";
 
 function containsRuntimeToken(command: string, token: string): boolean {
   const escaped = token.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  return new RegExp(`(^|[\\s"'\\\`])${escaped}(?=$|[\\s"'\\\`])`).test(command);
+  return new RegExp(
+    `(^|[\\s"'\\\`/\\\\])${escaped}(?=$|[\\s"'\\\`/\\\\])`
+  ).test(command);
+}
+
+async function readInjectedSkillNames(destination: string): Promise<string[]> {
+  try {
+    const parsed: unknown = JSON.parse(
+      await readFile(join(destination, INJECTED_SKILLS_MANIFEST), "utf8")
+    );
+    return Array.isArray(parsed)
+      ? parsed.filter((name): name is string => typeof name === "string")
+      : [];
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return [];
+    }
+    return [];
+  }
+}
+
+async function readSkillNames(source: string): Promise<string[]> {
+  try {
+    return (await readdir(source, { withFileTypes: true }))
+      .filter((entry) => entry.name !== INJECTED_SKILLS_MANIFEST)
+      .map((entry) => entry.name);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return [];
+    }
+    throw error;
+  }
+}
+
+async function isTrackedPath(
+  repositoryDirectory: string,
+  path: string
+): Promise<boolean> {
+  try {
+    const { stdout } = await execFileAsync(
+      "git",
+      ["-C", repositoryDirectory, "ls-files", "-z", "--", path],
+      { encoding: "utf8" }
+    );
+    return stdout.length > 0;
+  } catch {
+    return false;
+  }
 }
 
 export function resolveRuntimeSkillsDirectory(
@@ -47,26 +95,50 @@ export async function injectLayeredSkills(input: {
     return null;
   }
 
-  // Start every attempt from an empty destination so removed or changed skills
-  // are reflected. Project skills are copied last and therefore take precedence.
-  await rm(destination, { recursive: true, force: true });
+  // Only remove entries written by a previous injection. Recreating the whole
+  // runtime directory would delete repository-tracked skills from older setups.
   await mkdir(destination, { recursive: true });
+  for (const name of await readInjectedSkillNames(destination)) {
+    const target = join(destination, name);
+    if (
+      !(await isTrackedPath(
+        input.repositoryDirectory,
+        relative(input.repositoryDirectory, target)
+      ))
+    ) {
+      await rm(target, { recursive: true, force: true });
+    }
+  }
+
+  const injectedNames = new Set<string>();
   for (const source of [
     input.globalSkillsDirectory ?? GLOBAL_SKILLS_DIRECTORY,
     join(input.projectDirectory, PROJECT_SKILLS_DIRECTORY),
   ]) {
-    try {
-      await cp(source, destination, {
+    for (const name of await readSkillNames(source)) {
+      const target = join(destination, name);
+      if (
+        await isTrackedPath(
+          input.repositoryDirectory,
+          relative(input.repositoryDirectory, target)
+        )
+      ) {
+        continue;
+      }
+      await rm(target, { recursive: true, force: true });
+      await cp(join(source, name), target, {
         recursive: true,
         dereference: true,
         force: true,
       });
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
-        throw error;
-      }
+      injectedNames.add(name);
     }
   }
+  await writeFile(
+    join(destination, INJECTED_SKILLS_MANIFEST),
+    JSON.stringify([...injectedNames].sort()),
+    "utf8"
+  );
   return destination;
 }
 
@@ -81,22 +153,19 @@ export async function excludeRuntimeSkillsFromGit(
   if (!skillsDirectory) {
     return;
   }
-  const relativePath = `${skillsDirectory
-    .slice(resolve(repositoryDirectory).length + 1)
-    .replaceAll("\\", "/")}/`;
+  const relativePath = `${relative(repositoryDirectory, skillsDirectory).replaceAll(
+    "\\",
+    "/"
+  )}/`;
   const { stdout } = await execFileAsync(
     "git",
-    ["-C", repositoryDirectory, "rev-parse", "--git-dir"],
+    ["-C", repositoryDirectory, "rev-parse", "--git-path", "info/exclude"],
     { encoding: "utf8" }
   );
-  const gitDirectory = stdout.trim();
-  const excludePath = join(
-    isAbsolute(gitDirectory)
-      ? gitDirectory
-      : resolve(repositoryDirectory, gitDirectory),
-    "info",
-    "exclude"
-  );
+  const gitPath = stdout.trim();
+  const excludePath = isAbsolute(gitPath)
+    ? gitPath
+    : resolve(repositoryDirectory, gitPath);
   let existing = "";
   try {
     existing = await readFile(excludePath, "utf8");


### PR DESCRIPTION
## TL;DR

- worker attempt마다 전역·프로젝트 스킬을 런타임 worktree 경로에 비링크 복사합니다.
- 프로젝트 레이어가 충돌 시 우선하며, linked worktree에서도 injected 경로는 Git 상태에 나타나지 않습니다.
- 기존 리포지토리가 추적하는 runtime skill은 보존합니다.

## 변경 지점 다이어그램

`~/.gh-symphony/skills + <tenant.projectDir>/.agent/skills → orchestrator before_run → <worktree>/.codex|.claude/skills`

## 여기부터 보세요

- `packages/orchestrator/src/skills.ts`: 계층 병합·attempt 재복사·추적 스킬 보존·worktree exclude
- `packages/orchestrator/src/service.ts`: standalone 프로젝트의 `tenant.projectDir` 레이어를 before_run 직전에 연결
- `packages/orchestrator/src/skills.test.ts`: bare cache linked worktree 및 기존 runtime skill 회귀 TC

## 위험 & 롤백

- Symphony가 주입한 항목만 manifest로 다음 attempt에서 갱신합니다. 추적된 runtime skill은 건드리지 않습니다.
- 롤백하면 기존 runtime skill 경로의 주입 동작으로 되돌아갑니다.

## 변경 파일

- `packages/orchestrator/src/skills.ts`, `skills.test.ts`, `service.ts`
- `packages/cli/src/skills/skill-writer.ts` 및 관련 TC
- `.changeset/layered-worker-skills.md`

## Issues — Closed #567

## 머지 후/사람 확인

- [ ] 실제 설치된 Codex 및 Claude worker에서 프로젝트-local skill discovery를 확인

## Evidence

- `pnpm lint && pnpm test && pnpm typecheck && pnpm build` — pass
- `pnpm --filter @gh-symphony/orchestrator test -- skills.test.ts` — pass; global-only·project-only·충돌 우선·attempt 재복사·linked worktree exclude·추적 스킬 보존 TC
- Docker E2E: `docker compose -f docker-compose.e2e.yml -f docker-compose.e2e.events.yml up -d --build`, `/api/v1/refresh` — pass; stub worker dispatched and emitted `completed` event

