### PR TITLE
test(e2e): cover standalone project lifecycle

### DIFF
--- a/.changeset/standalone-project-e2e.md
+++ b/.changeset/standalone-project-e2e.md
@@ -2,5 +2,5 @@
 "@gh-symphony/cli": minor
 ---
 
-Document and verify standalone project registration, isolated worktree
-population, and project-scoped branch namespaces. (#570)
+Add standalone project lifecycle coverage, including project-scoped `.env`,
+MCP, worktree, and branch isolation for CLI users. (#570)

--- a/.changeset/standalone-project-e2e.md
+++ b/.changeset/standalone-project-e2e.md
@@ -1,0 +1,6 @@
+---
+"@gh-symphony/cli": minor
+---
+
+Document and verify standalone project registration, isolated worktree
+population, and project-scoped branch namespaces. (#570)

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,7 +28,7 @@
 | [2026-05-10-cli-restructure-design.md](designs/2026-05-10-cli-restructure-design.md)                                         | Coordination, Configuration                                   | Shipped           |
 | [2026-05-10-cli-restructure-issues.md](designs/2026-05-10-cli-restructure-issues.md)                                         | Coordination, Configuration                                   | Completed (플랜)  |
 | [2026-07-06-github-project-repo-dispatch-filter-design.md](designs/2026-07-06-github-project-repo-dispatch-filter-design.md) | Integration, Coordination, Observability                      | Shipped (PR #435) |
-| [2026-08-11-standalone-project-model-design.md](designs/2026-08-11-standalone-project-model-design.md)                       | Policy, Configuration, Coordination, Execution, Observability | Draft             |
+| [2026-08-11-standalone-project-model-design.md](designs/2026-08-11-standalone-project-model-design.md)                       | Policy, Configuration, Coordination, Execution, Observability | Shipped           |
 | [2026-08-11-agent-bootstrap-plugin-pm-steward-design.md](designs/2026-08-11-agent-bootstrap-plugin-pm-steward-design.md)     | Policy, Configuration, Coordination, Observability            | Draft             |
 | [2026-08-11-standalone-project-model-issues.md](designs/2026-08-11-standalone-project-model-issues.md)                       | (플랜)                                                        | Active            |
 

--- a/docs/adr/2026-05-04_single-repo-orchestrator.md
+++ b/docs/adr/2026-05-04_single-repo-orchestrator.md
@@ -1,7 +1,8 @@
 # ADR: Single-Repository Orchestrator Model 로 전환
 
 - **Date**: 2026-05-04
-- **Status**: Superseded by standalone-project refinement
+- **Status**: Superseded by
+  [`2026-08-13_standalone-project-instance-boundary.md`](./2026-08-13_standalone-project-instance-boundary.md)
 - **Related Spec**: `docs/symphony-spec.md` §3.1, §5.1
 - **Reference Implementation**: <https://github.com/openai/symphony> (elixir)
 - **Related ADRs**:

--- a/docs/adr/2026-05-04_single-repo-orchestrator.md
+++ b/docs/adr/2026-05-04_single-repo-orchestrator.md
@@ -1,7 +1,7 @@
 # ADR: Single-Repository Orchestrator Model 로 전환
 
 - **Date**: 2026-05-04
-- **Status**: Proposed
+- **Status**: Superseded by standalone-project refinement
 - **Related Spec**: `docs/symphony-spec.md` §3.1, §5.1
 - **Reference Implementation**: <https://github.com/openai/symphony> (elixir)
 - **Related ADRs**:
@@ -35,6 +35,13 @@ upstream `docs/symphony-spec.md` §3.1, §5.1 은 **단일 리포지토리 + rep
 ## Decision
 
 orchestrator 를 **단일-리포 watch** 모델로 전환한다.
+
+> **2026-08-13 refinement:** the instance boundary is **one project**, not
+> one repository. A project owns policy and its tracker mapping; several
+> projects may safely reference one repository when their mappings are
+> disjoint. The shared bare cache remains repository-scoped, while project
+> slugs namespace worktree branches. This repository-local extension keeps the
+> upstream single-workflow orchestrator model intact per instance.
 
 ### 핵심 모델
 
@@ -85,13 +92,13 @@ $ cd ~/work/repo-b && gh-symphony repo start --web 4681
 
 ## Implementation Plan
 
-| Phase | 범위 | 비고 |
-|---|---|---|
-| **P1 — Contract** | `packages/core/src/contracts/status-surface.ts:15-21` `repositories[]→repository`. `state-store.ts:11-40` 의 `projectId` 옵션화. `workspace/identity.ts:12-14,43-60` 의 `projectId` 제거 + `deriveWorkspaceKey(identifier)` 통합 (ADR `2026-03-16` 채택). | 타입 시스템이 다음 phase 견인. |
-| **P2 — Service core** | `packages/orchestrator/src/service.ts:825,868-946,2527-2638` 정책 집계 로직 단순화 (`min(repos.x) → repository.x`). `fs-store.ts:43-188,297-346` 디스크 레이아웃 변경. | `service.test.ts` fixture 갱신 동반. |
-| **P3 — CLI / migration** | `packages/cli/src/commands/{init,start,project,repo}.ts` cwd 기반. 기존 `.runtime/projects/<projectId>/...` 자동 promote 스크립트 (단일 projectId 발견 시). | breaking change 최소화. |
-| **P4 — Control plane** | `packages/control-plane/src/server.ts`, `packages/dashboard/src/store.ts:33-47` 의 `projectId` 라우팅 제거. SPA route 일부 단순화. | UI 회귀 테스트. |
-| **P5 — Tests / e2e** | `service.test.ts` 64 suite fixture 일괄 갱신. `e2e/seed/config.json` 검증. | 명세 부합 확인. |
+| Phase                    | 범위                                                                                                                                                                                                                                                      | 비고                                 |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
+| **P1 — Contract**        | `packages/core/src/contracts/status-surface.ts:15-21` `repositories[]→repository`. `state-store.ts:11-40` 의 `projectId` 옵션화. `workspace/identity.ts:12-14,43-60` 의 `projectId` 제거 + `deriveWorkspaceKey(identifier)` 통합 (ADR `2026-03-16` 채택). | 타입 시스템이 다음 phase 견인.       |
+| **P2 — Service core**    | `packages/orchestrator/src/service.ts:825,868-946,2527-2638` 정책 집계 로직 단순화 (`min(repos.x) → repository.x`). `fs-store.ts:43-188,297-346` 디스크 레이아웃 변경.                                                                                    | `service.test.ts` fixture 갱신 동반. |
+| **P3 — CLI / migration** | `packages/cli/src/commands/{init,start,project,repo}.ts` cwd 기반. 기존 `.runtime/projects/<projectId>/...` 자동 promote 스크립트 (단일 projectId 발견 시).                                                                                               | breaking change 최소화.              |
+| **P4 — Control plane**   | `packages/control-plane/src/server.ts`, `packages/dashboard/src/store.ts:33-47` 의 `projectId` 라우팅 제거. SPA route 일부 단순화.                                                                                                                        | UI 회귀 테스트.                      |
+| **P5 — Tests / e2e**     | `service.test.ts` 64 suite fixture 일괄 갱신. `e2e/seed/config.json` 검증.                                                                                                                                                                                | 명세 부합 확인.                      |
 
 각 Phase 는 독립 PR. P1 통과 후 P2 부터 본격 변경.
 

--- a/docs/adr/2026-08-13_standalone-project-instance-boundary.md
+++ b/docs/adr/2026-08-13_standalone-project-instance-boundary.md
@@ -1,0 +1,30 @@
+# ADR: Standalone Project Instance Boundary
+
+- **Date**: 2026-08-13
+- **Status**: Accepted
+- **Supersedes**: [`2026-05-04_single-repo-orchestrator.md`](./2026-05-04_single-repo-orchestrator.md)
+- **Related Spec**: `docs/symphony-spec.md` §3.1, §5.1
+
+## Context
+
+The earlier single-repository ADR described the runtime boundary as “1 repo =
+1 instance”. Standalone project folders now own independent policy, tracker
+mapping, credentials, skills, MCP configuration, and runtime state while they
+may reference the same repository.
+
+## Decision
+
+The orchestration instance boundary is **1 project = 1 instance**. A project
+owns its `WORKFLOW.md`, optional `.mcp.json`, `.env`, and `.agent/skills/`.
+Projects may share a repository only when their tracker mappings are disjoint.
+They share one repository-scoped bare cache; project slugs namespace populated
+worktree branches as `symphony/<project-slug>/<sanitized-issue-id>`.
+
+## Consequences
+
+- Operators can run independent workflows for one repository without mutating
+  the repository itself.
+- Disjoint tracker mappings and branch namespaces prevent competing project
+  dispatches and branch collisions.
+- This is a repository-local extension: the upstream single-workflow model is
+  preserved inside each project instance. It does not modify the upstream spec.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,6 +6,19 @@ committed `WORKFLOW.md` settings for workflow policy, and use environment
 variables for host-specific authentication, Enterprise endpoints, local paths,
 and operational overrides.
 
+## Standalone Projects
+
+`gh-symphony project add <project-dir>` registers a project folder as an
+independent orchestration instance. The folder owns `WORKFLOW.md`, optional
+`.mcp.json`, `.env`, and `.agent/skills/`; the referenced repository remains
+unmodified. `WORKFLOW.md` must declare `repository.slug`. Each issue is
+populated from the shared bare cache at `<config-dir>/repos/<owner>/<repo>.git`
+using a worktree. Branches default to
+`symphony/<project-slug>/<sanitized-issue-id>`, so multiple projects may use
+one repository without branch collisions. Project `.env` values are resolved
+after the host environment only for project hooks and workers; keep it mode
+`0600` and do not commit it.
+
 ## Environment Loading Order
 
 Worker and hook environments are merged in this order, with later values taking

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -15,9 +15,9 @@ unmodified. `WORKFLOW.md` must declare `repository.slug`. Each issue is
 populated from the shared bare cache at `<config-dir>/repos/<owner>/<repo>.git`
 using a worktree. Branches default to
 `symphony/<project-slug>/<sanitized-issue-id>`, so multiple projects may use
-one repository without branch collisions. Project `.env` values are resolved
-after the host environment only for project hooks and workers; keep it mode
-`0600` and do not commit it.
+one repository without branch collisions. The project `.env` is loaded first
+for project hooks and workers, then host process values override it; keep it
+mode `0600` and do not commit it.
 
 ## Environment Loading Order
 
@@ -30,10 +30,10 @@ precedence:
 | 2        | Orchestrator process environment | CLI, orchestrator, worker, runtime adapters       |
 | 3        | Symphony-injected context        | Worker identity, issue metadata, runtime settings |
 
-The project `.env` file lives at
-`~/.gh-symphony/projects/<project-id>/.env`, or
-`<config-dir>/projects/<project-id>/.env` when `--config <dir>` or
-`GH_SYMPHONY_CONFIG_DIR` selects another config directory.
+For standalone projects, the project `.env` lives in the registered external
+project folder. For registry-backed or repo-embedded projects it lives at
+`<config-dir>/projects/<project-id>/.env` (or the default config directory
+when no `--config <dir>`/`GH_SYMPHONY_CONFIG_DIR` override is set).
 
 ## Auth And API Endpoints
 

--- a/docs/designs/2026-08-11-standalone-project-model-design.md
+++ b/docs/designs/2026-08-11-standalone-project-model-design.md
@@ -1,7 +1,7 @@
 # Spec: Standalone 프로젝트 모델 — 리포 비종속 실행 단위와 수퍼바이저 토폴로지
 
 - **Date**: 2026-08-11
-- **Status**: Draft
+- **Status**: Shipped
 - **Symphony Layers**: Policy (WORKFLOW.md 외부화), Configuration (프로젝트 매니페스트·MCP·스킬 레이어), Coordination (수퍼바이저 토폴로지, 등록 검증), Execution (worktree populate, 스킬/MCP 주입), Observability (상태 집계, 그림자 경고)
 - **Related ADRs**:
   - `docs/adr/2026-05-04_single-repo-orchestrator.md` — "1 repo = 1 instance" 채택. 본 설계는 이를 **"1 project = 1 instance"로 정밀화**한다(리포 1 : 프로젝트 N 허용). 확정 시 후속 ADR로 관계를 명시할 것.

--- a/e2e/run-standalone-project-e2e.sh
+++ b/e2e/run-standalone-project-e2e.sh
@@ -17,6 +17,13 @@ ALPHA_FIXTURE=/tmp/standalone-alpha-issues.json
 BETA_FIXTURE=/tmp/standalone-beta-issues.json
 
 mkdir -p "$PROJECT_ROOT/project-alpha/.agent/skills/alpha" "$PROJECT_ROOT/project-beta/.agent/skills/beta"
+mkdir -p /tmp/standalone-bin
+cat > /tmp/standalone-bin/codex <<'EOF'
+#!/usr/bin/env sh
+exec node /app/e2e/stub-worker.js
+EOF
+chmod +x /tmp/standalone-bin/codex
+export PATH="/tmp/standalone-bin:$PATH"
 
 write_project() {
   project_dir=$1
@@ -37,7 +44,7 @@ agent:
   max_concurrent_agents: 1
   max_turns: 1
 codex:
-  command: node /app/e2e/stub-worker.js
+  command: codex
 repository:
   slug: test-owner/test-repo
 workspace:
@@ -77,7 +84,10 @@ for project_id in "$alpha_id" "$beta_id"; do
     if grep -q "\"dispatched\": 1" "/tmp/$project_id.json"; then break; fi
     sleep 1
   done
-  grep -q "\"dispatched\": 1" "/tmp/$project_id.json"
+  if ! grep -q "\"dispatched\": 1" "/tmp/$project_id.json"; then
+    cat "/tmp/$project_id.json" >&2
+    exit 1
+  fi
 done
 
 sleep 8
@@ -90,16 +100,20 @@ for project in project-alpha project-beta; do
   if [ "$label" = beta ]; then issue=102; fi
   project_id="$alpha_id"
   if [ "$label" = beta ]; then project_id="$beta_id"; fi
-  repo="$CONFIG_DIR/projects/$project_id/test-owner_test-repo_$issue/repository"
-  test -d "$repo/.git"
+  repo=$(find "$CONFIG_DIR/projects/$project_id" -path "*/repository" -type d | head -1)
+  # A linked worktree records its gitdir in a .git file; a normal checkout
+  # uses a directory. Either shape proves the populated workspace is a repo.
+  test -e "$repo/.git"
   test -f "$repo/.codex/skills/$label/SKILL.md"
-  test -f "$repo/.runtime/mcp.json"
+  test -f "$PROJECT_ROOT/$project/.mcp.json"
   test -z "$(git -C "$repo" status --porcelain)"
   branch=$(git -C "$repo" branch --show-current)
   case "$branch" in symphony/$project/*) ;; *) echo "unexpected branch: $branch" >&2; exit 1;; esac
 done
-alpha_branch=$(git -C "$CONFIG_DIR/projects/$alpha_id/test-owner_test-repo_101/repository" branch --show-current)
-beta_branch=$(git -C "$CONFIG_DIR/projects/$beta_id/test-owner_test-repo_102/repository" branch --show-current)
+alpha_repo=$(find "$CONFIG_DIR/projects/$alpha_id" -path "*/repository" -type d | head -1)
+beta_repo=$(find "$CONFIG_DIR/projects/$beta_id" -path "*/repository" -type d | head -1)
+alpha_branch=$(git -C "$alpha_repo" branch --show-current)
+beta_branch=$(git -C "$beta_repo" branch --show-current)
 test "$alpha_branch" != "$beta_branch"
 find "$CONFIG_DIR/projects" -path "*/runs/*/worker.log" -type f | grep -q .
 for pid in $run_pids; do kill "$pid" 2>/dev/null || true; done

--- a/e2e/run-standalone-project-e2e.sh
+++ b/e2e/run-standalone-project-e2e.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# This bypasses the repo-embedded entrypoint and dispatches two registered
+# standalone projects once against the same local seed repository.
+COMPOSE="docker compose -f docker-compose.e2e.yml"
+
+${COMPOSE} build symphony-e2e >/dev/null
+${COMPOSE} run --rm --no-deps --entrypoint bash symphony-e2e -lc '
+set -euo pipefail
+
+export HOME=/tmp/standalone-home
+CONFIG_DIR=/tmp/standalone-config
+PROJECT_ROOT=/tmp/standalone-projects
+FIXTURE=/tmp/standalone-issues.json
+ALPHA_FIXTURE=/tmp/standalone-alpha-issues.json
+BETA_FIXTURE=/tmp/standalone-beta-issues.json
+
+mkdir -p "$PROJECT_ROOT/project-alpha/.agent/skills/alpha" "$PROJECT_ROOT/project-beta/.agent/skills/beta"
+
+write_project() {
+  project_dir=$1
+  label=$2
+  cat > "$project_dir/WORKFLOW.md" <<EOF
+---
+tracker:
+  kind: file
+  project_id: standalone-e2e
+  active_states:
+    - Ready
+  pickup_labels:
+    include:
+      - $label
+    exclude:
+      - $(test "$label" = alpha && printf beta || printf alpha)
+agent:
+  max_concurrent_agents: 1
+  max_turns: 1
+codex:
+  command: node /app/e2e/stub-worker.js
+repository:
+  slug: test-owner/test-repo
+workspace:
+  root: .runtime/workspaces
+---
+Standalone E2E project.
+EOF
+  printf "{\"mcpServers\":{\"%s\":{\"command\":\"node\",\"args\":[\"-e\",\"process.exit(0)\"]}}}\n" "$label" > "$project_dir/.mcp.json"
+  printf "STUB_SCENARIO=happy\n" > "$project_dir/.env"
+  printf "%s\n" "---" "name: $label" "---" "$label skill" > "$project_dir/.agent/skills/$label/SKILL.md"
+}
+
+write_project "$PROJECT_ROOT/project-alpha" alpha
+write_project "$PROJECT_ROOT/project-beta" beta
+
+cat > "$FIXTURE" <<EOF
+[
+  {"id":"standalone-alpha","identifier":"test-owner/test-repo#101","number":101,"title":"alpha","description":null,"priority":null,"state":"Ready","branchName":null,"url":null,"labels":["alpha"],"blockedBy":[],"createdAt":null,"updatedAt":null,"repository":{"owner":"test-owner","name":"test-repo","cloneUrl":"/e2e/repos/test-owner/test-repo"},"tracker":{"adapter":"file","bindingId":"standalone-e2e","itemId":"standalone-alpha"},"metadata":{}},
+  {"id":"standalone-beta","identifier":"test-owner/test-repo#102","number":102,"title":"beta","description":null,"priority":null,"state":"Ready","branchName":null,"url":null,"labels":["beta"],"blockedBy":[],"createdAt":null,"updatedAt":null,"repository":{"owner":"test-owner","name":"test-repo","cloneUrl":"/e2e/repos/test-owner/test-repo"},"tracker":{"adapter":"file","bindingId":"standalone-e2e","itemId":"standalone-beta"},"metadata":{}}
+]
+EOF
+node -e "const fs=require(\"fs\"); const issues=require(\"$FIXTURE\"); fs.writeFileSync(\"$ALPHA_FIXTURE\", JSON.stringify([issues[0]])); fs.writeFileSync(\"$BETA_FIXTURE\", JSON.stringify([issues[1]]))"
+
+for project in project-alpha project-beta; do
+  node /app/packages/cli/dist/index.js --config "$CONFIG_DIR" project add "$PROJECT_ROOT/$project"
+done
+alpha_id=$(node -e "console.log(require(\"$CONFIG_DIR/config.json\").projects[0])")
+beta_id=$(node -e "console.log(require(\"$CONFIG_DIR/config.json\").projects[1])")
+for project_id in "$alpha_id" "$beta_id"; do
+  fixture="$ALPHA_FIXTURE"
+  if [ "$project_id" = "$beta_id" ]; then fixture="$BETA_FIXTURE"; fi
+  node -e "const fs=require(\"fs\"); const path=\"$CONFIG_DIR/projects/$project_id/project.json\"; const config=require(path); config.repository.cloneUrl=\"/e2e/repos/test-owner/test-repo\"; config.tracker.settings.issuesPath=\"$fixture\"; fs.writeFileSync(path, JSON.stringify(config, null, 2)+\"\\n\")"
+  GH_SYMPHONY_CONFIG_DIR="$CONFIG_DIR" node /app/packages/orchestrator/dist/index.js run-once --runtime-root "$CONFIG_DIR" --project-id "$project_id" > "/tmp/$project_id.json" 2>&1 &
+  for _ in $(seq 1 20); do
+    if grep -q "\"dispatched\": 1" "/tmp/$project_id.json"; then break; fi
+    sleep 1
+  done
+  grep -q "\"dispatched\": 1" "/tmp/$project_id.json"
+done
+
+sleep 8
+bare=$(find /tmp -path "*/repos/test-owner/test-repo.git" -type d | head -1)
+test -d "$bare"
+test "$(git -C "$bare" rev-parse --is-bare-repository)" = true
+for project in project-alpha project-beta; do
+  label=${project#project-}
+  issue=101
+  if [ "$label" = beta ]; then issue=102; fi
+  project_id="$alpha_id"
+  if [ "$label" = beta ]; then project_id="$beta_id"; fi
+  repo="$CONFIG_DIR/projects/$project_id/test-owner_test-repo_$issue/repository"
+  test -d "$repo/.git"
+  test -f "$repo/.codex/skills/$label/SKILL.md"
+  test -f "$repo/.runtime/mcp.json"
+  test -z "$(git -C "$repo" status --porcelain)"
+  branch=$(git -C "$repo" branch --show-current)
+  case "$branch" in symphony/$project/*) ;; *) echo "unexpected branch: $branch" >&2; exit 1;; esac
+done
+alpha_branch=$(git -C "$CONFIG_DIR/projects/$alpha_id/test-owner_test-repo_101/repository" branch --show-current)
+beta_branch=$(git -C "$CONFIG_DIR/projects/$beta_id/test-owner_test-repo_102/repository" branch --show-current)
+test "$alpha_branch" != "$beta_branch"
+find "$CONFIG_DIR/projects" -path "*/runs/*/worker.log" -type f | grep -q .
+echo "standalone-project Docker E2E passed"
+'

--- a/e2e/run-standalone-project-e2e.sh
+++ b/e2e/run-standalone-project-e2e.sh
@@ -110,8 +110,10 @@ for project in project-alpha project-beta; do
   branch=$(git -C "$repo" branch --show-current)
   expected="symphony/$project/test-owner-test-repo-$issue"
   test "$branch" = "$expected"
-  find "$CONFIG_DIR/projects/$project_id" -path "*/runs/*/worker.log" -type f -exec grep -q "\\[stub-worker\\] mcp_servers=$label" {} +
-  find "$CONFIG_DIR/projects/$project_id" -path "*/runs/*/worker.log" -type f -exec grep -q "\\[stub-worker\\] status=completed" {} +
+  logs=$(find "$CONFIG_DIR/projects/$project_id" -path "*/runs/*/worker.log" -type f -print)
+  test -n "$logs"
+  grep -q "\\[stub-worker\\] mcp_servers=$label" $logs
+  grep -q "\\[stub-worker\\] status=completed" $logs
 done
 alpha_repo=$(find "$CONFIG_DIR/projects/$alpha_id" -path "*/repository" -type d | head -1)
 beta_repo=$(find "$CONFIG_DIR/projects/$beta_id" -path "*/repository" -type d | head -1)

--- a/e2e/run-standalone-project-e2e.sh
+++ b/e2e/run-standalone-project-e2e.sh
@@ -13,18 +13,9 @@ export HOME=/tmp/standalone-home
 CONFIG_DIR=/tmp/standalone-config
 PROJECT_ROOT=/tmp/standalone-projects
 FIXTURE=/tmp/standalone-issues.json
-ALPHA_FIXTURE=/tmp/standalone-alpha-issues.json
-BETA_FIXTURE=/tmp/standalone-beta-issues.json
 
+mkdir -p "$HOME"
 mkdir -p "$PROJECT_ROOT/project-alpha/.agent/skills/alpha" "$PROJECT_ROOT/project-beta/.agent/skills/beta"
-mkdir -p /tmp/standalone-bin
-cat > /tmp/standalone-bin/codex <<'EOF'
-#!/usr/bin/env sh
-exec node /app/e2e/stub-worker.js
-EOF
-chmod +x /tmp/standalone-bin/codex
-export PATH="/tmp/standalone-bin:$PATH"
-
 write_project() {
   project_dir=$1
   label=$2
@@ -54,6 +45,7 @@ Standalone E2E project.
 EOF
   printf "{\"mcpServers\":{\"%s\":{\"command\":\"node\",\"args\":[\"-e\",\"process.exit(0)\"]}}}\n" "$label" > "$project_dir/.mcp.json"
   printf "STUB_SCENARIO=happy\n" > "$project_dir/.env"
+  chmod 600 "$project_dir/.env"
   printf "%s\n" "---" "name: $label" "---" "$label skill" > "$project_dir/.agent/skills/$label/SKILL.md"
 }
 
@@ -66,7 +58,6 @@ cat > "$FIXTURE" <<EOF
   {"id":"standalone-beta","identifier":"test-owner/test-repo#102","number":102,"title":"beta","description":null,"priority":null,"state":"Ready","branchName":null,"url":null,"labels":["beta"],"blockedBy":[],"createdAt":null,"updatedAt":null,"repository":{"owner":"test-owner","name":"test-repo","cloneUrl":"/e2e/repos/test-owner/test-repo"},"tracker":{"adapter":"file","bindingId":"standalone-e2e","itemId":"standalone-beta"},"metadata":{}}
 ]
 EOF
-node -e "const fs=require(\"fs\"); const issues=require(\"$FIXTURE\"); fs.writeFileSync(\"$ALPHA_FIXTURE\", JSON.stringify([issues[0]])); fs.writeFileSync(\"$BETA_FIXTURE\", JSON.stringify([issues[1]]))"
 
 for project in project-alpha project-beta; do
   node /app/packages/cli/dist/index.js --config "$CONFIG_DIR" project add "$PROJECT_ROOT/$project"
@@ -75,9 +66,7 @@ alpha_id=$(node -e "console.log(require(\"$CONFIG_DIR/config.json\").projects[0]
 beta_id=$(node -e "console.log(require(\"$CONFIG_DIR/config.json\").projects[1])")
 run_pids=""
 for project_id in "$alpha_id" "$beta_id"; do
-  fixture="$ALPHA_FIXTURE"
-  if [ "$project_id" = "$beta_id" ]; then fixture="$BETA_FIXTURE"; fi
-  node -e "const fs=require(\"fs\"); const path=\"$CONFIG_DIR/projects/$project_id/project.json\"; const config=require(path); config.repository.cloneUrl=\"/e2e/repos/test-owner/test-repo\"; config.tracker.settings.issuesPath=\"$fixture\"; fs.writeFileSync(path, JSON.stringify(config, null, 2)+\"\\n\")"
+  node -e "const fs=require(\"fs\"); const path=\"$CONFIG_DIR/projects/$project_id/project.json\"; const config=require(path); config.repository.cloneUrl=\"/e2e/repos/test-owner/test-repo\"; config.tracker.settings.issuesPath=\"$FIXTURE\"; fs.writeFileSync(path, JSON.stringify(config, null, 2)+\"\\n\")"
   GH_SYMPHONY_CONFIG_DIR="$CONFIG_DIR" node /app/packages/orchestrator/dist/index.js run-once --runtime-root "$CONFIG_DIR" --project-id "$project_id" > "/tmp/$project_id.json" 2>&1 &
   run_pids="$run_pids $!"
   for _ in $(seq 1 20); do
@@ -90,10 +79,22 @@ for project_id in "$alpha_id" "$beta_id"; do
   fi
 done
 
-sleep 8
-bare=$(find /tmp -path "*/repos/test-owner/test-repo.git" -type d | head -1)
+for _ in $(seq 1 30); do
+  completed_logs=$(find "$CONFIG_DIR/projects" -path "*/runs/*/worker.log" -type f -exec grep -l "\\[stub-worker\\] status=completed" {} + 2>/dev/null | wc -l | tr -d " " || true)
+  test "$completed_logs" = 2 && break
+  sleep 1
+done
+if [ "${completed_logs:-0}" != 2 ]; then
+  for log in $(find "$CONFIG_DIR/projects" -path "*/runs/*/worker.log" -type f); do
+    echo "--- $log" >&2
+    cat "$log" >&2
+  done
+  exit 1
+fi
+bare="$CONFIG_DIR/repos/test-owner/test-repo.git"
 test -d "$bare"
 test "$(git -C "$bare" rev-parse --is-bare-repository)" = true
+test "$(find "$CONFIG_DIR" "$HOME" "$PROJECT_ROOT" -path "*/repos/test-owner/test-repo.git" -type d | wc -l | tr -d " ")" = 1
 for project in project-alpha project-beta; do
   label=${project#project-}
   issue=101
@@ -105,17 +106,18 @@ for project in project-alpha project-beta; do
   # uses a directory. Either shape proves the populated workspace is a repo.
   test -e "$repo/.git"
   test -f "$repo/.codex/skills/$label/SKILL.md"
-  test -f "$PROJECT_ROOT/$project/.mcp.json"
   test -z "$(git -C "$repo" status --porcelain)"
   branch=$(git -C "$repo" branch --show-current)
-  case "$branch" in symphony/$project/*) ;; *) echo "unexpected branch: $branch" >&2; exit 1;; esac
+  expected="symphony/$project/test-owner-test-repo-$issue"
+  test "$branch" = "$expected"
+  find "$CONFIG_DIR/projects/$project_id" -path "*/runs/*/worker.log" -type f -exec grep -q "\\[stub-worker\\] mcp_servers=$label" {} +
+  find "$CONFIG_DIR/projects/$project_id" -path "*/runs/*/worker.log" -type f -exec grep -q "\\[stub-worker\\] status=completed" {} +
 done
 alpha_repo=$(find "$CONFIG_DIR/projects/$alpha_id" -path "*/repository" -type d | head -1)
 beta_repo=$(find "$CONFIG_DIR/projects/$beta_id" -path "*/repository" -type d | head -1)
 alpha_branch=$(git -C "$alpha_repo" branch --show-current)
 beta_branch=$(git -C "$beta_repo" branch --show-current)
 test "$alpha_branch" != "$beta_branch"
-find "$CONFIG_DIR/projects" -path "*/runs/*/worker.log" -type f | grep -q .
 for pid in $run_pids; do kill "$pid" 2>/dev/null || true; done
 echo "standalone-project Docker E2E passed"
 '

--- a/e2e/run-standalone-project-e2e.sh
+++ b/e2e/run-standalone-project-e2e.sh
@@ -66,11 +66,13 @@ for project in project-alpha project-beta; do
 done
 alpha_id=$(node -e "console.log(require(\"$CONFIG_DIR/config.json\").projects[0])")
 beta_id=$(node -e "console.log(require(\"$CONFIG_DIR/config.json\").projects[1])")
+run_pids=""
 for project_id in "$alpha_id" "$beta_id"; do
   fixture="$ALPHA_FIXTURE"
   if [ "$project_id" = "$beta_id" ]; then fixture="$BETA_FIXTURE"; fi
   node -e "const fs=require(\"fs\"); const path=\"$CONFIG_DIR/projects/$project_id/project.json\"; const config=require(path); config.repository.cloneUrl=\"/e2e/repos/test-owner/test-repo\"; config.tracker.settings.issuesPath=\"$fixture\"; fs.writeFileSync(path, JSON.stringify(config, null, 2)+\"\\n\")"
   GH_SYMPHONY_CONFIG_DIR="$CONFIG_DIR" node /app/packages/orchestrator/dist/index.js run-once --runtime-root "$CONFIG_DIR" --project-id "$project_id" > "/tmp/$project_id.json" 2>&1 &
+  run_pids="$run_pids $!"
   for _ in $(seq 1 20); do
     if grep -q "\"dispatched\": 1" "/tmp/$project_id.json"; then break; fi
     sleep 1
@@ -100,5 +102,6 @@ alpha_branch=$(git -C "$CONFIG_DIR/projects/$alpha_id/test-owner_test-repo_101/r
 beta_branch=$(git -C "$CONFIG_DIR/projects/$beta_id/test-owner_test-repo_102/repository" branch --show-current)
 test "$alpha_branch" != "$beta_branch"
 find "$CONFIG_DIR/projects" -path "*/runs/*/worker.log" -type f | grep -q .
+for pid in $run_pids; do kill "$pid" 2>/dev/null || true; done
 echo "standalone-project Docker E2E passed"
 '

--- a/e2e/scenarios/13-standalone-project-model.md
+++ b/e2e/scenarios/13-standalone-project-model.md
@@ -15,10 +15,12 @@ local seed repository를 참조하는 `project-alpha`, `project-beta`를 만든�
 
 ## Expected
 
-- 두 프로젝트가 같은 `~/.gh-symphony/repos/test-owner/test-repo.git` bare cache를 공유한다.
-- 각각은 자기 label 이슈만 dispatch하고 `symphony/project-alpha/*`,
-  `symphony/project-beta/*`의 서로 다른 브랜치에서 실행한다.
-- project skill/MCP 주입 뒤 `git status --porcelain`은 비어 있으며 worker log가 생성된다.
+- 두 프로젝트가 같은 `<config-dir>/repos/test-owner/test-repo.git` bare cache 하나를 공유한다.
+- 같은 통합 fixture에서 각각은 자기 label 이슈만 dispatch하고
+  `symphony/project-alpha/test-owner-test-repo-101`,
+  `symphony/project-beta/test-owner-test-repo-102`의 서로 다른 브랜치에서 실행한다.
+- project skill 주입 뒤 `git status --porcelain`은 비어 있고, worker가 project MCP server를
+  compose한 뒤 두 worker 모두 `status=completed`를 기록한다.
 
 ## Cleanup
 

--- a/e2e/scenarios/13-standalone-project-model.md
+++ b/e2e/scenarios/13-standalone-project-model.md
@@ -1,0 +1,25 @@
+# TC-13: standalone 프로젝트 모델 Docker E2E
+
+## Setup
+
+`pnpm e2e:standalone-project`는 entrypoint를 우회한 일회성 컨테이너에서 같은
+local seed repository를 참조하는 `project-alpha`, `project-beta`를 만든다. 각 폴더에
+`WORKFLOW.md`, `.mcp.json`, `.env`, `.agent/skills/<name>/SKILL.md`를 둔다.
+
+## Steps
+
+1. 두 프로젝트를 `gh-symphony project add`로 하나의 registry에 등록한다.
+2. label mapping이 서로소인 두 file-tracker 이슈를 준비한다.
+3. 각 project ID의 orchestrator `run-once`를 실행한다.
+4. bare cache, worktree, branch, MCP/skill 주입, `git status`, worker log를 검사한다.
+
+## Expected
+
+- 두 프로젝트가 같은 `~/.gh-symphony/repos/test-owner/test-repo.git` bare cache를 공유한다.
+- 각각은 자기 label 이슈만 dispatch하고 `symphony/project-alpha/*`,
+  `symphony/project-beta/*`의 서로 다른 브랜치에서 실행한다.
+- project skill/MCP 주입 뒤 `git status --porcelain`은 비어 있으며 worker log가 생성된다.
+
+## Cleanup
+
+일회성 컨테이너 종료와 함께 `/tmp` runtime 및 cache가 제거된다.

--- a/e2e/stub-worker.ts
+++ b/e2e/stub-worker.ts
@@ -9,8 +9,10 @@
  *   transition-race — requests Ready → In review, then stalls for reconciliation
  */
 
+import { existsSync } from "node:fs";
 import { writeFile, mkdir } from "node:fs/promises";
-import { join } from "node:path";
+import { dirname, join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
 
 // ── Environment ──────────────────────────────────────────────────
 
@@ -46,6 +48,25 @@ const SCENARIO_DURATIONS: Record<Scenario, { startMs: number; runMs: number }> =
     slow: { startMs: 2000, runMs: 30000 },
     "transition-race": { startMs: 2000, runMs: Infinity },
   };
+
+function resolveCoreModuleUrl(): string {
+  const workerPath = process.argv[1];
+  if (!workerPath) {
+    throw new Error("stub_worker_path_unavailable");
+  }
+  const workerDir = dirname(resolve(workerPath));
+  for (const root of [
+    workerDir,
+    resolve(workerDir, ".."),
+    resolve(workerDir, "../.."),
+  ]) {
+    const corePath = join(root, "packages/core/dist/index.js");
+    if (existsSync(corePath)) {
+      return pathToFileURL(corePath).href;
+    }
+  }
+  throw new Error(`stub_core_module_not_found:${workerPath}`);
+}
 
 const ORCHESTRATOR_URL = process.env.SYMPHONY_ORCHESTRATOR_URL ?? "";
 const ORCHESTRATOR_TOKEN = process.env.SYMPHONY_ORCHESTRATOR_TOKEN ?? "";
@@ -164,11 +185,16 @@ async function run() {
   const durations = SCENARIO_DURATIONS[SCENARIO];
 
   console.error(`[stub-worker] scenario=${SCENARIO} runId=${RUN_ID}`);
-  // The Docker image compiles this standalone worker without workspace module
-  // resolution, so load the already-built core package at runtime.
-  const { composeMcpServers } = (await import(
-    "/app/packages/core/dist/index.js"
-  )) as {
+  // Record the starting event before loading the runtime dependency so a
+  // resolution failure remains observable in both local and Docker E2E runs.
+  status = "starting";
+  lastEventAt = new Date().toISOString();
+  console.error(`[stub-worker] status=starting`);
+  emitOrchestratorEvent("starting");
+
+  // Local and Docker builds emit the worker into different directories; find
+  // the built core package relative to the emitted worker rather than /app.
+  const { composeMcpServers } = (await import(resolveCoreModuleUrl())) as {
     composeMcpServers: (options: {
       repositoryDir: string;
       projectDir?: string;
@@ -182,11 +208,6 @@ async function run() {
     `[stub-worker] mcp_servers=${Object.keys(mcpServers).sort().join(",")}`
   );
 
-  // Starting phase
-  status = "starting";
-  lastEventAt = new Date().toISOString();
-  console.error(`[stub-worker] status=starting`);
-  emitOrchestratorEvent("starting");
   await sleep(durations.startMs);
 
   // Running phase

--- a/e2e/stub-worker.ts
+++ b/e2e/stub-worker.ts
@@ -164,6 +164,23 @@ async function run() {
   const durations = SCENARIO_DURATIONS[SCENARIO];
 
   console.error(`[stub-worker] scenario=${SCENARIO} runId=${RUN_ID}`);
+  // The Docker image compiles this standalone worker without workspace module
+  // resolution, so load the already-built core package at runtime.
+  const { composeMcpServers } = (await import(
+    "/app/packages/core/dist/index.js"
+  )) as {
+    composeMcpServers: (options: {
+      repositoryDir: string;
+      projectDir?: string;
+    }) => Record<string, unknown>;
+  };
+  const mcpServers = composeMcpServers({
+    repositoryDir: process.env.WORKING_DIRECTORY ?? process.cwd(),
+    projectDir: process.env.SYMPHONY_PROJECT_DIR,
+  });
+  console.error(
+    `[stub-worker] mcp_servers=${Object.keys(mcpServers).sort().join(",")}`
+  );
 
   // Starting phase
   status = "starting";

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "cli": "node packages/cli/dist/index.js --config .runtime",
     "e2e:init": "bash e2e/seed/init-local.sh",
     "e2e:start": "cd .runtime/e2e/work/test-repo && GH_SYMPHONY_HTTP_TOKEN=\"${GH_SYMPHONY_HTTP_TOKEN:-e2e-http-token}\" GH_SYMPHONY_FILE_TRACKER_ISSUES_PATH=\"$(pwd)/../../../../e2e/fixtures/issues.json\" SYMPHONY_WORKER_COMMAND=\"node $(pwd)/../../../../e2e/dist/stub-worker.js\" node ../../../../packages/cli/dist/index.js repo start --http 4680",
+    "e2e:standalone-project": "bash e2e/run-standalone-project-e2e.sh",
     "e2e:claude": "bash test/e2e/claude/run-docker-e2e.sh",
     "dev:orchestrator": "pnpm --filter @gh-symphony/orchestrator dev",
     "dev:worker": "pnpm --filter @gh-symphony/worker dev",

--- a/packages/cli/src/repo-runtime.ts
+++ b/packages/cli/src/repo-runtime.ts
@@ -102,7 +102,7 @@ export async function initRepoRuntime(flags: RepoInitFlags): Promise<{
     repository: `${repository.owner}/${repository.name}`,
   };
   if (
-    trackerAdapter === "linear" &&
+    (trackerAdapter === "linear" || trackerAdapter === "file") &&
     (workflow.tracker.pickupLabels.include.length > 0 ||
       workflow.tracker.pickupLabels.exclude.length > 0)
   ) {

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -2554,7 +2554,8 @@ export class OrchestratorService {
           PROJECT_ID: tenant.projectId,
           WORKING_DIRECTORY: repositoryDirectory,
           WORKSPACE_RUNTIME_DIR: workspaceRuntimeDir,
-          SYMPHONY_PROJECT_DIR: this.store.projectDir(tenant.projectId),
+          SYMPHONY_PROJECT_DIR:
+            tenant.projectDir ?? this.store.projectDir(tenant.projectId),
           SYMPHONY_TRUST_REPO_CONFIG: String(
             workflow.workflow.runtime?.isolation.trustRepoConfig === true
           ),

--- a/packages/tracker-file/src/file-tracker-adapter.test.ts
+++ b/packages/tracker-file/src/file-tracker-adapter.test.ts
@@ -79,6 +79,26 @@ describe("fileTrackerAdapter", () => {
       expect(issues[0].state).toBe("Ready");
     });
 
+    it("filters issues using configured pickup labels", async () => {
+      const issuesPath = join(testDir, "issues.json");
+      await writeFile(
+        issuesPath,
+        JSON.stringify([
+          { ...sampleIssue, labels: ["alpha"] },
+          { ...sampleIssue, id: "issue-2", labels: ["beta"] },
+        ])
+      );
+      const project = makeProject(issuesPath);
+      project.tracker.settings = {
+        ...project.tracker.settings,
+        pickupLabels: { include: ["alpha"], exclude: ["beta"] },
+      };
+
+      await expect(fileTrackerAdapter.listIssues(project)).resolves.toEqual([
+        expect.objectContaining({ id: "issue-1" }),
+      ]);
+    });
+
     it("returns empty array when file does not exist", async () => {
       const project = makeProject(join(testDir, "nonexistent.json"));
       const issues = await fileTrackerAdapter.listIssues(project);

--- a/packages/tracker-file/src/file-tracker-adapter.test.ts
+++ b/packages/tracker-file/src/file-tracker-adapter.test.ts
@@ -187,6 +187,32 @@ describe("fileTrackerAdapter", () => {
       expect(issues[0]?.id).toBe("issue-2");
       expect(issues[0]?.state).toBe("Done");
     });
+
+    it("does not apply pickup labels to state or recovery lookups", async () => {
+      const issuesPath = join(testDir, "issues.json");
+      await writeFile(
+        issuesPath,
+        JSON.stringify([
+          { ...sampleIssue, id: "alpha", labels: ["alpha"] },
+          { ...sampleIssue, id: "beta", labels: ["beta"] },
+        ])
+      );
+      const project = makeProject(issuesPath);
+      project.tracker.settings = {
+        ...project.tracker.settings,
+        pickupLabels: { include: ["alpha"] },
+      };
+
+      await expect(fileTrackerAdapter.listIssues(project)).resolves.toEqual([
+        expect.objectContaining({ id: "alpha" }),
+      ]);
+      await expect(
+        fileTrackerAdapter.listIssuesByStates(project, ["Ready"])
+      ).resolves.toHaveLength(2);
+      await expect(
+        fileTrackerAdapter.fetchIssueStatesByIds(project, ["alpha", "beta"])
+      ).resolves.toHaveLength(2);
+    });
   });
 
   describe("buildWorkerEnvironment", () => {

--- a/packages/tracker-file/src/file-tracker-adapter.ts
+++ b/packages/tracker-file/src/file-tracker-adapter.ts
@@ -92,6 +92,41 @@ async function writeIssueEntries(
   await writeFile(issuesPath, `${JSON.stringify(entries, null, 2)}\n`);
 }
 
+async function readValidIssues(
+  project: OrchestratorProjectConfig
+): Promise<TrackedIssue[]> {
+  const issuesPath = requireTrackerSetting(project, "issuesPath");
+  try {
+    const entries = await readIssueEntries(issuesPath);
+    const valid: TrackedIssue[] = [];
+    for (let i = 0; i < entries.length; i++) {
+      if (isValidIssueShape(entries[i])) {
+        valid.push(entries[i] as TrackedIssue);
+      } else {
+        process.stderr.write(
+          `[tracker-file] Skipping invalid issue at index ${i} in ${issuesPath}\n`
+        );
+      }
+    }
+    return valid;
+  } catch (err) {
+    if (
+      err instanceof Error &&
+      "code" in err &&
+      (err as NodeJS.ErrnoException).code === "ENOENT"
+    ) {
+      return [];
+    }
+    if (err instanceof SyntaxError) {
+      throw new Error(
+        `[tracker-file] Failed to parse issues JSON at ${issuesPath}: ${err.message}`,
+        { cause: err }
+      );
+    }
+    throw err;
+  }
+}
+
 function buildTrackerStateResult(
   request: TrackerStateRequest,
   result: Pick<TrackerStateResult, "ok" | "outcome" | "state" | "error">
@@ -112,42 +147,7 @@ function buildTrackerStateResult(
 
 export const fileTrackerAdapter: OrchestratorTrackerAdapter = {
   async listIssues(project) {
-    const issuesPath = requireTrackerSetting(project, "issuesPath");
-    try {
-      const raw = await readFile(issuesPath, "utf-8");
-      const parsed: unknown = JSON.parse(raw);
-      if (!Array.isArray(parsed)) {
-        throw new Error(
-          `Expected an array of issues in ${issuesPath}, got ${typeof parsed}`
-        );
-      }
-      const valid: TrackedIssue[] = [];
-      for (let i = 0; i < parsed.length; i++) {
-        if (isValidIssueShape(parsed[i])) {
-          valid.push(parsed[i]);
-        } else {
-          process.stderr.write(
-            `[tracker-file] Skipping invalid issue at index ${i} in ${issuesPath}\n`
-          );
-        }
-      }
-      return filterIssuesByPickupLabels(valid, project);
-    } catch (err) {
-      if (
-        err instanceof Error &&
-        "code" in err &&
-        (err as NodeJS.ErrnoException).code === "ENOENT"
-      ) {
-        return [];
-      }
-      if (err instanceof SyntaxError) {
-        throw new Error(
-          `[tracker-file] Failed to parse issues JSON at ${issuesPath}: ${err.message}`,
-          { cause: err }
-        );
-      }
-      throw err;
-    }
+    return filterIssuesByPickupLabels(await readValidIssues(project), project);
   },
 
   async listIssuesByStates(project, states) {
@@ -155,7 +155,7 @@ export const fileTrackerAdapter: OrchestratorTrackerAdapter = {
       return [];
     }
 
-    const issues = await this.listIssues(project);
+    const issues = await readValidIssues(project);
     const normalizedStates = new Set(
       states.map((state) => state.trim().toLowerCase())
     );
@@ -169,7 +169,7 @@ export const fileTrackerAdapter: OrchestratorTrackerAdapter = {
       return [];
     }
 
-    const issues = await this.listIssues(project);
+    const issues = await readValidIssues(project);
     const ids = new Set(issueIds);
     return issues.filter((issue) => ids.has(issue.id));
   },

--- a/packages/tracker-file/src/file-tracker-adapter.ts
+++ b/packages/tracker-file/src/file-tracker-adapter.ts
@@ -25,6 +25,36 @@ function parseIssueNumber(identifier: string): number {
   return match ? Number.parseInt(match[1] ?? "0", 10) : 0;
 }
 
+function filterIssuesByPickupLabels(
+  issues: TrackedIssue[],
+  project: OrchestratorProjectConfig
+): TrackedIssue[] {
+  const pickupLabels = project.tracker.settings?.pickupLabels;
+  if (
+    !pickupLabels ||
+    typeof pickupLabels !== "object" ||
+    Array.isArray(pickupLabels)
+  ) {
+    return issues;
+  }
+  const config = pickupLabels as Record<string, unknown>;
+  const readLabels = (value: unknown): string[] =>
+    Array.isArray(value)
+      ? value.filter((label): label is string => typeof label === "string")
+      : [];
+  const include = readLabels(config.include);
+  const exclude = new Set(readLabels(config.exclude));
+  if (include.length === 0 && exclude.size === 0) return issues;
+
+  return issues.filter((issue) => {
+    const labels = new Set(issue.labels);
+    return (
+      ![...exclude].some((label) => labels.has(label)) &&
+      (include.length === 0 || include.some((label) => labels.has(label)))
+    );
+  });
+}
+
 function isValidIssueShape(entry: unknown): entry is TrackedIssue {
   if (!entry || typeof entry !== "object") return false;
   const e = entry as Record<string, unknown>;
@@ -101,7 +131,7 @@ export const fileTrackerAdapter: OrchestratorTrackerAdapter = {
           );
         }
       }
-      return valid;
+      return filterIssuesByPickupLabels(valid, project);
     } catch (err) {
       if (
         err instanceof Error &&


### PR DESCRIPTION
## TL;DR

- 두 standalone 프로젝트가 같은 repository를 공유해도 project-scoped branch, worktree, skill, MCP를 격리하는 Docker TC-13을 검증합니다.
- E2E failure propagation, local stub worker resolution, file tracker recovery lookup을 보완했습니다.

## 변경 지점 다이어그램

```text
project-alpha ─┐                         ┌─ symphony/project-alpha/test-owner-test-repo-101
               ├─ shared bare cache ────┤
project-beta ──┘                         └─ symphony/project-beta/test-owner-test-repo-102
       │                                           │
       └─ WORKFLOW.md/.mcp.json/.env/.agent/skills ─┴─ injected worker workspace
```

## 여기부터 보세요

- `e2e/run-standalone-project-e2e.sh`: 등록부터 `run-once`, shared cache, worktree, worker 로그까지 blackbox 검증합니다.
- `packages/tracker-file/src/file-tracker-adapter.ts`: pickup filter와 explicit state/recovery lookup을 분리합니다.
- `e2e/stub-worker.ts`: Docker와 local E2E가 모두 core MCP composer를 로드합니다.

## 위험 & 롤백

- TC-13은 Docker 이미지 빌드 시간이 필요합니다.
- 롤백은 이 PR의 E2E·file tracker 보완 커밋을 되돌리면 되며 production migration은 없습니다.

## 변경 파일

- `e2e/run-standalone-project-e2e.sh`, `e2e/stub-worker.ts`, `e2e/scenarios/13-standalone-project-model.md`
- `packages/tracker-file/src/file-tracker-adapter.ts`, `packages/tracker-file/src/file-tracker-adapter.test.ts`
- `docs/configuration.md`, ADR/design 문서, `.changeset/standalone-project-e2e.md`

## Issues

- Closed #570

## Evidence

- `pnpm e2e:init` — pass
- `pnpm e2e:standalone-project` — pass
- `pnpm lint && pnpm test && pnpm typecheck && pnpm build` — pass

## 머지 후/사람 확인

- [ ] Docker 사용 가능 환경에서 `pnpm e2e:standalone-project`를 재실행합니다.
- [ ] 두 standalone 프로젝트의 branch namespace와 MCP injection을 확인합니다.

## Divergence

- upstream Symphony spec의 단일 workflow 인스턴스 모델은 각 project 인스턴스 안에서 유지합니다. 여러 project가 한 repository를 참조하는 topology는 ADR에 명시한 repository-local extension입니다.
