### PR TITLE
fix(tracker-github): map GHES REST API base

### DIFF
--- a/.changeset/ghes-rest-api-v3.md
+++ b/.changeset/ghes-rest-api-v3.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Map GitHub Enterprise Server GraphQL endpoints to the correct REST API base for authenticated-user and issue-comment requests (#497).

--- a/packages/tracker-github/src/adapter.ts
+++ b/packages/tracker-github/src/adapter.ts
@@ -2684,6 +2684,9 @@ function resolveRestApiUrl(apiUrl: string | undefined, path: string): string {
 
   if (pathSegments.at(-1) === "graphql") {
     pathSegments.pop();
+    if (pathSegments.at(-1) === "api") {
+      pathSegments.push("v3");
+    }
   }
 
   parsed.pathname =

--- a/packages/tracker-github/src/tracker-github.test.ts
+++ b/packages/tracker-github/src/tracker-github.test.ts
@@ -4284,6 +4284,10 @@ describe("resolveTrackerAdapter", () => {
       "https://github.example/api/v3/user",
     ],
     [
+      "https://github.example/api/graphql/",
+      "https://github.example/api/v3/user",
+    ],
+    [
       "https://github.example/api/v3/graphql",
       "https://github.example/api/v3/user",
     ],

--- a/packages/tracker-github/src/tracker-github.test.ts
+++ b/packages/tracker-github/src/tracker-github.test.ts
@@ -1267,120 +1267,141 @@ describe("resolveTrackerAdapter", () => {
     expect(mutationBody.variables.subjectId).toBe("issue-1");
   });
 
-  it("creates an advisory comment through REST and persists its ETag", async () => {
-    const adapter = resolveTrackerAdapter({
-      adapter: "github-project",
-      bindingId: "project-123",
-      settings: { projectId: "project-123" },
-    });
-    const marker = "<!-- gh-symphony:advisory -->";
-    const body = `${marker}\ncreated body`;
-    const cache: IssueCommentCache = {
-      get: vi.fn(async () => null),
-      set: vi.fn(async () => undefined),
-      delete: vi.fn(async () => undefined),
-    };
-    const fetchImpl = vi
-      .fn()
-      .mockResolvedValueOnce(
-        new Response(
-          JSON.stringify({
-            data: {
-              node: {
-                __typename: "Issue",
-                comments: {
-                  nodes: [],
-                  pageInfo: { endCursor: null, hasNextPage: false },
+  it.each([
+    ["https://api.github.com/graphql", "https://api.github.com"],
+    ["https://github.example/api/graphql", "https://github.example/api/v3"],
+    ["https://github.example/api/v3/graphql", "https://github.example/api/v3"],
+  ])(
+    "creates an advisory comment through REST from %s and persists its ETag",
+    async (apiUrl, restApiUrl) => {
+      const adapter = resolveTrackerAdapter({
+        adapter: "github-project",
+        bindingId: "project-123",
+        settings: { projectId: "project-123" },
+      });
+      const marker = "<!-- gh-symphony:advisory -->";
+      const body = `${marker}\ncreated body`;
+      const cache: IssueCommentCache = {
+        get: vi.fn(async () => null),
+        set: vi.fn(async () => undefined),
+        delete: vi.fn(async () => undefined),
+      };
+      const fetchImpl = vi
+        .fn()
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              data: {
+                node: {
+                  __typename: "Issue",
+                  comments: {
+                    nodes: [],
+                    pageInfo: { endCursor: null, hasNextPage: false },
+                  },
                 },
               },
-            },
-          })
+            })
+          )
         )
-      )
-      .mockResolvedValueOnce(
-        new Response(JSON.stringify({ id: 42, body }), {
-          status: 201,
-          headers: { etag: '"comment-v1"' },
-        })
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify({ id: 42, body }), {
+            status: 201,
+            headers: { etag: '"comment-v1"' },
+          })
+        );
+
+      await expect(
+        adapter.upsertIssueComment?.(
+          makeProjectConfig({ apiUrl }),
+          makeTrackedIssue(),
+          { marker, body },
+          { token: "test-token", fetchImpl, issueCommentCache: cache }
+        )
+      ).resolves.toMatchObject({ outcome: "created", rateLimits: null });
+
+      expect(String(fetchImpl.mock.calls[0]?.[0])).toBe(apiUrl);
+      expect(String(fetchImpl.mock.calls[1]?.[0])).toBe(
+        `${restApiUrl}/repos/acme/platform/issues/1/comments`
       );
-
-    await expect(
-      adapter.upsertIssueComment?.(
-        makeProjectConfig(),
-        makeTrackedIssue(),
-        { marker, body },
-        { token: "test-token", fetchImpl, issueCommentCache: cache }
-      )
-    ).resolves.toMatchObject({ outcome: "created", rateLimits: null });
-
-    expect(String(fetchImpl.mock.calls[1]?.[0])).toBe(
-      "https://api.github.com/repos/acme/platform/issues/1/comments"
-    );
-    expect(fetchImpl.mock.calls[1]?.[1]).toMatchObject({
-      method: "POST",
-      body: JSON.stringify({ body }),
-    });
-    expect(cache.set).toHaveBeenCalledTimes(1);
-    expect(cache.set).toHaveBeenCalledWith(expect.any(String), {
-      commentId: 42,
-      etag: '"comment-v1"',
-      body,
-    });
-  });
-
-  it("updates a cached advisory comment through REST with one cache write", async () => {
-    const adapter = resolveTrackerAdapter({
-      adapter: "github-project",
-      bindingId: "project-123",
-      settings: { projectId: "project-123" },
-    });
-    const marker = "<!-- gh-symphony:advisory -->";
-    const body = `${marker}\nupdated body`;
-    const cache: IssueCommentCache = {
-      get: vi.fn(async () => ({
+      expect(fetchImpl.mock.calls[1]?.[1]).toMatchObject({
+        method: "POST",
+        body: JSON.stringify({ body }),
+      });
+      expect(cache.set).toHaveBeenCalledTimes(1);
+      expect(cache.set).toHaveBeenCalledWith(expect.any(String), {
         commentId: 42,
         etag: '"comment-v1"',
-        body: `${marker}\nold body`,
-      })),
-      set: vi.fn(async () => undefined),
-      delete: vi.fn(async () => undefined),
-    };
-    const fetchImpl = vi
-      .fn()
-      .mockResolvedValueOnce(
-        new Response(JSON.stringify({ id: 42, body: `${marker}\nold body` }), {
-          headers: { etag: '"comment-v1"' },
-        })
-      )
-      .mockResolvedValueOnce(
-        new Response(JSON.stringify({ id: 42, body }), {
-          headers: { etag: '"comment-v2"' },
-        })
+        body,
+      });
+    }
+  );
+
+  it.each([
+    ["https://api.github.com/graphql", "https://api.github.com"],
+    ["https://github.example/api/graphql", "https://github.example/api/v3"],
+    ["https://github.example/api/v3/graphql", "https://github.example/api/v3"],
+  ])(
+    "updates a cached advisory comment through REST from %s with one cache write",
+    async (apiUrl, restApiUrl) => {
+      const adapter = resolveTrackerAdapter({
+        adapter: "github-project",
+        bindingId: "project-123",
+        settings: { projectId: "project-123" },
+      });
+      const marker = "<!-- gh-symphony:advisory -->";
+      const body = `${marker}\nupdated body`;
+      const cache: IssueCommentCache = {
+        get: vi.fn(async () => ({
+          commentId: 42,
+          etag: '"comment-v1"',
+          body: `${marker}\nold body`,
+        })),
+        set: vi.fn(async () => undefined),
+        delete: vi.fn(async () => undefined),
+      };
+      const fetchImpl = vi
+        .fn()
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({ id: 42, body: `${marker}\nold body` }),
+            {
+              headers: { etag: '"comment-v1"' },
+            }
+          )
+        )
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify({ id: 42, body }), {
+            headers: { etag: '"comment-v2"' },
+          })
+        );
+
+      await expect(
+        adapter.upsertIssueComment?.(
+          makeProjectConfig({ apiUrl }),
+          makeTrackedIssue(),
+          { marker, body },
+          { token: "test-token", fetchImpl, issueCommentCache: cache }
+        )
+      ).resolves.toMatchObject({ outcome: "updated", rateLimits: null });
+
+      expect(String(fetchImpl.mock.calls[0]?.[0])).toBe(
+        `${restApiUrl}/repos/acme/platform/issues/comments/42`
       );
-
-    await expect(
-      adapter.upsertIssueComment?.(
-        makeProjectConfig(),
-        makeTrackedIssue(),
-        { marker, body },
-        { token: "test-token", fetchImpl, issueCommentCache: cache }
-      )
-    ).resolves.toMatchObject({ outcome: "updated", rateLimits: null });
-
-    expect(String(fetchImpl.mock.calls[1]?.[0])).toBe(
-      "https://api.github.com/repos/acme/platform/issues/comments/42"
-    );
-    expect(fetchImpl.mock.calls[1]?.[1]).toMatchObject({
-      method: "PATCH",
-      body: JSON.stringify({ body }),
-    });
-    expect(cache.set).toHaveBeenCalledTimes(1);
-    expect(cache.set).toHaveBeenCalledWith(expect.any(String), {
-      commentId: 42,
-      etag: '"comment-v2"',
-      body,
-    });
-  });
+      expect(String(fetchImpl.mock.calls[1]?.[0])).toBe(
+        `${restApiUrl}/repos/acme/platform/issues/comments/42`
+      );
+      expect(fetchImpl.mock.calls[1]?.[1]).toMatchObject({
+        method: "PATCH",
+        body: JSON.stringify({ body }),
+      });
+      expect(cache.set).toHaveBeenCalledTimes(1);
+      expect(cache.set).toHaveBeenCalledWith(expect.any(String), {
+        commentId: 42,
+        etag: '"comment-v2"',
+        body,
+      });
+    }
+  );
 
   it("does not update advisory comments when the existing body is unchanged", async () => {
     const adapter = resolveTrackerAdapter({
@@ -4256,11 +4277,21 @@ describe("resolveTrackerAdapter", () => {
     expect(issues[0]?.priority).toBe(1);
   });
 
-  it("resolves the REST user endpoint from a graphql URL with a trailing slash", async () => {
+  it.each([
+    ["https://api.github.com/graphql/", "https://api.github.com/user"],
+    [
+      "https://github.example/api/graphql",
+      "https://github.example/api/v3/user",
+    ],
+    [
+      "https://github.example/api/v3/graphql",
+      "https://github.example/api/v3/user",
+    ],
+  ])("resolves the REST user endpoint from %s", async (apiUrl, expectedUrl) => {
     const adapter = resolveTrackerAdapter({
       adapter: "github-project",
       bindingId: "project-123",
-      apiUrl: "https://api.github.com/graphql/",
+      apiUrl,
       settings: {
         projectId: "project-123",
         assignedOnly: true,
@@ -4268,30 +4299,15 @@ describe("resolveTrackerAdapter", () => {
     });
 
     await adapter.listIssues(
-      {
-        projectId: "workspace-1",
-        slug: "workspace-1",
-        workspaceDir: "/tmp/workspace-1",
-        repository: {
-          owner: "acme",
-          name: "platform",
-          cloneUrl: "https://github.com/acme/platform.git",
-        },
-        tracker: {
-          adapter: "github-project",
-          bindingId: "project-123",
-          apiUrl: "https://api.github.com/graphql/",
-          settings: {
-            projectId: "project-123",
-            assignedOnly: true,
-          },
-        },
-      },
+      makeProjectConfig({
+        apiUrl,
+        trackerSettings: { assignedOnly: true },
+      }),
       {
         token: "dependencies-token",
         fetchImpl: async (url, init) => {
           if (init?.method === "GET") {
-            expect(String(url)).toBe("https://api.github.com/user");
+            expect(String(url)).toBe(expectedUrl);
             return new Response(JSON.stringify({ login: "machine-user" }), {
               status: 200,
               headers: { "content-type": "application/json" },
@@ -5706,6 +5722,7 @@ function makePullRequestStateLookupNode(input: {
 
 function makeProjectConfig(
   input: {
+    apiUrl?: string;
     repository?: {
       owner: string;
       name: string;
@@ -5727,6 +5744,7 @@ function makeProjectConfig(
     tracker: {
       adapter: "github-project" as const,
       bindingId: "project-123",
+      ...(input.apiUrl ? { apiUrl: input.apiUrl } : {}),
       settings: {
         projectId: "project-123",
         ...input.trackerSettings,


### PR DESCRIPTION
## TL;DR

Map GHES GraphQL endpoints to the correct REST API base while preserving GitHub.com and `/api/v3/graphql` behavior.

## Issues — Closed #497

Fixes #497

## Change-Point Diagram

```text
GraphQL endpoint
      │
      ▼
resolveRestApiUrl ──► REST base URL ──► `/user`, issue-comment GET/POST/PATCH requests
```

## Start Here

- REST URL resolution and focused request-path tests are implemented in the GitHub tracker integration package.
- The key regression cases are GHES `/api/graphql`, GHES `/api/v3/graphql`, and github.com endpoints.
- The release metadata is recorded in `.changeset/ghes-rest-api-v3.md` for `@gh-symphony/cli`.

## Summary

- Map GHES `/api/graphql` to `/api/v3` for REST requests.
- Preserve existing GitHub.com and `/api/v3/graphql` mappings.
- Cover `/user` and issue-comment GET/POST/PATCH request paths for all supported endpoint forms.
- Preserve GHES `/api/graphql/` trailing-slash handling with an explicit regression case.

## Risks & Rollback

- Risk: changing endpoint normalization could affect non-GHES API requests.
- Rollback: revert the focused URL-resolution change and its tests.

## Changed Files

- `packages/tracker-github/src/adapter.ts` — GHES REST base normalization.
- `packages/tracker-github/src/tracker-github.test.ts` — endpoint and request-path regression coverage.
- `.changeset/ghes-rest-api-v3.md` — patch release metadata for `@gh-symphony/cli`.

## Evidence

- `pnpm --filter @gh-symphony/tracker-github test -- tracker-github.test.ts` — passed (94 tests).
- `pnpm --filter @gh-symphony/tracker-github lint` — passed.
- `pnpm --filter @gh-symphony/tracker-github test` — passed (114 tests).
- `pnpm lint` — passed.
- `pnpm test` — passed repository-wide in cycle 3.
- `pnpm typecheck` — passed.
- `pnpm build` — passed.
- `pnpm exec prettier --check .changeset/ghes-rest-api-v3.md packages/tracker-github/src/adapter.ts packages/tracker-github/src/tracker-github.test.ts` — passed.
- `pnpm changeset status` — passed; the new entry targets `@gh-symphony/cli` with a patch bump.
- `gh pr checks 597 --repo hojinzs/github-symphony --watch --interval 10` — passed (`Test`, `Container Smoke`).
- Docker E2E: standard happy-path compose run passed in cycle 1; no integration code changed in this rework cycle.

## Changeset

- `.changeset/ghes-rest-api-v3.md` — `@gh-symphony/cli` patch release for issue #497.

## Post-Merge / Human Validation

- [ ] Confirm the main user flow works as expected.
- [ ] Confirm there is no obvious regression in adjacent behavior.
- [ ] Confirm REST requests against a GHES `/api/graphql` endpoint resolve under `/api/v3`.
- [ ] Confirm existing GitHub.com behavior remains unchanged.
- [ ] Confirm issue-comment GET/POST/PATCH flows against a representative GHES instance.
