### PR TITLE
refactor(cli): share status liveness banner rendering

### DIFF
--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -19,44 +19,18 @@ import { renderDashboard } from "../dashboard/renderer.js";
 import { formatRepositoryDisplay } from "../format/repository.js";
 import { resolveDaemonLiveness } from "../daemon-liveness.js";
 import { resolveAdaptivePollIntervalMs } from "@gh-symphony/orchestrator";
+import {
+  createStatusLivenessBanner,
+  relativeTime,
+  renderStatusLivenessBanner,
+  type StatusLivenessRuntime,
+} from "../status-liveness-banner.js";
+
+export { relativeTime };
 
 const workflowConfigStore = new WorkflowConfigStore();
 
-function healthIcon(
-  health: "idle" | "running" | "degraded" | "stopped"
-): string {
-  switch (health) {
-    case "idle":
-    case "running":
-      return green("●");
-    case "degraded":
-    case "stopped":
-      return red("●");
-  }
-}
-
-export function relativeTime(
-  isoString: string,
-  nowMs: number = Date.now()
-): string {
-  const now = new Date(nowMs);
-  const then = new Date(isoString);
-  const diffMs = now.getTime() - then.getTime();
-  const diffS = Math.floor(diffMs / 1000);
-  const diffM = Math.floor(diffS / 60);
-  const diffH = Math.floor(diffM / 60);
-  const diffD = Math.floor(diffH / 24);
-
-  if (diffS < 60) return `${diffS}s ago`;
-  if (diffM < 60) return `${diffM}m ago`;
-  if (diffH >= 48) return `${diffD}d ago`;
-  return `${diffH}h ago`;
-}
-
-type RuntimeStatus = {
-  daemonRunning: boolean;
-  lastTickStale: boolean;
-};
+type RuntimeStatus = StatusLivenessRuntime;
 
 async function resolveStaleThresholdMs(
   workspaceDir: string,
@@ -167,25 +141,12 @@ function renderLegacyStatus(
   lines.push("");
 
   // Health and last tick
-  const renderedHealth = runtimeStatus.daemonRunning
-    ? snapshot.health
-    : "stopped";
-  const healthStr = apply(
-    `${healthIcon(renderedHealth)} Health    ${renderedHealth}`
-  );
-  const staleLabel = runtimeStatus.lastTickStale
-    ? apply(yellow(" (stale)"))
-    : "";
-  const lastTickStr = apply(`Last tick  ${relativeTime(snapshot.lastTickAt)}`);
   lines.push(
-    `  ${healthStr}${" ".repeat(Math.max(0, 30 - stripAnsi(healthStr).length))}${lastTickStr}${staleLabel}`
+    ...renderStatusLivenessBanner(
+      createStatusLivenessBanner(snapshot, runtimeStatus),
+      { layout: "legacy", noColor }
+    )
   );
-  if (!runtimeStatus.daemonRunning) {
-    lines.push(
-      apply(yellow("  daemon not running — run 'gh-symphony repo start'"))
-    );
-    lines.push(apply(dim(`  Last known state: ${snapshot.health}`)));
-  }
   lines.push("");
 
   // Summary stats

--- a/packages/cli/src/dashboard/renderer.ts
+++ b/packages/cli/src/dashboard/renderer.ts
@@ -13,6 +13,11 @@ import {
 } from "../ansi.js";
 import type { ProjectStatusSnapshot } from "@gh-symphony/core";
 import { formatRepositoryDisplay } from "../format/repository.js";
+import {
+  createStatusLivenessBanner,
+  renderStatusLivenessBanner,
+  type StatusLivenessRuntime,
+} from "../status-liveness-banner.js";
 
 // ── Public types ─────────────────────────────────────────────────────────────
 
@@ -20,11 +25,7 @@ export type DashboardOptions = {
   terminalWidth: number;
   noColor: boolean;
   maxAgents?: number;
-  runtimeStatus?: {
-    daemonRunning: boolean;
-    lastTickLabel: string;
-    lastTickStale: boolean;
-  };
+  runtimeStatus?: StatusLivenessRuntime & { lastTickLabel: string };
   /** Override Date.now() for deterministic testing */
   now?: number;
 };
@@ -233,22 +234,16 @@ function buildSummaryLines(
   const runtimeStatus = options.runtimeStatus;
   const primarySnapshot = snapshots[0];
   if (runtimeStatus && primarySnapshot) {
-    const health = runtimeStatus.daemonRunning
-      ? primarySnapshot.health
-      : "stopped";
-    const healthDot =
-      health === "degraded" || health === "stopped"
-        ? c.red("\u25CF")
-        : c.green("\u25CF");
-    const staleLabel = runtimeStatus.lastTickStale ? c.yellow(" (stale)") : "";
     lines.push(
-      `  ${healthDot} ${c.dim("Health")}  ${c.bold(health)}     ${c.dim("Last tick")}  ${runtimeStatus.lastTickLabel}${staleLabel}`
+      ...renderStatusLivenessBanner(
+        createStatusLivenessBanner(
+          primarySnapshot,
+          runtimeStatus,
+          runtimeStatus.lastTickLabel
+        ),
+        { layout: "dashboard", noColor: options.noColor }
+      )
     );
-    if (!runtimeStatus.daemonRunning) {
-      lines.push(
-        `  ${c.yellow("daemon not running \u2014 run 'gh-symphony repo start'")}  ${c.dim(`Last known state: ${primarySnapshot.health}`)}`
-      );
-    }
   }
 
   return lines;

--- a/packages/cli/src/status-liveness-banner.test.ts
+++ b/packages/cli/src/status-liveness-banner.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import {
+  createStatusLivenessBanner,
+  renderStatusLivenessBanner,
+} from "./status-liveness-banner.js";
+
+const snapshot = {
+  health: "running",
+  lastTickAt: "2026-03-30T11:00:00.000Z",
+} as const;
+
+describe("status liveness banner", () => {
+  it("derives stopped health, restart guidance, and last-known state together", () => {
+    const banner = createStatusLivenessBanner(
+      snapshot,
+      { daemonRunning: false, lastTickStale: false },
+      "22d ago"
+    );
+
+    expect(banner).toEqual({
+      health: "stopped",
+      lastTickLabel: "22d ago",
+      stale: false,
+      restartGuidance: "daemon not running — run 'gh-symphony repo start'",
+      lastKnownState: "Last known state: running",
+    });
+  });
+
+  it("renders the same liveness details for both CLI layouts", () => {
+    const banner = createStatusLivenessBanner(
+      snapshot,
+      { daemonRunning: false, lastTickStale: false },
+      "22d ago"
+    );
+
+    expect(
+      renderStatusLivenessBanner(banner, { layout: "legacy", noColor: true })
+    ).toEqual([
+      "  ● Health    stopped           Last tick  22d ago",
+      "  daemon not running — run 'gh-symphony repo start'",
+      "  Last known state: running",
+    ]);
+    expect(
+      renderStatusLivenessBanner(banner, {
+        layout: "dashboard",
+        noColor: true,
+      })
+    ).toEqual([
+      "  ● Health  stopped     Last tick  22d ago",
+      "  daemon not running — run 'gh-symphony repo start'  Last known state: running",
+    ]);
+  });
+
+  it("keeps live stale state separate from stopped guidance", () => {
+    const banner = createStatusLivenessBanner(
+      snapshot,
+      { daemonRunning: true, lastTickStale: true },
+      "2m ago"
+    );
+
+    expect(banner.restartGuidance).toBeNull();
+    expect(banner.lastKnownState).toBeNull();
+    expect(
+      renderStatusLivenessBanner(banner, { layout: "dashboard", noColor: true })
+    ).toEqual(["  ● Health  running     Last tick  2m ago (stale)"]);
+  });
+});

--- a/packages/cli/src/status-liveness-banner.ts
+++ b/packages/cli/src/status-liveness-banner.ts
@@ -1,0 +1,113 @@
+import type { ProjectStatusSnapshot } from "@gh-symphony/core";
+import { bold, dim, green, red, stripAnsi, yellow } from "./ansi.js";
+
+export type StatusLivenessRuntime = {
+  daemonRunning: boolean;
+  lastTickStale: boolean;
+};
+
+export type StatusLivenessBanner = {
+  health: ProjectStatusSnapshot["health"] | "stopped";
+  lastTickLabel: string;
+  stale: boolean;
+  restartGuidance: string | null;
+  lastKnownState: string | null;
+};
+
+type BannerLayout = "legacy" | "dashboard";
+
+export function relativeTime(
+  isoString: string,
+  nowMs: number = Date.now()
+): string {
+  const now = new Date(nowMs);
+  const then = new Date(isoString);
+  const diffMs = now.getTime() - then.getTime();
+  const diffS = Math.floor(diffMs / 1000);
+  const diffM = Math.floor(diffS / 60);
+  const diffH = Math.floor(diffM / 60);
+  const diffD = Math.floor(diffH / 24);
+
+  if (diffS < 60) return `${diffS}s ago`;
+  if (diffM < 60) return `${diffM}m ago`;
+  if (diffH >= 48) return `${diffD}d ago`;
+  return `${diffH}h ago`;
+}
+
+export function createStatusLivenessBanner(
+  snapshot: Pick<ProjectStatusSnapshot, "health" | "lastTickAt">,
+  runtime: StatusLivenessRuntime,
+  lastTickLabel: string = relativeTime(snapshot.lastTickAt)
+): StatusLivenessBanner {
+  const stopped = !runtime.daemonRunning;
+
+  return {
+    health: stopped ? "stopped" : snapshot.health,
+    lastTickLabel,
+    stale: runtime.daemonRunning && runtime.lastTickStale,
+    restartGuidance: stopped
+      ? "daemon not running — run 'gh-symphony repo start'"
+      : null,
+    lastKnownState: stopped ? `Last known state: ${snapshot.health}` : null,
+  };
+}
+
+function healthIcon(health: StatusLivenessBanner["health"]): string {
+  switch (health) {
+    case "idle":
+    case "running":
+      return green("●");
+    case "degraded":
+    case "stopped":
+      return red("●");
+  }
+}
+
+function applyColor(noColor: boolean, value: string): string {
+  return noColor ? stripAnsi(value) : value;
+}
+
+export function renderStatusLivenessBanner(
+  banner: StatusLivenessBanner,
+  options: { layout: BannerLayout; noColor: boolean }
+): string[] {
+  const healthLabel = options.layout === "dashboard" ? dim("Health") : "Health";
+  const healthValue =
+    options.layout === "dashboard" ? bold(banner.health) : banner.health;
+  const healthText = applyColor(
+    options.noColor,
+    `${healthIcon(banner.health)} ${healthLabel}${options.layout === "legacy" ? "    " : "  "}${healthValue}`
+  );
+  const lastTickLabel =
+    options.layout === "dashboard" ? dim("Last tick") : "Last tick";
+  const lastTickText = applyColor(
+    options.noColor,
+    `${lastTickLabel}  ${banner.lastTickLabel}${banner.stale ? yellow(" (stale)") : ""}`
+  );
+
+  const lines = [
+    options.layout === "legacy"
+      ? `  ${healthText}${" ".repeat(Math.max(0, 30 - stripAnsi(healthText).length))}${lastTickText}`
+      : `  ${healthText}     ${lastTickText}`,
+  ];
+
+  if (banner.restartGuidance && banner.lastKnownState) {
+    if (options.layout === "legacy") {
+      lines.push(
+        applyColor(options.noColor, `  ${yellow(banner.restartGuidance)}`)
+      );
+      lines.push(
+        applyColor(options.noColor, `  ${dim(banner.lastKnownState)}`)
+      );
+    } else {
+      lines.push(
+        applyColor(
+          options.noColor,
+          `  ${yellow(banner.restartGuidance)}  ${dim(banner.lastKnownState)}`
+        )
+      );
+    }
+  }
+
+  return lines;
+}


### PR DESCRIPTION
## TL;DR

Extract the stopped/stale daemon banner into a shared CLI rendering helper so legacy `repo status` and the watch dashboard use the same health, staleness, restart guidance, and last-known-state presentation.

## Change-point diagram

```text
daemon liveness + snapshot
          │
          ▼
  shared banner view/renderer
       ┌──┴──┐
       ▼     ▼
 legacy status  watch dashboard
```

## Start here

1. `packages/cli/src/commands/status.ts` — legacy status flow and runtime liveness inputs.
2. `packages/cli/src/dashboard/renderer.ts` — watch dashboard summary flow.
3. The focused status and dashboard tests — expected stopped/stale output.

## Risks & rollback

- Risk: formatting changes could make the two status surfaces inconsistent with existing snapshots.
- Mitigation: preserve the current output strings and add shared-helper coverage for live, stale, and stopped states.
- Rollback: revert this PR; no persisted data or protocol changes are involved.

## Changed files

- `packages/cli/src/status-liveness-banner.ts` — shared liveness representation and layout-aware renderer.
- `packages/cli/src/status-liveness-banner.test.ts` — shared representation and output coverage.
- `packages/cli/src/commands/status.ts` — legacy status integration.
- `packages/cli/src/dashboard/renderer.ts` — watch dashboard integration.

## Evidence

- `pnpm lint` — passed.
- `pnpm test` — passed in the prior validation run for commit `ac131fd`; three later parallel reruns hit the unrelated concurrent bare-cache test race in `packages/orchestrator/src/git.test.ts`.
- `pnpm -r test -- --no-file-parallelism` — passed all 14 test packages (CLI: 526 tests; orchestrator: 289 tests).
- `pnpm typecheck` — passed.
- `pnpm build` — passed.
- `pnpm exec prettier --check packages/cli/src/status-liveness-banner.ts packages/cli/src/status-liveness-banner.test.ts packages/cli/src/commands/status.ts packages/cli/src/dashboard/renderer.ts` — passed.

## Issues — Closed #556

- Fixes #556

## Post-merge / human validation

- [ ] Confirm stopped daemon output in `gh-symphony repo status` shows restart guidance and the last-known state.
- [ ] Confirm `gh-symphony repo status --watch` uses the same stopped/stale banner presentation.
- [ ] Confirm live fresh and stale daemon states remain distinguishable.

## Human validation

- [ ] Confirm the main user flow works as expected.
- [ ] Confirm there is no obvious regression in adjacent CLI behavior.
- [ ] Confirm reviewer-visible behavior matches the issue requirements.
