### PR TITLE
fix(standalone): acceptance findings from the standalone project model

### DIFF
--- a/.changeset/standalone-project-final-test-fixes.md
+++ b/.changeset/standalone-project-final-test-fixes.md
@@ -1,0 +1,29 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Fix defects found while validating the standalone project model end to end:
+
+- GitHub Project tracker now honors `tracker.pickup_labels`. Label-disjoint projects that
+  share one repository previously dispatched each other's issues even though `project add`
+  validates registrations against those same labels.
+- The shared bare-clone cache re-points `origin` and refetches when a project's clone URL
+  changes, instead of serving the previously cached remote forever.
+- An explicit `--config <dir>` is exported to the environment so the bare-clone cache and
+  spawned workers use the same directory as the rest of the CLI state.
+- The standalone shadow warning reads the shared bare cache instead of the process working
+  directory, so it names the repository that actually commits a `WORKFLOW.md` rather than
+  whichever directory the CLI was started from.
+- `gh-symphony doctor` validates the registered project `WORKFLOW.md` for standalone
+  projects instead of reporting the repository root file as missing.
+- Standalone projects create issue workspaces under their `workspace.root` (spec 9.1), resolved
+  relative to the project folder and defaulting to `<project-dir>/.runtime/workspaces`, instead of
+  inside the runtime state directory. Repo-embedded projects are unchanged.
+- **Breaking (unreleased standalone surface):** `gh-symphony project add` is removed. `project
+start|status|stop` now address the project folder itself — the working directory by default, or
+  `--project-dir <path>` — and derive the runtime configuration from its `WORKFLOW.md` on every
+  start, so an edited workflow no longer needs re-registration and no active-project state decides
+  which project runs. Tracker-mapping overlap is validated at start instead of at registration, and
+  an overlap with an already running project is refused outright.
+- `WORKFLOW.md` accepts `repository.clone_url` to override the derived clone URL for mirrors,
+  Enterprise hosts, or local paths.

--- a/.changeset/standalone-project-final-test-fixes.md
+++ b/.changeset/standalone-project-final-test-fixes.md
@@ -1,12 +1,12 @@
 ---
-"@gh-symphony/cli": patch
+"@gh-symphony/cli": minor
 ---
 
 Fix defects found while validating the standalone project model end to end:
 
 - GitHub Project tracker now honors `tracker.pickup_labels`. Label-disjoint projects that
-  share one repository previously dispatched each other's issues even though `project add`
-  validates registrations against those same labels.
+  share one repository previously dispatched each other's issues despite those labels being
+  intended to keep project mappings disjoint.
 - The shared bare-clone cache re-points `origin` and refetches when a project's clone URL
   changes, instead of serving the previously cached remote forever.
 - An explicit `--config <dir>` is exported to the environment so the bare-clone cache and
@@ -14,7 +14,7 @@ Fix defects found while validating the standalone project model end to end:
 - The standalone shadow warning reads the shared bare cache instead of the process working
   directory, so it names the repository that actually commits a `WORKFLOW.md` rather than
   whichever directory the CLI was started from.
-- `gh-symphony doctor` validates the registered project `WORKFLOW.md` for standalone
+- `gh-symphony doctor` validates the folder-addressed project `WORKFLOW.md` for standalone
   projects instead of reporting the repository root file as missing.
 - Standalone projects create issue workspaces under their `workspace.root` (spec 9.1), resolved
   relative to the project folder and defaulting to `<project-dir>/.runtime/workspaces`, instead of

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ The full component-to-package map, sliced by Symphony layer, lives in [docs/arch
 ### Key Packages
 
 - **`packages/core`** — Domain types, contracts (`OrchestratorStateStore`, `OrchestratorTrackerAdapter`), workflow loading/config, lifecycle (`WorkflowExecutionPhase`: planning → human-review → implementation → awaiting-merge → completed), MCP config composition, observability snapshots. No external dependencies.
-- **`packages/cli`** — `gh-symphony` published entrypoint: `setup`, `doctor`, `workflow`, `config`, `repo` (init/start/stop/status/run/logs/recover/explain), and `project` (standalone project add/list/start/status/stop).
+- **`packages/cli`** — `gh-symphony` published entrypoint: `setup`, `doctor`, `workflow`, `config`, `repo` (init/start/stop/status/run/logs/recover/explain), and `project` (standalone project list/start/status/stop, addressed by folder).
 - **`packages/orchestrator`** — `OrchestratorService` dispatch loop, filesystem-backed state store (`OrchestratorFsStore`), shared bare clone cache + worktree populate, layered skill injection, leases/retries/recovery.
 - **`packages/worker`** — Runs a single issue; serves `/api/v1/state`; drives a runtime adapter; manages approval workflow and hooks.
 - **`packages/runtime-codex` / `packages/runtime-claude`** — Agent runtime adapters (Codex app-server protocol; Claude print mode).

--- a/README.md
+++ b/README.md
@@ -370,7 +370,7 @@ gh-symphony repo stop                # Stop this repository
 
 ### Standalone Projects
 
-A standalone project is a project folder registered as an independent orchestration instance, decoupled from the repository it targets. The folder owns `WORKFLOW.md` (which must declare `repository.slug: owner/name`), plus optional `.mcp.json`, `.env`, and `.agent/skills/`; the referenced repository itself stays unmodified. Issue workspaces are created under the project's `workspace.root`, relative to the project folder and defaulting to `<project-dir>/.runtime/workspaces`. Issue workspaces are populated as worktrees from a shared bare clone cache, and branches default to `symphony/<project-slug>/<issue-id>`, so multiple projects can orchestrate the same repository without branch collisions.
+A standalone project is a project folder used as an independent orchestration instance, decoupled from the repository it targets. The folder owns `WORKFLOW.md` (which must declare `repository.slug: owner/name`), plus optional `.mcp.json`, `.env`, and `.agent/skills/`; the referenced repository itself stays unmodified. Issue workspaces are created under the project's `workspace.root`, relative to the project folder and defaulting to `<project-dir>/.runtime/workspaces`. Issue workspaces are populated as worktrees from a shared bare clone cache, and branches default to `symphony/<project-slug>/<issue-id>`, so multiple projects can orchestrate the same repository without branch collisions.
 
 ```bash
 cd <projectDir> && gh-symphony project start   # Start the project in this folder

--- a/README.md
+++ b/README.md
@@ -370,17 +370,17 @@ gh-symphony repo stop                # Stop this repository
 
 ### Standalone Projects
 
-A standalone project is a project folder registered as an independent orchestration instance, decoupled from the repository it targets. The folder owns `WORKFLOW.md` (which must declare `repository.slug: owner/name`), plus optional `.mcp.json`, `.env`, and `.agent/skills/`; the referenced repository itself stays unmodified. Issue workspaces are populated as worktrees from a shared bare clone cache, and branches default to `symphony/<project-slug>/<issue-id>`, so multiple projects can orchestrate the same repository without branch collisions.
+A standalone project is a project folder registered as an independent orchestration instance, decoupled from the repository it targets. The folder owns `WORKFLOW.md` (which must declare `repository.slug: owner/name`), plus optional `.mcp.json`, `.env`, and `.agent/skills/`; the referenced repository itself stays unmodified. Issue workspaces are created under the project's `workspace.root`, relative to the project folder and defaulting to `<project-dir>/.runtime/workspaces`. Issue workspaces are populated as worktrees from a shared bare clone cache, and branches default to `symphony/<project-slug>/<issue-id>`, so multiple projects can orchestrate the same repository without branch collisions.
 
 ```bash
-gh-symphony project add <projectDir>   # Register a project folder (validates WORKFLOW.md, rejects overlapping tracker mappings)
-gh-symphony project list               # List registered standalone projects as JSON
-gh-symphony project start              # Start orchestration for the active standalone project (same flags as repo start)
-gh-symphony project status             # Show standalone project status
-gh-symphony project stop               # Stop the standalone project daemon
+cd <projectDir> && gh-symphony project start   # Start the project in this folder
+gh-symphony project start --project-dir <dir>  # ...or name the folder explicitly
+gh-symphony project status                     # Status for the project in this folder
+gh-symphony project stop                       # Stop its daemon
+gh-symphony project list                       # List projects started on this host, as JSON
 ```
 
-`project start` accepts the same flags as `repo start` (`--once`, `--daemon`, `--web`, `--http`, and so on). Registration refuses tracker mappings that overlap an already-registered project for the same repository unless you confirm interactively. See [docs/configuration.md](docs/configuration.md) for the project `.env` loading order and skill layering details.
+The project folder is the source of truth and the address: every command derives the runtime from the folder's `WORKFLOW.md` on each start, so editing the workflow takes effect on the next start with no registration step. `project start` accepts the same flags as `repo start` (`--once`, `--daemon`, `--web`, `--http`, and so on). Starting refuses a tracker mapping that overlaps a project already running against the same repository, and asks for confirmation when the overlapping project is stopped. Two projects on one repository stay disjoint through `tracker.pickup_labels`, which the GitHub, Linear, and file trackers all apply when listing dispatch candidates. `repository.clone_url` overrides the derived clone URL for mirrors, Enterprise hosts, or local paths. See [docs/configuration.md](docs/configuration.md) for the project `.env` loading order and skill layering details.
 
 ### Official Container Deployment
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -34,7 +34,7 @@ touches a layer, check that its slice (and the linked documents) still holds.
 
 - `WORKFLOW.md` front matter parsing and validation: `packages/core/src/workflow/`
 - Layered MCP composition (`.mcp.json` sidecar): `packages/core/src/runtime/mcp-compose.ts` + each runtime adapter
-- CLI global/project config, standalone project registration: `packages/cli/src/config.ts`, `commands/project.ts`
+- CLI global/project config and folder-addressed standalone project derivation: `packages/cli/src/config.ts`, `commands/project.ts`
 - Environment variables and `.env` loading order: [configuration.md](configuration.md)
 
 ### 3. Coordination — the orchestrator

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -8,16 +8,38 @@ and operational overrides.
 
 ## Standalone Projects
 
-`gh-symphony project add <project-dir>` registers a project folder as an
-independent orchestration instance. The folder owns `WORKFLOW.md`, optional
-`.mcp.json`, `.env`, and `.agent/skills/`; the referenced repository remains
-unmodified. `WORKFLOW.md` must declare `repository.slug`. Each issue is
+`gh-symphony project start` runs the project folder in the working directory as
+an independent orchestration instance; `--project-dir <path>` names a different
+folder. The folder owns `WORKFLOW.md`, optional `.mcp.json`, `.env`, and
+`.agent/skills/`; the referenced repository remains unmodified. `WORKFLOW.md`
+must declare `repository.slug`, which is also what distinguishes a standalone
+project from a repository that embeds its own workflow. Configuration is derived
+from the folder on every start and cached under
+`<config-dir>/projects/<project-id>/`, where the project id is a stable function
+of the folder path — there is no registration step and no active-project state. Issue workspaces are
+created under the project's `workspace.root` (spec 9.1), resolved relative to
+the project folder and defaulting to `<project-dir>/.runtime/workspaces`; the
+directory is created with mode `0700` when it does not exist. Repo-embedded
+projects still keep issue workspaces beside their runtime state and ignore
+`workspace.root`; converging them is tracked in
+[#599](https://github.com/hojinzs/github-symphony/issues/599). Each issue is
 populated from the shared bare cache at `<config-dir>/repos/<owner>/<repo>.git`
 using a worktree. Branches default to
 `symphony/<project-slug>/<sanitized-issue-id>`, so multiple projects may use
 one repository without branch collisions. The project `.env` is loaded first
 for project hooks and workers, then host process values override it; keep it
-mode `0600` and do not commit it.
+mode `0600` and do not commit it. An explicit `--config <dir>` is exported to
+`GH_SYMPHONY_CONFIG_DIR` for the process, so the bare cache and spawned workers
+use the same directory as the rest of the CLI state. The cache is keyed by
+`<owner>/<name>`; when a project's clone URL changes, the cache re-points
+`origin` and refetches on the next populate.
+
+When a standalone project targets a repository that also commits its own
+`WORKFLOW.md`, the status surface reports a shadow warning naming the
+repository. The repository file is never executed — only the registered project
+policy is. The check reads the shared bare cache rather than the working
+directory, so it reflects the repository as of the cache's last fetch and
+catches up on the next issue populate.
 
 ## Skill Layering
 

--- a/docs/designs/2026-08-11-standalone-project-model-design.md
+++ b/docs/designs/2026-08-11-standalone-project-model-design.md
@@ -173,7 +173,7 @@ projects/
 2. **`workspaces/` state directory naming cleanup** — terminology collision with the spec's Workspace (D2)
 3. **Verify the codex runtime skill discovery path** — confirm whether it is cwd-based, then finalize D5 placement (verify in `runtime-codex`)
 4. **Control Plane secret store** — how to manage the origins of `$VAR` per project (during Control Plane design). D9's `.env` is the store for now, and the Control Plane can treat it as something to manage rather than replace
-5. **repo-embedded → standalone migration path** — procedure for wrapping existing setups into the project model (including `clone` → `worktree-cache` populate strategy convergence)
+5. **repo-embedded → standalone migration path** — procedure for wrapping existing setups into the project model (including `clone` → `worktree-cache` populate strategy convergence). The related workspace-layout half — repo-embedded still ignores `workspace.root` while standalone honors it (spec §9.1) — is tracked in [#599](https://github.com/hojinzs/github-symphony/issues/599).
 6. **Follow-up ADR** — a decision record refining the relationship with `2026-05-04_single-repo-orchestrator.md` ("1 repo = 1 instance") to "1 project = 1 instance"
 
 Resolved items (2026-08-11): clone cache operations and branch namespace → D4, D8 and the "Clone cache operational details" section. Project env declaration → D9.

--- a/e2e/run-standalone-project-e2e.sh
+++ b/e2e/run-standalone-project-e2e.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# This bypasses the repo-embedded entrypoint and dispatches two registered
+# This bypasses the repo-embedded entrypoint and dispatches two folder-addressed
 # standalone projects once against the same local seed repository.
 COMPOSE="docker compose -f docker-compose.e2e.yml"
 

--- a/e2e/run-standalone-project-e2e.sh
+++ b/e2e/run-standalone-project-e2e.sh
@@ -38,6 +38,7 @@ codex:
   command: codex
 repository:
   slug: test-owner/test-repo
+  clone_url: /e2e/repos/test-owner/test-repo
 workspace:
   root: .runtime/workspaces
 ---
@@ -59,32 +60,35 @@ cat > "$FIXTURE" <<EOF
 ]
 EOF
 
-for project in project-alpha project-beta; do
-  node /app/packages/cli/dist/index.js --config "$CONFIG_DIR" project add "$PROJECT_ROOT/$project"
-done
-alpha_id=$(node -e "console.log(require(\"$CONFIG_DIR/config.json\").projects[0])")
-beta_id=$(node -e "console.log(require(\"$CONFIG_DIR/config.json\").projects[1])")
+# Both projects run at once against one repository, addressed only by their
+# folder: no registration step, no shared active-project state.
 run_pids=""
-for project_id in "$alpha_id" "$beta_id"; do
-  node -e "const fs=require(\"fs\"); const path=\"$CONFIG_DIR/projects/$project_id/project.json\"; const config=require(path); config.repository.cloneUrl=\"/e2e/repos/test-owner/test-repo\"; config.tracker.settings.issuesPath=\"$FIXTURE\"; fs.writeFileSync(path, JSON.stringify(config, null, 2)+\"\\n\")"
-  GH_SYMPHONY_CONFIG_DIR="$CONFIG_DIR" node /app/packages/orchestrator/dist/index.js run-once --runtime-root "$CONFIG_DIR" --project-id "$project_id" > "/tmp/$project_id.json" 2>&1 &
+for project in project-alpha project-beta; do
+  (cd "$PROJECT_ROOT/$project" && \
+    GH_SYMPHONY_FILE_TRACKER_ISSUES_PATH="$FIXTURE" \
+    node /app/packages/cli/dist/index.js --config "$CONFIG_DIR" project start \
+      > "/tmp/$project.log" 2>&1) &
   run_pids="$run_pids $!"
-  for _ in $(seq 1 20); do
-    if grep -q "\"dispatched\": 1" "/tmp/$project_id.json"; then break; fi
-    sleep 1
-  done
-  if ! grep -q "\"dispatched\": 1" "/tmp/$project_id.json"; then
-    cat "/tmp/$project_id.json" >&2
-    exit 1
-  fi
 done
+alpha_id=$(node -e "const {createHash}=require(\"crypto\");const d=\"$PROJECT_ROOT/project-alpha\";console.log(\"project-alpha-\"+createHash(\"sha256\").update(d).digest(\"hex\").slice(0,8))")
+beta_id=$(node -e "const {createHash}=require(\"crypto\");const d=\"$PROJECT_ROOT/project-beta\";console.log(\"project-beta-\"+createHash(\"sha256\").update(d).digest(\"hex\").slice(0,8))")
+for _ in $(seq 1 40); do
+  if test -f "$CONFIG_DIR/projects/$alpha_id/project.json" &&
+     test -f "$CONFIG_DIR/projects/$beta_id/project.json"; then
+    break
+  fi
+  sleep 1
+done
+test -f "$CONFIG_DIR/projects/$alpha_id/project.json"
+test -f "$CONFIG_DIR/projects/$beta_id/project.json"
 
-for _ in $(seq 1 30); do
+for _ in $(seq 1 60); do
   completed_logs=$(find "$CONFIG_DIR/projects" -path "*/runs/*/worker.log" -type f -exec grep -l "\\[stub-worker\\] status=completed" {} + 2>/dev/null | wc -l | tr -d " " || true)
   test "$completed_logs" = 2 && break
   sleep 1
 done
 if [ "${completed_logs:-0}" != 2 ]; then
+  cat /tmp/project-alpha.log /tmp/project-beta.log >&2 || true
   for log in $(find "$CONFIG_DIR/projects" -path "*/runs/*/worker.log" -type f); do
     echo "--- $log" >&2
     cat "$log" >&2
@@ -101,7 +105,10 @@ for project in project-alpha project-beta; do
   if [ "$label" = beta ]; then issue=102; fi
   project_id="$alpha_id"
   if [ "$label" = beta ]; then project_id="$beta_id"; fi
-  repo=$(find "$CONFIG_DIR/projects/$project_id" -path "*/repository" -type d | head -1)
+  # Standalone workspaces live under the workspace.root of the project folder,
+  # not under the runtime state directory (spec 9.1).
+  test -z "$(find "$CONFIG_DIR/projects/$project_id" -path "*/repository" -type d)"
+  repo=$(find "$PROJECT_ROOT/$project/.runtime/workspaces" -path "*/repository" -type d | head -1)
   # A linked worktree records its gitdir in a .git file; a normal checkout
   # uses a directory. Either shape proves the populated workspace is a repo.
   test -e "$repo/.git"
@@ -115,8 +122,8 @@ for project in project-alpha project-beta; do
   grep -q "\\[stub-worker\\] mcp_servers=$label" $logs
   grep -q "\\[stub-worker\\] status=completed" $logs
 done
-alpha_repo=$(find "$CONFIG_DIR/projects/$alpha_id" -path "*/repository" -type d | head -1)
-beta_repo=$(find "$CONFIG_DIR/projects/$beta_id" -path "*/repository" -type d | head -1)
+alpha_repo=$(find "$PROJECT_ROOT/project-alpha/.runtime/workspaces" -path "*/repository" -type d | head -1)
+beta_repo=$(find "$PROJECT_ROOT/project-beta/.runtime/workspaces" -path "*/repository" -type d | head -1)
 alpha_branch=$(git -C "$alpha_repo" branch --show-current)
 beta_branch=$(git -C "$beta_repo" branch --show-current)
 test "$alpha_branch" != "$beta_branch"

--- a/e2e/scenarios/13-standalone-project-model.md
+++ b/e2e/scenarios/13-standalone-project-model.md
@@ -8,10 +8,11 @@ local seed repository, in a one-shot container that bypasses the entrypoint. Eac
 
 ## Steps
 
-1. Register both projects into a single registry with `gh-symphony project add`.
-2. Prepare two file-tracker issues whose label mappings are disjoint.
-3. Run the orchestrator `run-once` for each project ID.
-4. Inspect the bare cache, worktree, branch, MCP/skill injection, `git status`, and worker log.
+1. Prepare two file-tracker issues whose label mappings are disjoint.
+2. Start both projects at once by running `gh-symphony project start` from inside each
+   project folder — no registration step and no shared active-project state.
+3. Inspect the bare cache, worktree location, branch, MCP/skill injection, `git status`,
+   and worker log.
 
 ## Expected
 
@@ -20,6 +21,8 @@ local seed repository, in a one-shot container that bypasses the entrypoint. Eac
   runs on distinct branches:
   `symphony/project-alpha/test-owner-test-repo-101` and
   `symphony/project-beta/test-owner-test-repo-102`.
+- Issue workspaces are created under each project folder's `workspace.root`
+  (`.runtime/workspaces`), not inside the runtime state directory.
 - After project skill injection, `git status --porcelain` is empty, the workers compose the
   project MCP server, and both workers record `status=completed`.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -338,14 +338,16 @@ gh-symphony repo recover --dry-run       # Preview what would be recovered
 
 ### Standalone Projects
 
-Register a project folder as an orchestration instance decoupled from the repository it targets. The folder owns `WORKFLOW.md` (with `repository.slug: owner/name`), plus optional `.mcp.json`, `.env`, and `.agent/skills/`. Issue workspaces are populated as worktrees from a shared bare clone cache with `symphony/<project-slug>/<issue-id>` branches, so multiple projects can share one repository.
+Use a project folder as an orchestration instance decoupled from the repository it targets. The folder owns `WORKFLOW.md` (with `repository.slug: owner/name`), plus optional `.mcp.json`, `.env`, and `.agent/skills/`. Issue workspaces are populated as worktrees from a shared bare clone cache with `symphony/<project-slug>/<issue-id>` branches, so multiple projects can share one repository. `start` derives and caches configuration from the folder on every run; `status` and `stop` address the same runtime by folder without reading `WORKFLOW.md`.
 
 ```bash
-gh-symphony project add <projectDir>     # Register (validates WORKFLOW.md, rejects overlapping tracker mappings)
-gh-symphony project list                 # List registered standalone projects
-gh-symphony project start                # Same flags as repo start (--once, --daemon, --web, --http)
-gh-symphony project status
+cd <projectDir>
+gh-symphony project start                # Derive WORKFLOW.md and start this folder's project
+gh-symphony project status               # Address this folder's runtime
 gh-symphony project stop
+gh-symphony project start --project-dir <projectDir>
+gh-symphony project list                 # List cached standalone projects
+gh-symphony doctor --project-dir <projectDir>
 ```
 
 ## Diagnostics
@@ -436,11 +438,11 @@ Orchestration:
   completion <shell>  Print shell completion for bash/zsh/fish
 
 Standalone Projects:
-  project add <dir>   Register a project folder as an independent orchestration instance
-  project list        List registered standalone projects as JSON
-  project start       Start the active standalone project (same flags as repo start)
-  project status      Show standalone project status
-  project stop        Stop the standalone project daemon
+  project list        List cached standalone projects as JSON
+  project start       Start the cwd project folder (same flags as repo start)
+  project status      Show the cwd project folder's status
+  project stop        Stop the cwd project folder's daemon
+  --project-dir <dir> Address an explicit standalone project folder
 
 Global Options:
   --config <dir>      Config directory (default: initialized cwd runtime, then ~/.gh-symphony)

--- a/packages/cli/src/commands/doctor.test.ts
+++ b/packages/cli/src/commands/doctor.test.ts
@@ -438,6 +438,61 @@ beforeEach(() => {
 });
 
 describe("runDoctorDiagnostics", () => {
+  it("reads the registered project WORKFLOW.md for standalone projects", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "doctor-config-"));
+    const workspaceDir = join(configDir, "workspaces");
+    await prepareDoctorPaths(configDir, workspaceDir);
+    // The policy lives outside the repository, and doctor runs from a
+    // directory that deliberately has no WORKFLOW.md.
+    const { repoDir, pathEnv } = await createWorkflowFixture();
+    const projectDir = await mkdtemp(join(tmpdir(), "doctor-project-"));
+    const projectWorkflowPath = join(projectDir, "WORKFLOW.md");
+    await writeFile(
+      projectWorkflowPath,
+      "---\ntracker:\n  kind: github-project\ncodex:\n  command: fake-agent\n---\nStandalone prompt\n",
+      "utf8"
+    );
+    const emptyCwd = await mkdtemp(join(tmpdir(), "doctor-cwd-"));
+
+    const report = await withCwd(emptyCwd, () =>
+      runDoctorDiagnostics(baseOptions(configDir), [], {
+        ...authDependencies(),
+        inspectManagedProjectSelection: async () => ({
+          kind: "resolved",
+          projectId: "tenant-a",
+          projectConfig: {
+            ...createProjectConfig(workspaceDir),
+            projectDir,
+            workflowSource: { type: "external", path: projectWorkflowPath },
+          } as never,
+        }),
+        getProjectDetail: (async () =>
+          ({
+            id: "PVT_test",
+            title: "Acme Platform",
+            url: "https://github.com/orgs/acme/projects/1",
+            statusFields: [],
+            textFields: [],
+            linkedRepositories: [],
+          }) as never) as never,
+        execFileSync: (() => "git version 2.43.0") as never,
+        pathEnv,
+      })
+    );
+
+    const workflowCheck = report.checks.find(
+      (check) => check.id === "workflow_file"
+    );
+    expect(workflowCheck).toMatchObject({
+      status: "pass",
+      title: "Project WORKFLOW.md",
+    });
+    expect(workflowCheck?.details).toMatchObject({
+      path: projectWorkflowPath,
+    });
+    expect(repoDir).toBeTruthy();
+  });
+
   it("reports success when all required checks pass", async () => {
     const configDir = await mkdtemp(join(tmpdir(), "doctor-config-"));
     const workspaceDir = join(configDir, "workspaces");

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -689,7 +689,7 @@ async function checkWorkflow(
         ? `WORKFLOW.md was not found at the registered project path ${workflowPath}.`
         : "WORKFLOW.md was not found in the repository root.",
       remediation: externalWorkflowPath
-        ? `Restore ${workflowPath} or re-register the project with 'gh-symphony project add'.`
+        ? `Restore ${workflowPath}; the folder's workflow is derived on every 'gh-symphony project start'.`
         : "Run 'gh-symphony workflow init' in this repository or add a valid WORKFLOW.md at the repo root.",
     };
   }

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -50,6 +50,7 @@ import {
   buildPriorityDriftDiagnostics,
 } from "../priority-diagnostics.js";
 import { inspectManagedProjectSelection } from "../project-selection.js";
+import { standaloneProjectId } from "./project.js";
 import {
   createSupportBundle,
   type SupportBundleSummary,
@@ -244,7 +245,7 @@ const DEFAULT_DEPENDENCIES: DoctorDependencies = {
 const MINIMUM_NODE_MAJOR = 24;
 const MINIMUM_NODE_VERSION = `v${MINIMUM_NODE_MAJOR}.0.0`;
 const DOCTOR_USAGE =
-  "Usage: gh-symphony doctor [--project-id <project-id>] [--fix] [--smoke] [--issue <owner/repo#number>] [--bundle [path]]";
+  "Usage: gh-symphony doctor [--project-id <project-id>] [--project-dir <path>] [--fix] [--smoke] [--issue <owner/repo#number>] [--bundle [path]]";
 
 type GitInstallationState =
   | {
@@ -268,6 +269,19 @@ function parseDoctorArgs(args: string[]): ParsedDoctorArgs {
         return parsed;
       }
       parsed.projectId = value;
+      i += 1;
+      continue;
+    }
+
+    if (arg === "--project-dir") {
+      const value = args[i + 1];
+      if (!value || value.startsWith("-")) {
+        parsed.error = `Option '${arg}' argument missing`;
+        return parsed;
+      }
+      // Standalone projects are addressed by folder everywhere else, and the
+      // identifier is derived from the path.
+      parsed.projectId = standaloneProjectId(value);
       i += 1;
       continue;
     }
@@ -656,9 +670,12 @@ async function checkGitInstallation(
 
 async function checkWorkflow(
   repoRoot: string,
-  deps: Pick<DoctorDependencies, "readFile" | "parseWorkflowMarkdown">
+  deps: Pick<DoctorDependencies, "readFile" | "parseWorkflowMarkdown">,
+  externalWorkflowPath?: string | null
 ): Promise<WorkflowCheckState> {
-  const workflowPath = join(repoRoot, "WORKFLOW.md");
+  // A standalone project owns its policy outside the repository, so the cwd
+  // lookup would report a missing file for a perfectly healthy setup.
+  const workflowPath = externalWorkflowPath ?? join(repoRoot, "WORKFLOW.md");
   let markdown: string;
 
   try {
@@ -668,9 +685,12 @@ async function checkWorkflow(
       status: "fail",
       reason: "missing",
       workflowPath,
-      summary: "WORKFLOW.md was not found in the repository root.",
-      remediation:
-        "Run 'gh-symphony workflow init' in this repository or add a valid WORKFLOW.md at the repo root.",
+      summary: externalWorkflowPath
+        ? `WORKFLOW.md was not found at the registered project path ${workflowPath}.`
+        : "WORKFLOW.md was not found in the repository root.",
+      remediation: externalWorkflowPath
+        ? `Restore ${workflowPath} or re-register the project with 'gh-symphony project add'.`
+        : "Run 'gh-symphony workflow init' in this repository or add a valid WORKFLOW.md at the repo root.",
     };
   }
 
@@ -2030,12 +2050,21 @@ export async function runDoctorDiagnostics(
     );
   }
 
-  const workflow = await checkWorkflow(process.cwd(), deps);
+  const externalWorkflowPath =
+    resolvedProjectConfig?.kind === "resolved" &&
+    resolvedProjectConfig.projectConfig.workflowSource?.type === "external"
+      ? resolvedProjectConfig.projectConfig.workflowSource.path
+      : null;
+  const workflow = await checkWorkflow(
+    process.cwd(),
+    deps,
+    externalWorkflowPath
+  );
   if (workflow.status === "pass") {
     checks.push(
       passCheck(
         "workflow_file",
-        "Repository WORKFLOW.md",
+        externalWorkflowPath ? "Project WORKFLOW.md" : "Repository WORKFLOW.md",
         `WORKFLOW.md parsed successfully (${workflow.format}).`,
         { path: workflow.workflowPath, format: workflow.format }
       )
@@ -2044,7 +2073,7 @@ export async function runDoctorDiagnostics(
     checks.push(
       failCheck(
         "workflow_file",
-        "Repository WORKFLOW.md",
+        externalWorkflowPath ? "Project WORKFLOW.md" : "Repository WORKFLOW.md",
         workflow.summary,
         workflow.remediation,
         {

--- a/packages/cli/src/commands/project-lifecycle.test.ts
+++ b/packages/cli/src/commands/project-lifecycle.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, writeFile } from "node:fs/promises";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -11,7 +11,8 @@ vi.mock("./start.js", () => ({ default: startMock }));
 vi.mock("./status.js", () => ({ default: statusMock }));
 vi.mock("./stop.js", () => ({ default: stopMock }));
 
-const { default: projectCommand } = await import("./project.js");
+const { default: projectCommand, standaloneProjectId } =
+  await import("./project.js");
 
 const workflow = `---
 tracker:
@@ -40,7 +41,7 @@ afterEach(() => {
 });
 
 describe("standalone project lifecycle command", () => {
-  it("round-trips add, list, start, status, and stop through one registry", async () => {
+  it("addresses the project by folder for list, start, status, and stop", async () => {
     const configDir = await mkdtemp(join(tmpdir(), "cli-project-config-"));
     const projectDir = await mkdtemp(join(tmpdir(), "cli-project-dir-"));
     await writeFile(join(projectDir, "WORKFLOW.md"), workflow, "utf8");
@@ -48,29 +49,91 @@ describe("standalone project lifecycle command", () => {
       .spyOn(process.stdout, "write")
       .mockImplementation(() => true);
 
-    await projectCommand(["add", projectDir], baseOptions(configDir));
-    await projectCommand(["list"], {
-      ...baseOptions(configDir),
-      json: true,
-    });
-    await projectCommand(["start", "--daemon"], baseOptions(configDir));
-    await projectCommand(["status"], baseOptions(configDir));
-    await projectCommand(["stop"], baseOptions(configDir));
+    await projectCommand(
+      ["start", "--daemon", "--project-dir", projectDir],
+      baseOptions(configDir)
+    );
+    await projectCommand(["list"], { ...baseOptions(configDir), json: true });
+    await projectCommand(
+      ["status", "--project-dir", projectDir],
+      baseOptions(configDir)
+    );
+    await projectCommand(
+      ["stop", "--project-dir", projectDir],
+      baseOptions(configDir)
+    );
 
+    const projectId = standaloneProjectId(projectDir);
     expect(
       stdout.mock.calls.map(([chunk]) => String(chunk)).join("")
     ).toContain(projectDir);
     expect(startMock).toHaveBeenCalledWith(
       ["--daemon"],
-      expect.objectContaining({ configDir, invocation: "project" })
+      expect.objectContaining({ configDir, invocation: "project", projectId })
     );
     expect(statusMock).toHaveBeenCalledWith(
       [],
-      expect.objectContaining({ configDir })
+      expect.objectContaining({ configDir, projectId })
     );
     expect(stopMock).toHaveBeenCalledWith(
       [],
-      expect.objectContaining({ configDir })
+      expect.objectContaining({ configDir, projectId })
+    );
+  });
+
+  it("starts the project in the working directory without a flag", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "cli-project-config-"));
+    const projectDir = await mkdtemp(join(tmpdir(), "cli-project-dir-"));
+    await writeFile(join(projectDir, "WORKFLOW.md"), workflow, "utf8");
+    const cwd = vi.spyOn(process, "cwd").mockReturnValue(projectDir);
+
+    await projectCommand(["start"], baseOptions(configDir));
+
+    expect(startMock).toHaveBeenCalledWith(
+      [],
+      expect.objectContaining({ projectId: standaloneProjectId(projectDir) })
+    );
+    cwd.mockRestore();
+  });
+
+  it("refuses to stop a directory that was never started", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "cli-project-config-"));
+    const projectDir = await mkdtemp(join(tmpdir(), "cli-project-dir-"));
+    const stderr = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+
+    await projectCommand(
+      ["stop", "--project-dir", projectDir],
+      baseOptions(configDir)
+    );
+
+    expect(stopMock).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+    expect(
+      stderr.mock.calls.map(([chunk]) => String(chunk)).join("")
+    ).toContain("No standalone project runtime for");
+  });
+
+  it("stops a started project even after its WORKFLOW.md is gone", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "cli-project-config-"));
+    const projectDir = await mkdtemp(join(tmpdir(), "cli-project-dir-"));
+    const workflowPath = join(projectDir, "WORKFLOW.md");
+    await writeFile(workflowPath, workflow, "utf8");
+    await projectCommand(
+      ["start", "--project-dir", projectDir],
+      baseOptions(configDir)
+    );
+    await rm(workflowPath);
+
+    await projectCommand(
+      ["stop", "--project-dir", projectDir],
+      baseOptions(configDir)
+    );
+
+    expect(stopMock).toHaveBeenCalledWith(
+      [],
+      expect.objectContaining({ projectId: standaloneProjectId(projectDir) })
     );
   });
 });

--- a/packages/cli/src/commands/project.test.ts
+++ b/packages/cli/src/commands/project.test.ts
@@ -137,6 +137,28 @@ describe("deriveStandaloneProject", () => {
     ).rejects.toThrow("Tracker mapping overlaps project(s)");
   });
 
+  it("serializes concurrent derivation before validating overlaps", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "cli-standalone-config-"));
+    const first = await mkdtemp(join(tmpdir(), "cli-standalone-project-"));
+    const second = await mkdtemp(join(tmpdir(), "cli-standalone-project-"));
+    await Promise.all([
+      writeFile(join(first, "WORKFLOW.md"), workflow, "utf8"),
+      writeFile(join(second, "WORKFLOW.md"), workflow, "utf8"),
+    ]);
+
+    const results = await Promise.allSettled([
+      deriveStandaloneProject(first, { configDir }),
+      deriveStandaloneProject(second, { configDir }),
+    ]);
+
+    expect(
+      results.filter((result) => result.status === "fulfilled")
+    ).toHaveLength(1);
+    expect(
+      results.filter((result) => result.status === "rejected")
+    ).toHaveLength(1);
+  });
+
   it("preserves Linear label filters and normalizes overlapping states", async () => {
     const configDir = await mkdtemp(join(tmpdir(), "cli-standalone-config-"));
     const first = await mkdtemp(join(tmpdir(), "cli-standalone-project-"));

--- a/packages/cli/src/commands/project.test.ts
+++ b/packages/cli/src/commands/project.test.ts
@@ -2,8 +2,8 @@ import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
-import { loadGlobalConfig, loadProjectConfig } from "../config.js";
-import { registerStandaloneProject } from "./project.js";
+import { loadProjectConfig } from "../config.js";
+import { deriveStandaloneProject, standaloneProjectId } from "./project.js";
 import projectCommand from "./project.js";
 
 const workflow = `---
@@ -34,13 +34,13 @@ repository:
 ---
 Implement the issue.`;
 
-describe("registerStandaloneProject", () => {
-  it("persists an external workflow project and makes it active", async () => {
+describe("deriveStandaloneProject", () => {
+  it("derives an external workflow project from its folder", async () => {
     const configDir = await mkdtemp(join(tmpdir(), "cli-standalone-config-"));
     const projectDir = await mkdtemp(join(tmpdir(), "cli-standalone-project-"));
     await writeFile(join(projectDir, "WORKFLOW.md"), workflow, "utf8");
 
-    const project = await registerStandaloneProject(projectDir, { configDir });
+    const project = await deriveStandaloneProject(projectDir, { configDir });
 
     await expect(
       loadProjectConfig(configDir, project.projectId)
@@ -54,10 +54,71 @@ describe("registerStandaloneProject", () => {
       workspaceDir: join(projectDir, ".runners"),
       populateStrategy: "worktree-cache",
     });
-    await expect(loadGlobalConfig(configDir)).resolves.toEqual({
-      activeProject: project.projectId,
-      projects: [project.projectId],
+    expect(project.projectId).toBe(standaloneProjectId(projectDir));
+  });
+
+  it("derives a clone URL override from the repository extension", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "cli-standalone-config-"));
+    const projectDir = await mkdtemp(join(tmpdir(), "cli-standalone-project-"));
+    await writeFile(
+      join(projectDir, "WORKFLOW.md"),
+      workflow.replace(
+        "repository:\n  slug: acme/platform",
+        "repository:\n  slug: acme/platform\n  clone_url: /srv/mirrors/platform.git"
+      ),
+      "utf8"
+    );
+
+    const project = await deriveStandaloneProject(projectDir, { configDir });
+
+    expect(project.repository).toMatchObject({
+      owner: "acme",
+      name: "platform",
+      cloneUrl: "/srv/mirrors/platform.git",
     });
+  });
+
+  it("re-derives the stored config when the workflow changes", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "cli-standalone-config-"));
+    const projectDir = await mkdtemp(join(tmpdir(), "cli-standalone-project-"));
+    await writeFile(join(projectDir, "WORKFLOW.md"), workflow, "utf8");
+    await deriveStandaloneProject(projectDir, { configDir });
+
+    await writeFile(
+      join(projectDir, "WORKFLOW.md"),
+      workflow.replace("PVT_example", "PVT_changed"),
+      "utf8"
+    );
+    const project = await deriveStandaloneProject(projectDir, { configDir });
+
+    await expect(
+      loadProjectConfig(configDir, project.projectId)
+    ).resolves.toMatchObject({
+      tracker: { bindingId: "PVT_changed" },
+    });
+  });
+
+  it("explains that a folder without WORKFLOW.md is not a project", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "cli-standalone-config-"));
+    const projectDir = await mkdtemp(join(tmpdir(), "cli-standalone-empty-"));
+
+    await expect(
+      deriveStandaloneProject(projectDir, { configDir })
+    ).rejects.toThrow("No WORKFLOW.md in");
+  });
+
+  it("points a repo-embedded workflow at repo start", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "cli-standalone-config-"));
+    const projectDir = await mkdtemp(join(tmpdir(), "cli-standalone-project-"));
+    await writeFile(
+      join(projectDir, "WORKFLOW.md"),
+      workflow.replace("repository:\n  slug: acme/platform\n", ""),
+      "utf8"
+    );
+
+    await expect(
+      deriveStandaloneProject(projectDir, { configDir })
+    ).rejects.toThrow("gh-symphony repo start");
   });
 
   it("rejects an overlapping mapping without interactive confirmation", async () => {
@@ -69,11 +130,11 @@ describe("registerStandaloneProject", () => {
       writeFile(join(second, "WORKFLOW.md"), workflow, "utf8"),
       mkdir(join(first, ".runners"), { recursive: true }),
     ]);
-    await registerStandaloneProject(first, { configDir });
+    await deriveStandaloneProject(first, { configDir });
 
     await expect(
-      registerStandaloneProject(second, { configDir })
-    ).rejects.toThrow("Tracker mapping overlaps registered project(s)");
+      deriveStandaloneProject(second, { configDir })
+    ).rejects.toThrow("Tracker mapping overlaps project(s)");
   });
 
   it("preserves Linear label filters and normalizes overlapping states", async () => {
@@ -89,7 +150,7 @@ describe("registerStandaloneProject", () => {
       ),
     ]);
 
-    const project = await registerStandaloneProject(first, { configDir });
+    const project = await deriveStandaloneProject(first, { configDir });
 
     await expect(
       loadProjectConfig(configDir, project.projectId)
@@ -101,15 +162,15 @@ describe("registerStandaloneProject", () => {
       },
     });
     await expect(
-      registerStandaloneProject(second, { configDir })
-    ).rejects.toThrow("Tracker mapping overlaps registered project(s)");
+      deriveStandaloneProject(second, { configDir })
+    ).rejects.toThrow("Tracker mapping overlaps project(s)");
   });
 
-  it("lists registered standalone projects", async () => {
+  it("lists standalone projects that have been derived", async () => {
     const configDir = await mkdtemp(join(tmpdir(), "cli-standalone-config-"));
     const projectDir = await mkdtemp(join(tmpdir(), "cli-standalone-project-"));
     await writeFile(join(projectDir, "WORKFLOW.md"), workflow, "utf8");
-    const project = await registerStandaloneProject(projectDir, { configDir });
+    const project = await deriveStandaloneProject(projectDir, { configDir });
     const writes: string[] = [];
     const spy = vi
       .spyOn(process.stdout, "write")

--- a/packages/cli/src/commands/project.ts
+++ b/packages/cli/src/commands/project.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { readFile } from "node:fs/promises";
+import { readFile, readdir } from "node:fs/promises";
 import { basename, resolve } from "node:path";
 import * as p from "@clack/prompts";
 import {
@@ -12,12 +12,11 @@ import startCommand from "./start.js";
 import statusCommand from "./status.js";
 import stopCommand from "./stop.js";
 import {
-  loadGlobalConfig,
   loadProjectConfig,
-  saveGlobalConfig,
   saveProjectConfig,
   type CliProjectConfig,
 } from "../config.js";
+import { resolveDaemonLiveness } from "../daemon-liveness.js";
 
 type PickupLabels = { include: string[]; exclude: string[] };
 
@@ -28,13 +27,26 @@ type Mapping = {
   labels: PickupLabels;
 };
 
-export async function registerStandaloneProject(
+/**
+ * The project folder is the source of truth: every field below is derived from
+ * it, so the stored config is a cache that each start refreshes rather than a
+ * registration the operator has to perform first.
+ */
+export async function deriveStandaloneProject(
   projectDirInput: string,
   options: Pick<GlobalOptions, "configDir">
 ): Promise<CliProjectConfig> {
   const projectDir = resolve(projectDirInput);
   const workflowPath = resolve(projectDir, "WORKFLOW.md");
-  const workflow = parseWorkflowMarkdown(await readFile(workflowPath, "utf8"));
+  let markdown: string;
+  try {
+    markdown = await readFile(workflowPath, "utf8");
+  } catch {
+    throw new Error(
+      `No WORKFLOW.md in ${projectDir}. Run this command from a standalone project folder or pass --project-dir <path>.`
+    );
+  }
+  const workflow = parseWorkflowMarkdown(markdown);
   const repository = parseRepository(workflow.repository);
   const adapter = workflow.tracker.kind ?? "github-project";
   const bindingId =
@@ -68,49 +80,140 @@ export async function registerStandaloneProject(
   };
 
   const overlap = await findOverlappingProjects(options.configDir, config);
+  const running = overlap.filter((entry) => entry.running);
+  const describe = (entries: OverlappingProject[]): string =>
+    entries.map((entry) => entry.label).join(", ");
+  if (running.length > 0) {
+    // A live instance with an overlapping mapping would dispatch the same
+    // issues, so this is refused outright rather than confirmed away.
+    throw new Error(
+      `Tracker mapping overlaps running project(s): ${describe(running)}. Stop them or make the mappings disjoint with tracker.pickup_labels.`
+    );
+  }
   if (overlap.length > 0 && !process.stdin.isTTY) {
     throw new Error(
-      `Tracker mapping overlaps registered project(s): ${overlap.join(", ")}. Re-run interactively to confirm.`
+      `Tracker mapping overlaps project(s): ${describe(overlap)}. Re-run interactively to confirm.`
     );
   }
   if (overlap.length > 0) {
     const confirmed = await p.confirm({
-      message: `Tracker mapping overlaps registered project(s): ${overlap.join(", ")}. Register anyway?`,
+      message: `Tracker mapping overlaps project(s): ${describe(overlap)}. Continue anyway?`,
       initialValue: false,
     });
     if (p.isCancel(confirmed) || !confirmed) {
       throw new Error(
-        "Standalone project registration cancelled because tracker mappings overlap."
+        "Standalone project start cancelled because tracker mappings overlap."
       );
     }
   }
 
   await saveProjectConfig(options.configDir, projectId, config);
-  const global = await loadGlobalConfig(options.configDir);
-  await saveGlobalConfig(options.configDir, {
-    activeProject: projectId,
-    projects: [...new Set([...(global?.projects ?? []), projectId])],
-  });
   return config;
 }
 
+/**
+ * The identifier is a pure function of the folder path, so a project can be
+ * addressed without reading its configuration first.
+ */
+export function standaloneProjectId(projectDirInput: string): string {
+  return projectIdentifier(resolve(projectDirInput));
+}
+
+async function listStandaloneProjects(
+  configDir: string
+): Promise<CliProjectConfig[]> {
+  let entries: string[];
+  try {
+    entries = await readdir(resolve(configDir, "projects"));
+  } catch {
+    return [];
+  }
+
+  const configs = await Promise.all(
+    entries.map((projectId) => loadProjectConfig(configDir, projectId))
+  );
+  return configs.filter(
+    (config): config is CliProjectConfig =>
+      config?.workflowSource?.type === "external"
+  );
+}
+
+/** Splits `--project-dir <path>` out of the flags forwarded to the runtime. */
+function extractProjectDir(args: string[]): {
+  projectDir: string | null;
+  forwarded: string[];
+  error?: string;
+} {
+  const forwarded: string[] = [];
+  let projectDir: string | null = null;
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index]!;
+    if (arg === "--project-dir") {
+      const value = args[index + 1];
+      if (!value || value.startsWith("-")) {
+        return {
+          projectDir: null,
+          forwarded,
+          error: "Option '--project-dir' requires a directory path",
+        };
+      }
+      projectDir = value;
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith("--project-dir=")) {
+      const value = arg.slice("--project-dir=".length);
+      if (!value) {
+        return {
+          projectDir: null,
+          forwarded,
+          error: "Option '--project-dir' requires a directory path",
+        };
+      }
+      projectDir = value;
+      continue;
+    }
+    forwarded.push(arg);
+  }
+  return { projectDir, forwarded };
+}
+
+type OverlappingProject = {
+  projectId: string;
+  label: string;
+  running: boolean;
+};
+
+/**
+ * Runs on every start rather than once at registration, so an edited
+ * `pickup_labels` cannot leave two projects competing for the same issues, and
+ * so a conflict with an already running instance is detectable.
+ */
 async function findOverlappingProjects(
   configDir: string,
   candidate: CliProjectConfig
-): Promise<string[]> {
-  const global = await loadGlobalConfig(configDir);
+): Promise<OverlappingProject[]> {
   const candidateMapping = mappingFor(candidate);
-  const overlaps: string[] = [];
-  for (const id of global?.projects ?? []) {
-    const existing = await loadProjectConfig(configDir, id);
-    if (!existing || existing.projectId === candidate.projectId) continue;
+  const overlaps: OverlappingProject[] = [];
+  for (const existing of await listStandaloneProjects(configDir)) {
+    if (existing.projectId === candidate.projectId) continue;
     if (
       existing.repository?.owner !== candidate.repository?.owner ||
       existing.repository?.name !== candidate.repository?.name
     )
       continue;
-    if (mappingsOverlap(candidateMapping, mappingFor(existing)))
-      overlaps.push(id);
+    if (!mappingsOverlap(candidateMapping, mappingFor(existing))) continue;
+
+    const liveness = await resolveDaemonLiveness({
+      configDir,
+      projectId: existing.projectId,
+      workspaceDir: existing.workspaceDir,
+    });
+    overlaps.push({
+      projectId: existing.projectId,
+      label: existing.projectDir ?? existing.projectId,
+      running: liveness.running,
+    });
   }
   return overlaps;
 }
@@ -208,6 +311,11 @@ function trackerSettings(
       ? { pickupLabels: workflow.tracker.pickupLabels }
       : {}),
     repository: `${repository.owner}/${repository.name}`,
+    ...(workflow.tracker.kind === "file" &&
+    process.env.GH_SYMPHONY_FILE_TRACKER_ISSUES_PATH
+      ? // E2E-only escape hatch, mirroring the repo-embedded runtime.
+        { issuesPath: process.env.GH_SYMPHONY_FILE_TRACKER_ISSUES_PATH }
+      : {}),
   };
 }
 
@@ -221,10 +329,18 @@ function parseRepository(value: Record<string, unknown> | null): RepositoryRef {
   const [owner, name] = spec?.split("/") ?? [];
   if (!owner || !name || name.includes("/")) {
     throw new Error(
-      'WORKFLOW.md repository extension requires "slug: owner/name".'
+      'WORKFLOW.md repository extension requires "slug: owner/name". Repositories that embed their own workflow are started with "gh-symphony repo start".'
     );
   }
-  return { owner, name, cloneUrl: `https://github.com/${owner}/${name}.git` };
+  // `clone_url` lets a project point at a mirror, a GHES host, or a local path
+  // while keeping owner/name as the tracker and cache identity.
+  const cloneUrl =
+    typeof value?.clone_url === "string" && value.clone_url
+      ? value.clone_url
+      : typeof value?.cloneUrl === "string" && value.cloneUrl
+        ? value.cloneUrl
+        : `https://github.com/${owner}/${name}.git`;
+  return { owner, name, cloneUrl };
 }
 
 function projectIdentifier(projectDir: string): string {
@@ -238,45 +354,80 @@ function slugify(value: string): string {
     .replace(/^-|-$/g, "");
 }
 
+const USAGE =
+  "Usage: gh-symphony project <list|start|status|stop> [--project-dir <path>] [runtime options]\n";
+
 const handler = async (
   args: string[],
   options: GlobalOptions
 ): Promise<void> => {
-  const [subcommand, projectDir] = args;
-  if (subcommand === "add" && projectDir && args.length === 2) {
-    const project = await registerStandaloneProject(projectDir, options);
-    process.stdout.write(
-      `Standalone project registered: ${project.projectId}\n`
-    );
+  const [subcommand, ...rest] = args;
+
+  if (subcommand === "list" && rest.length === 0) {
+    const projects = await listStandaloneProjects(options.configDir);
+    process.stdout.write(JSON.stringify(projects, null, 2) + "\n");
     return;
   }
-  if (subcommand === "list" && args.length === 1) {
-    const global = await loadGlobalConfig(options.configDir);
-    const projects = await Promise.all(
-      (global?.projects ?? []).map((id) =>
-        loadProjectConfig(options.configDir, id)
-      )
-    );
-    process.stdout.write(
-      JSON.stringify(projects.filter(Boolean), null, 2) + "\n"
-    );
+
+  if (
+    subcommand === "start" ||
+    subcommand === "status" ||
+    subcommand === "stop"
+  ) {
+    const { projectDir, forwarded, error } = extractProjectDir(rest);
+    if (error) {
+      process.stderr.write(`${error}\n${USAGE}`);
+      process.exitCode = 2;
+      return;
+    }
+
+    const resolvedProjectDir = resolve(projectDir ?? process.cwd());
+    if (subcommand === "start") {
+      // Re-derive on every start so an edited WORKFLOW.md takes effect without
+      // a separate registration step.
+      const project = await deriveStandaloneProject(
+        resolvedProjectDir,
+        options
+      );
+      await startCommand(forwarded, {
+        ...options,
+        invocation: "project",
+        projectId: project.projectId,
+      });
+      return;
+    }
+
+    // Status and stop only need to address the runtime, which the folder path
+    // identifies on its own — a removed or broken WORKFLOW.md must not block
+    // stopping a running daemon.
+    const projectId = standaloneProjectId(resolvedProjectDir);
+    const project = await loadProjectConfig(options.configDir, projectId);
+    if (!project) {
+      const known = await listStandaloneProjects(options.configDir);
+      process.stderr.write(
+        `No standalone project runtime for ${resolvedProjectDir}.\n` +
+          (known.length > 0
+            ? `Started projects: ${known.map((entry) => entry.projectDir ?? entry.projectId).join(", ")}\n`
+            : "Run 'gh-symphony project start' from a project folder first.\n")
+      );
+      process.exitCode = 1;
+      return;
+    }
+
+    const runtimeOptions = {
+      ...options,
+      invocation: "project" as const,
+      projectId,
+    };
+    if (subcommand === "status") {
+      await statusCommand(forwarded, runtimeOptions);
+      return;
+    }
+    await stopCommand(forwarded, runtimeOptions);
     return;
   }
-  if (subcommand === "start") {
-    await startCommand(args.slice(1), { ...options, invocation: "project" });
-    return;
-  }
-  if (subcommand === "status") {
-    await statusCommand(args.slice(1), options);
-    return;
-  }
-  if (subcommand === "stop") {
-    await stopCommand(args.slice(1), options);
-    return;
-  }
-  process.stderr.write(
-    "Usage: gh-symphony project <add <projectDir>|list|start|status|stop>\n"
-  );
+
+  process.stderr.write(USAGE);
   process.exitCode = 2;
 };
 

--- a/packages/cli/src/commands/project.ts
+++ b/packages/cli/src/commands/project.ts
@@ -13,8 +13,9 @@ import statusCommand from "./status.js";
 import stopCommand from "./stop.js";
 import {
   loadProjectConfig,
-  saveProjectConfig,
+  saveProjectConfigWithinLock,
   type CliProjectConfig,
+  withConfigLock,
 } from "../config.js";
 import { resolveDaemonLiveness } from "../daemon-liveness.js";
 
@@ -79,35 +80,37 @@ export async function deriveStandaloneProject(
     },
   };
 
-  const overlap = await findOverlappingProjects(options.configDir, config);
-  const running = overlap.filter((entry) => entry.running);
-  const describe = (entries: OverlappingProject[]): string =>
-    entries.map((entry) => entry.label).join(", ");
-  if (running.length > 0) {
-    // A live instance with an overlapping mapping would dispatch the same
-    // issues, so this is refused outright rather than confirmed away.
-    throw new Error(
-      `Tracker mapping overlaps running project(s): ${describe(running)}. Stop them or make the mappings disjoint with tracker.pickup_labels.`
-    );
-  }
-  if (overlap.length > 0 && !process.stdin.isTTY) {
-    throw new Error(
-      `Tracker mapping overlaps project(s): ${describe(overlap)}. Re-run interactively to confirm.`
-    );
-  }
-  if (overlap.length > 0) {
-    const confirmed = await p.confirm({
-      message: `Tracker mapping overlaps project(s): ${describe(overlap)}. Continue anyway?`,
-      initialValue: false,
-    });
-    if (p.isCancel(confirmed) || !confirmed) {
+  await withConfigLock(options.configDir, async () => {
+    const overlap = await findOverlappingProjects(options.configDir, config);
+    const running = overlap.filter((entry) => entry.running);
+    const describe = (entries: OverlappingProject[]): string =>
+      entries.map((entry) => entry.label).join(", ");
+    if (running.length > 0) {
+      // A live instance with an overlapping mapping would dispatch the same
+      // issues, so this is refused outright rather than confirmed away.
       throw new Error(
-        "Standalone project start cancelled because tracker mappings overlap."
+        `Tracker mapping overlaps running project(s): ${describe(running)}. Stop them or make the mappings disjoint with tracker.pickup_labels.`
       );
     }
-  }
+    if (overlap.length > 0 && !process.stdin.isTTY) {
+      throw new Error(
+        `Tracker mapping overlaps project(s): ${describe(overlap)}. Re-run interactively to confirm.`
+      );
+    }
+    if (overlap.length > 0) {
+      const confirmed = await p.confirm({
+        message: `Tracker mapping overlaps project(s): ${describe(overlap)}. Continue anyway?`,
+        initialValue: false,
+      });
+      if (p.isCancel(confirmed) || !confirmed) {
+        throw new Error(
+          "Standalone project start cancelled because tracker mappings overlap."
+        );
+      }
+    }
 
-  await saveProjectConfig(options.configDir, projectId, config);
+    await saveProjectConfigWithinLock(options.configDir, projectId, config);
+  });
   return config;
 }
 

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -895,7 +895,7 @@ const handler = async (
   if (parsed.error) {
     process.stderr.write(`${parsed.error}\n`);
     process.stderr.write(
-      "Usage: gh-symphony repo start [--daemon] [--once] [--assigned-only] [--http [port]] [--web [port]] [--bind-all]\n"
+      `Usage: gh-symphony ${options.invocation === "project" ? "project" : "repo"} start [--daemon] [--once] [--assigned-only] [--http [port]] [--web [port]] [--bind-all]${options.invocation === "project" ? " [--project-dir <path>]" : ""}\n`
     );
     process.exitCode = 2;
     return;
@@ -909,7 +909,7 @@ const handler = async (
   }
   const projectConfig = await resolveManagedProjectConfig({
     configDir: options.configDir,
-    requestedProjectId: process.env[DAEMON_PROJECT_ID_ENV],
+    requestedProjectId: options.projectId ?? process.env[DAEMON_PROJECT_ID_ENV],
   });
   if (!projectConfig) {
     handleMissingManagedProjectConfig();

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -144,7 +144,12 @@ function renderLegacyStatus(
   // Health and last tick
   lines.push(
     ...renderStatusLivenessBanner(
-      createStatusLivenessBanner(snapshot, runtimeStatus),
+      createStatusLivenessBanner(
+        snapshot,
+        runtimeStatus,
+        undefined,
+        startCommandName
+      ),
       { layout: "legacy", noColor }
     )
   );

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -120,7 +120,8 @@ function resolveProjectTokenDelta(snapshot: ProjectStatusSnapshot): number {
 function renderLegacyStatus(
   snapshot: ProjectStatusSnapshot,
   noColor: boolean,
-  runtimeStatus: RuntimeStatus
+  runtimeStatus: RuntimeStatus,
+  startCommandName = "gh-symphony repo start"
 ): string {
   const apply = noColor ? (s: string) => stripAnsi(s) : (s: string) => s;
 
@@ -302,7 +303,7 @@ const handler = async (
     writeCliError({
       code: "invalid_arguments",
       message: parsed.error,
-      usage: "Usage: gh-symphony repo status [--watch]",
+      usage: `Usage: gh-symphony ${options.invocation === "project" ? "project" : "repo"} status [--watch]`,
       json: options.json,
       exitCode: 2,
     });
@@ -311,7 +312,7 @@ const handler = async (
 
   const projectConfig = await resolveManagedProjectConfig({
     configDir: options.configDir,
-    requestedProjectId: undefined,
+    requestedProjectId: options.projectId,
     json: options.json,
   });
   if (!projectConfig) {
@@ -416,7 +417,14 @@ const handler = async (
       );
     } else {
       process.stdout.write(
-        renderLegacyStatus(snapshot, options.noColor, runtimeStatus) + "\n"
+        renderLegacyStatus(
+          snapshot,
+          options.noColor,
+          runtimeStatus,
+          options.invocation === "project"
+            ? "gh-symphony project start"
+            : "gh-symphony repo start"
+        ) + "\n"
       );
     }
   } else {

--- a/packages/cli/src/commands/stop.ts
+++ b/packages/cli/src/commands/stop.ts
@@ -42,14 +42,16 @@ const handler = async (
   const parsed = parseStopArgs(args);
   if (parsed.error) {
     process.stderr.write(`${parsed.error}\n`);
-    process.stderr.write("Usage: gh-symphony repo stop [--force]\n");
+    process.stderr.write(
+      `Usage: gh-symphony ${options.invocation === "project" ? "project" : "repo"} stop [--force]\n`
+    );
     process.exitCode = 2;
     return;
   }
   const resolvedForce = parsed.force;
   const projectConfig = await resolveManagedProjectConfig({
     configDir: options.configDir,
-    requestedProjectId: undefined,
+    requestedProjectId: options.projectId,
   });
   if (!projectConfig) {
     handleMissingManagedProjectConfig();

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -208,6 +208,20 @@ export async function saveProjectConfig(
   );
 }
 
+/** Writes a project config while the caller already owns the config lock. */
+export async function saveProjectConfigWithinLock(
+  configDir: string,
+  projectId: string,
+  config: CliProjectConfig
+): Promise<void> {
+  await writeJsonFile(
+    projectConfigPath(configDir, projectId),
+    normalizeOrchestratorProjectConfig(
+      config as OrchestratorProjectConfig
+    ) as CliProjectConfig
+  );
+}
+
 export async function loadActiveProjectConfig(
   configDir: string
 ): Promise<CliProjectConfig | null> {
@@ -300,7 +314,7 @@ export function parseDaemonPidRecord(raw: string): DaemonPidRecord | null {
   }
 }
 
-async function withConfigLock<T>(
+export async function withConfigLock<T>(
   configDir: string,
   action: () => Promise<T>
 ): Promise<T> {

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -71,6 +71,10 @@ describe("Commander CLI entrypoint", () => {
         resolveGlobalOptions({ configDir: "/tmp/from-config-dir" })
           .configDirOverride
       ).toBe(true);
+      // An explicit --config is exported to the environment so child processes
+      // and the shared bare-clone cache resolve the same directory. Clear it
+      // again before asserting the unset-environment defaults.
+      delete process.env.GH_SYMPHONY_CONFIG_DIR;
       expect(resolveGlobalOptions({}).configDirOverride).toBe(false);
       expect(resolveGlobalOptions({}).configDirSource).toBe("default");
 
@@ -433,7 +437,7 @@ describe("Commander CLI entrypoint", () => {
 
   it.each([
     [["project"], undefined, undefined],
-    [["project", "add", "--non-interactive"], "stderr", "unknown option"],
+    [["project", "add", "./somewhere"], "stderr", "unknown command 'add'"],
   ])("reports project command usage for %s", async (argv, stream, message) => {
     const stdout = captureWrites(process.stdout);
     const stderr = captureWrites(process.stderr);
@@ -471,5 +475,34 @@ describe("Commander CLI entrypoint", () => {
     expect(output).toContain("--bundle");
     expect(output).toContain("--issue");
     expect(output).toContain("remediation");
+  });
+});
+
+describe("config directory export", () => {
+  const originalConfigDir = process.env.GH_SYMPHONY_CONFIG_DIR;
+
+  afterEach(() => {
+    if (originalConfigDir === undefined) {
+      delete process.env.GH_SYMPHONY_CONFIG_DIR;
+    } else {
+      process.env.GH_SYMPHONY_CONFIG_DIR = originalConfigDir;
+    }
+  });
+
+  it("exports an explicit --config directory so the bare cache honors it", () => {
+    delete process.env.GH_SYMPHONY_CONFIG_DIR;
+
+    const options = resolveGlobalOptions({ config: "/tmp/symphony-config" });
+
+    expect(options.configDir).toBe("/tmp/symphony-config");
+    expect(process.env.GH_SYMPHONY_CONFIG_DIR).toBe("/tmp/symphony-config");
+  });
+
+  it("leaves the environment untouched when no override is given", () => {
+    delete process.env.GH_SYMPHONY_CONFIG_DIR;
+
+    resolveGlobalOptions({});
+
+    expect(process.env.GH_SYMPHONY_CONFIG_DIR).toBeUndefined();
   });
 });

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { resolveGlobalOptions, runCli } from "./index.js";
+import { standaloneProjectId } from "./commands/project.js";
 import {
   saveGlobalConfig,
   saveProjectConfig,
@@ -474,7 +475,40 @@ describe("Commander CLI entrypoint", () => {
     expect(output).toContain("--smoke");
     expect(output).toContain("--bundle");
     expect(output).toContain("--issue");
+    expect(output).toContain("--project-dir");
     expect(output).toContain("remediation");
+  });
+
+  it("forwards doctor --project-dir through the Commander entrypoint", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "cli-doctor-config-"));
+    const projectDir = await mkdtemp(join(tmpdir(), "cli-doctor-project-"));
+    const projectId = standaloneProjectId(projectDir);
+    await saveProjectConfig(configDir, projectId, {
+      ...createProject(projectId),
+      projectDir,
+      workflowSource: {
+        type: "external",
+        path: join(projectDir, "WORKFLOW.md"),
+      },
+    });
+    const stdout = captureWrites(process.stdout);
+    const stderr = captureWrites(process.stderr);
+
+    try {
+      await runCli([
+        "doctor",
+        "--project-dir",
+        projectDir,
+        "--config",
+        configDir,
+        "--json",
+      ]);
+    } finally {
+      stdout.restore();
+      stderr.restore();
+    }
+
+    expect(JSON.parse(stdout.output())).toMatchObject({ projectId });
   });
 });
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -22,6 +22,8 @@ export type GlobalOptions = {
   json: boolean;
   noColor: boolean;
   invocation?: "project";
+  /** Explicit runtime target, resolved from a standalone project folder. */
+  projectId?: string;
 };
 
 export type CommandHandler = (
@@ -128,6 +130,14 @@ export function resolveGlobalOptions(values: CliOptionValues): GlobalOptions {
     process.env.NO_COLOR = "1";
   }
   setNoColor(options.noColor);
+
+  // The shared bare-clone cache and spawned child processes resolve the config
+  // directory from the environment. Without exporting an explicit `--config`,
+  // the cache would stay in the default home directory while every other
+  // artifact honors the override.
+  if (configDirSource === "cli") {
+    process.env.GH_SYMPHONY_CONFIG_DIR = options.configDir;
+  }
 
   return options;
 }
@@ -518,19 +528,6 @@ function createProgram(): { program: Command; wasInvoked: () => boolean } {
   const project = addGlobalOptions(
     program.command("project").description("Manage standalone projects")
   );
-  addGlobalOptions(
-    project
-      .command("add")
-      .argument("<projectDir>", "Standalone project directory")
-      .allowExcessArguments(false)
-  ).action(async function (this: Command, projectDir: string) {
-    markInvoked();
-    await invokeHandler(
-      "project",
-      ["add", projectDir],
-      this.optsWithGlobals<CliOptionValues>()
-    );
-  });
   addGlobalOptions(project.command("list").allowExcessArguments(false)).action(
     async function (this: Command) {
       markInvoked();

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -62,6 +62,7 @@ type CliOptionValues = Partial<
     output?: string;
     project?: string;
     projectId?: string;
+    projectDir?: string;
     prune?: boolean;
     run?: string;
     runtime?: string;
@@ -451,6 +452,7 @@ function createProgram(): { program: Command; wasInvoked: () => boolean } {
       .command("doctor")
       .description("Run diagnostics and optional first-run remediation")
       .option("--project-id <projectId>", "Project identifier")
+      .option("--project-dir <path>", "Standalone project folder")
       .option(
         "--fix",
         "Apply safe remediation steps and print manual follow-ups"
@@ -471,6 +473,7 @@ function createProgram(): { program: Command; wasInvoked: () => boolean } {
     const values = this.optsWithGlobals<CliOptionValues>();
     const args: string[] = [];
     pushOption(args, "--project-id", resolveProjectId(values));
+    pushOption(args, "--project-dir", values.projectDir);
     pushOption(args, "--fix", values.fix);
     pushOption(args, "--smoke", values.smoke);
     pushOption(args, "--bundle", values.bundle);

--- a/packages/cli/src/status-liveness-banner.ts
+++ b/packages/cli/src/status-liveness-banner.ts
@@ -37,7 +37,8 @@ export function relativeTime(
 export function createStatusLivenessBanner(
   snapshot: Pick<ProjectStatusSnapshot, "health" | "lastTickAt">,
   runtime: StatusLivenessRuntime,
-  lastTickLabel: string = relativeTime(snapshot.lastTickAt)
+  lastTickLabel: string = relativeTime(snapshot.lastTickAt),
+  startCommandName = "gh-symphony repo start"
 ): StatusLivenessBanner {
   const stopped = !runtime.daemonRunning;
 
@@ -46,7 +47,7 @@ export function createStatusLivenessBanner(
     lastTickLabel,
     stale: runtime.daemonRunning && runtime.lastTickStale,
     restartGuidance: stopped
-      ? "daemon not running — run 'gh-symphony repo start'"
+      ? `daemon not running — run '${startCommandName}'`
       : null,
     lastKnownState: stopped ? `Last known state: ${snapshot.health}` : null,
   };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,6 +13,7 @@ export * from "./workflow/loader.js";
 export * from "./workflow/render.js";
 export * from "./workflow/exit-classification.js";
 export * from "./workflow/issue-identity.js";
+export * from "./workflow/pickup-labels.js";
 export * from "./orchestration/index.js";
 export * from "./runtime/index.js";
 export * from "./workspace/index.js";

--- a/packages/core/src/orchestration/index.ts
+++ b/packages/core/src/orchestration/index.ts
@@ -1,1 +1,2 @@
 export * from "./retry-policy.js";
+export * from "./pickup-labels.js";

--- a/packages/core/src/orchestration/index.ts
+++ b/packages/core/src/orchestration/index.ts
@@ -1,2 +1,1 @@
 export * from "./retry-policy.js";
-export * from "./pickup-labels.js";

--- a/packages/core/src/orchestration/pickup-labels.ts
+++ b/packages/core/src/orchestration/pickup-labels.ts
@@ -1,0 +1,43 @@
+import type { OrchestratorProjectConfig } from "../contracts/status-surface.js";
+import type { TrackedIssue } from "../contracts/tracker-adapter.js";
+
+/**
+ * Candidate listing may be narrowed by `tracker.pickup_labels`, which is how
+ * two projects sharing one repository stay disjoint. State lookups and revive
+ * paths must stay unfiltered, so this is applied only where candidates are
+ * enumerated.
+ */
+export function filterIssuesByPickupLabels<T extends TrackedIssue>(
+  issues: T[],
+  project: Pick<OrchestratorProjectConfig, "tracker">
+): T[] {
+  const pickupLabels = project.tracker.settings?.pickupLabels;
+  if (
+    !pickupLabels ||
+    typeof pickupLabels !== "object" ||
+    Array.isArray(pickupLabels)
+  ) {
+    return issues;
+  }
+
+  const config = pickupLabels as Record<string, unknown>;
+  const include = readLabelList(config.include);
+  const exclude = new Set(readLabelList(config.exclude));
+  if (include.length === 0 && exclude.size === 0) {
+    return issues;
+  }
+
+  return issues.filter((issue) => {
+    const labels = new Set(issue.labels);
+    return (
+      ![...exclude].some((label) => labels.has(label)) &&
+      (include.length === 0 || include.some((label) => labels.has(label)))
+    );
+  });
+}
+
+function readLabelList(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((label): label is string => typeof label === "string")
+    : [];
+}

--- a/packages/core/src/workflow/pickup-labels.ts
+++ b/packages/core/src/workflow/pickup-labels.ts
@@ -2,7 +2,7 @@ import type { OrchestratorProjectConfig } from "../contracts/status-surface.js";
 import type { TrackedIssue } from "../contracts/tracker-adapter.js";
 
 /**
- * Candidate listing may be narrowed by `tracker.pickup_labels`, which is how
+ * Workflow policy may narrow candidate listing by `tracker.pickup_labels`, which is how
  * two projects sharing one repository stay disjoint. State lookups and revive
  * paths must stay unfiltered, so this is applied only where candidates are
  * enumerated.

--- a/packages/orchestrator/src/repository-cache.test.ts
+++ b/packages/orchestrator/src/repository-cache.test.ts
@@ -1,0 +1,87 @@
+import { execFileSync } from "node:child_process";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { ensureGlobalBareRepositoryCache } from "./repository-cache.js";
+
+async function createRemote(root: string, marker: string): Promise<string> {
+  const directory = join(root, "acme-platform");
+  await mkdir(directory, { recursive: true });
+  const git = (args: string[]) =>
+    execFileSync("git", args, { cwd: directory, stdio: "ignore" });
+  git(["init", "-b", "main"]);
+  git(["config", "user.email", "cache@example.test"]);
+  git(["config", "user.name", "cache"]);
+  await writeFile(join(directory, "marker.txt"), marker, "utf8");
+  git(["add", "-A"]);
+  git(["commit", "-m", "seed"]);
+  return directory;
+}
+
+function bareContent(bareDirectory: string): string {
+  return execFileSync("git", [
+    "-C",
+    bareDirectory,
+    "show",
+    "origin/main:marker.txt",
+  ])
+    .toString()
+    .trim();
+}
+
+function bareOrigin(bareDirectory: string): string {
+  return execFileSync("git", [
+    "-C",
+    bareDirectory,
+    "remote",
+    "get-url",
+    "origin",
+  ])
+    .toString()
+    .trim();
+}
+
+describe("global bare repository cache", () => {
+  it("re-points and refetches when the project clone URL changes", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "repository-cache-config-"));
+    const firstRoot = await mkdtemp(join(tmpdir(), "repository-cache-first-"));
+    const secondRoot = await mkdtemp(
+      join(tmpdir(), "repository-cache-second-")
+    );
+    const firstRemote = await createRemote(firstRoot, "first-remote");
+    const secondRemote = await createRemote(secondRoot, "second-remote");
+
+    const bareDirectory = await ensureGlobalBareRepositoryCache({
+      repository: { owner: "acme", name: "platform", cloneUrl: firstRemote },
+      configDir,
+    });
+    expect(bareContent(bareDirectory)).toBe("first-remote");
+
+    await ensureGlobalBareRepositoryCache({
+      repository: { owner: "acme", name: "platform", cloneUrl: secondRemote },
+      configDir,
+    });
+
+    expect(bareOrigin(bareDirectory)).toBe(secondRemote);
+    expect(bareContent(bareDirectory)).toBe("second-remote");
+  });
+
+  it("keeps serving the cached remote while the clone URL is unchanged", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "repository-cache-config-"));
+    const root = await mkdtemp(join(tmpdir(), "repository-cache-stable-"));
+    const remote = await createRemote(root, "stable-remote");
+
+    const bareDirectory = await ensureGlobalBareRepositoryCache({
+      repository: { owner: "acme", name: "platform", cloneUrl: remote },
+      configDir,
+    });
+    await ensureGlobalBareRepositoryCache({
+      repository: { owner: "acme", name: "platform", cloneUrl: remote },
+      configDir,
+    });
+
+    expect(bareOrigin(bareDirectory)).toBe(remote);
+    expect(bareContent(bareDirectory)).toBe("stable-remote");
+  });
+});

--- a/packages/orchestrator/src/repository-cache.ts
+++ b/packages/orchestrator/src/repository-cache.ts
@@ -113,11 +113,31 @@ async function ensureBareRepositoryCacheUnderLock(input: {
   const requiredRefExists = requiredRef
     ? await hasRef(input.bareDirectory, requiredRef)
     : true;
-  if (!(await hasOriginRemote(input.bareDirectory))) {
+  const originUrl = await readOriginRemoteUrl(input.bareDirectory);
+  if (originUrl === null) {
     await recreateBareRepository(input.bareDirectory, input.cloneUrl, now);
     return input.bareDirectory;
   }
-  if (!(await isFetchFresh(input.bareDirectory, now)) || !requiredRefExists) {
+  // The cache is keyed by owner/name, so a repository that moved hosts,
+  // switched protocols, or was re-pointed at a fork would otherwise keep
+  // serving the previous remote forever. Re-point it and refetch immediately
+  // instead of trusting the fetch TTL.
+  const originChanged = originUrl !== input.cloneUrl;
+  if (originChanged) {
+    await runGitCommand([
+      "-C",
+      input.bareDirectory,
+      "remote",
+      "set-url",
+      "origin",
+      input.cloneUrl,
+    ]);
+  }
+  if (
+    originChanged ||
+    !(await isFetchFresh(input.bareDirectory, now)) ||
+    !requiredRefExists
+  ) {
     await fetchOriginBranches(input.bareDirectory);
     await writeLastFetchMarker(input.bareDirectory, now);
     await runGitCommand(["-C", input.bareDirectory, "gc", "--auto"]);
@@ -146,7 +166,14 @@ async function recreateBareRepository(
   // missing parent directory.
   await mkdir(dirname(bareDirectory), { recursive: true });
   await runGitCommand(["init", "--bare", bareDirectory]);
-  await runGitCommand(["-C", bareDirectory, "remote", "add", "origin", cloneUrl]);
+  await runGitCommand([
+    "-C",
+    bareDirectory,
+    "remote",
+    "add",
+    "origin",
+    cloneUrl,
+  ]);
   await fetchOriginBranches(bareDirectory);
   await writeLastFetchMarker(bareDirectory, now);
   await runGitCommand(["-C", bareDirectory, "gc", "--auto"]);
@@ -162,7 +189,14 @@ async function fetchOriginBranches(bareDirectory: string): Promise<void> {
     "origin",
     "+refs/heads/*:refs/remotes/origin/*",
   ]);
-  await runGitCommand(["-C", bareDirectory, "remote", "set-head", "origin", "--auto"]);
+  await runGitCommand([
+    "-C",
+    bareDirectory,
+    "remote",
+    "set-head",
+    "origin",
+    "--auto",
+  ]);
 }
 
 /**
@@ -177,12 +211,19 @@ function normalizeRequiredRef(ref: string): string {
     : ref;
 }
 
-async function hasOriginRemote(directory: string): Promise<boolean> {
+async function readOriginRemoteUrl(directory: string): Promise<string | null> {
   try {
-    await runGitCommand(["-C", directory, "remote", "get-url", "origin"]);
-    return true;
+    return (
+      await runGitCommandCapture([
+        "-C",
+        directory,
+        "remote",
+        "get-url",
+        "origin",
+      ])
+    ).trim();
   } catch {
-    return false;
+    return null;
   }
 }
 

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -8,6 +8,7 @@ import {
   readFile,
   readdir,
   rm,
+  stat,
   writeFile,
 } from "node:fs/promises";
 import { join } from "node:path";
@@ -28,6 +29,7 @@ import {
 import { GitHubGraphQLRateLimitError } from "@gh-symphony/tracker-github";
 import { OrchestratorFsStore } from "./fs-store.js";
 import * as gitModule from "./git.js";
+import { ensureGlobalBareRepositoryCache } from "./repository-cache.js";
 import { clampPollInterval, OrchestratorService } from "./service.js";
 import * as trackerAdapters from "./tracker-adapters.js";
 
@@ -11454,6 +11456,97 @@ Workspace prompt.
     expect(spawnImpl).not.toHaveBeenCalled();
   });
 
+  it("places standalone issue workspaces under the configured workspace root", async () => {
+    process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
+    const tempRoot = await mkdtemp(
+      join(tmpdir(), "orchestrator-standalone-workspace-root-")
+    );
+    const repository = await createRepositoryFixture(
+      tempRoot,
+      "acme",
+      "platform"
+    );
+    const store = new OrchestratorFsStore(tempRoot);
+    const projectDir = join(tempRoot, "projects", "sandbox");
+    const workspaceRoot = join(projectDir, ".runners");
+    await mkdir(projectDir, { recursive: true });
+    const externalWorkflowPath = join(projectDir, "WORKFLOW.md");
+    await writeFile(
+      externalWorkflowPath,
+      await readFile(join(repository.path, "WORKFLOW.md"), "utf8"),
+      "utf8"
+    );
+    const projectConfig = {
+      ...createProjectConfig(tempRoot, repository, workspaceRoot),
+      projectDir,
+      workflowSource: { type: "external" as const, path: externalWorkflowPath },
+    };
+    await store.saveProjectConfig(projectConfig);
+
+    const spawnImpl = vi.fn().mockReturnValue({ pid: 5301, unref: vi.fn() });
+    const service = new OrchestratorService(store, projectConfig, {
+      fetchImpl: vi.fn().mockResolvedValue(createTrackerResponse(repository)),
+      spawnImpl: spawnImpl as never,
+      now: () => new Date("2026-03-08T00:00:00.000Z"),
+    });
+
+    const snapshot = await service.runOnce();
+    const [workspaceRecord] = await store.loadIssueWorkspaces("tenant-1");
+
+    expect(snapshot.summary.dispatched).toBe(1);
+    expect(workspaceRecord?.workspacePath).toBe(
+      join(workspaceRoot, workspaceRecord!.workspaceKey)
+    );
+    expect(
+      (
+        await stat(join(workspaceRecord!.workspacePath, "repository"))
+      ).isDirectory()
+    ).toBe(true);
+    // The worker is pointed at the relocated workspace, not the state directory.
+    const workerEnv = spawnImpl.mock.calls[0]?.[2]?.env as
+      | Record<string, string>
+      | undefined;
+    expect(workerEnv?.WORKING_DIRECTORY).toBe(
+      join(workspaceRecord!.workspacePath, "repository")
+    );
+    expect((await stat(workspaceRoot)).mode & 0o777).toBe(0o700);
+  });
+
+  it("keeps repo-embedded issue workspaces beside the project state", async () => {
+    process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
+    const tempRoot = await mkdtemp(
+      join(tmpdir(), "orchestrator-embedded-workspace-root-")
+    );
+    const repository = await createRepositoryFixture(
+      tempRoot,
+      "acme",
+      "platform"
+    );
+    const store = new OrchestratorFsStore(tempRoot);
+    // repo-embedded registration stores the repository checkout here, which
+    // must never be used as a workspace root.
+    const projectConfig = createProjectConfig(
+      tempRoot,
+      repository,
+      repository.path
+    );
+    await store.saveProjectConfig(projectConfig);
+
+    const spawnImpl = vi.fn().mockReturnValue({ pid: 5302, unref: vi.fn() });
+    const service = new OrchestratorService(store, projectConfig, {
+      fetchImpl: vi.fn().mockResolvedValue(createTrackerResponse(repository)),
+      spawnImpl: spawnImpl as never,
+      now: () => new Date("2026-03-08T00:00:00.000Z"),
+    });
+
+    await service.runOnce();
+    const [workspaceRecord] = await store.loadIssueWorkspaces("tenant-1");
+
+    expect(workspaceRecord?.workspacePath).toBe(
+      join(store.projectDir("tenant-1"), workspaceRecord!.workspaceKey)
+    );
+  });
+
   it("loads only an external workflow and warns when it shadows the repository workflow", async () => {
     process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
     const tempRoot = await mkdtemp(
@@ -11505,6 +11598,114 @@ Workspace prompt.
     expect(snapshot.warnings).toEqual([
       `External workflow source ${externalWorkflowPath} shadows repository WORKFLOW.md at ${join(repository.path, "WORKFLOW.md")}.`,
     ]);
+  });
+
+  it("warns from the shared cache when a remote repository commits its own WORKFLOW.md", async () => {
+    process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
+    const tempRoot = await mkdtemp(
+      join(tmpdir(), "orchestrator-external-workflow-remote-")
+    );
+    const origin = await createRepositoryFixture(tempRoot, "acme", "platform");
+    const configDir = join(tempRoot, "config");
+    process.env.GH_SYMPHONY_CONFIG_DIR = configDir;
+    // The cache is what populate leaves behind; the repository itself is never
+    // checked out to resolve policy in standalone mode.
+    await ensureGlobalBareRepositoryCache({
+      repository: {
+        owner: "acme",
+        name: "platform",
+        cloneUrl: origin.path,
+      },
+      configDir,
+    });
+
+    const store = new OrchestratorFsStore(tempRoot);
+    const externalWorkflowPath = join(
+      store.projectDir("tenant-1"),
+      "WORKFLOW.md"
+    );
+    const projectConfig = {
+      ...createProjectConfig(tempRoot, {
+        owner: "acme",
+        name: "platform",
+        cloneUrl: "https://github.com/acme/platform.git",
+      }),
+      workflowSource: { type: "external" as const, path: externalWorkflowPath },
+    };
+    await store.saveProjectConfig(projectConfig);
+    await writeFile(
+      externalWorkflowPath,
+      await readFile(join(origin.path, "WORKFLOW.md"), "utf8"),
+      "utf8"
+    );
+
+    const service = new OrchestratorService(store, projectConfig, {
+      fetchImpl: vi.fn().mockResolvedValue(createTrackerResponse(origin)),
+      spawnImpl: vi
+        .fn()
+        .mockReturnValue({ pid: 4711, unref: vi.fn() }) as never,
+      now: () => new Date("2026-03-08T00:00:00.000Z"),
+    });
+
+    const snapshot = await service.runOnce();
+
+    expect(snapshot.warnings).toEqual([
+      `External workflow source ${externalWorkflowPath} shadows WORKFLOW.md committed to acme/platform.`,
+    ]);
+  });
+
+  it("does not warn for a remote repository without a committed WORKFLOW.md", async () => {
+    process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
+    const tempRoot = await mkdtemp(
+      join(tmpdir(), "orchestrator-external-workflow-unaware-")
+    );
+    const origin = await createRepositoryFixture(tempRoot, "acme", "platform");
+    execSync(`git -C ${JSON.stringify(origin.path)} rm -q WORKFLOW.md`);
+    execSync(
+      `git -C ${JSON.stringify(origin.path)} commit -q -m "remove workflow"`
+    );
+    const configDir = join(tempRoot, "config");
+    process.env.GH_SYMPHONY_CONFIG_DIR = configDir;
+    await ensureGlobalBareRepositoryCache({
+      repository: {
+        owner: "acme",
+        name: "platform",
+        cloneUrl: origin.path,
+      },
+      configDir,
+    });
+
+    const store = new OrchestratorFsStore(tempRoot);
+    const externalWorkflowPath = join(
+      store.projectDir("tenant-1"),
+      "WORKFLOW.md"
+    );
+    const projectConfig = {
+      ...createProjectConfig(tempRoot, {
+        owner: "acme",
+        name: "platform",
+        cloneUrl: "https://github.com/acme/platform.git",
+      }),
+      workflowSource: { type: "external" as const, path: externalWorkflowPath },
+    };
+    await store.saveProjectConfig(projectConfig);
+    await writeFile(
+      externalWorkflowPath,
+      "---\ntracker:\n  kind: github-project\n  project_id: project-123\ncodex:\n  command: codex app-server\n---\nExternal prompt\n",
+      "utf8"
+    );
+
+    const service = new OrchestratorService(store, projectConfig, {
+      fetchImpl: vi.fn().mockResolvedValue(createTrackerResponse(origin)),
+      spawnImpl: vi
+        .fn()
+        .mockReturnValue({ pid: 4712, unref: vi.fn() }) as never,
+      now: () => new Date("2026-03-08T00:00:00.000Z"),
+    });
+
+    const snapshot = await service.runOnce();
+
+    expect(snapshot.warnings).toEqual([]);
   });
 
   it("does not warn when an external workflow is the resolved repository workflow", async () => {

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -63,7 +63,9 @@ import {
   quarantineIssueWorkspace,
   readGitCurrentBranch,
   removeIssueWorkspaceWorktree,
+  runGitCommand,
 } from "./git.js";
+import { globalBareRepositoryDirectory } from "./repository-cache.js";
 import { excludeRuntimeSkillsFromGit, injectLayeredSkills } from "./skills.js";
 import { OrchestratorFsStore } from "./fs-store.js";
 import { getProcessStartIdentity } from "./lock.js";
@@ -2232,22 +2234,71 @@ export class OrchestratorService {
       return [];
     }
 
-    const repositoryWorkflowPath = join(
-      this.resolveWorkflowRepositoryDirectory(tenant.repository),
-      "WORKFLOW.md"
+    const localRepositoryDirectory = this.resolveLocalRepositoryDirectory(
+      tenant.repository
     );
-    if (
-      resolve(tenant.workflowSource.path) === resolve(repositoryWorkflowPath)
-    ) {
-      return [];
+    if (localRepositoryDirectory) {
+      const repositoryWorkflowPath = join(
+        localRepositoryDirectory,
+        "WORKFLOW.md"
+      );
+      if (
+        resolve(tenant.workflowSource.path) === resolve(repositoryWorkflowPath)
+      ) {
+        return [];
+      }
+      try {
+        await access(repositoryWorkflowPath);
+        return [
+          `External workflow source ${tenant.workflowSource.path} shadows repository WORKFLOW.md at ${repositoryWorkflowPath}.`,
+        ];
+      } catch {
+        return [];
+      }
     }
+
+    // A remote repository is never checked out to resolve policy in standalone
+    // mode, and the working directory the operator happened to start from is
+    // not the repository. The shared bare cache is the only copy of the
+    // repository on this host, so read the committed file from there.
+    return (await this.repositoryCacheContainsWorkflow(tenant.repository))
+      ? [
+          `External workflow source ${tenant.workflowSource.path} shadows WORKFLOW.md committed to ${tenant.repository.owner}/${tenant.repository.name}.`,
+        ]
+      : [];
+  }
+
+  private resolveLocalRepositoryDirectory(
+    repository: RepositoryRef
+  ): string | null {
+    return (
+      repository.path ?? this.resolveLocalCloneUrlPath(repository.cloneUrl)
+    );
+  }
+
+  private async repositoryCacheContainsWorkflow(
+    repository: RepositoryRef
+  ): Promise<boolean> {
+    let bareDirectory: string;
     try {
-      await access(repositoryWorkflowPath);
-      return [
-        `External workflow source ${tenant.workflowSource.path} shadows repository WORKFLOW.md at ${repositoryWorkflowPath}.`,
-      ];
+      bareDirectory = globalBareRepositoryDirectory({ repository });
     } catch {
-      return [];
+      return false;
+    }
+
+    try {
+      // Reads the default branch of the cache populate already maintains; no
+      // fetch and no cache lock, so a status tick never contends with a run.
+      await runGitCommand([
+        "-C",
+        bareDirectory,
+        "cat-file",
+        "-e",
+        "origin/HEAD:WORKFLOW.md",
+      ]);
+      return true;
+    } catch {
+      return false;
     }
   }
 
@@ -2297,9 +2348,8 @@ export class OrchestratorService {
           ));
     const workspaceKey =
       existingWorkspaceRecord?.workspaceKey ?? preferredWorkspaceKey;
-    const projectDir = this.store.projectDir(tenant.projectId);
     const issueWorkspacePath = resolveIssueWorkspaceDirectory(
-      projectDir,
+      this.resolveIssueWorkspaceRoot(tenant),
       workspaceKey
     );
     const pullRequestBranch = resolvePullRequestBranchCheckoutTarget(issue);
@@ -2367,6 +2417,13 @@ export class OrchestratorService {
     const baseBranch = isRecord(repositoryExtension)
       ? readOptionalStringValue(repositoryExtension.base_branch)
       : null;
+    // An external workspace root lives outside the 0700 state directory, so
+    // create it with the same restricted mode. `mkdir` leaves the permissions
+    // of a directory the operator already created untouched.
+    await mkdir(this.resolveIssueWorkspaceRoot(tenant), {
+      recursive: true,
+      mode: 0o700,
+    });
     const repositoryDirectory = await ensureIssueWorkspaceRepository({
       repository: issue.repository,
       issueWorkspacePath,
@@ -2913,7 +2970,7 @@ export class OrchestratorService {
 
     if (run.issueWorkspaceKey) {
       const issueWorkspacePath = resolveIssueWorkspaceDirectory(
-        this.store.projectDir(tenant.projectId),
+        this.resolveIssueWorkspaceRoot(tenant),
         run.issueWorkspaceKey
       );
 
@@ -3588,7 +3645,7 @@ export class OrchestratorService {
         run.issueIdentifier
       );
     const issueWorkspacePath = resolveIssueWorkspaceDirectory(
-      this.store.projectDir(tenant.projectId),
+      this.resolveIssueWorkspaceRoot(tenant),
       workspaceKey
     );
     const dirtyStatus = await inspectIssueWorkspaceDirtyStatus({
@@ -3634,7 +3691,7 @@ export class OrchestratorService {
     const workspaceKey = latestRun.issueWorkspaceKey ?? preferredWorkspaceKey;
     const dirtyStatus = await inspectIssueWorkspaceDirtyStatus({
       issueWorkspacePath: resolveIssueWorkspaceDirectory(
-        this.store.projectDir(tenant.projectId),
+        this.resolveIssueWorkspaceRoot(tenant),
         workspaceKey
       ),
     });
@@ -3673,7 +3730,7 @@ export class OrchestratorService {
       );
     const dirtyStatus = await inspectIssueWorkspaceDirtyStatus({
       issueWorkspacePath: resolveIssueWorkspaceDirectory(
-        this.store.projectDir(tenant.projectId),
+        this.resolveIssueWorkspaceRoot(tenant),
         workspaceKey
       ),
     });
@@ -4236,6 +4293,18 @@ export class OrchestratorService {
 
   private workflowCacheKey(repository: RepositoryRef): string {
     return `${repository.owner}/${repository.name}:${this.normalizeRepositoryCloneUrl(repository.cloneUrl)}`;
+  }
+
+  /**
+   * Per-issue workspaces live under the project's configured `workspace.root`
+   * (spec 9.1). Standalone projects carry that root as `workspaceDir`; the
+   * repo-embedded layout still keeps workspaces beside the project state,
+   * where `workspaceDir` means the repository checkout instead.
+   */
+  private resolveIssueWorkspaceRoot(tenant: OrchestratorProjectConfig): string {
+    return tenant.workflowSource?.type === "external" && tenant.workspaceDir
+      ? resolve(tenant.workspaceDir)
+      : this.store.projectDir(tenant.projectId);
   }
 
   private resolveWorkflowRepositoryDirectory(

--- a/packages/orchestrator/vitest.config.ts
+++ b/packages/orchestrator/vitest.config.ts
@@ -40,6 +40,10 @@ export default defineConfig({
   },
   test: {
     environment: "node",
+    // Git-heavy integration files create and mutate many repositories and
+    // process-level Git resources. Keep files serial while preserving the
+    // explicit concurrency exercised inside individual cache/lock tests.
+    fileParallelism: false,
     setupFiles: ["./vitest.setup.ts"],
   },
 });

--- a/packages/orchestrator/vitest.config.ts
+++ b/packages/orchestrator/vitest.config.ts
@@ -40,5 +40,6 @@ export default defineConfig({
   },
   test: {
     environment: "node",
+    setupFiles: ["./vitest.setup.ts"],
   },
 });

--- a/packages/orchestrator/vitest.setup.ts
+++ b/packages/orchestrator/vitest.setup.ts
@@ -1,0 +1,16 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll } from "vitest";
+
+// The shared bare-clone cache falls back to the operator's real ~/.gh-symphony
+// directory. A test that populates a workspace without pinning its own config
+// directory would leave a cache entry keyed by the fixture's owner/name behind,
+// which later runs then reuse with a dead origin. Sandbox the default here so
+// no test file can reach the developer's home directory.
+const sandbox = mkdtempSync(join(tmpdir(), "orchestrator-config-"));
+process.env.GH_SYMPHONY_CONFIG_DIR ??= sandbox;
+
+afterAll(() => {
+  rmSync(sandbox, { recursive: true, force: true });
+});

--- a/packages/tracker-file/src/file-tracker-adapter.ts
+++ b/packages/tracker-file/src/file-tracker-adapter.ts
@@ -8,6 +8,7 @@ import type {
   TrackerStateRequest,
   TrackerStateResult,
 } from "@gh-symphony/core";
+import { filterIssuesByPickupLabels } from "@gh-symphony/core";
 
 function requireTrackerSetting(
   project: OrchestratorProjectConfig,
@@ -23,36 +24,6 @@ function requireTrackerSetting(
 function parseIssueNumber(identifier: string): number {
   const match = identifier.match(/#(\d+)$/);
   return match ? Number.parseInt(match[1] ?? "0", 10) : 0;
-}
-
-function filterIssuesByPickupLabels(
-  issues: TrackedIssue[],
-  project: OrchestratorProjectConfig
-): TrackedIssue[] {
-  const pickupLabels = project.tracker.settings?.pickupLabels;
-  if (
-    !pickupLabels ||
-    typeof pickupLabels !== "object" ||
-    Array.isArray(pickupLabels)
-  ) {
-    return issues;
-  }
-  const config = pickupLabels as Record<string, unknown>;
-  const readLabels = (value: unknown): string[] =>
-    Array.isArray(value)
-      ? value.filter((label): label is string => typeof label === "string")
-      : [];
-  const include = readLabels(config.include);
-  const exclude = new Set(readLabels(config.exclude));
-  if (include.length === 0 && exclude.size === 0) return issues;
-
-  return issues.filter((issue) => {
-    const labels = new Set(issue.labels);
-    return (
-      ![...exclude].some((label) => labels.has(label)) &&
-      (include.length === 0 || include.some((label) => labels.has(label)))
-    );
-  });
 }
 
 function isValidIssueShape(entry: unknown): entry is TrackedIssue {

--- a/packages/tracker-github/src/orchestrator-adapter.ts
+++ b/packages/tracker-github/src/orchestrator-adapter.ts
@@ -5,6 +5,7 @@ import type {
   OrchestratorTrackerConfig,
   TrackedIssueList,
 } from "@gh-symphony/core";
+import { filterIssuesByPickupLabels } from "@gh-symphony/core";
 import {
   fetchGithubIssueStatesByIds,
   fetchGithubProjectIssueByRepositoryAndNumber,
@@ -16,7 +17,15 @@ import {
 
 export const githubProjectTrackerAdapter: OrchestratorTrackerAdapter = {
   async listIssues(project, dependencies = {}) {
-    return listProjectIssues(project, dependencies);
+    const issues = await listProjectIssues(project, dependencies);
+    const filtered = filterIssuesByPickupLabels(
+      issues,
+      project
+    ) as TrackedIssueList;
+    if (filtered !== issues) {
+      filtered.rateLimits = (issues as TrackedIssueList).rateLimits;
+    }
+    return filtered;
   },
 
   async listIssuesByStates(project, states, dependencies = {}) {

--- a/packages/tracker-github/src/orchestrator-adapter.ts
+++ b/packages/tracker-github/src/orchestrator-adapter.ts
@@ -24,6 +24,7 @@ export const githubProjectTrackerAdapter: OrchestratorTrackerAdapter = {
     ) as TrackedIssueList;
     if (filtered !== issues) {
       filtered.rateLimits = (issues as TrackedIssueList).rateLimits;
+      filtered.skippedItems = (issues as TrackedIssueList).skippedItems;
     }
     return filtered;
   },

--- a/packages/tracker-github/src/tracker-github.test.ts
+++ b/packages/tracker-github/src/tracker-github.test.ts
@@ -5480,6 +5480,86 @@ describe("detectTransferRebindRequired", () => {
   });
 });
 
+describe("pickup label filtering", () => {
+  const adapter = resolveTrackerAdapter({
+    adapter: "github-project",
+    bindingId: "project-123",
+  });
+  const payload = makeProjectItemsPayload([
+    makeProjectItem({
+      itemId: "item-1",
+      issueId: "issue-1",
+      number: 1,
+      title: "Alpha work",
+      assignees: [],
+      labels: ["alpha"],
+    }),
+    makeProjectItem({
+      itemId: "item-2",
+      issueId: "issue-2",
+      number: 2,
+      title: "Beta work",
+      assignees: [],
+      labels: ["beta"],
+    }),
+    makeProjectItem({
+      itemId: "item-3",
+      issueId: "issue-3",
+      number: 3,
+      title: "Unlabeled work",
+      assignees: [],
+    }),
+  ]);
+
+  it("lists only issues matching the configured pickup labels", async () => {
+    const config = makeProjectConfig();
+    config.tracker.settings = {
+      ...config.tracker.settings,
+      pickupLabels: { include: ["alpha"], exclude: ["beta"] },
+    } as never;
+
+    const issues = await adapter.listIssues(config, {
+      token: "dependencies-token",
+      fetchImpl: vi.fn(async () => makeJsonResponse(payload)),
+    });
+
+    expect(issues.map((issue) => issue.identifier)).toEqual([
+      "acme/platform#1",
+    ]);
+  });
+
+  it("keeps every issue when no pickup labels are configured", async () => {
+    const issues = await adapter.listIssues(makeProjectConfig(), {
+      token: "dependencies-token",
+      fetchImpl: vi.fn(async () => makeJsonResponse(payload)),
+    });
+
+    expect(issues.map((issue) => issue.identifier)).toEqual([
+      "acme/platform#1",
+      "acme/platform#2",
+      "acme/platform#3",
+    ]);
+  });
+
+  it("preserves rate limit metadata on the filtered list", async () => {
+    const config = makeProjectConfig();
+    config.tracker.settings = {
+      ...config.tracker.settings,
+      pickupLabels: { include: ["alpha"], exclude: [] },
+    } as never;
+
+    const issues = await adapter.listIssues(config, {
+      token: "dependencies-token",
+      fetchImpl: vi.fn(async () => makeJsonResponse(payload)),
+    });
+
+    expect(issues.map((issue) => issue.identifier)).toEqual([
+      "acme/platform#1",
+    ]);
+    expect("rateLimits" in issues).toBe(true);
+  });
+});
+
 function makeProjectItem(input: {
   itemId: string;
   issueId: string;

--- a/packages/tracker-github/src/tracker-github.test.ts
+++ b/packages/tracker-github/src/tracker-github.test.ts
@@ -5558,6 +5558,43 @@ describe("pickup label filtering", () => {
     ]);
     expect("rateLimits" in issues).toBe(true);
   });
+
+  it("preserves skipped-item metadata on the filtered list", async () => {
+    const missingState = makeProjectItem({
+      itemId: "item-missing-state",
+      issueId: "issue-missing-state",
+      number: 4,
+      title: "Missing state",
+      assignees: [],
+      labels: ["alpha"],
+    });
+    missingState.fieldValues = { nodes: [] };
+    const config = makeProjectConfig();
+    config.tracker.settings = {
+      ...config.tracker.settings,
+      pickupLabels: { include: ["alpha"], exclude: [] },
+    } as never;
+
+    const issues = await adapter.listIssues(config, {
+      token: "dependencies-token",
+      fetchImpl: vi.fn(async () =>
+        makeJsonResponse(
+          makeProjectItemsPayload([
+            ...payload.data.node.items.nodes,
+            missingState,
+          ])
+        )
+      ),
+    });
+
+    expect(issues.skippedItems).toEqual([
+      {
+        id: "item-missing-state",
+        identifier: "acme/platform#4",
+        reason: "missing Status",
+      },
+    ]);
+  });
 });
 
 function makeProjectItem(input: {


### PR DESCRIPTION
## Issues — Closed #600

## TL;DR

- Standalone projects are now addressed by their folder: use the current directory or `--project-dir <path>` for `project start|status|stop` and `doctor`.
- `project start` derives and caches configuration from the folder's `WORKFLOW.md` every time; `project add` and project-namespace reliance on `activeProject` are removed.
- Multiple label-disjoint projects can run against one repository, while overlap validation is serialized and refuses overlap with a running project.

## Change-point diagram

```text
project folder / --project-dir
        |
        +-- start --> read WORKFLOW.md --> derive config --> overlap guard --> cache + runtime
        |
        +-- status/stop -------------> path-derived project id ---------> cached runtime
        |
        +-- doctor ------------------> same path-derived project id

repository.slug      = tracker/cache identity (owner/name)
repository.clone_url = optional checkout source (mirror, GHES, or local path)
```

## Start here

1. Review `packages/cli/src/commands/project.ts` for folder identity, per-start derivation, locking, and overlap behavior.
2. Review `packages/cli/src/commands/project-lifecycle.test.ts` and `packages/cli/src/commands/project.test.ts` for folder lifecycle, removed-workflow stop/status, overlap, and re-derivation coverage.
3. Review `e2e/run-standalone-project-e2e.sh` for two concurrent projects sharing one repository without registration.
4. Review `packages/cli/src/commands/doctor.ts` and `packages/cli/src/index.test.ts` for `doctor --project-dir` selection.

## Requirement coverage

| Requirement | Implementation / evidence |
| --- | --- |
| Remove `project add`; address start/status/stop by cwd or `--project-dir` | `project.ts`, `index.ts`, `project-lifecycle.test.ts` |
| Re-derive and cache configuration on every start | `deriveStandaloneProject` + re-derivation test in `project.test.ts` |
| Status/stop work without reading `WORKFLOW.md` | `project.ts` cached-runtime path + removed-workflow lifecycle test |
| Validate disjointness at start; reject running overlap; confirm stopped overlap | `findOverlappingProjects`, config-wide critical section, overlap/concurrency tests |
| Project namespace ignores `activeProject` | folder-derived `standaloneProjectId` lifecycle path |
| Support `repository.clone_url` while retaining slug identity | parser/config tests and shared-cache tests |
| Distinguish standalone mode with `repository.slug` and explain repo-embedded mode | `parseRepository` error + `project.test.ts` |
| `doctor --project-dir` selects the same project | Commander option forwarding + `index.test.ts` |
| Two disjoint projects run concurrently without registration | TC-13 and `pnpm e2e:standalone-project` |

## Changes

- Added folder-derived standalone identity and per-start workflow/config derivation.
- Moved overlap checks to start and serialized scan/liveness/config persistence under the config-wide lock.
- Applied workflow pickup-label policy in tracker candidate listing while preserving list metadata.
- Added clone URL override support and corrected shared bare-cache behavior, workspace placement, and shadow warnings found during acceptance.
- Updated README, packaged CLI documentation, architecture/configuration docs, TC-13, and the CLI minor changeset.

## Evidence

- `pnpm lint` — passed.
- `pnpm test` — passed; orchestrator test files run serially to avoid cross-file contention between Git-heavy integration suites while preserving explicit within-test concurrency.
- `pnpm typecheck` — passed.
- `pnpm build` — passed.
- `pnpm exec vitest run packages/cli/src/commands/project.test.ts packages/cli/src/index.test.ts packages/tracker-github/src/tracker-github.test.ts` — 144 tests passed.
- `pnpm --filter @gh-symphony/orchestrator exec vitest run src/git.test.ts -t 'serializes concurrent cache initialization for the same repository'` — passed.
- `pnpm --filter @gh-symphony/orchestrator test -- --no-file-parallelism` — 295 tests passed.
- `pnpm e2e:standalone-project` — passed; two folder-addressed projects dispatched label-disjoint issues against one shared repository.

## Risks & rollback

- Risk: folder canonicalization defines project identity, so moving a project folder intentionally creates a different runtime identity.
- Risk: stopped overlapping projects require an interactive confirmation and fail closed in non-interactive shells.
- Risk: this is a breaking change to the unreleased standalone command surface; published CLI 0.7.14 has no `project` commands.
- Rollback: revert this PR to restore registration-based standalone behavior; cached project directories are derived state and can be discarded.

## Changed files

- CLI lifecycle/config/doctor: `packages/cli/src/commands/{project,doctor,start,status,stop}.ts`, `packages/cli/src/config.ts`, `packages/cli/src/index.ts`
- Policy and trackers: `packages/core/src/workflow/pickup-labels.ts`, tracker adapters/tests
- Runtime/cache acceptance fixes: orchestrator service and repository-cache files/tests
- Documentation and blackbox coverage: `README.md`, `packages/cli/README.md`, `docs/{architecture,configuration}.md`, `AGENT_TEST.md`, TC-13/E2E script
- Release: `.changeset/standalone-project-final-test-fixes.md` (`@gh-symphony/cli`: minor)

## Human validation

- [ ] Run `project start|status|stop` from a standalone folder and with `--project-dir`.
- [ ] Edit `pickup_labels`, restart, and confirm the updated mapping is used.
- [ ] Confirm running overlap is refused and stopped overlap prompts interactively.
- [ ] Remove `WORKFLOW.md` after daemon start and confirm status/stop remain available.
- [ ] Confirm `doctor --project-dir <path>` selects the same cached runtime.

## Post-merge validation

- None required beyond normal release verification; Docker TC-13 covers the standalone blackbox flow before merge.
