### PR TITLE
fix(orchestrator): isolate dispatch start failures

### DIFF
--- a/.changeset/calm-ravens-dispatch.md
+++ b/.changeset/calm-ravens-dispatch.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Prevent a failed issue checkout from aborting the remaining dispatch candidates in the same orchestrator tick, and retain retry diagnostics for the failed issue (#579).

--- a/AGENT_TEST.md
+++ b/AGENT_TEST.md
@@ -341,11 +341,12 @@ idle → [inject issue + refresh]
 
 ### Predefined Fixtures
 
-| File                              | Purpose                                          |
-| --------------------------------- | ------------------------------------------------ |
-| `e2e/fixtures/happy-path.json`    | Single issue (state: Ready)                      |
-| `e2e/fixtures/multi-issue.json`   | 3 issues (concurrency test, concurrency_limit=2) |
-| `e2e/fixtures/blocked-issue.json` | Issue with blockedBy                             |
+| File                                       | Purpose                                                         |
+| ------------------------------------------ | --------------------------------------------------------------- |
+| `e2e/fixtures/happy-path.json`             | Single issue (state: Ready)                                     |
+| `e2e/fixtures/multi-issue.json`            | 3 issues (concurrency test, concurrency_limit=2)                |
+| `e2e/fixtures/blocked-issue.json`          | Issue with blockedBy                                            |
+| `e2e/fixtures/dispatch-start-failure.json` | Poison first candidate followed by a healthy dispatch candidate |
 
 ### Predefined Scenario Documents
 
@@ -367,6 +368,7 @@ idle → [inject issue + refresh]
 | `e2e/scenarios/11-stale-run-recovery.md`                  | Verify stale-run ownership and lifecycle recovery                                                                         |
 | `e2e/scenarios/12-transition-comment-race.md`             | Verify orchestrator-owned transition comments survive reconciliation races                                                |
 | `e2e/scenarios/13-standalone-project-model.md`            | Verify the standalone project model (project `.env`, MCP, worktree, and branch isolation) — `pnpm e2e:standalone-project` |
+| `e2e/scenarios/14-dispatch-start-failure-isolation.md`    | Verify one candidate's pre-spawn failure records retry state without starving later candidates                            |
 
 ## TC Writing Guide
 

--- a/e2e/fixtures/dispatch-start-failure.json
+++ b/e2e/fixtures/dispatch-start-failure.json
@@ -1,0 +1,56 @@
+[
+  {
+    "id": "poison-pr",
+    "identifier": "test-owner/test-repo#20",
+    "number": 20,
+    "title": "Pull request with missing checkout metadata",
+    "description": "This candidate must fail before worker spawn without aborting the tick.",
+    "priority": 1,
+    "state": "Ready",
+    "branchName": null,
+    "url": null,
+    "labels": [],
+    "blockedBy": [],
+    "createdAt": "2026-08-21T00:00:00Z",
+    "updatedAt": "2026-08-21T00:00:00Z",
+    "repository": {
+      "owner": "test-owner",
+      "name": "test-repo",
+      "cloneUrl": "/e2e/repos/test-owner/test-repo"
+    },
+    "tracker": {
+      "adapter": "file",
+      "bindingId": "e2e-test",
+      "itemId": "poison-pr"
+    },
+    "metadata": {
+      "contentType": "PullRequest"
+    }
+  },
+  {
+    "id": "healthy-issue",
+    "identifier": "test-owner/test-repo#21",
+    "number": 21,
+    "title": "Healthy candidate after poison pull request",
+    "description": "This candidate must dispatch in the same reconciliation tick.",
+    "priority": 2,
+    "state": "Ready",
+    "branchName": null,
+    "url": null,
+    "labels": [],
+    "blockedBy": [],
+    "createdAt": "2026-08-21T00:00:01Z",
+    "updatedAt": "2026-08-21T00:00:01Z",
+    "repository": {
+      "owner": "test-owner",
+      "name": "test-repo",
+      "cloneUrl": "/e2e/repos/test-owner/test-repo"
+    },
+    "tracker": {
+      "adapter": "file",
+      "bindingId": "e2e-test",
+      "itemId": "healthy-issue"
+    },
+    "metadata": {}
+  }
+]

--- a/e2e/scenarios/14-dispatch-start-failure-isolation.md
+++ b/e2e/scenarios/14-dispatch-start-failure-isolation.md
@@ -27,11 +27,13 @@
 
 ## Expected
 
-- Candidate `#20` is released with `failureRetryCount: 1` and a populated
-  `retryEntry` whose error reports missing pull request metadata.
+- Candidate `#20` is released with `failureRetryCount` at the configured
+  suppression limit and no `retryEntry`, because missing pull request metadata
+  is a permanent dispatch error.
 - Candidate `#21` reaches `running` in the same reconciliation tick.
-- The project does not retain a tick-level `lastError` from candidate `#20`.
-- The log reports the isolated failure and its scheduled retry time.
+- The project remains `degraded` and retains candidate `#20`'s error in
+  `lastError` without aborting the tick.
+- The log reports the isolated failure and that retries were suppressed.
 
 ## Cleanup
 

--- a/e2e/scenarios/14-dispatch-start-failure-isolation.md
+++ b/e2e/scenarios/14-dispatch-start-failure-isolation.md
@@ -1,0 +1,41 @@
+# TC-14: Dispatch start failure isolation
+
+## Setup
+
+1. Reset `e2e/fixtures/issues.json` to `[]`.
+2. Start the Docker E2E stack with the default `happy` stub scenario:
+
+   ```bash
+   GH_SYMPHONY_HTTP_TOKEN=e2e-http-token \
+     docker compose -f docker-compose.e2e.yml up -d --build
+   ```
+
+3. Wait for `http://localhost:4680/healthz` to become ready.
+
+## Steps
+
+1. Copy `e2e/fixtures/dispatch-start-failure.json` to
+   `e2e/fixtures/issues.json`.
+2. Trigger `POST /api/v1/refresh` with the configured bearer token.
+3. Poll `GET /api/v1/state` until `test-owner/test-repo#21` appears in
+   `activeRuns`.
+4. Inspect
+   `/e2e/work/test-repo/.runtime/orchestrator/projects/repository/issues.json`
+   in the container.
+5. Inspect the container logs for the failed `test-owner/test-repo#20`
+   dispatch.
+
+## Expected
+
+- Candidate `#20` is released with `failureRetryCount: 1` and a populated
+  `retryEntry` whose error reports missing pull request metadata.
+- Candidate `#21` reaches `running` in the same reconciliation tick.
+- The project does not retain a tick-level `lastError` from candidate `#20`.
+- The log reports the isolated failure and its scheduled retry time.
+
+## Cleanup
+
+```bash
+echo "[]" > e2e/fixtures/issues.json
+docker compose -f docker-compose.e2e.yml down
+```

--- a/packages/core/src/contracts/issue-orchestration.test.ts
+++ b/packages/core/src/contracts/issue-orchestration.test.ts
@@ -21,7 +21,7 @@ describe("issue orchestration transitions", () => {
 
   it.each<[IssueOrchestrationState, IssueOrchestrationState]>([
     ["unclaimed", "released"],
-    ["claimed", "retry_queued"],
+    ["released", "retry_queued"],
     ["running", "claimed"],
     ["retry_queued", "claimed"],
     ["released", "running"],

--- a/packages/core/src/contracts/issue-orchestration.ts
+++ b/packages/core/src/contracts/issue-orchestration.ts
@@ -26,7 +26,7 @@ export const ISSUE_ORCHESTRATION_TRANSITIONS: Record<
   // No orchestrator code writes this; it can appear in legacy or externally
   // authored records and is retained for Record completeness and display-only use.
   unclaimed: ["unclaimed", "claimed"],
-  claimed: ["claimed", "running", "released"],
+  claimed: ["claimed", "running", "retry_queued", "released"],
   running: ["running", "retry_queued", "released"],
   retry_queued: ["retry_queued", "running", "released"],
   released: ["released", "claimed"],

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -105,6 +105,127 @@ describe("OrchestratorService", () => {
     expect(dependencies.assignedOnly).toBe(true);
   });
 
+  it("continues dispatching after an earlier candidate fails to start", async () => {
+    process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
+    const tempRoot = await mkdtemp(
+      join(tmpdir(), "orchestrator-dispatch-failure-")
+    );
+    const repository = await createRepositoryFixture(
+      tempRoot,
+      "acme",
+      "platform",
+      {
+        retryBaseDelayMs: 1000,
+        retryMaxDelayMs: 1000,
+        maxConcurrentAgents: 2,
+      }
+    );
+    const store = new OrchestratorFsStore(tempRoot);
+    const projectConfig = createProjectConfig(tempRoot, repository);
+    await store.saveProjectConfig(projectConfig);
+
+    const listIssues = vi.fn().mockResolvedValue([
+      {
+        id: "issue-1",
+        identifier: "acme/platform#1",
+        title: "Poison candidate",
+        description: null,
+        state: "Todo",
+        priority: 1,
+        createdAt: "2026-03-08T00:00:00.000Z",
+        updatedAt: "2026-03-08T00:00:00.000Z",
+        url: "https://example.test/acme/platform/issues/1",
+        labels: [],
+        blockedBy: [],
+        repository,
+        tracker: { adapter: "github-project", issueId: "issue-1" },
+        metadata: {},
+      },
+      {
+        id: "issue-2",
+        identifier: "acme/platform#2",
+        title: "Dispatchable candidate",
+        description: null,
+        state: "Todo",
+        priority: 2,
+        createdAt: "2026-03-08T00:00:01.000Z",
+        updatedAt: "2026-03-08T00:00:01.000Z",
+        url: "https://example.test/acme/platform/issues/2",
+        labels: [],
+        blockedBy: [],
+        repository,
+        tracker: { adapter: "github-project", issueId: "issue-2" },
+        metadata: {},
+      },
+    ]);
+    vi.spyOn(trackerAdapters, "resolveTrackerAdapter").mockReturnValue({
+      listIssues,
+      listIssuesByStates: vi.fn().mockResolvedValue([]),
+      fetchIssueStatesByIds: vi.fn().mockResolvedValue([]),
+      buildWorkerEnvironment: vi.fn().mockReturnValue({
+        GITHUB_PROJECT_ID: "project-123",
+      }),
+      reviveIssue: vi.fn(),
+    });
+    const spawnImpl = vi.fn().mockReturnValue({
+      pid: 4100,
+      stderr: null,
+      on: vi.fn(),
+      unref: vi.fn(),
+    });
+    const service = new OrchestratorService(store, projectConfig, {
+      concurrency: 2,
+      fetchImpl: vi.fn().mockResolvedValue(createEmptyTrackerResponse()),
+      spawnImpl: spawnImpl as never,
+      now: () => new Date("2026-03-08T00:00:00.000Z"),
+      writeStderr: vi.fn(),
+    });
+    const startRun = (
+      service as unknown as {
+        startRun: (
+          tenant: OrchestratorProjectConfig,
+          issue: { id: string },
+          options: unknown
+        ) => Promise<OrchestratorRunRecord>;
+      }
+    ).startRun.bind(service);
+    vi.spyOn(service as never, "startRun").mockImplementation(
+      (
+        tenant: OrchestratorProjectConfig,
+        issue: { id: string },
+        options: unknown
+      ) =>
+        issue.id === "issue-1"
+          ? Promise.reject(new Error("checkout failed"))
+          : startRun(tenant, issue, options)
+    );
+
+    const result = await service.runOnce();
+    const issueRecords = await store.loadProjectIssueOrchestrations("tenant-1");
+
+    expect(result.summary.dispatched).toBe(1);
+    expect(spawnImpl).toHaveBeenCalledOnce();
+    expect(issueRecords).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          issueId: "issue-1",
+          state: "released",
+          failureRetryCount: 1,
+          currentRunId: null,
+          retryEntry: {
+            attempt: 2,
+            dueAt: "2026-03-08T00:00:01.000Z",
+            error: expect.stringContaining("Worker spawn failed:"),
+          },
+        }),
+        expect.objectContaining({
+          issueId: "issue-2",
+          state: "running",
+        }),
+      ])
+    );
+  });
+
   it("rejects a live PID whose worker process identity was reused", () => {
     const service = new OrchestratorService(
       {

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -117,6 +117,7 @@ describe("OrchestratorService", () => {
       {
         retryBaseDelayMs: 1000,
         retryMaxDelayMs: 1000,
+        maxFailureRetries: 3,
         maxConcurrentAgents: 2,
       }
     );
@@ -173,11 +174,12 @@ describe("OrchestratorService", () => {
       on: vi.fn(),
       unref: vi.fn(),
     });
+    let currentTime = new Date("2026-03-08T00:00:00.000Z");
     const service = new OrchestratorService(store, projectConfig, {
       concurrency: 2,
       fetchImpl: vi.fn().mockResolvedValue(createEmptyTrackerResponse()),
       spawnImpl: spawnImpl as never,
-      now: () => new Date("2026-03-08T00:00:00.000Z"),
+      now: () => currentTime,
       writeStderr: vi.fn(),
     });
     const startRun = (
@@ -204,16 +206,18 @@ describe("OrchestratorService", () => {
     const issueRecords = await store.loadProjectIssueOrchestrations("tenant-1");
 
     expect(result.summary.dispatched).toBe(1);
+    expect(result.health).toBe("degraded");
+    expect(result.lastError).toContain("checkout failed");
     expect(spawnImpl).toHaveBeenCalledOnce();
     expect(issueRecords).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           issueId: "issue-1",
-          state: "released",
+          state: "retry_queued",
           failureRetryCount: 1,
           currentRunId: null,
           retryEntry: {
-            attempt: 2,
+            attempt: 1,
             dueAt: "2026-03-08T00:00:01.000Z",
             error: expect.stringContaining("Worker spawn failed:"),
           },
@@ -221,6 +225,24 @@ describe("OrchestratorService", () => {
         expect.objectContaining({
           issueId: "issue-2",
           state: "running",
+        }),
+      ])
+    );
+
+    vi.spyOn(service as never, "isRunProcessRunning").mockReturnValue(true);
+    currentTime = new Date("2026-03-08T00:00:01.000Z");
+    await service.runOnce();
+    currentTime = new Date("2026-03-08T00:00:03.000Z");
+    await service.runOnce();
+    const cappedIssueRecords =
+      await store.loadProjectIssueOrchestrations("tenant-1");
+    expect(cappedIssueRecords).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          issueId: "issue-1",
+          state: "released",
+          failureRetryCount: 3,
+          retryEntry: null,
         }),
       ])
     );

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -6835,6 +6835,66 @@ Prefer focused changes.
     expect(issueRecords[0]?.currentRunId).not.toBeNull();
   });
 
+  it("starts a fresh dispatch retry chain after tracker reactivation", async () => {
+    process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
+    const tempRoot = await mkdtemp(
+      join(tmpdir(), "orchestrator-failure-retry-reactivation-")
+    );
+    const repository = await createRepositoryFixture(
+      tempRoot,
+      "acme",
+      "platform",
+      {
+        retryBaseDelayMs: 1000,
+        retryMaxDelayMs: 1000,
+        maxFailureRetries: 3,
+      }
+    );
+    const store = new OrchestratorFsStore(tempRoot);
+    const projectConfig = createProjectConfig(tempRoot, repository);
+    await store.saveProjectConfig(projectConfig);
+    await store.saveProjectIssueOrchestrations("tenant-1", [
+      {
+        issueId: "issue-1",
+        identifier: "acme/platform#1",
+        workspaceKey: "acme_platform_1",
+        completedOnce: false,
+        failureRetryCount: 3,
+        state: "released",
+        currentRunId: null,
+        retryEntry: null,
+        updatedAt: "2026-03-08T00:05:00.000Z",
+      },
+    ]);
+
+    const service = new OrchestratorService(store, projectConfig, {
+      fetchImpl: vi.fn().mockResolvedValue(
+        createTrackerResponseWithState(repository, "Todo", {
+          updatedAt: "2026-03-08T00:06:00.000Z",
+        })
+      ) as never,
+      spawnImpl: vi.fn() as never,
+      now: () => new Date("2026-03-08T00:06:00.000Z"),
+    });
+    vi.spyOn(service as never, "startRun").mockRejectedValue(
+      new Error("temporary checkout failure")
+    );
+
+    await service.runOnce();
+    const issueRecords = await store.loadProjectIssueOrchestrations("tenant-1");
+
+    expect(issueRecords[0]).toMatchObject({
+      state: "retry_queued",
+      failureRetryCount: 1,
+      currentRunId: null,
+      retryEntry: {
+        attempt: 1,
+        dueAt: "2026-03-08T00:06:01.000Z",
+        error: expect.stringContaining("temporary checkout failure"),
+      },
+    });
+  });
+
   it("redispatches a failure-suppressed issue after its tracker state changes", async () => {
     process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
     const tempRoot = await mkdtemp(

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -6752,6 +6752,94 @@ Prefer focused changes.
     expect(issueRecords[0]?.currentRunId).not.toBeNull();
   });
 
+  it("redispatches a failure-suppressed issue after its tracker state changes", async () => {
+    process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
+    const tempRoot = await mkdtemp(
+      join(tmpdir(), "orchestrator-failure-retry-state-change-")
+    );
+    const repository = await createRepositoryFixture(
+      tempRoot,
+      "acme",
+      "platform",
+      {
+        maxFailureRetries: 3,
+        activeStates: ["Ready", "Todo"],
+      }
+    );
+    const store = new OrchestratorFsStore(tempRoot);
+    const projectConfig = createProjectConfig(tempRoot, repository);
+    await store.saveProjectConfig(projectConfig);
+    await store.saveProjectIssueOrchestrations("tenant-1", [
+      {
+        issueId: "issue-1",
+        identifier: "acme/platform#1",
+        workspaceKey: "acme_platform_1",
+        completedOnce: false,
+        failureRetryCount: 3,
+        state: "released",
+        currentRunId: null,
+        retryEntry: null,
+        updatedAt: "2026-03-08T00:05:00.000Z",
+      },
+    ]);
+    await store.saveRun({
+      runId: "run-1",
+      projectId: "tenant-1",
+      projectSlug: "tenant-1",
+      issueId: "issue-1",
+      issueSubjectId: "issue-1",
+      issueIdentifier: "acme/platform#1",
+      issueState: "Ready",
+      repository,
+      status: "suppressed",
+      attempt: 3,
+      processId: null,
+      port: 4601,
+      workingDirectory: join(tempRoot, "suppressed-run"),
+      issueWorkspaceKey: null,
+      workspaceRuntimeDir: join(
+        tempRoot,
+        "suppressed-run",
+        "workspace-runtime"
+      ),
+      workflowPath: null,
+      retryKind: null,
+      createdAt: "2026-03-08T00:00:00.000Z",
+      updatedAt: "2026-03-08T00:05:00.000Z",
+      startedAt: "2026-03-08T00:00:00.000Z",
+      completedAt: "2026-03-08T00:05:00.000Z",
+      lastError:
+        "Run suppressed: max_failure_retries_exceeded. failureRetryCount=3. maxFailureRetries=3.",
+      nextRetryAt: null,
+      runPhase: "failed",
+    });
+
+    const spawnImpl = vi.fn().mockReturnValue({
+      pid: 4107,
+      unref: vi.fn(),
+    });
+    const service = new OrchestratorService(store, projectConfig, {
+      fetchImpl: vi.fn().mockResolvedValue(
+        createTrackerResponseWithState(repository, "Todo", {
+          updatedAt: "2026-03-08T00:04:00.000Z",
+        })
+      ) as never,
+      spawnImpl: spawnImpl as never,
+      now: () => new Date("2026-03-08T00:06:00.000Z"),
+    });
+
+    const result = await service.runOnce();
+    const issueRecords = await store.loadProjectIssueOrchestrations("tenant-1");
+
+    expect(result.summary.dispatched).toBe(1);
+    expect(spawnImpl).toHaveBeenCalledTimes(1);
+    expect(issueRecords[0]).toMatchObject({
+      state: "running",
+      failureRetryCount: 0,
+    });
+    expect(issueRecords[0]?.currentRunId).not.toBeNull();
+  });
+
   it("redispatches a convergence-locked issue after it re-enters the same active state with a newer tracker timestamp", async () => {
     process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
     const tempRoot = await mkdtemp(

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -6665,6 +6665,89 @@ Prefer focused changes.
     });
   });
 
+  it("does not redispatch a run-less failure-suppressed issue with an older completed run", async () => {
+    process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
+    const tempRoot = await mkdtemp(
+      join(tmpdir(), "orchestrator-runless-failure-suppressed-")
+    );
+    const repository = await createRepositoryFixture(
+      tempRoot,
+      "acme",
+      "platform",
+      {
+        maxFailureRetries: 3,
+      }
+    );
+    const store = new OrchestratorFsStore(tempRoot);
+    const projectConfig = createProjectConfig(tempRoot, repository);
+    await store.saveProjectConfig(projectConfig);
+    await store.saveProjectIssueOrchestrations("tenant-1", [
+      {
+        issueId: "issue-1",
+        identifier: "acme/platform#1",
+        workspaceKey: "acme_platform_1",
+        completedOnce: true,
+        failureRetryCount: 3,
+        state: "released",
+        currentRunId: null,
+        retryEntry: null,
+        updatedAt: "2026-03-08T00:05:00.000Z",
+      },
+    ]);
+    await store.saveRun({
+      runId: "run-1",
+      projectId: "tenant-1",
+      projectSlug: "tenant-1",
+      issueId: "issue-1",
+      issueSubjectId: "issue-1",
+      issueIdentifier: "acme/platform#1",
+      issueState: "Todo",
+      repository,
+      status: "completed",
+      attempt: 1,
+      processId: null,
+      port: 4601,
+      workingDirectory: join(tempRoot, "completed-run"),
+      issueWorkspaceKey: "acme_platform_1",
+      workspaceRuntimeDir: join(tempRoot, "completed-run", "workspace-runtime"),
+      workflowPath: null,
+      retryKind: null,
+      createdAt: "2026-03-08T00:00:00.000Z",
+      updatedAt: "2026-03-08T00:01:00.000Z",
+      startedAt: "2026-03-08T00:00:00.000Z",
+      completedAt: "2026-03-08T00:01:00.000Z",
+      lastError: null,
+      nextRetryAt: null,
+      runPhase: "completed",
+    });
+
+    const spawnImpl = vi.fn().mockReturnValue({
+      pid: 4106,
+      unref: vi.fn(),
+    });
+    const service = new OrchestratorService(store, projectConfig, {
+      fetchImpl: vi.fn().mockResolvedValue(
+        createTrackerResponseWithState(repository, "Todo", {
+          updatedAt: "2026-03-08T00:04:00.000Z",
+        })
+      ) as never,
+      spawnImpl: spawnImpl as never,
+      now: () => new Date("2026-03-08T00:06:00.000Z"),
+    });
+
+    const result = await service.runOnce();
+    const issueRecords = await store.loadProjectIssueOrchestrations("tenant-1");
+
+    expect(result.summary.dispatched).toBe(0);
+    expect(spawnImpl).not.toHaveBeenCalled();
+    expect(issueRecords[0]).toMatchObject({
+      state: "released",
+      failureRetryCount: 3,
+      currentRunId: null,
+      updatedAt: "2026-03-08T00:05:00.000Z",
+    });
+  });
+
   it("redispatches a max-failure-retry-suppressed issue after the tracker updates", async () => {
     process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
     const tempRoot = await mkdtemp(

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -271,6 +271,8 @@ function matchesTargetIssueIdentifier(
   );
 }
 
+class NonRetryableDispatchError extends Error {}
+
 function resolvePullRequestBranchCheckoutTarget(
   issue: TrackedIssue
 ): { headRefName: string } | null {
@@ -281,7 +283,7 @@ function resolvePullRequestBranchCheckoutTarget(
 
   if (!pullRequest) {
     if (issue.metadata.contentType === "PullRequest") {
-      throw new Error(
+      throw new NonRetryableDispatchError(
         `Cannot checkout pull request branch for ${issue.identifier}: missing pull request metadata.`
       );
     }
@@ -291,7 +293,7 @@ function resolvePullRequestBranchCheckoutTarget(
 
   const headRefName = pullRequest.headRefName?.trim();
   if (!headRefName) {
-    throw new Error(
+    throw new NonRetryableDispatchError(
       `Cannot checkout pull request branch for ${pullRequest.identifier}: missing headRefName.`
     );
   }
@@ -306,7 +308,7 @@ function resolvePullRequestBranchCheckoutTarget(
     const source = headRepository
       ? `${headRepository.owner}/${headRepository.name}`
       : "unknown fork";
-    throw new Error(
+    throw new NonRetryableDispatchError(
       `Cannot checkout pull request branch for ${pullRequest.identifier}: fork pull requests are unsupported for automatic checkout/push (${source} -> ${issue.repository.owner}/${issue.repository.name}).`
     );
   }
@@ -1326,8 +1328,10 @@ export class OrchestratorService {
       );
       this.rememberTrackerRateLimits(tenant.projectId, trackerRateLimits);
       const concurrency = await this.getProjectConcurrency(tenant);
-      const currentlyActive = issueRecords.filter((record) =>
-        isIssueOrchestrationClaimedState(record.state)
+      const currentlyActive = issueRecords.filter(
+        (record) =>
+          isIssueOrchestrationClaimedState(record.state) &&
+          (record.state !== "retry_queued" || record.currentRunId !== null)
       ).length;
       const availableSlots = Math.max(0, concurrency - currentlyActive);
       const latestRunsByIssueId = buildLatestRunMapByIssueId(
@@ -1355,7 +1359,8 @@ export class OrchestratorService {
         return !issueRecords.some(
           (record) =>
             record.issueId === issue.id &&
-            isIssueOrchestrationClaimedState(record.state)
+            isIssueOrchestrationClaimedState(record.state) &&
+            (record.state !== "retry_queued" || record.currentRunId !== null)
         );
       });
       // Sort candidates by priority (asc, null last) → createdAt (oldest) → identifier (lexicographic)
@@ -1382,13 +1387,21 @@ export class OrchestratorService {
         }
         if (slotsRemaining <= 0) break;
         const existingIssueRecord = issueRecords.find(
-          (record) => record.issueId === issue.id
+          (record) =>
+            record.issueId === issue.id ||
+            record.identifier === issue.identifier
         );
-        if (
-          existingIssueRecord?.retryEntry &&
-          Date.parse(existingIssueRecord.retryEntry.dueAt) > now.getTime()
-        ) {
-          continue;
+        if (existingIssueRecord?.retryEntry) {
+          const retryDueAtMs = parseTimestampMs(
+            existingIssueRecord.retryEntry.dueAt
+          );
+          if (retryDueAtMs === null) {
+            lastError = `Invalid retry dueAt for ${issue.identifier}: ${existingIssueRecord.retryEntry.dueAt}`;
+            continue;
+          }
+          if (retryDueAtMs > now.getTime()) {
+            continue;
+          }
         }
         if (
           await this.isFailureRetrySuppressedIssue(
@@ -1450,8 +1463,13 @@ export class OrchestratorService {
           issueId: issue.id,
           identifier: issue.identifier,
           workspaceKey: preferredWorkspaceKey,
-          state: "claimed",
-          failureRetryCount: existingIssueRecord?.failureRetryCount ?? 0,
+          state:
+            existingIssueRecord?.state === "retry_queued"
+              ? "retry_queued"
+              : "claimed",
+          failureRetryCount: existingIssueRecord?.retryEntry
+            ? existingIssueRecord.failureRetryCount
+            : 0,
           currentRunId: null,
           retryEntry: null,
           updatedAt: now.toISOString(),
@@ -1486,44 +1504,62 @@ export class OrchestratorService {
           });
         } catch (error) {
           const errorMessage = `Worker spawn failed: ${this.formatErrorMessage(error)}`;
+          lastError = errorMessage;
           const failedPreparedRun = preparedRun as OrchestratorRunRecord | null;
-          if (failedPreparedRun) {
-            await this.store.saveRun({
-              ...failedPreparedRun,
-              status: "failed",
-              completedAt: now.toISOString(),
-              updatedAt: now.toISOString(),
-              lastError: errorMessage,
-            });
-          }
           const retryAttempt =
-            (existingIssueRecord?.retryEntry?.attempt ?? 1) + 1;
-          const retryPolicy = await this.loadRetryPolicy(
+            (existingIssueRecord?.retryEntry?.attempt ?? 0) + 1;
+          const maxFailureRetries = await this.loadMaxFailureRetries(
             tenant,
             issue.repository
           );
-          const retryDueAt = (
-            retryPolicy
-              ? scheduleRetryAt(now, retryAttempt, retryPolicy)
-              : new Date(
-                  now.getTime() +
-                    (this.dependencies.retryBackoffMs ??
-                      DEFAULT_RETRY_BACKOFF_MS)
-                )
-          ).toISOString();
+          const failureRetryCount =
+            error instanceof NonRetryableDispatchError
+              ? maxFailureRetries
+              : (existingIssueRecord?.failureRetryCount ?? 0) + 1;
+          const retrySuppressed = failureRetryCount >= maxFailureRetries;
+          const suppressionError = [
+            `Run suppressed: ${MAX_FAILURE_RETRIES_EXCEEDED_REASON}.`,
+            `failureRetryCount=${failureRetryCount}.`,
+            `maxFailureRetries=${maxFailureRetries}.`,
+            errorMessage,
+          ].join(" ");
+          if (failedPreparedRun) {
+            await this.store.saveRun({
+              ...failedPreparedRun,
+              status: retrySuppressed ? "suppressed" : "failed",
+              completedAt: now.toISOString(),
+              updatedAt: now.toISOString(),
+              lastError: retrySuppressed ? suppressionError : errorMessage,
+            });
+          }
+          const retryPolicy = retrySuppressed
+            ? null
+            : await this.loadRetryPolicy(tenant, issue.repository);
+          const retryDueAt = retrySuppressed
+            ? null
+            : (
+                retryPolicy
+                  ? scheduleRetryAt(now, retryAttempt, retryPolicy)
+                  : new Date(
+                      now.getTime() +
+                        (this.dependencies.retryBackoffMs ??
+                          DEFAULT_RETRY_BACKOFF_MS)
+                    )
+              ).toISOString();
           issueRecords = upsertIssueOrchestration(issueRecords, {
             issueId: issue.id,
             identifier: issue.identifier,
             workspaceKey: preferredWorkspaceKey,
-            state: "released",
-            failureRetryCount:
-              (existingIssueRecord?.failureRetryCount ?? 0) + 1,
+            state: retrySuppressed ? "released" : "retry_queued",
+            failureRetryCount,
             currentRunId: null,
-            retryEntry: {
-              attempt: retryAttempt,
-              dueAt: retryDueAt,
-              error: errorMessage,
-            },
+            retryEntry: retryDueAt
+              ? {
+                  attempt: retryAttempt,
+                  dueAt: retryDueAt,
+                  error: errorMessage,
+                }
+              : null,
             updatedAt: now.toISOString(),
           });
           await this.store.saveProjectIssueOrchestrations(
@@ -1531,7 +1567,9 @@ export class OrchestratorService {
             issueRecords
           );
           this.writeStderr(
-            `[orchestrator] dispatch failed for ${issue.identifier}; retry scheduled at ${retryDueAt}: ${this.formatErrorMessage(error)}`
+            retryDueAt
+              ? `[orchestrator] dispatch failed for ${issue.identifier}; retry scheduled at ${retryDueAt}: ${this.formatErrorMessage(error)}`
+              : `[orchestrator] dispatch failed for ${issue.identifier}; retries suppressed: ${this.formatErrorMessage(error)}`
           );
           continue;
         }
@@ -4627,19 +4665,18 @@ export class OrchestratorService {
       return false;
     }
 
-    if (
-      !latestRun ||
-      latestRun.status !== "suppressed" ||
-      latestRun.issueState !== issue.state ||
-      !latestRun.lastError?.includes(MAX_FAILURE_RETRIES_EXCEEDED_REASON)
-    ) {
-      return false;
-    }
+    const suppressedAt =
+      latestRun?.status === "suppressed" &&
+      latestRun.issueState === issue.state &&
+      latestRun.lastError?.includes(MAX_FAILURE_RETRIES_EXCEEDED_REASON)
+        ? (latestRun.completedAt ?? latestRun.updatedAt)
+        : issueRecord.retryEntry === null
+          ? issueRecord.updatedAt
+          : null;
+    if (suppressedAt === null) return false;
 
     const issueUpdatedAtMs = parseTimestampMs(issue.updatedAt);
-    const suppressedAtMs = parseTimestampMs(
-      latestRun.completedAt ?? latestRun.updatedAt
-    );
+    const suppressedAtMs = parseTimestampMs(suppressedAt);
     if (issueUpdatedAtMs === null || suppressedAtMs === null) {
       return true;
     }

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -4674,7 +4674,12 @@ export class OrchestratorService {
       latestRun.issueState === issue.state &&
       latestRun.lastError?.includes(MAX_FAILURE_RETRIES_EXCEEDED_REASON)
         ? (latestRun.completedAt ?? latestRun.updatedAt)
-        : latestRun === null && issueRecord.retryEntry === null
+        : issueRecord.retryEntry === null &&
+            (latestRun === null ||
+              (parseTimestampMs(issueRecord.updatedAt) ?? 0) >
+                (parseTimestampMs(
+                  latestRun.completedAt ?? latestRun.updatedAt
+                ) ?? 0))
           ? issueRecord.updatedAt
           : null;
     if (suppressedAt === null) return false;

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -1381,6 +1381,15 @@ export class OrchestratorService {
           break;
         }
         if (slotsRemaining <= 0) break;
+        const existingIssueRecord = issueRecords.find(
+          (record) => record.issueId === issue.id
+        );
+        if (
+          existingIssueRecord?.retryEntry &&
+          Date.parse(existingIssueRecord.retryEntry.dueAt) > now.getTime()
+        ) {
+          continue;
+        }
         if (
           await this.isFailureRetrySuppressedIssue(
             tenant,
@@ -1442,7 +1451,7 @@ export class OrchestratorService {
           identifier: issue.identifier,
           workspaceKey: preferredWorkspaceKey,
           state: "claimed",
-          failureRetryCount: 0,
+          failureRetryCount: existingIssueRecord?.failureRetryCount ?? 0,
           currentRunId: null,
           retryEntry: null,
           updatedAt: now.toISOString(),
@@ -1476,6 +1485,7 @@ export class OrchestratorService {
             },
           });
         } catch (error) {
+          const errorMessage = `Worker spawn failed: ${this.formatErrorMessage(error)}`;
           const failedPreparedRun = preparedRun as OrchestratorRunRecord | null;
           if (failedPreparedRun) {
             await this.store.saveRun({
@@ -1483,15 +1493,47 @@ export class OrchestratorService {
               status: "failed",
               completedAt: now.toISOString(),
               updatedAt: now.toISOString(),
-              lastError: `Worker spawn failed: ${this.formatErrorMessage(error)}`,
+              lastError: errorMessage,
             });
           }
-          issueRecords = releaseIssueOrchestration(issueRecords, issue.id, now);
+          const retryAttempt =
+            (existingIssueRecord?.retryEntry?.attempt ?? 1) + 1;
+          const retryPolicy = await this.loadRetryPolicy(
+            tenant,
+            issue.repository
+          );
+          const retryDueAt = (
+            retryPolicy
+              ? scheduleRetryAt(now, retryAttempt, retryPolicy)
+              : new Date(
+                  now.getTime() +
+                    (this.dependencies.retryBackoffMs ??
+                      DEFAULT_RETRY_BACKOFF_MS)
+                )
+          ).toISOString();
+          issueRecords = upsertIssueOrchestration(issueRecords, {
+            issueId: issue.id,
+            identifier: issue.identifier,
+            workspaceKey: preferredWorkspaceKey,
+            state: "released",
+            failureRetryCount:
+              (existingIssueRecord?.failureRetryCount ?? 0) + 1,
+            currentRunId: null,
+            retryEntry: {
+              attempt: retryAttempt,
+              dueAt: retryDueAt,
+              error: errorMessage,
+            },
+            updatedAt: now.toISOString(),
+          });
           await this.store.saveProjectIssueOrchestrations(
             tenant.projectId,
             issueRecords
           );
-          throw error;
+          this.writeStderr(
+            `[orchestrator] dispatch failed for ${issue.identifier}; retry scheduled at ${retryDueAt}: ${this.formatErrorMessage(error)}`
+          );
+          continue;
         }
         issueRecords = upsertIssueOrchestration(issueRecords, {
           issueId: run.issueId,

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -1516,10 +1516,13 @@ export class OrchestratorService {
             tenant,
             issue.repository
           );
+          const priorFailureRetryCount = existingIssueRecord?.retryEntry
+            ? existingIssueRecord.failureRetryCount
+            : 0;
           const failureRetryCount =
             error instanceof NonRetryableDispatchError
               ? maxFailureRetries
-              : (existingIssueRecord?.failureRetryCount ?? 0) + 1;
+              : priorFailureRetryCount + 1;
           const retrySuppressed = failureRetryCount >= maxFailureRetries;
           const suppressionError = [
             `Run suppressed: ${MAX_FAILURE_RETRIES_EXCEEDED_REASON}.`,

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -1503,7 +1503,11 @@ export class OrchestratorService {
             },
           });
         } catch (error) {
-          const errorMessage = `Worker spawn failed: ${this.formatErrorMessage(error)}`;
+          const errorDetail =
+            error instanceof Error
+              ? error.message
+              : this.formatErrorMessage(error);
+          const errorMessage = `Worker spawn failed: ${errorDetail}`;
           lastError = errorMessage;
           const failedPreparedRun = preparedRun as OrchestratorRunRecord | null;
           const retryAttempt =
@@ -4670,7 +4674,7 @@ export class OrchestratorService {
       latestRun.issueState === issue.state &&
       latestRun.lastError?.includes(MAX_FAILURE_RETRIES_EXCEEDED_REASON)
         ? (latestRun.completedAt ?? latestRun.updatedAt)
-        : issueRecord.retryEntry === null
+        : latestRun === null && issueRecord.retryEntry === null
           ? issueRecord.updatedAt
           : null;
     if (suppressedAt === null) return false;


### PR DESCRIPTION
## Issues — Closed #579

- Fixes #579

## TL;DR

- Isolate each `startRun` failure so one poison candidate cannot abort the remaining dispatch loop.
- Keep candidate failures operator-visible through project `degraded` / `lastError`, while retrying transient failures with backoff and suppressing permanent or exhausted failures without churn.

## Change-point diagram

```text
sorted candidates
  ├─ candidate A → startRun fails
  │                 ├─ persist concise degraded diagnostics
  │                 └─ retry_queued or suppressed → continue
  └─ candidate B → startRun succeeds in the same tick
```

## Start here

- `packages/orchestrator/src/service.ts` — per-candidate failure boundary, retry scheduling, retry-chain reset, suppression, and project diagnostics.
- `packages/orchestrator/src/service.test.ts` — same-tick dispatch, retry cap, prior-run suppression, tracker changes, and reactivation coverage.
- `packages/core/src/contracts/issue-orchestration.ts` — legal `claimed` → `retry_queued` coordination transition.
- `e2e/scenarios/14-dispatch-start-failure-isolation.md` — Docker black-box procedure and expected persisted state.

## Changes

- Replace the dispatch-loop rethrow with per-candidate persistence and `continue`.
- Represent scheduled start failures as `retry_queued`, exclude run-less queued records from running-slot accounting, and retry them only when due.
- Preserve counts only within a live dispatch-start retry chain; reset stale counts after tracker reactivation and use attempt/count 1 for the first new failure.
- Enforce `max_failure_retries`; classify invalid pull-request checkout metadata as immediately non-retryable.
- Preserve project `degraded` health and concise `lastError` text for isolated candidate failures.
- Distinguish run-less terminal suppression from older persisted runs while preserving tracker-based reactivation.

The optional `repo explain` diagnostic for a prior tick aborted by a higher-priority candidate is intentionally not added: after this change, candidate start failures no longer abort the tick, so that proposed condition cannot occur. The failed issue remains diagnosable through project status, issue retry state, and orchestrator logs.

## Evidence

- Cycle 6 review audit on `118e84e` found no new activity after the Cycle 5 response; every known inline thread is answered, the head is merge-clean, and CI is green.
- `pnpm lint` — passed across all workspace packages.
- `pnpm test` — passed across all workspace packages; orchestrator service 150/150.
- `pnpm exec vitest run packages/orchestrator/src/service.test.ts --reporter=dot` — passed 150/150.
- `pnpm typecheck` — passed across all workspace packages.
- `pnpm build` — passed across all workspace packages.
- `git diff --check` — passed.
- Docker TC-14 — passed on the unchanged `118e84e` integration implementation: poison `#20` was released at `failureRetryCount: 10` with no retry entry; logs show its suppression and healthy `#21` starting in the same second/tick.
- CI `Test` and `Container Smoke` — green on `118e84e`.

## Risks & rollback

- Risk: transient pre-spawn errors occupy retry-queue state without a prepared run; focused and Docker tests cover due-time redispatch and slot accounting.
- Risk: suppression and reactivation depend on persisted timestamps and retry-chain identity; regressions cover older runs, equal-time worker suppression, tracker updates/state changes, and a transient failure immediately after reactivation.
- Rollback: revert `118e84e` and the preceding #579 commits together.

## Changed files

- `packages/orchestrator/src/service.ts` — isolate failures, retain diagnostics, queue retries, and reset stale counts outside live retry chains.
- `packages/orchestrator/src/service.test.ts` — starvation, health, backoff, cap, prior-run, tracker-state, and reactivation regression coverage.
- `packages/core/src/contracts/issue-orchestration.ts` and test — allow claimed dispatches to enter retry-queued state.
- `e2e/fixtures/dispatch-start-failure.json` — poison/healthy candidate fixture.
- `e2e/scenarios/14-dispatch-start-failure-isolation.md` — Docker TC and final expectations.
- `AGENT_TEST.md` — fixture and scenario catalog.
- `.changeset/calm-ravens-dispatch.md` — `@gh-symphony/cli` patch release note.

## Human validation

- [ ] Confirm a permanently failing first candidate does not starve a later eligible candidate.
- [ ] Confirm the failed candidate remains visible through project status and logs.
- [ ] Confirm tracker reactivation starts a fresh dispatch retry chain while unchanged terminal failures stay suppressed.

## Post-merge validation

- No deploy or external smoke test is required beyond CI and the included Docker black-box scenario.
