### PR TITLE
fix(orchestrator): reconcile stale terminal candidates

### DIFF
--- a/.changeset/terminal-candidate-reconciliation.md
+++ b/.changeset/terminal-candidate-reconciliation.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Prevent issue #578's stale active Project items from repeatedly dispatching after the source issue closes or a linked pull request merges by reconciling them to the workflow terminal state.

--- a/AGENT_TEST.md
+++ b/AGENT_TEST.md
@@ -354,6 +354,7 @@ idle → [inject issue + refresh]
 | `e2e/fixtures/multi-issue.json`            | 3 issues (concurrency test, concurrency_limit=2)                |
 | `e2e/fixtures/blocked-issue.json`          | Issue with blockedBy                                            |
 | `e2e/fixtures/dispatch-start-failure.json` | Poison first candidate followed by a healthy dispatch candidate |
+| `e2e/fixtures/terminal-candidate.json`     | Closed source issue left in active Project status               |
 
 ### Predefined Scenario Documents
 
@@ -377,6 +378,7 @@ idle → [inject issue + refresh]
 | `e2e/scenarios/13-api-progress-convergence.md`            | Verify confirmed API lifecycle progress persists as a successful run without workspace mutations                          |
 | `e2e/scenarios/13-standalone-project-model.md`            | Verify the standalone project model (project `.env`, MCP, worktree, and branch isolation) — `pnpm e2e:standalone-project` |
 | `e2e/scenarios/14-dispatch-start-failure-isolation.md`    | Verify one candidate's pre-spawn failure records retry state without starving later candidates                            |
+| `e2e/scenarios/15-terminal-candidate-reconciliation.md`   | Verify a closed issue in active Project status converges to `Done` without worker dispatch                                |
 
 ## TC Writing Guide
 

--- a/README.md
+++ b/README.md
@@ -222,6 +222,8 @@ This walkthrough shows the default happy path for one repository after `gh-symph
 
 The expected first success is an opened PR for the managed issue. After that, the lifecycle continues through the statuses and handoff rules encoded in the repository `WORKFLOW.md`.
 
+If GitHub reports that the source issue is already closed, or that a linked closing PR is merged, Symphony does not dispatch a worker even when the Project item was accidentally left in an active status. It reconciles that Project item to the first terminal status configured in `WORKFLOW.md` and emits a `tracker-terminal-candidate-reconciled` event.
+
 If the issue does not dispatch, start with:
 
 ```bash

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -41,6 +41,7 @@ touches a layer, check that its slice (and the linked documents) still holds.
 
 - Dispatch loop, concurrency, retry, reconciliation: `packages/orchestrator/src/service.ts`
 - Confirmed tracker transitions outside the configured active states are recorded on the active run. When the canonical item becomes non-actionable, reconciliation gives the worker a bounded clean-exit grace; successful finalization then re-reads the current canonical state and preserves `succeeded` only while it remains non-actionable. An unavailable final read defers classification to a later tick instead of manufacturing a failure retry. Per-turn `state-read` requests do not reload or rewrite workflow snapshots.
+- Before dispatch, active candidates carrying an adapter-provided terminal fact are converged to the workflow terminal state and suppressed from worker startup.
 - Filesystem state store (`OrchestratorFsStore`), leases: `packages/orchestrator/src/fs-store.ts`
 - Shared bare clone cache (`<config-dir>/repos/<owner>/<repo>.git`) and worktree populate: `repository-cache.ts`, `git.ts`
 - Workflow source resolution (declared external/repo sources): `service.ts` + core workflow config
@@ -54,14 +55,14 @@ touches a layer, check that its slice (and the linked documents) still holds.
 
 ### 5. Integration — tracker adapters (tracker-specific code lives only here)
 
-- GitHub Project V2: `packages/tracker-github`
+- GitHub Project V2: `packages/tracker-github` (including source issue state and linked-PR metadata kept distinct from Project workflow status)
 - Linear: `packages/tracker-linear`
 - File-based (E2E only): `packages/tracker-file`
 - GitHub-specific planning/approval/PR-reporting extensions: `packages/extension-github-workflow`
 
 ### 6. Observability — events and status surfaces
 
-- Structured events and snapshot builder: `packages/core/src/observability/`
+- Structured events and snapshot builder: `packages/core/src/observability/`; candidate-level reconciliation also emits `tracker-terminal-candidate-reconciled` from the orchestrator before any run exists.
 - Operator HTTP control plane (bearer auth, redaction): `packages/control-plane`
 - Browser dashboard: `packages/dashboard` — details in [../packages/control-plane/README.md](../packages/control-plane/README.md)
 - Runtime state files: `.runtime/orchestrator/` (`workspaces/<id>/`, `runs/<run-id>/`)

--- a/e2e/fixtures/terminal-candidate.json
+++ b/e2e/fixtures/terminal-candidate.json
@@ -1,0 +1,30 @@
+[
+  {
+    "id": "issue-terminal-1",
+    "identifier": "test-owner/test-repo#30",
+    "number": 30,
+    "title": "Closed issue with stale active Project status",
+    "description": null,
+    "priority": null,
+    "state": "Ready",
+    "branchName": null,
+    "url": null,
+    "labels": [],
+    "blockedBy": [],
+    "createdAt": "2026-08-21T00:00:00.000Z",
+    "updatedAt": "2026-08-21T00:00:00.000Z",
+    "repository": {
+      "owner": "test-owner",
+      "name": "test-repo",
+      "cloneUrl": "/e2e/repos/test-owner/test-repo"
+    },
+    "tracker": {
+      "adapter": "file",
+      "bindingId": "e2e-test",
+      "itemId": "issue-terminal-1"
+    },
+    "metadata": {
+      "sourceState": "CLOSED"
+    }
+  }
+]

--- a/e2e/fixtures/terminal-candidate.json
+++ b/e2e/fixtures/terminal-candidate.json
@@ -24,7 +24,11 @@
       "itemId": "issue-terminal-1"
     },
     "metadata": {
-      "sourceState": "CLOSED"
+      "terminalFact": {
+        "kind": "issue_closed",
+        "reason": "Source issue is closed while its Project status is active.",
+        "relatedIdentifier": null
+      }
     }
   }
 ]

--- a/e2e/scenarios/15-terminal-candidate-reconciliation.md
+++ b/e2e/scenarios/15-terminal-candidate-reconciliation.md
@@ -17,7 +17,7 @@
 
 - Issue `#30` is never present in `activeRuns`; the stub worker is not started.
 - Its stale active `Ready` state is reconciled to terminal state `Done`.
-- The reconciliation tick counts one suppressed candidate; a later idle poll may reset the current summary counters to zero.
+- Reconciliation is tracked by its dedicated event and does not inflate the worker-run `summary.suppressed` counter.
 - Container logs contain a `tracker-terminal-candidate-reconciled` structured event with `terminalFact: issue_closed`, `targetState: Done`, and `outcome: confirmed`.
 
 ## Cleanup

--- a/e2e/scenarios/15-terminal-candidate-reconciliation.md
+++ b/e2e/scenarios/15-terminal-candidate-reconciliation.md
@@ -1,0 +1,28 @@
+# TC-15: Terminal candidate reconciliation
+
+## Setup
+
+1. Reset `e2e/fixtures/issues.json` to `[]`.
+2. Start the Docker E2E stack with the default `happy` stub scenario.
+3. Wait for `http://localhost:4680/healthz` to become ready.
+
+## Steps
+
+1. Copy `e2e/fixtures/terminal-candidate.json` to `e2e/fixtures/issues.json`.
+2. Trigger `POST /api/v1/refresh` with the configured bearer token.
+3. Poll the mounted fixture until issue `#30` has state `Done`.
+4. Inspect `GET /api/v1/state` and the container logs.
+
+## Expected
+
+- Issue `#30` is never present in `activeRuns`; the stub worker is not started.
+- Its stale active `Ready` state is reconciled to terminal state `Done`.
+- The reconciliation tick counts one suppressed candidate; a later idle poll may reset the current summary counters to zero.
+- Container logs contain a `tracker-terminal-candidate-reconciled` structured event with `terminalFact: issue_closed`, `targetState: Done`, and `outcome: confirmed`.
+
+## Cleanup
+
+```bash
+echo "[]" > e2e/fixtures/issues.json
+docker compose -f docker-compose.e2e.yml down
+```

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -111,6 +111,8 @@ You can further customize the agent's behavior by editing `WORKFLOW.md` — this
 
 > Currently supported runtimes: **[Codex CLI](https://developers.openai.com/codex/cli/)** and **[Claude Code](https://code.claude.com/docs/en/quickstart)**. The selected runtime command must be installed and authenticated before `gh-symphony repo start` can dispatch worker runs.
 
+Before dispatch, GitHub candidates are checked against the source issue and linked closing PR state. A closed issue or merged linked PR left in an active Project status is reconciled to the first configured terminal status, suppressed from worker startup, and reported as `tracker-terminal-candidate-reconciled`.
+
 ### Explicit Priority Mapping
 
 GitHub Project V2 does not have a native issue priority. For GitHub Project workflows, dispatch priority is controlled only by the explicit `tracker.priority` policy in `WORKFLOW.md`; there is no fallback from Project fields to labels and no guessed label naming convention. Unmapped values resolve to `priority = null`, so dispatch falls back to created time and identifier.

--- a/packages/core/src/contracts/tracker-adapter.ts
+++ b/packages/core/src/contracts/tracker-adapter.ts
@@ -68,6 +68,8 @@ export type TrackedPullRequestContext = {
 
 export type TrackedIssueMetadata = {
   contentType?: TrackedIssueContentType;
+  /** Source-provider state, distinct from the workflow/project state. */
+  sourceState?: string | null;
   linkedPullRequests?: TrackedPullRequestContext[];
   pullRequest?: TrackedPullRequestContext;
   [key: string]: unknown;

--- a/packages/core/src/contracts/tracker-adapter.ts
+++ b/packages/core/src/contracts/tracker-adapter.ts
@@ -170,6 +170,12 @@ export type TrackerStateResult = {
   error: string | null;
 };
 
+export type TrackerTerminalFact = {
+  kind: string;
+  reason: string;
+  relatedIdentifier: string | null;
+};
+
 export type OrchestratorTrackerAdapter = {
   listIssues(
     project: OrchestratorProjectConfig,
@@ -193,6 +199,7 @@ export type OrchestratorTrackerAdapter = {
     project: OrchestratorProjectConfig,
     run: OrchestratorRunRecord
   ): TrackedIssue;
+  resolveTerminalFact?(issue: TrackedIssue): TrackerTerminalFact | null;
   requestState?(
     project: OrchestratorProjectConfig,
     input: {

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -1276,6 +1276,8 @@ describe("OrchestratorService", () => {
       name: "closed source issue",
       metadata: { sourceState: "CLOSED" },
       terminalFact: "issue_closed",
+      requestFails: false,
+      targetIdentifier: null,
     },
     {
       name: "merged linked pull request",
@@ -1293,10 +1295,26 @@ describe("OrchestratorService", () => {
         ],
       },
       terminalFact: "linked_pull_request_merged",
+      requestFails: false,
+      targetIdentifier: null,
+    },
+    {
+      name: "terminal candidate when the provider transition fails",
+      metadata: { sourceState: "CLOSED" },
+      terminalFact: "issue_closed",
+      requestFails: true,
+      targetIdentifier: null,
+    },
+    {
+      name: "unrelated terminal candidate during a targeted run",
+      metadata: { sourceState: "CLOSED" },
+      terminalFact: "issue_closed",
+      requestFails: false,
+      targetIdentifier: "acme/platform#99",
     },
   ])(
     "reconciles a $name to Done without dispatching",
-    async ({ metadata, terminalFact }) => {
+    async ({ metadata, terminalFact, requestFails, targetIdentifier }) => {
       const tempRoot = await mkdtemp(
         join(tmpdir(), "orchestrator-terminal-candidate-")
       );
@@ -1340,10 +1358,13 @@ describe("OrchestratorService", () => {
         state: "Done",
         expectedState: "Todo",
         targetState: "Done",
-        reason: expect.any(String),
+        reason: "Terminal fact provided by tracker adapter.",
         rateLimits: null,
         error: null,
       });
+      if (requestFails) {
+        requestState.mockRejectedValueOnce(new Error("provider unavailable"));
+      }
       const spawnImpl = vi.fn();
       vi.spyOn(trackerAdapters, "resolveTrackerAdapter").mockReturnValue({
         listIssues: vi.fn().mockResolvedValue(issues),
@@ -1351,6 +1372,14 @@ describe("OrchestratorService", () => {
         fetchIssueStatesByIds: vi.fn().mockResolvedValue([]),
         buildWorkerEnvironment: vi.fn(),
         reviveIssue: vi.fn(),
+        resolveTerminalFact: vi.fn().mockReturnValue({
+          kind: terminalFact,
+          reason: "Terminal fact provided by tracker adapter.",
+          relatedIdentifier:
+            terminalFact === "linked_pull_request_merged"
+              ? "acme/platform#2"
+              : null,
+        }),
         requestState,
       });
       const info = vi.spyOn(console, "info").mockImplementation(() => {});
@@ -1359,11 +1388,22 @@ describe("OrchestratorService", () => {
         now: () => new Date("2026-03-08T00:00:00.000Z"),
       });
 
-      const result = await service.runOnce();
+      const result = await service.runOnce({
+        issueIdentifier: targetIdentifier ?? undefined,
+      });
 
       expect(result.summary.dispatched).toBe(0);
-      expect(result.summary.suppressed).toBe(1);
+      expect(result.summary.suppressed).toBe(0);
       expect(spawnImpl).not.toHaveBeenCalled();
+      if (targetIdentifier) {
+        expect(requestState).not.toHaveBeenCalled();
+        expect(info).not.toHaveBeenCalledWith(
+          expect.stringContaining(
+            `"event":"tracker-terminal-candidate-reconciled"`
+          )
+        );
+        return;
+      }
       expect(requestState).toHaveBeenCalledWith(
         projectConfig,
         expect.objectContaining({
@@ -1385,6 +1425,14 @@ describe("OrchestratorService", () => {
       expect(info).toHaveBeenCalledWith(
         expect.stringContaining(`"terminalFact":"${terminalFact}"`)
       );
+      if (requestFails) {
+        expect(info).toHaveBeenCalledWith(
+          expect.stringContaining(`"outcome":"failed"`)
+        );
+        expect(info).toHaveBeenCalledWith(
+          expect.stringContaining(`"error":"Error: provider unavailable`)
+        );
+      }
     }
   );
 

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -1271,6 +1271,123 @@ describe("OrchestratorService", () => {
     );
   });
 
+  it.each([
+    {
+      name: "closed source issue",
+      metadata: { sourceState: "CLOSED" },
+      terminalFact: "issue_closed",
+    },
+    {
+      name: "merged linked pull request",
+      metadata: {
+        sourceState: "OPEN",
+        linkedPullRequests: [
+          {
+            id: "pr-2",
+            number: 2,
+            identifier: "acme/platform#2",
+            url: "https://github.com/acme/platform/pull/2",
+            state: "MERGED",
+            merged: true,
+          },
+        ],
+      },
+      terminalFact: "linked_pull_request_merged",
+    },
+  ])(
+    "reconciles a $name to Done without dispatching",
+    async ({ metadata, terminalFact }) => {
+      const tempRoot = await mkdtemp(
+        join(tmpdir(), "orchestrator-terminal-candidate-")
+      );
+      const repository = await createRepositoryFixture(
+        tempRoot,
+        "acme",
+        "platform"
+      );
+      const store = new OrchestratorFsStore(tempRoot);
+      const projectConfig = createProjectConfig(tempRoot, repository);
+      await store.saveProjectConfig(projectConfig);
+      const issue = {
+        id: "issue-1",
+        identifier: "acme/platform#1",
+        number: 1,
+        title: "Already terminal issue",
+        description: null,
+        priority: null,
+        state: "Todo",
+        branchName: null,
+        url: "https://github.com/acme/platform/issues/1",
+        labels: [],
+        blockedBy: [],
+        createdAt: "2026-03-08T00:00:00.000Z",
+        updatedAt: "2026-03-08T00:00:00.000Z",
+        repository,
+        tracker: {
+          adapter: "github-project" as const,
+          bindingId: "project-123",
+          itemId: "item-1",
+        },
+        metadata,
+      };
+      const issues = Object.assign([issue], {
+        rateLimits: null,
+        skippedItems: [],
+      }) as TrackedIssueList;
+      const requestState = vi.fn().mockResolvedValue({
+        ok: true,
+        outcome: "confirmed",
+        state: "Done",
+        expectedState: "Todo",
+        targetState: "Done",
+        reason: expect.any(String),
+        rateLimits: null,
+        error: null,
+      });
+      const spawnImpl = vi.fn();
+      vi.spyOn(trackerAdapters, "resolveTrackerAdapter").mockReturnValue({
+        listIssues: vi.fn().mockResolvedValue(issues),
+        listIssuesByStates: vi.fn().mockResolvedValue([]),
+        fetchIssueStatesByIds: vi.fn().mockResolvedValue([]),
+        buildWorkerEnvironment: vi.fn(),
+        reviveIssue: vi.fn(),
+        requestState,
+      });
+      const info = vi.spyOn(console, "info").mockImplementation(() => {});
+      const service = new OrchestratorService(store, projectConfig, {
+        spawnImpl: spawnImpl as never,
+        now: () => new Date("2026-03-08T00:00:00.000Z"),
+      });
+
+      const result = await service.runOnce();
+
+      expect(result.summary.dispatched).toBe(0);
+      expect(result.summary.suppressed).toBe(1);
+      expect(spawnImpl).not.toHaveBeenCalled();
+      expect(requestState).toHaveBeenCalledWith(
+        projectConfig,
+        expect.objectContaining({
+          issueSubjectId: "issue-1",
+          itemId: "item-1",
+          request: expect.objectContaining({
+            type: "transition-request",
+            expectedState: "Todo",
+            targetState: "Done",
+          }),
+        }),
+        expect.any(Object)
+      );
+      expect(info).toHaveBeenCalledWith(
+        expect.stringContaining(
+          `\"event\":\"tracker-terminal-candidate-reconciled\"`
+        )
+      );
+      expect(info).toHaveBeenCalledWith(
+        expect.stringContaining(`\"terminalFact\":\"${terminalFact}\"`)
+      );
+    }
+  );
+
   it("passes worktree-cache settings into issue populate", async () => {
     process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
     const tempRoot = await mkdtemp(

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -1379,11 +1379,11 @@ describe("OrchestratorService", () => {
       );
       expect(info).toHaveBeenCalledWith(
         expect.stringContaining(
-          `\"event\":\"tracker-terminal-candidate-reconciled\"`
+          `"event":"tracker-terminal-candidate-reconciled"`
         )
       );
       expect(info).toHaveBeenCalledWith(
-        expect.stringContaining(`\"terminalFact\":\"${terminalFact}\"`)
+        expect.stringContaining(`"terminalFact":"${terminalFact}"`)
       );
     }
   );

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -1250,6 +1250,15 @@ export class OrchestratorService {
         );
       }
       const canonicalIssues = resolveCanonicalSubjectIssues(issues);
+      const terminalCandidateReconciliation =
+        await this.reconcileTerminalCandidates(
+          tenant,
+          trackerAdapter,
+          canonicalIssues,
+          candidateTrackerDependencies,
+          now
+        );
+      suppressed += terminalCandidateReconciliation.suppressedIdentifiers.size;
       // The map is unconditionally seeded from `canonicalIssues`, so the old
       // second reverse-order merge loop is unnecessary. If seeding ever
       // becomes conditional, revisit the precedence here.
@@ -1327,7 +1336,15 @@ export class OrchestratorService {
       const {
         candidates: trackedActionableIssues,
         lifecyclesByIssueIdentifier,
-      } = await this.resolveActionableCandidates(tenant, canonicalIssues);
+      } = await this.resolveActionableCandidates(
+        tenant,
+        canonicalIssues.filter(
+          (issue) =>
+            !terminalCandidateReconciliation.suppressedIdentifiers.has(
+              issue.identifier
+            )
+        )
+      );
       const resolveTrackedIssueLifecycle = async (
         issue: TrackedIssue
       ): Promise<WorkflowLifecycleConfig | null> => {
@@ -1594,14 +1611,13 @@ export class OrchestratorService {
             : await this.loadRetryPolicy(tenant, issue.repository);
           const retryDueAt = retrySuppressed
             ? null
-            : (
-                retryPolicy
-                  ? scheduleRetryAt(now, retryAttempt, retryPolicy)
-                  : new Date(
-                      now.getTime() +
-                        (this.dependencies.retryBackoffMs ??
-                          DEFAULT_RETRY_BACKOFF_MS)
-                    )
+            : (retryPolicy
+                ? scheduleRetryAt(now, retryAttempt, retryPolicy)
+                : new Date(
+                    now.getTime() +
+                      (this.dependencies.retryBackoffMs ??
+                        DEFAULT_RETRY_BACKOFF_MS)
+                  )
               ).toISOString();
           issueRecords = upsertIssueOrchestration(issueRecords, {
             issueId: issue.id,
@@ -2236,6 +2252,103 @@ export class OrchestratorService {
       candidates,
       lifecyclesByIssueIdentifier,
     };
+  }
+
+  private async reconcileTerminalCandidates(
+    tenant: OrchestratorProjectConfig,
+    trackerAdapter: OrchestratorTrackerAdapter,
+    issues: readonly TrackedIssue[],
+    trackerDependencies: OrchestratorTrackerDependencies,
+    now: Date
+  ): Promise<{ suppressedIdentifiers: Set<string> }> {
+    const suppressedIdentifiers = new Set<string>();
+
+    for (const issue of issues) {
+      if (
+        isArchivedProjectItem(issue) ||
+        issue.metadata.contentType === "PullRequest"
+      ) {
+        continue;
+      }
+
+      const lifecycle = await this.resolveIssueLifecycle(tenant, issue);
+      if (
+        !lifecycle ||
+        isStateTerminal(issue.state, lifecycle) ||
+        !matchesWorkflowState(issue.state, lifecycle.activeStates)
+      ) {
+        continue;
+      }
+
+      const terminalFact = resolveTerminalCandidateFact(issue);
+      if (!terminalFact) {
+        continue;
+      }
+      suppressedIdentifiers.add(issue.identifier);
+
+      const targetState = lifecycle.terminalStates[0]?.trim() ?? "";
+      let result: TrackerStateResult;
+      if (!targetState) {
+        result = buildTerminalCandidateFailure(
+          issue,
+          targetState,
+          terminalFact.reason,
+          "terminal_state_missing"
+        );
+      } else if (!trackerAdapter.requestState) {
+        result = buildTerminalCandidateFailure(
+          issue,
+          targetState,
+          terminalFact.reason,
+          "tracker_state_requests_unsupported"
+        );
+      } else {
+        try {
+          result = await trackerAdapter.requestState(
+            tenant,
+            {
+              issueSubjectId: issue.id,
+              itemId: issue.tracker.itemId,
+              request: {
+                type: "transition-request",
+                expectedState: issue.state,
+                targetState,
+                reason: terminalFact.reason,
+              },
+            },
+            trackerDependencies
+          );
+        } catch (error) {
+          result = buildTerminalCandidateFailure(
+            issue,
+            targetState,
+            terminalFact.reason,
+            this.formatErrorMessage(error)
+          );
+        }
+      }
+
+      this.rememberTrackerRateLimits(tenant.projectId, result.rateLimits);
+      console.info(
+        JSON.stringify({
+          at: now.toISOString(),
+          event: "tracker-terminal-candidate-reconciled",
+          projectId: tenant.projectId,
+          issueIdentifier: issue.identifier,
+          issueId: issue.id,
+          trackerItemId: issue.tracker.itemId,
+          terminalFact: terminalFact.kind,
+          linkedPullRequest: terminalFact.linkedPullRequestIdentifier,
+          expectedState: issue.state,
+          targetState,
+          confirmedState: result.state,
+          outcome: result.outcome,
+          error: result.error,
+        })
+      );
+    }
+
+    return { suppressedIdentifiers };
   }
 
   private async resolveIssueLifecycle(
@@ -5509,4 +5622,49 @@ function releaseIssueOrchestration(
 
 function isArchivedProjectItem(issue: TrackedIssue): boolean {
   return issue.metadata.isArchived === true;
+}
+
+function resolveTerminalCandidateFact(issue: TrackedIssue): {
+  kind: "issue_closed" | "linked_pull_request_merged";
+  reason: string;
+  linkedPullRequestIdentifier: string | null;
+} | null {
+  if (issue.metadata.sourceState?.trim().toLowerCase() === "closed") {
+    return {
+      kind: "issue_closed",
+      reason: "Source issue is closed while its Project status is active.",
+      linkedPullRequestIdentifier: null,
+    };
+  }
+
+  const mergedPullRequest = issue.metadata.linkedPullRequests?.find(
+    (pullRequest) =>
+      pullRequest.merged === true ||
+      pullRequest.state?.trim().toLowerCase() === "merged"
+  );
+  return mergedPullRequest
+    ? {
+        kind: "linked_pull_request_merged",
+        reason: `Linked pull request ${mergedPullRequest.identifier} is merged while the issue Project status is active.`,
+        linkedPullRequestIdentifier: mergedPullRequest.identifier,
+      }
+    : null;
+}
+
+function buildTerminalCandidateFailure(
+  issue: TrackedIssue,
+  targetState: string,
+  reason: string,
+  error: string
+): TrackerStateResult {
+  return {
+    ok: false,
+    outcome: "failed",
+    state: issue.state,
+    expectedState: issue.state,
+    targetState: targetState || null,
+    reason,
+    rateLimits: null,
+    error,
+  };
 }

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -1250,15 +1250,29 @@ export class OrchestratorService {
         );
       }
       const canonicalIssues = resolveCanonicalSubjectIssues(issues);
+      const terminalCandidateIssues = issueIdentifier
+        ? canonicalIssues.filter((issue) =>
+            matchesTargetIssueIdentifier(issue, issueIdentifier)
+          )
+        : canonicalIssues;
       const terminalCandidateReconciliation =
         await this.reconcileTerminalCandidates(
           tenant,
           trackerAdapter,
-          canonicalIssues,
+          terminalCandidateIssues,
+          new Set(
+            issueRecords
+              .filter(
+                (record) =>
+                  isIssueOrchestrationClaimedState(record.state) &&
+                  (record.state !== "retry_queued" ||
+                    record.currentRunId !== null)
+              )
+              .map((record) => record.issueId)
+          ),
           candidateTrackerDependencies,
           now
         );
-      suppressed += terminalCandidateReconciliation.suppressedIdentifiers.size;
       // The map is unconditionally seeded from `canonicalIssues`, so the old
       // second reverse-order merge loop is unnecessary. If seeding ever
       // becomes conditional, revisit the precedence here.
@@ -1391,7 +1405,8 @@ export class OrchestratorService {
       );
       trackerRateLimits = mergeTrackerRateLimits(
         trackerRateLimits,
-        advisoryRateLimits
+        advisoryRateLimits,
+        terminalCandidateReconciliation.rateLimits
       );
       this.rememberTrackerRateLimits(tenant.projectId, trackerRateLimits);
       const concurrency = await this.getProjectConcurrency(tenant);
@@ -2258,15 +2273,25 @@ export class OrchestratorService {
     tenant: OrchestratorProjectConfig,
     trackerAdapter: OrchestratorTrackerAdapter,
     issues: readonly TrackedIssue[],
+    claimedIssueIds: ReadonlySet<string>,
     trackerDependencies: OrchestratorTrackerDependencies,
     now: Date
-  ): Promise<{ suppressedIdentifiers: Set<string> }> {
+  ): Promise<{
+    suppressedIdentifiers: Set<string>;
+    rateLimits: Record<string, unknown> | null;
+  }> {
     const suppressedIdentifiers = new Set<string>();
+    let rateLimits: Record<string, unknown> | null = null;
+
+    if (!trackerAdapter.resolveTerminalFact) {
+      return { suppressedIdentifiers, rateLimits };
+    }
 
     for (const issue of issues) {
       if (
         isArchivedProjectItem(issue) ||
-        issue.metadata.contentType === "PullRequest"
+        issue.metadata.contentType === "PullRequest" ||
+        claimedIssueIds.has(issue.id)
       ) {
         continue;
       }
@@ -2280,7 +2305,7 @@ export class OrchestratorService {
         continue;
       }
 
-      const terminalFact = resolveTerminalCandidateFact(issue);
+      const terminalFact = trackerAdapter.resolveTerminalFact(issue);
       if (!terminalFact) {
         continue;
       }
@@ -2329,6 +2354,7 @@ export class OrchestratorService {
       }
 
       this.rememberTrackerRateLimits(tenant.projectId, result.rateLimits);
+      rateLimits = mergeTrackerRateLimits(rateLimits, result.rateLimits);
       console.info(
         JSON.stringify({
           at: now.toISOString(),
@@ -2338,7 +2364,7 @@ export class OrchestratorService {
           issueId: issue.id,
           trackerItemId: issue.tracker.itemId,
           terminalFact: terminalFact.kind,
-          linkedPullRequest: terminalFact.linkedPullRequestIdentifier,
+          linkedPullRequest: terminalFact.relatedIdentifier,
           expectedState: issue.state,
           targetState,
           confirmedState: result.state,
@@ -2348,7 +2374,7 @@ export class OrchestratorService {
       );
     }
 
-    return { suppressedIdentifiers };
+    return { suppressedIdentifiers, rateLimits };
   }
 
   private async resolveIssueLifecycle(
@@ -5622,33 +5648,6 @@ function releaseIssueOrchestration(
 
 function isArchivedProjectItem(issue: TrackedIssue): boolean {
   return issue.metadata.isArchived === true;
-}
-
-function resolveTerminalCandidateFact(issue: TrackedIssue): {
-  kind: "issue_closed" | "linked_pull_request_merged";
-  reason: string;
-  linkedPullRequestIdentifier: string | null;
-} | null {
-  if (issue.metadata.sourceState?.trim().toLowerCase() === "closed") {
-    return {
-      kind: "issue_closed",
-      reason: "Source issue is closed while its Project status is active.",
-      linkedPullRequestIdentifier: null,
-    };
-  }
-
-  const mergedPullRequest = issue.metadata.linkedPullRequests?.find(
-    (pullRequest) =>
-      pullRequest.merged === true ||
-      pullRequest.state?.trim().toLowerCase() === "merged"
-  );
-  return mergedPullRequest
-    ? {
-        kind: "linked_pull_request_merged",
-        reason: `Linked pull request ${mergedPullRequest.identifier} is merged while the issue Project status is active.`,
-        linkedPullRequestIdentifier: mergedPullRequest.identifier,
-      }
-    : null;
 }
 
 function buildTerminalCandidateFailure(

--- a/packages/tracker-file/src/file-tracker-adapter.ts
+++ b/packages/tracker-file/src/file-tracker-adapter.ts
@@ -145,6 +145,24 @@ export const fileTrackerAdapter: OrchestratorTrackerAdapter = {
     return issues.filter((issue) => ids.has(issue.id));
   },
 
+  resolveTerminalFact(issue) {
+    const terminalFact = issue.metadata.terminalFact;
+    if (!terminalFact || typeof terminalFact !== "object") {
+      return null;
+    }
+    const fact = terminalFact as Record<string, unknown>;
+    return typeof fact.kind === "string" && typeof fact.reason === "string"
+      ? {
+          kind: fact.kind,
+          reason: fact.reason,
+          relatedIdentifier:
+            typeof fact.relatedIdentifier === "string"
+              ? fact.relatedIdentifier
+              : null,
+        }
+      : null;
+  },
+
   async requestState(project, input): Promise<TrackerStateResult> {
     const issuesPath = requireTrackerSetting(project, "issuesPath");
     let entries: Record<string, unknown>[];

--- a/packages/tracker-github/src/adapter.ts
+++ b/packages/tracker-github/src/adapter.ts
@@ -2326,12 +2326,13 @@ function withIssueMetadata(
   isArchived = false
 ): TrackedIssue["metadata"] {
   if (
-    sourceState === null &&
     linkedPullRequests.length === 0 &&
     !linkedPullRequestsTruncated &&
     !isArchived
   ) {
-    return fieldValues;
+    return sourceState === null
+      ? fieldValues
+      : withGitHubMetadata(fieldValues, { sourceState });
   }
 
   return withGitHubMetadata(fieldValues, {

--- a/packages/tracker-github/src/adapter.ts
+++ b/packages/tracker-github/src/adapter.ts
@@ -135,6 +135,7 @@ type GraphQLIssueNode = {
   url: string | null;
   createdAt: string | null;
   updatedAt: string | null;
+  state?: string | null;
   labels: { nodes: Array<{ name: string | null } | null> | null } | null;
   assignees: { nodes: Array<{ login: string | null } | null> | null } | null;
   repository: {
@@ -498,6 +499,7 @@ export function normalizeProjectItem(
     },
     metadata: withIssueMetadata(
       fieldValues,
+      item.content.state ?? null,
       linkedPullRequests,
       linkedPullRequestsTruncated,
       isArchived
@@ -2318,11 +2320,13 @@ function withGitHubMetadata(
 
 function withIssueMetadata(
   fieldValues: Record<string, string>,
+  sourceState: string | null,
   linkedPullRequests: GitHubPullRequestMetadata[],
   linkedPullRequestsTruncated = false,
   isArchived = false
 ): TrackedIssue["metadata"] {
   if (
+    sourceState === null &&
     linkedPullRequests.length === 0 &&
     !linkedPullRequestsTruncated &&
     !isArchived
@@ -2331,6 +2335,7 @@ function withIssueMetadata(
   }
 
   return withGitHubMetadata(fieldValues, {
+    sourceState,
     linkedPullRequests,
     linkedPullRequestsTruncated,
     isArchived,
@@ -2994,6 +2999,7 @@ const PROJECT_ITEMS_QUERY = `
                 title
                 body
                 url
+                state
                 createdAt
                 updatedAt
                 labels(first: 20) {

--- a/packages/tracker-github/src/orchestrator-adapter.ts
+++ b/packages/tracker-github/src/orchestrator-adapter.ts
@@ -91,6 +91,29 @@ export const githubProjectTrackerAdapter: OrchestratorTrackerAdapter = {
     };
   },
 
+  resolveTerminalFact(issue) {
+    if (issue.metadata.sourceState?.trim().toLowerCase() === "closed") {
+      return {
+        kind: "issue_closed",
+        reason: "Source issue is closed while its Project status is active.",
+        relatedIdentifier: null,
+      };
+    }
+
+    const mergedPullRequest = issue.metadata.linkedPullRequests?.find(
+      (pullRequest) =>
+        pullRequest.merged === true ||
+        pullRequest.state?.trim().toLowerCase() === "merged"
+    );
+    return mergedPullRequest
+      ? {
+          kind: "linked_pull_request_merged",
+          reason: `Linked pull request ${mergedPullRequest.identifier} is merged while the issue Project status is active.`,
+          relatedIdentifier: mergedPullRequest.identifier,
+        }
+      : null;
+  },
+
   async requestState(project, input, dependencies = {}) {
     const trackerConfig = resolveGitHubTrackerConfig(project, dependencies);
     return requestGithubProjectItemState(

--- a/packages/tracker-github/src/tracker-github.test.ts
+++ b/packages/tracker-github/src/tracker-github.test.ts
@@ -670,6 +670,27 @@ describe("resolveTrackerAdapter", () => {
     expect(metadata?.linkedPullRequestsTruncated).toBe(false);
   });
 
+  it("keeps the source issue state distinct from the Project status", () => {
+    const projectItem = makeProjectItem({
+      itemId: "item-1",
+      issueId: "issue-1",
+      number: 1,
+      title: "Closed issue with active Project status",
+      assignees: [],
+    });
+    const issue = normalizeGithubProjectItem(
+      "project-123",
+      {
+        ...projectItem,
+        content: { ...projectItem.content, state: "CLOSED" },
+      },
+      DEFAULT_WORKFLOW_LIFECYCLE
+    );
+
+    expect(issue?.state).toBe("Todo");
+    expect(issue?.metadata.sourceState).toBe("CLOSED");
+  });
+
   it("marks Issue linked pull request metadata as truncated when GitHub has another page", () => {
     const linkedPullRequests = Array.from({ length: 20 }, (_, index) => {
       const number = index + 1;


### PR DESCRIPTION
## Issues

- Closed #578

## TL;DR

The orchestrator now self-heals unclaimed active Project items when the tracker reports a terminal source fact, transitioning them to the workflow terminal state before dispatch and emitting a structured reconciliation event.

## Change-point diagram

```text
GitHub issue/closing PR state
  -> tracker-github resolveTerminalFact
  -> provider-neutral TrackerTerminalFact
  -> orchestrator pre-dispatch reconciliation
     -> confirmed terminal transition + event
     -> no worker dispatch
```

## Changes

- Add an optional provider-neutral terminal-fact capability to tracker adapters; keep GitHub enum interpretation in `tracker-github`.
- Reconcile only the targeted canonical issue set and exclude currently claimed issues, preventing unrelated mutation or active-worker termination.
- Preserve worker suppression counters and merge transition rate-limit costs into the tick snapshot.
- Preserve sparse GitHub metadata and add happy-path, provider-failure, and targeted-run regression coverage.
- Document and black-box test TC-15, including a file-adapter terminal fact used only by E2E fixtures.

## Start here

1. `packages/core/src/contracts/tracker-adapter.ts` — provider-neutral capability.
2. `packages/tracker-github/src/orchestrator-adapter.ts` — GitHub terminal interpretation.
3. `packages/orchestrator/src/service.ts` — scoped pre-dispatch reconciliation.
4. `packages/orchestrator/src/service.test.ts` — regression and failure coverage.

## Evidence

- `pnpm lint` — pass
- `pnpm test` — pass (orchestrator: 14 files / 305 tests)
- `pnpm typecheck` — pass
- `pnpm build` — pass
- `pnpm --filter @gh-symphony/tracker-github test` — pass after approval (3 files / 119 tests)
- Docker TC-15 — pass on `1e4f5c09`: issue #30 `Ready` → `Done`, `activeRuns: []`, structured `tracker-terminal-candidate-reconciled` event confirmed
- GitHub CI — `Test` and `Container Smoke` pass on approved head `1e4f5c09`

## Risks & rollback

- A merged closing PR remains a terminal signal for an unclaimed active item, matching #578; claimed items are deliberately left to their active worker to avoid interrupting follow-up cycles.
- Transition failures suppress that candidate for the current tick and emit a failed event; later ticks retry.
- Rollback: revert this PR to restore Project-status-only candidate selection.

## Changed files

- Core tracker contract and GitHub/file adapter implementations
- Orchestrator reconciliation and regression tests
- README/architecture/E2E documentation and TC-15 fixture
- CLI patch changeset

## Human Validation

- [ ] Confirm a closed GitHub issue left in Ready converges to Done without a worker.
- [ ] Confirm a targeted run does not mutate unrelated stale candidates.
- [ ] Confirm an issue with an active claimed worker is not terminally reconciled mid-run.

## Post-merge validation

- None required beyond normal release CI.
