### PR TITLE
docs: reconcile standalone project design

### DIFF
--- a/.changeset/standalone-project-design-records.md
+++ b/.changeset/standalone-project-design-records.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": minor
+---
+
+Document the completed standalone project lifecycle and folder-addressed CLI delivered for #561.

--- a/docs/designs/2026-08-11-standalone-project-model-design.md
+++ b/docs/designs/2026-08-11-standalone-project-model-design.md
@@ -68,9 +68,10 @@ A "project" is an **orchestration execution unit** bundling WORKFLOW.md policy +
 
 - Instead of inventing a new concept, extend the existing `OrchestratorProjectConfig` (`packages/core/src/contracts/status-surface.ts`). It already has `projectId`/`slug`/`workspaceDir`/`repository`/`tracker`, and the state store and status surface sit on top of it, minimizing migration.
 - Additional fields: `workflowSource: { type: "repo" } | { type: "external"; path }`, etc.
-- **The project folder is the source of truth; `config.json` is cached runtime state derived at
-  start.** Folder identity, rather than a registration command or `activeProject`, selects the
-  standalone project.
+- **The project folder is the source of truth; `<configDir>/projects/<projectId>/project.json` is
+  cached runtime state derived at start.** The top-level `config.json` remains the global registry;
+  folder identity, rather than a registration command or `activeProject`, selects the standalone
+  project.
 - The `workspaces/` state directory naming collides with the spec's Workspace (§4.1.4, per-issue directory) — separate cleanup item.
 
 ### D3. The workflow source is a mode declaration, not a priority contest

--- a/docs/designs/2026-08-11-standalone-project-model-design.md
+++ b/docs/designs/2026-08-11-standalone-project-model-design.md
@@ -216,13 +216,13 @@ Resolved item (2026-08-13): the instance boundary was recorded in
 
 ## Spec Conformance Summary
 
-| Item                          | Classification                                                                   |
-| ----------------------------- | -------------------------------------------------------------------------------- |
-| External WORKFLOW.md          | **Conforming** — §5.1 priority 1. Only the soft expectation is documented        |
-| `repository` extension key    | **Conforming** — §5.3 extension rules                                            |
-| .runners via `workspace.root` | **Conforming** — §5.3.3, §9.1                                                    |
-| Built-in worktree populate    | **Conforming** — §9.3 implementation-defined                                     |
-| Skill/MCP injection           | **Extension outside the spec** — the spec has no skill/MCP concepts              |
+| Item                           | Classification                                                                        |
+| ------------------------------ | ------------------------------------------------------------------------------------- |
+| External WORKFLOW.md           | **Conforming** — §5.1 priority 1. Only the soft expectation is documented             |
+| `repository` extension key     | **Conforming** — §5.3 extension rules                                                 |
+| .runners via `workspace.root`  | **Conforming** — §5.3.3, §9.1                                                         |
+| Built-in worktree populate     | **Conforming** — §9.3 implementation-defined                                          |
+| Skill/MCP injection            | **Extension outside the spec** — the spec has no skill/MCP concepts                   |
 | Per-project process management | **Extension layer outside the spec** — §2.2 Non-Goals keeps it above the orchestrator |
-| Branch namespace (D8)         | **Outside the spec** — the spec does not prescribe VCS workflows (§9.3)          |
-| Orchestrator changes          | **None** — single-project process preserved                                      |
+| Branch namespace (D8)          | **Outside the spec** — the spec does not prescribe VCS workflows (§9.3)               |
+| Orchestrator changes           | **None** — single-project process preserved                                           |

--- a/docs/designs/2026-08-11-standalone-project-model-design.md
+++ b/docs/designs/2026-08-11-standalone-project-model-design.md
@@ -2,13 +2,37 @@
 
 - **Date**: 2026-08-11
 - **Status**: Shipped
-- **Symphony Layers**: Policy (WORKFLOW.md externalization), Configuration (project manifest, MCP, skill layers), Coordination (supervisor topology, registration validation), Execution (worktree populate, skill/MCP injection), Observability (status aggregation, shadow warnings)
+- **Symphony Layers**: Policy (WORKFLOW.md externalization), Configuration (project manifest, MCP, skill layers), Coordination (per-project process topology, start-time overlap validation), Execution (worktree populate, skill/MCP injection), Integration (folder-addressed CLI lifecycle), Observability (status surfaces, shadow warnings)
 - **Related ADRs**:
-  - `docs/adr/2026-05-04_single-repo-orchestrator.md` — adopted "1 repo = 1 instance". This design **refines it to "1 project = 1 instance"** (allowing 1 repo : N projects). Once finalized, record the relationship in a follow-up ADR.
+  - `docs/adr/2026-05-04_single-repo-orchestrator.md` — adopted "1 repo = 1 instance".
+  - `docs/adr/2026-08-13_standalone-project-instance-boundary.md` — supersedes that deployment boundary with **"1 project = 1 instance"**, allowing 1 repo : N projects.
+
+## Shipped Outcome (2026-08-21)
+
+Issues [#562](https://github.com/hojinzs/github-symphony/issues/562) through
+[#570](https://github.com/hojinzs/github-symphony/issues/570) delivered D1–D9. Follow-up
+[#600](https://github.com/hojinzs/github-symphony/issues/600), merged in
+[PR #601](https://github.com/hojinzs/github-symphony/pull/601), replaced the initial registration
+command with a folder-addressed model:
+
+- `gh-symphony project start|status|stop` use the current directory or `--project-dir <path>`.
+- `project start` re-derives configuration from the folder's `WORKFLOW.md` on every start and caches
+  only the runtime state needed by `status` and `stop`; `project add` is not part of the shipped CLI.
+- Tracker-mapping overlap is validated under a config-wide lock when a project starts. Running
+  overlap is rejected; stopped overlap requires interactive confirmation and fails closed in
+  non-interactive use.
+- Two label-disjoint project folders can run against one repository as separate orchestrator
+  instances while sharing the bare clone cache.
+
+Final acceptance exercised the full standalone lifecycle and the 1 repo : 2 projects case. It also
+fixed pickup-label filtering, clone-URL re-pointing, config-directory propagation to the bare cache,
+standalone `workspace.root`, and repository shadow detection. `pnpm e2e:standalone-project`, the
+repo-embedded happy path, and the Claude E2E passed for the closure.
 
 ## Context / Problem
 
-The current approach is a repo-embedded model that commits WORKFLOW.md and skills inside the repository. There are five problems:
+At design time, the only approach was a repo-embedded model that committed WORKFLOW.md and skills
+inside the repository. It had five problems:
 
 | #   | Problem                                                                                  |
 | --- | ---------------------------------------------------------------------------------------- |
@@ -44,7 +68,9 @@ A "project" is an **orchestration execution unit** bundling WORKFLOW.md policy +
 
 - Instead of inventing a new concept, extend the existing `OrchestratorProjectConfig` (`packages/core/src/contracts/status-surface.ts`). It already has `projectId`/`slug`/`workspaceDir`/`repository`/`tracker`, and the state store and status surface sit on top of it, minimizing migration.
 - Additional fields: `workflowSource: { type: "repo" } | { type: "external"; path }`, etc.
-- **The project folder is the source of truth; `config.json` is registration/derived state.**
+- **The project folder is the source of truth; `config.json` is cached runtime state derived at
+  start.** Folder identity, rather than a registration command or `activeProject`, selects the
+  standalone project.
 - The `workspaces/` state directory naming collides with the spec's Workspace (§4.1.4, per-issue directory) — separate cleanup item.
 
 ### D3. The workflow source is a mode declaration, not a priority contest
@@ -89,13 +115,19 @@ The upstream spec has no MCP at all (zero occurrences). Tools are defined only v
 - **Composition**: reuse the existing `mcp-compose.ts` pattern — every attempt, composed at 0600 into the runtime directory outside the worktree. Per-attempt composition means no sidecar watch is needed (dynamic reload only applies to front matter for the orchestrator loop).
 - **Runtime asymmetry**: declaration happens once in core in a runtime-neutral shape; translation is the adapter's responsibility — claude uses a composed `.mcp.json` + `--mcp-config` argv, codex uses `RuntimeToolDefinition` registration (`packages/runtime-codex/src/runtime.ts`).
 
-### D7. Topology — orchestrator unchanged, supervisor placed above
+### D7. Topology — orchestrator unchanged, one managed process per project
 
-**The orchestrator stays as-is: one process = one project** (keeping the current structure where the `OrchestratorService` constructor takes a single `projectConfig`). Multi-project is handled by a **supervisor** above it.
+**The orchestrator stays as-is: one process = one project** (keeping the structure where the
+`OrchestratorService` constructor takes a single `projectConfig`). Multi-project process management
+stays above the orchestrator.
 
 - Rationale: spec §2.2 Non-Goals explicitly lists "Rich web UI or multi-tenant control plane" — putting multi-tenancy inside the orchestrator contradicts the spec's scope declaration. The entire spec treats the orchestrator as a single-workflow standalone service and the single state authority (§7, §8.1, Appendix A), and multi-instance topology is deliberately left to implementers. Therefore the supervisor is not a divergence but an **extension layer outside the spec**.
-- Supervisor responsibilities: project folder registration and discovery, spawning/restarting/health-checking one orchestrator process per project, assigning child status-server ports (or unix sockets), aggregating status APIs and exposing a single endpoint (:4680). **The Control Plane talks only to the supervisor.**
-- **Registration-time disjointness validation**: the supervisor validates at project registration that the tracker mappings (project_slug, labels, status boards) of projects sharing the same repo+tracker do not overlap. Since orchestrators do not know about each other, registration-time validation — not runtime coordination — is the right place.
+- The shipped CLI derives a stable project ID from the canonical project-folder path and manages one
+  daemon/runtime directory per project. A future aggregate supervisor or Control Plane can discover
+  and manage those instances without making the orchestrator multi-project.
+- **Start-time disjointness validation**: `project start` validates tracker mappings against cached
+  projects sharing the same repo+tracker. This reflects the folder-addressed model: there is no
+  separate registration step, and re-validating on every start observes WORKFLOW.md changes.
 - Rate limiting: polling is independent per instance, but the existing self-throttling (widening polling intervals when a low rate limit is detected) prevents runaway. If cross-coordination becomes necessary, add it to the supervisor later.
 
 ### D9. Project env is a `<project>/.env` file — no front matter `env` key
@@ -109,7 +141,9 @@ Project env is declared in the project folder's `.env` (dotenv format, 0600 enfo
 
 ## Clone Cache Operational Details (D4, D8)
 
-The current implementation does a full clone per issue workspace (`packages/orchestrator/src/git.ts` `syncRepositoryForRun` — clone into `<workspace>/repository`, re-clone on failure). This design replaces it with a shared bare cache + worktrees.
+At design time, the implementation performed a full clone per issue workspace
+(`packages/orchestrator/src/git.ts` `syncRepositoryForRun`). The shipped standalone strategy replaces
+that path with a shared bare cache plus worktrees while repo-embedded mode retains clone behavior.
 
 ### Layout and locking
 
@@ -169,14 +203,16 @@ projects/
 
 ## Open Questions (follow-up decisions)
 
-1. **Supervisor detailed design** — **split into a separate design document** (out of scope for this spec). Process lifecycle, status aggregation API shape, registration protocol. Note: proto-supervisor infrastructure already exists in the CLI — the `~/.gh-symphony/projects/<id>/project.json` registry, per-project daemon PID/log/liveness determination (`packages/cli/src/daemon-liveness.ts`), and the `@gh-symphony/control-plane` and `@gh-symphony/dashboard` packages. The separate design should start on top of these.
+1. **Supervisor detailed design** — **split into a separate design document** (out of scope for this spec). Process lifecycle and status aggregation API shape remain open. The shipped CLI already provides folder-derived project identity, cached per-project runtime state, and daemon PID/log/liveness determination (`packages/cli/src/daemon-liveness.ts`); a future supervisor should build on those boundaries rather than introduce a registration command.
 2. **`workspaces/` state directory naming cleanup** — terminology collision with the spec's Workspace (D2)
 3. **Verify the codex runtime skill discovery path** — confirm whether it is cwd-based, then finalize D5 placement (verify in `runtime-codex`)
 4. **Control Plane secret store** — how to manage the origins of `$VAR` per project (during Control Plane design). D9's `.env` is the store for now, and the Control Plane can treat it as something to manage rather than replace
 5. **repo-embedded → standalone migration path** — procedure for wrapping existing setups into the project model (including `clone` → `worktree-cache` populate strategy convergence). The related workspace-layout half — repo-embedded still ignores `workspace.root` while standalone honors it (spec §9.1) — is tracked in [#599](https://github.com/hojinzs/github-symphony/issues/599).
-6. **Follow-up ADR** — a decision record refining the relationship with `2026-05-04_single-repo-orchestrator.md` ("1 repo = 1 instance") to "1 project = 1 instance"
 
 Resolved items (2026-08-11): clone cache operations and branch namespace → D4, D8 and the "Clone cache operational details" section. Project env declaration → D9.
+
+Resolved item (2026-08-13): the instance boundary was recorded in
+`docs/adr/2026-08-13_standalone-project-instance-boundary.md`.
 
 ## Spec Conformance Summary
 
@@ -187,6 +223,6 @@ Resolved items (2026-08-11): clone cache operations and branch namespace → D4,
 | .runners via `workspace.root` | **Conforming** — §5.3.3, §9.1                                                    |
 | Built-in worktree populate    | **Conforming** — §9.3 implementation-defined                                     |
 | Skill/MCP injection           | **Extension outside the spec** — the spec has no skill/MCP concepts              |
-| Supervisor                    | **Extension layer outside the spec** — §2.2 Non-Goals points to placing it above |
+| Per-project process management | **Extension layer outside the spec** — §2.2 Non-Goals keeps it above the orchestrator |
 | Branch namespace (D8)         | **Outside the spec** — the spec does not prescribe VCS workflows (§9.3)          |
 | Orchestrator changes          | **None** — single-project process preserved                                      |

--- a/docs/designs/2026-08-11-standalone-project-model-issues.md
+++ b/docs/designs/2026-08-11-standalone-project-model-issues.md
@@ -1,30 +1,46 @@
 # Standalone Project Model — Issue Breakdown Plan
 
-> **Source spec:** `docs/designs/2026-08-11-standalone-project-model-design.md` (commit `d994c6e`)
+> **Source spec:** `docs/designs/2026-08-11-standalone-project-model-design.md`
 > **Repository:** `hojinzs/github-symphony`
-> **Status:** Active — executed by dogfooding gh-symphony (Project #14, initial state Backlog, promotion to Ready is done by a human)
-> **Composition:** 1 epic + 9 implementation issues. Each issue body can be used directly with `gh issue create --body-file -`.
+> **Status:** Completed — D1–D9 shipped through #562–#570; the final folder-addressed CLI and acceptance fixes shipped through #600 / PR #601
+> **Composition:** Epic #561 + 9 implementation issues (#562–#570) + final CLI correction #600
 
-The design document is the single source of truth. Each issue embeds its relevant slice so workers do not have to read the entire document.
+The design document is the single source of truth. The issue bodies below preserve the original
+implementation plan. The shipped-outcome notes record where the final implementation intentionally
+superseded that plan.
+
+## Final outcome
+
+- All implementation issues #562–#570 are complete.
+- The standalone project folder is the execution unit and the repository remains unaware of
+  Symphony configuration.
+- #600 removed `project add`: `project start|status|stop` now address a folder directly, and start
+  re-derives its configuration every time.
+- PR #601 validated the full Ready → PR → In review → Land → merge → Done → cleanup lifecycle and
+  two label-disjoint projects running one repository concurrently.
+- `pnpm e2e:standalone-project`, the repo-embedded happy-path E2E, and `pnpm e2e:claude` passed.
+- `docs/adr/2026-08-13_standalone-project-instance-boundary.md` records "1 project = 1 instance".
 
 ## Dependency graph
 
 ```
-┌─ #1 D2 core: ProjectConfig extension ──────────── (foundation — everything depends on this)
+┌─ #562 D2 core: ProjectConfig extension ────────── (foundation — everything depends on this)
 │
-├──┬─ #2 D3: workflow source resolution + shadow warning
-│  └─ #3 D4a: bare clone cache module (lock + TTL fetch)     ← can run in parallel with #2
+├──┬─ #563 D3: workflow source resolution + shadow warning
+│  └─ #564 D4a: bare clone cache module (lock + TTL fetch)   ← can run in parallel with #563
 │         │
-│         └─ #4 D4b+D8: worktree populate + branch template + cleanup lifecycle
+│         └─ #565 D4b+D8: worktree populate + branch template + cleanup lifecycle
 │                │
-│                └─ #6 D5: layered skill merge injection + git exclude
+│                └─ #567 D5: layered skill merge injection + git exclude
 │
-├─ #5 D9: project .env relocation + $VAR source expansion      ← can run in parallel with #2–4
-├─ #7 D6: MCP layering (.mcp.json sidecar)          ← can run in parallel after #1
+├─ #566 D9: project .env relocation + $VAR source expansion  ← parallel with #563–#565
+├─ #568 D6: MCP layering (.mcp.json sidecar)        ← parallel after #562
 │
-└─ #8 CLI: project add / project-folder startup + disjointness validation   ← after #2
+└─ #569 CLI: initial standalone registration/startup          ← after #563
       │
-      └─ #9 closure: Docker E2E + docs + changeset + ADR    ← after everything
+      └─ #570 closure: Docker E2E + docs + changeset + ADR   ← after everything
+             │
+             └─ #600 folder addressing + project add removal + final acceptance
 ```
 
 ## Verification gates
@@ -35,7 +51,7 @@ Every issue's PR must pass:
 pnpm lint && pnpm test && pnpm typecheck && pnpm build
 ```
 
-CLAUDE.md convention: after completing work, test cases must be written and executed for verification. Integration behavior that unit tests cannot cover is verified with black-box tests in the Docker E2E environment (AGENT_TEST.md) — E2E integration verification is owned by #9, but each issue also includes unit/integration TCs for its own scope.
+CLAUDE.md convention: after completing work, test cases must be written and executed for verification. Integration behavior that unit tests cannot cover is verified with black-box tests in the Docker E2E environment (AGENT_TEST.md) — E2E integration verification was owned by #570, but each issue also included unit/integration TCs for its own scope.
 
 ---
 
@@ -43,7 +59,7 @@ CLAUDE.md convention: after completing work, test cases must be written and exec
 
 **Title:** `epic: standalone project model (repo-decoupled projects)`
 **Labels:** `epic`
-**Initial state:** Backlog (tracking only — do not promote to Ready)
+**Initial state:** Backlog (tracking only)
 
 ```markdown
 ## Overview
@@ -58,25 +74,24 @@ the execution unit, and the repository does not know Symphony is running (repo-u
 
 ## Sub-issues
 
-- [ ] #1 feat(core): extend OrchestratorProjectConfig
-- [ ] #2 feat(orchestrator): workflow source resolution
-- [ ] #3 feat(orchestrator): bare clone cache
-- [ ] #4 feat(orchestrator): worktree populate + branch namespace
-- [ ] #5 feat(orchestrator): project .env relocation
-- [ ] #6 feat(worker): layered skill injection
-- [ ] #7 feat(core,runtime): MCP layer composition
-- [ ] #8 feat(cli): standalone project registration and startup
-- [ ] #9 test(e2e): E2E + docs + changeset + ADR
-
-(Update with actual issue numbers after publishing)
+- [x] #562 feat(core): extend OrchestratorProjectConfig
+- [x] #563 feat(orchestrator): workflow source resolution
+- [x] #564 feat(orchestrator): bare clone cache
+- [x] #565 feat(orchestrator): worktree populate + branch namespace
+- [x] #566 feat(orchestrator): project .env relocation
+- [x] #567 feat(worker): layered skill injection
+- [x] #568 feat(core,runtime): MCP layer composition
+- [x] #569 feat(cli): standalone project registration and startup
+- [x] #570 test(e2e): E2E + docs + changeset + ADR
+- [x] #600 feat(cli)!: folder addressing + `project add` removal + final acceptance fixes
 
 ## Order
 
-#1 → {#2, #3, #5, #7 in parallel} → #4 → #6, #2 → #8 → #9
+#562 → {#563, #564, #566, #568 in parallel} → #565 → #567, #563 → #569 → #570 → #600
 
 ## Definition of done
 
-- Docker E2E: black-box pass from project folder creation → registration → run-once → worktree populate → skill/MCP injection → worker execution
+- Docker E2E: black-box pass from project folder creation → folder-addressed start → worktree populate → skill/MCP injection → worker execution
 - No regression in the existing repo-embedded mode
 - Follow-up "1 project = 1 instance" ADR merged
 ```
@@ -334,6 +349,10 @@ Composition follows the existing `mcp-compose.ts` pattern: every attempt, in the
 
 ## Issue #8 — feat(cli): standalone project registration and startup
 
+> **Published as #569; completed.** This issue shipped the initial registration-based CLI. #600
+> subsequently replaced that surface with folder-addressed `project start|status|stop`; the original
+> issue body below is retained as planning history, not current CLI documentation.
+
 **Labels:** `cli`, `enhancement`
 **Depends on:** #2
 **Effort:** M
@@ -366,6 +385,11 @@ the same repo+tracker — if they overlap, two orchestrators will pick up the sa
 ---
 
 ## Issue #9 — test(e2e): standalone project model end-to-end + docs + changeset + ADR
+
+> **Published as #570; completed.** The closure artifacts shipped, including the ADR and initial
+> standalone E2E. #600 / PR #601 updated the black-box scenario to start projects by folder and ran
+> final acceptance for the full lifecycle and 1 repo : 2 projects. References to `project add` below
+> describe the original test plan and are superseded.
 
 **Labels:** `test`, `documentation`
 **Depends on:** all of #1–#8


### PR DESCRIPTION
## Issues — Closed #561

## TL;DR

- Reconciles the standalone-project design records with #562–#570 and #600 / PR #601.
- Records the folder-addressed lifecycle, start-time overlap validation, final acceptance evidence, completed instance-boundary ADR, and the exact per-project runtime cache boundary.

## Change-point diagram

```text
original plan                         shipped model
project add -> registered config  -> project folder -> start-time derivation
global config runtime cache       -> projects/<projectId>/project.json cache
registration overlap check        -> locked start-time overlap validation
follow-up ADR pending             -> ADR accepted: 1 project = 1 instance
```

## Start here

1. Review `docs/designs/2026-08-11-standalone-project-model-design.md` for the shipped outcome, updated D2/D7 decisions, and corrected persisted-state boundary.
2. Review `docs/designs/2026-08-11-standalone-project-model-issues.md` for the actual dependency graph and completed checklist.
3. Review `.changeset/standalone-project-design-records.md` for the workflow-mandated CLI minor release note.

## Requirement coverage

| Issue #561 requirement | Evidence |
| --- | --- |
| Project folder is the execution unit; repository remains unaware | Design goals, D1–D6, target layout, and shipped-outcome summary |
| 1 repository : N projects | Shipped-outcome summary and PR #601 two-project acceptance record |
| D1–D9 implementation chain | Actual #562–#570 dependency graph and completed epic checklist |
| Folder-addressed CLI from #600 | D2/D7 shipped decisions and supersession notes |
| Standalone Docker blackbox | PR #601 evidence naming `pnpm e2e:standalone-project` |
| Repo-embedded regression coverage | PR #601 repo-embedded happy path and Claude E2E evidence |
| “1 project = 1 instance” ADR | `docs/adr/2026-08-13_standalone-project-instance-boundary.md` |

## Changes

- Added the final folder-based CLI contract and acceptance fixes to the design history.
- Updated D2 and D7 from registration terminology to derived per-project runtime state and start-time validation.
- Corrected the cache path to `<configDir>/projects/<projectId>/project.json` and distinguished the global `config.json` registry.
- Replaced placeholder issue numbers with the completed #562–#570 / #600 history while preserving superseded planning text.
- Retained the required `@gh-symphony/cli` minor changeset because #561 carries `changeset:minor`.

## Evidence

- `pnpm lint` — passed.
- `pnpm test` — passed.
- `pnpm typecheck` — passed.
- `pnpm build` — passed.
- `pnpm exec prettier --check docs/designs/2026-08-11-standalone-project-model-design.md .changeset/standalone-project-design-records.md` — passed.
- `git diff --check` — passed.
- `pnpm changeset status --output /tmp/issue-561-cycle-3-changeset.json` — passed; `@gh-symphony/cli` minor only.
- Spec conformance review against `docs/symphony-spec.md` — conforming; no intentional divergence added.
- Docker E2E was not rerun because this rework changes documentation only; PR #601 contains the referenced blackbox evidence.

## Risks & rollback

- Risk: the issue-breakdown file retains the original `project add` plan as labeled historical context.
- Rollback: revert this documentation-only PR and its changeset.

## Changed files

- `docs/designs/2026-08-11-standalone-project-model-design.md`
- `docs/designs/2026-08-11-standalone-project-model-issues.md`
- `.changeset/standalone-project-design-records.md`

## Human validation

- [ ] Confirm the shipped lifecycle and PR #601 acceptance findings are accurate.
- [ ] Confirm the persisted-state boundary distinguishes the global registry from per-project runtime cache.
- [ ] Confirm the design remains aligned with `docs/symphony-spec.md`.

## Post-merge validation

- None; runtime behavior is unchanged and was previously acceptance-tested in PR #601.
