### PR TITLE
feat(orchestrator): harden global bare cache operations

### DIFF
--- a/.changeset/fuzzy-caches-rest.md
+++ b/.changeset/fuzzy-caches-rest.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": minor
+---
+
+Add resilient global bare-cache fallback, heartbeat protection, and cache status/prune diagnostics for #588.

--- a/AGENT_TEST.md
+++ b/AGENT_TEST.md
@@ -379,6 +379,7 @@ idle → [inject issue + refresh]
 | `e2e/scenarios/13-standalone-project-model.md`            | Verify the standalone project model (project `.env`, MCP, worktree, and branch isolation) — `pnpm e2e:standalone-project` |
 | `e2e/scenarios/14-dispatch-start-failure-isolation.md`    | Verify one candidate's pre-spawn failure records retry state without starving later candidates                            |
 | `e2e/scenarios/15-terminal-candidate-reconciliation.md`   | Verify a closed issue in active Project status converges to `Done` without worker dispatch                                |
+| `e2e/scenarios/15-cache-maintenance.md`                   | Verify cache inventory, dry-run eviction, and active-worktree preservation                                                |
 
 ## TC Writing Guide
 

--- a/README.md
+++ b/README.md
@@ -368,11 +368,16 @@ gh-symphony repo explain owner/repo#123  # Explain why one issue is not dispatch
 gh-symphony repo start               # Start this repository
 gh-symphony repo start --once        # Run one orchestration tick for this repository
 gh-symphony repo stop                # Stop this repository
+gh-symphony cache status             # Inspect shared bare caches, sizes, locks, and worktrees
+gh-symphony cache prune --dry-run    # Preview 30-day cache eviction
+gh-symphony cache prune --max-age-days 30 # Remove old idle caches safely
 ```
 
 ### Standalone Projects
 
 A standalone project is a project folder used as an independent orchestration instance, decoupled from the repository it targets. The folder owns `WORKFLOW.md` (which must declare `repository.slug: owner/name`), plus optional `.mcp.json`, `.env`, and `.agent/skills/`; the referenced repository itself stays unmodified. Issue workspaces are created under the project's `workspace.root`, relative to the project folder and defaulting to `<project-dir>/.runtime/workspaces`. Issue workspaces are populated as worktrees from a shared bare clone cache, and branches default to `symphony/<project-slug>/<issue-id>`, so multiple projects can orchestrate the same repository without branch collisions.
+
+If cache storage is unavailable or lock acquisition times out, workspace population falls back to an isolated direct clone. Cache locks heartbeat during long clone/fetch operations. Cleanup is operator-driven: `cache prune` defaults to entries at least 30 days old and skips every locked cache, linked worktree, or cache whose worktree state cannot be verified.
 
 ```bash
 cd <projectDir> && gh-symphony project start   # Start the project in this folder

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -43,7 +43,7 @@ touches a layer, check that its slice (and the linked documents) still holds.
 - Confirmed tracker transitions outside the configured active states are recorded on the active run. When the canonical item becomes non-actionable, reconciliation gives the worker a bounded clean-exit grace; successful finalization then re-reads the current canonical state and preserves `succeeded` only while it remains non-actionable. An unavailable final read defers classification to a later tick instead of manufacturing a failure retry. Per-turn `state-read` requests do not reload or rewrite workflow snapshots.
 - Before dispatch, active candidates carrying an adapter-provided terminal fact are converged to the workflow terminal state and suppressed from worker startup.
 - Filesystem state store (`OrchestratorFsStore`), leases: `packages/orchestrator/src/fs-store.ts`
-- Shared bare clone cache (`<config-dir>/repos/<owner>/<repo>.git`) and worktree populate: `repository-cache.ts`, `git.ts`
+- Shared bare clone cache (`<config-dir>/repos/<owner>/<repo>.git`), heartbeat locks, direct-clone degradation, safe inventory/eviction, and worktree populate: `repository-cache.ts`, `git.ts`; operator diagnostics and cleanup: `packages/cli/src/commands/cache.ts`
 - Workflow source resolution (declared external/repo sources): `service.ts` + core workflow config
 
 ### 4. Execution — worker and agent subprocess

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -33,6 +33,12 @@ mode `0600` and do not commit it. An explicit `--config <dir>` is exported to
 use the same directory as the rest of the CLI state. The cache is keyed by
 `<owner>/<name>`; when a project's clone URL changes, the cache re-points
 `origin` and refetches on the next populate.
+Cache operations heartbeat their repository lock once per minute so a healthy
+large clone or fetch is not treated as stale. If the cache directory is
+unavailable or its lock times out, workspace creation uses an isolated direct
+clone. `gh-symphony cache status` inventories cache size and safety state;
+`gh-symphony cache prune` applies an operator-triggered 30-day default age
+policy and skips locked caches, linked worktrees, and unverifiable entries.
 
 When a standalone project targets a repository that also commits its own
 `WORKFLOW.md`, the status surface reports a shadow warning naming the

--- a/e2e/scenarios/15-cache-maintenance.md
+++ b/e2e/scenarios/15-cache-maintenance.md
@@ -1,0 +1,20 @@
+# TC-15: Global repository cache maintenance
+
+## Setup
+
+Build the image and start the default Docker E2E stack so one issue workspace is populated from the shared bare cache.
+
+## Steps
+
+1. Run `gh-symphony cache status --json` in the container and verify the seeded repository is listed with a positive byte count.
+2. Run `gh-symphony cache prune --max-age-days 0 --dry-run --json` and verify the active cache is skipped because it has a linked worktree.
+3. Run `gh-symphony cache prune --max-age-days 0 --json` and verify the cache directory remains present.
+4. Stop the orchestrator, remove the issue worktree through normal cleanup, run prune again, and verify the idle cache is removed.
+
+## Expected
+
+Inventory reports deterministic repository, size, lock, and worktree fields. Dry-run performs no deletion. Cleanup never deletes a locked cache or one backing an active worktree, and removes an eligible idle cache after normal workspace cleanup.
+
+## Cleanup
+
+Stop the Docker E2E stack and restore the fixture.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -338,6 +338,17 @@ gh-symphony repo recover                 # Recover stalled runs
 gh-symphony repo recover --dry-run       # Preview what would be recovered
 ```
 
+### Repository Cache Maintenance
+
+```bash
+gh-symphony cache status                 # Paths, sizes, timestamps, locks, and linked worktrees
+gh-symphony cache status --json
+gh-symphony cache prune --dry-run        # Preview the default 30-day eviction policy
+gh-symphony cache prune --max-age-days 7 # Remove old idle cache entries
+```
+
+Cache cleanup is conservative: locked entries, caches with linked worktrees, and caches whose worktree state cannot be verified are skipped. Long-running cache operations heartbeat their locks, and workspace population falls back to an isolated direct clone when cache preparation is unavailable.
+
 ### Standalone Projects
 
 Use a project folder as an orchestration instance decoupled from the repository it targets. The folder owns `WORKFLOW.md` (with `repository.slug: owner/name`), plus optional `.mcp.json`, `.env`, and `.agent/skills/`. Issue workspaces are populated as worktrees from a shared bare clone cache with `symphony/<project-slug>/<issue-id>` branches, so multiple projects can share one repository. `start` derives and caches configuration from the folder on every run; `status` and `stop` address the same runtime by folder without reading `WORKFLOW.md`.

--- a/packages/cli/src/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/src/commands/__snapshots__/help.test.ts.snap
@@ -26,6 +26,8 @@ exports[`help output > renders the colored grouped help snapshot 1`] = `
   [36mrepo explain <issue>[0m        Explain why an issue is not dispatching
 
 [33m[1mMaintenance:[0m[0m
+  [36mcache status[0m                Inspect the global bare repository cache
+  [36mcache prune[0m                 Remove old caches without locks or linked worktrees
   [36mupgrade[0m                     Upgrade the CLI to the latest published version
   [36mcompletion <shell>[0m          Print shell completion (bash/zsh/fish)
   [36mversion[0m                     Show version
@@ -68,6 +70,8 @@ Orchestration (current repository):
   repo explain <issue>        Explain why an issue is not dispatching
 
 Maintenance:
+  cache status                Inspect the global bare repository cache
+  cache prune                 Remove old caches without locks or linked worktrees
   upgrade                     Upgrade the CLI to the latest published version
   completion <shell>          Print shell completion (bash/zsh/fish)
   version                     Show version

--- a/packages/cli/src/commands/cache.test.ts
+++ b/packages/cli/src/commands/cache.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp } from "node:fs/promises";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
@@ -36,5 +36,26 @@ describe("cache command", () => {
         noColor: true,
       })
     ).rejects.toThrow(/non-negative number/);
+  });
+
+  it("distinguishes unverifiable cache entries from idle entries", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "cli-cache-"));
+    const bareDirectory = join(configDir, "repos", "acme", "broken.git");
+    await mkdir(bareDirectory, { recursive: true });
+    await writeFile(join(bareDirectory, "not-a-repository"), "broken");
+    const write = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+    try {
+      await handler(["status"], {
+        configDir,
+        verbose: false,
+        json: false,
+        noColor: true,
+      });
+      expect(String(write.mock.calls[0]?.[0])).toContain("unverifiable");
+    } finally {
+      write.mockRestore();
+    }
   });
 });

--- a/packages/cli/src/commands/cache.test.ts
+++ b/packages/cli/src/commands/cache.test.ts
@@ -1,0 +1,40 @@
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import handler from "./cache.js";
+
+describe("cache command", () => {
+  it("reports an empty cache as JSON", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "cli-cache-"));
+    const write = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+    try {
+      await handler(["status"], {
+        configDir,
+        verbose: false,
+        json: true,
+        noColor: true,
+      });
+      expect(JSON.parse(String(write.mock.calls[0]?.[0]))).toEqual({
+        entries: [],
+        totalBytes: 0,
+      });
+    } finally {
+      write.mockRestore();
+    }
+  });
+
+  it("rejects invalid prune ages", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "cli-cache-"));
+    await expect(
+      handler(["prune", "--max-age-days", "nope"], {
+        configDir,
+        verbose: false,
+        json: false,
+        noColor: true,
+      })
+    ).rejects.toThrow(/non-negative number/);
+  });
+});

--- a/packages/cli/src/commands/cache.ts
+++ b/packages/cli/src/commands/cache.ts
@@ -33,11 +33,15 @@ const handler = async (
       return;
     }
     for (const entry of entries) {
-      const state = entry.locked
-        ? "locked"
-        : entry.worktrees
-          ? `${entry.worktrees} linked worktree(s)`
-          : "idle";
+      const state = entry.staleLock
+        ? "stale-locked"
+        : entry.locked
+          ? "locked"
+          : entry.worktrees === null
+            ? "unverifiable"
+            : entry.worktrees > 0
+              ? `${entry.worktrees} linked worktree(s)`
+              : "idle";
       process.stdout.write(
         `${entry.repository}  ${formatBytes(entry.bytes)}  ${state}  ${entry.updatedAt}\n`
       );

--- a/packages/cli/src/commands/cache.ts
+++ b/packages/cli/src/commands/cache.ts
@@ -1,0 +1,80 @@
+import {
+  inspectGlobalRepositoryCache,
+  pruneGlobalRepositoryCache,
+} from "@gh-symphony/orchestrator";
+import type { GlobalOptions } from "../index.js";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+const handler = async (
+  args: string[],
+  options: GlobalOptions
+): Promise<void> => {
+  const [subcommand] = args;
+  if (subcommand === "status") {
+    const entries = await inspectGlobalRepositoryCache({
+      configDir: options.configDir,
+    });
+    if (options.json) {
+      process.stdout.write(
+        JSON.stringify(
+          {
+            entries,
+            totalBytes: entries.reduce((sum, entry) => sum + entry.bytes, 0),
+          },
+          null,
+          2
+        ) + "\n"
+      );
+      return;
+    }
+    if (entries.length === 0) {
+      process.stdout.write("Global repository cache is empty.\n");
+      return;
+    }
+    for (const entry of entries) {
+      const state = entry.locked
+        ? "locked"
+        : entry.worktrees
+          ? `${entry.worktrees} linked worktree(s)`
+          : "idle";
+      process.stdout.write(
+        `${entry.repository}  ${formatBytes(entry.bytes)}  ${state}  ${entry.updatedAt}\n`
+      );
+    }
+    return;
+  }
+  if (subcommand === "prune") {
+    const rawDays = valueAfter(args, "--max-age-days") ?? "30";
+    const days = Number(rawDays);
+    if (!Number.isFinite(days) || days < 0)
+      throw new Error("--max-age-days must be a non-negative number.");
+    const result = await pruneGlobalRepositoryCache({
+      configDir: options.configDir,
+      maxAgeMs: days * DAY_MS,
+      dryRun: args.includes("--dry-run"),
+    });
+    if (options.json) {
+      process.stdout.write(JSON.stringify(result, null, 2) + "\n");
+      return;
+    }
+    process.stdout.write(
+      `${result.dryRun ? "Would remove" : "Removed"} ${result.removed.length} cache entr${result.removed.length === 1 ? "y" : "ies"} (${formatBytes(result.reclaimedBytes)}); skipped ${result.skipped.length}.\n`
+    );
+    return;
+  }
+  throw new Error("Usage: gh-symphony cache <status|prune>");
+};
+
+function valueAfter(args: string[], flag: string): string | undefined {
+  const index = args.indexOf(flag);
+  return index >= 0 ? args[index + 1] : undefined;
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KiB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MiB`;
+}
+
+export default handler;

--- a/packages/cli/src/commands/help.ts
+++ b/packages/cli/src/commands/help.ts
@@ -19,6 +19,14 @@ export const HELP_SECTIONS: HelpSection[] = [
     title: "Setup",
     entries: [
       {
+        name: "cache status",
+        description: "Inspect the global bare repository cache",
+      },
+      {
+        name: "cache prune",
+        description: "Remove old caches without locks or linked worktrees",
+      },
+      {
         name: "setup",
         description: "Run the one-command first-run setup flow",
       },

--- a/packages/cli/src/commands/help.ts
+++ b/packages/cli/src/commands/help.ts
@@ -19,14 +19,6 @@ export const HELP_SECTIONS: HelpSection[] = [
     title: "Setup",
     entries: [
       {
-        name: "cache status",
-        description: "Inspect the global bare repository cache",
-      },
-      {
-        name: "cache prune",
-        description: "Remove old caches without locks or linked worktrees",
-      },
-      {
         name: "setup",
         description: "Run the one-command first-run setup flow",
       },
@@ -109,6 +101,14 @@ export const HELP_SECTIONS: HelpSection[] = [
   {
     title: "Maintenance",
     entries: [
+      {
+        name: "cache status",
+        description: "Inspect the global bare repository cache",
+      },
+      {
+        name: "cache prune",
+        description: "Remove old caches without locks or linked worktrees",
+      },
       {
         name: "upgrade",
         description: "Upgrade the CLI to the latest published version",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -39,6 +39,7 @@ type LoaderKey =
   | "repo"
   | "project"
   | "config"
+  | "cache"
   | "version";
 
 type CliOptionValues = Partial<
@@ -79,6 +80,7 @@ type CliOptionValues = Partial<
     bundle?: string | boolean;
     attempt?: string;
     tracker?: string;
+    maxAgeDays?: string;
   }
 >;
 
@@ -91,6 +93,7 @@ const COMMANDS: Record<LoaderKey, () => Promise<{ default: CommandHandler }>> =
     repo: () => import("./commands/repo.js"),
     project: () => import("./commands/project.js"),
     config: () => import("./commands/config-cmd.js"),
+    cache: () => import("./commands/cache.js"),
     version: () => import("./commands/version.js"),
   };
 
@@ -790,6 +793,40 @@ function createProgram(): { program: Command; wasInvoked: () => boolean } {
   const config = addGlobalOptions(
     program.command("config").description("Manage CLI configuration")
   );
+
+  const cache = addGlobalOptions(
+    program
+      .command("cache")
+      .description("Inspect and clean the global repository cache")
+  );
+  addGlobalOptions(
+    cache
+      .command("status")
+      .description("Show cached repositories")
+      .allowExcessArguments(false)
+  ).action(async function (this: Command) {
+    markInvoked();
+    await invokeHandler(
+      "cache",
+      ["status"],
+      this.optsWithGlobals<CliOptionValues>()
+    );
+  });
+  addGlobalOptions(
+    cache
+      .command("prune")
+      .description("Remove old unused cache entries")
+      .option("--max-age-days <days>", "Minimum unused age", "30")
+      .option("--dry-run", "Preview removals")
+      .allowExcessArguments(false)
+  ).action(async function (this: Command) {
+    markInvoked();
+    const values = this.optsWithGlobals<CliOptionValues>();
+    const args = ["prune"];
+    pushOption(args, "--max-age-days", values.maxAgeDays);
+    pushOption(args, "--dry-run", values.dryRun);
+    await invokeHandler("cache", args, values);
+  });
 
   config.action(async function (this: Command) {
     markInvoked();

--- a/packages/orchestrator/src/git.test.ts
+++ b/packages/orchestrator/src/git.test.ts
@@ -218,6 +218,26 @@ describe("global bare repository cache", () => {
 });
 
 describe("cloneRepositoryForRun", () => {
+  it("falls back to a direct clone when the global cache is unavailable", async () => {
+    const tempRoot = await mkdtemp(join(tmpdir(), "orchestrator-git-"));
+    const repository = await createRepositoryFixture(tempRoot);
+    const unavailableConfig = join(tempRoot, "config-file");
+    await writeFile(unavailableConfig, "not a directory");
+    process.env.GH_SYMPHONY_CONFIG_DIR = unavailableConfig;
+
+    const repositoryDirectory = await cloneRepositoryForRun({
+      repository,
+      targetDirectory: join(tempRoot, "workspace"),
+    });
+
+    expect(
+      await readFile(join(repositoryDirectory, "WORKFLOW.md"), "utf8")
+    ).toContain('project_id: "PVT_test"');
+    await expect(
+      access(join(repositoryDirectory, ".git", "objects", "info", "alternates"))
+    ).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
   it("serializes concurrent cache clones for the same repository", async () => {
     const tempRoot = await mkdtemp(join(tmpdir(), "orchestrator-git-"));
     const repository = await createRepositoryFixture(tempRoot);
@@ -780,6 +800,33 @@ describe("cloneRepositoryForRun", () => {
 });
 
 describe("worktree-cache issue workspaces", () => {
+  it("falls back to a direct clone with the project branch when the cache is unavailable", async () => {
+    const tempRoot = await mkdtemp(join(tmpdir(), "orchestrator-worktree-"));
+    const repository = await createRepositoryFixture(tempRoot);
+    const unavailableConfig = join(tempRoot, "config-file");
+    await writeFile(unavailableConfig, "not a directory");
+    process.env.GH_SYMPHONY_CONFIG_DIR = unavailableConfig;
+
+    const repositoryDirectory = await ensureIssueWorkspaceRepository({
+      repository,
+      issueWorkspacePath: join(tempRoot, "workspace"),
+      existingWorkspace: false,
+      populateStrategy: "worktree-cache",
+      projectSlug: "fallback-project",
+      issueIdentifier: "588",
+      baseBranch: "main",
+    });
+
+    expect(
+      execSync(`git -C "${repositoryDirectory}" branch --show-current`, {
+        encoding: "utf8",
+      }).trim()
+    ).toBe("symphony/fallback-project/588");
+    expect(
+      await readFile(join(repositoryDirectory, "WORKFLOW.md"), "utf8")
+    ).toContain('project_id: "PVT_test"');
+  });
+
   it("populates, reuses, and removes a project-scoped worktree", async () => {
     const tempRoot = await mkdtemp(join(tmpdir(), "orchestrator-worktree-"));
     const repository = await createRepositoryFixture(tempRoot);

--- a/packages/orchestrator/src/git.test.ts
+++ b/packages/orchestrator/src/git.test.ts
@@ -20,6 +20,7 @@ import {
   removeIssueWorkspaceWorktree,
   renderIssueBranchName,
   releaseRepositoryLock,
+  startRepositoryLockHeartbeat,
   syncRepositoryForRun,
 } from "./git.js";
 import {
@@ -167,6 +168,28 @@ describe("global bare repository cache", () => {
     await expect(
       ensureGlobalBareRepositoryCache({ repository, configDir })
     ).resolves.toBe(bareDirectory);
+  });
+
+  it("keeps a cache lock fresh while a long operation is running", async () => {
+    const tempRoot = await mkdtemp(
+      join(tmpdir(), "orchestrator-global-cache-")
+    );
+    const lockDirectory = join(tempRoot, "platform.lock");
+    const ownerToken = await acquireRepositoryLock(lockDirectory);
+    const staleAt = new Date(Date.now() - 31 * 60 * 1000);
+    await utimes(lockDirectory, staleAt, staleAt);
+
+    const heartbeat = startRepositoryLockHeartbeat(
+      lockDirectory,
+      ownerToken,
+      10
+    );
+    await new Promise((resolve) => setTimeout(resolve, 35));
+    const refreshed = await stat(lockDirectory);
+    await heartbeat.stop();
+    await releaseRepositoryLock(lockDirectory, ownerToken);
+
+    expect(Date.now() - refreshed.mtimeMs).toBeLessThan(1_000);
   });
 
   it("recreates a cache with a missing origin remote under its lock", async () => {

--- a/packages/orchestrator/src/git.test.ts
+++ b/packages/orchestrator/src/git.test.ts
@@ -248,9 +248,11 @@ describe("cloneRepositoryForRun", () => {
     await writeFile(unavailableConfig, "not a directory");
     process.env.GH_SYMPHONY_CONFIG_DIR = unavailableConfig;
 
+    const onCacheUnavailable = vi.fn();
     const repositoryDirectory = await cloneRepositoryForRun({
       repository,
       targetDirectory: join(tempRoot, "workspace"),
+      onCacheUnavailable,
     });
 
     expect(
@@ -259,6 +261,9 @@ describe("cloneRepositoryForRun", () => {
     await expect(
       access(join(repositoryDirectory, ".git", "objects", "info", "alternates"))
     ).rejects.toMatchObject({ code: "ENOENT" });
+    expect(onCacheUnavailable).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "RepositoryCacheUnavailableError" })
+    );
   });
 
   it("serializes concurrent cache clones for the same repository", async () => {
@@ -830,6 +835,7 @@ describe("worktree-cache issue workspaces", () => {
     await writeFile(unavailableConfig, "not a directory");
     process.env.GH_SYMPHONY_CONFIG_DIR = unavailableConfig;
 
+    const onCacheUnavailable = vi.fn();
     const repositoryDirectory = await ensureIssueWorkspaceRepository({
       repository,
       issueWorkspacePath: join(tempRoot, "workspace"),
@@ -838,6 +844,7 @@ describe("worktree-cache issue workspaces", () => {
       projectSlug: "fallback-project",
       issueIdentifier: "588",
       baseBranch: "main",
+      onCacheUnavailable,
     });
 
     expect(
@@ -848,6 +855,19 @@ describe("worktree-cache issue workspaces", () => {
     expect(
       await readFile(join(repositoryDirectory, "WORKFLOW.md"), "utf8")
     ).toContain('project_id: "PVT_test"');
+    expect(onCacheUnavailable).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "RepositoryCacheUnavailableError" })
+    );
+
+    await expect(
+      removeIssueWorkspaceWorktree({
+        repository,
+        repositoryDirectory,
+        projectSlug: "fallback-project",
+        issueIdentifier: "588",
+      })
+    ).resolves.toBeUndefined();
+    await expect(access(repositoryDirectory)).resolves.toBeUndefined();
   });
 
   it("populates, reuses, and removes a project-scoped worktree", async () => {

--- a/packages/orchestrator/src/git.test.ts
+++ b/packages/orchestrator/src/git.test.ts
@@ -12,7 +12,7 @@ import {
 } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   acquireRepositoryLock,
   cloneRepositoryForRun,

--- a/packages/orchestrator/src/git.ts
+++ b/packages/orchestrator/src/git.ts
@@ -20,7 +20,6 @@ import {
   type WorkflowResolution,
 } from "@gh-symphony/core";
 import {
-  ensureGlobalBareRepositoryCache,
   RepositoryCacheUnavailableError,
   withGlobalBareRepositoryCache,
 } from "./repository-cache.js";
@@ -104,19 +103,23 @@ export async function syncRepositoryForRun(input: {
 
     try {
       try {
-        const bareRepositoryDirectory = await ensureGlobalBareRepositoryCache({
-          repository: input.repository,
-          requiredRef: input.requiredRef,
-        });
-        await runCommand("git", [
-          "clone",
-          "--filter=blob:none",
-          "--reference-if-able",
-          bareRepositoryDirectory,
-          "--dissociate",
-          sanitizeRepositoryCloneUrl(input.repository.cloneUrl),
-          tempRepositoryDirectory,
-        ]);
+        await withGlobalBareRepositoryCache(
+          {
+            repository: input.repository,
+            requiredRef: input.requiredRef,
+          },
+          async (bareRepositoryDirectory) => {
+            await runCommand("git", [
+              "clone",
+              "--filter=blob:none",
+              "--reference-if-able",
+              bareRepositoryDirectory,
+              "--dissociate",
+              sanitizeRepositoryCloneUrl(input.repository.cloneUrl),
+              tempRepositoryDirectory,
+            ]);
+          }
+        );
       } catch (error) {
         if (!(error instanceof RepositoryCacheUnavailableError)) {
           throw error;

--- a/packages/orchestrator/src/git.ts
+++ b/packages/orchestrator/src/git.ts
@@ -47,6 +47,7 @@ export async function cloneRepositoryForRun(input: {
   repository: RepositoryRef;
   targetDirectory: string;
   requiredRef?: string;
+  onCacheUnavailable?: (error: RepositoryCacheUnavailableError) => void;
 }): Promise<string> {
   const result = await syncRepositoryForRun(input);
   return result.repositoryDirectory;
@@ -56,6 +57,7 @@ export async function syncRepositoryForRun(input: {
   repository: RepositoryRef;
   targetDirectory: string;
   requiredRef?: string;
+  onCacheUnavailable?: (error: RepositoryCacheUnavailableError) => void;
 }): Promise<RepositorySyncResult> {
   await mkdir(input.targetDirectory, { recursive: true });
   const repositoryDirectory = join(input.targetDirectory, "repository");
@@ -124,6 +126,7 @@ export async function syncRepositoryForRun(input: {
         if (!(error instanceof RepositoryCacheUnavailableError)) {
           throw error;
         }
+        input.onCacheUnavailable?.(error);
         await cloneRepositoryDirectly(
           input.repository,
           tempRepositoryDirectory
@@ -151,6 +154,7 @@ export async function ensureIssueWorkspaceRepository(input: {
   issueIdentifier?: string;
   branchTemplate?: string | null;
   baseBranch?: string | null;
+  onCacheUnavailable?: (error: RepositoryCacheUnavailableError) => void;
 }): Promise<string> {
   if (input.populateStrategy === "worktree-cache") {
     return ensureIssueWorkspaceWorktree(input);
@@ -173,6 +177,7 @@ export async function ensureIssueWorkspaceRepository(input: {
         requiredRef: input.pullRequestBranch
           ? `refs/heads/${input.pullRequestBranch.headRefName}`
           : undefined,
+        onCacheUnavailable: input.onCacheUnavailable,
       });
 
   if (input.pullRequestBranch && !dirtyExistingWorkspaceAllowed) {
@@ -192,6 +197,9 @@ export async function removeIssueWorkspaceWorktree(input: {
   issueIdentifier: string;
   branchTemplate?: string | null;
 }): Promise<void> {
+  if (await isDirectory(join(input.repositoryDirectory, ".git"))) {
+    return;
+  }
   const branch = renderIssueBranchName({
     template: input.branchTemplate,
     projectSlug: input.projectSlug,
@@ -286,6 +294,7 @@ async function ensureIssueWorkspaceWorktree(input: {
       if (!(error instanceof RepositoryCacheUnavailableError)) {
         throw error;
       }
+      input.onCacheUnavailable?.(error);
       await cloneRepositoryDirectly(input.repository, repositoryDirectory);
       const baseBranch =
         input.pullRequestBranch?.headRefName ??
@@ -305,6 +314,15 @@ async function ensureIssueWorkspaceWorktree(input: {
     if (!repositoryDirectoryExisted) {
       await rm(repositoryDirectory, { recursive: true, force: true });
     }
+    throw error;
+  }
+}
+
+async function isDirectory(path: string): Promise<boolean> {
+  try {
+    return (await stat(path)).isDirectory();
+  } catch (error) {
+    if (isMissingFileError(error)) return false;
     throw error;
   }
 }

--- a/packages/orchestrator/src/git.ts
+++ b/packages/orchestrator/src/git.ts
@@ -862,7 +862,7 @@ export async function acquireRepositoryLock(
       }
     }
 
-    const stale = await isStaleLock(lockDirectory);
+    const stale = await isRepositoryLockStale(lockDirectory);
     if (stale) {
       await rm(lockDirectory, { recursive: true, force: true });
       continue;
@@ -880,22 +880,29 @@ export async function acquireRepositoryLock(
 
 /** Attempts lock acquisition once; maintenance callers use this to skip busy caches. */
 export async function tryAcquireRepositoryLock(
-  lockDirectory: string
+  lockDirectory: string,
+  options: { breakStale?: boolean } = {}
 ): Promise<string | null> {
   const ownerToken = `${process.pid}:${randomUUID()}`;
-  try {
-    await mkdir(lockDirectory);
-    await writeFile(
-      join(lockDirectory, "owner"),
-      `${ownerToken}\n${new Date().toISOString()}\n`,
-      "utf8"
-    );
-    return ownerToken;
-  } catch (error) {
-    if (isAlreadyExistsError(error)) {
+  for (;;) {
+    try {
+      await mkdir(lockDirectory);
+      await writeFile(
+        join(lockDirectory, "owner"),
+        `${ownerToken}\n${new Date().toISOString()}\n`,
+        "utf8"
+      );
+      return ownerToken;
+    } catch (error) {
+      if (!isAlreadyExistsError(error)) {
+        throw error;
+      }
+    }
+
+    if (!options.breakStale || !(await isRepositoryLockStale(lockDirectory))) {
       return null;
     }
-    throw error;
+    await rm(lockDirectory, { recursive: true, force: true });
   }
 }
 
@@ -955,7 +962,9 @@ export function startRepositoryLockHeartbeat(
   };
 }
 
-async function isStaleLock(lockDirectory: string): Promise<boolean> {
+export async function isRepositoryLockStale(
+  lockDirectory: string
+): Promise<boolean> {
   try {
     const details = await stat(lockDirectory);
     return Date.now() - details.mtimeMs >= LOCK_STALE_MS;

--- a/packages/orchestrator/src/git.ts
+++ b/packages/orchestrator/src/git.ts
@@ -7,6 +7,7 @@ import {
   rename,
   rm,
   stat,
+  utimes,
   writeFile,
 } from "node:fs/promises";
 import { constants } from "node:fs";
@@ -29,6 +30,10 @@ const workflowConfigStore = new WorkflowConfigStore();
 const LOCK_RETRY_MS = 100;
 const LOCK_STALE_MS = 30 * 60 * 1000;
 const LOCK_TIMEOUT_MS = 2 * 60 * 1000;
+
+export type RepositoryLockHeartbeat = {
+  stop: () => Promise<void>;
+};
 
 export type RepositorySyncResult = {
   repositoryDirectory: string;
@@ -887,6 +892,43 @@ export async function releaseRepositoryLock(
   }
 
   await rm(lockDirectory, { recursive: true, force: true });
+}
+
+/**
+ * Keeps a long-running lock lease fresh without changing the generic lock's
+ * stale timeout. Ownership is checked before every touch so a replaced lock is
+ * never intentionally renewed by its previous holder.
+ */
+export function startRepositoryLockHeartbeat(
+  lockDirectory: string,
+  ownerToken: string,
+  intervalMs = 60_000
+): RepositoryLockHeartbeat {
+  let stopped = false;
+  let heartbeat = Promise.resolve();
+  const timer = setInterval(() => {
+    heartbeat = heartbeat
+      .then(async () => {
+        if (stopped || (await readLockOwner(lockDirectory)) !== ownerToken) {
+          return;
+        }
+        const now = new Date();
+        await utimes(lockDirectory, now, now);
+      })
+      .catch(() => {
+        // The cache operation itself remains authoritative. A removed or
+        // inaccessible lock will be handled by its normal failure path.
+      });
+  }, intervalMs);
+  timer.unref();
+
+  return {
+    async stop(): Promise<void> {
+      stopped = true;
+      clearInterval(timer);
+      await heartbeat;
+    },
+  };
 }
 
 async function isStaleLock(lockDirectory: string): Promise<boolean> {

--- a/packages/orchestrator/src/git.ts
+++ b/packages/orchestrator/src/git.ts
@@ -235,6 +235,7 @@ async function ensureIssueWorkspaceWorktree(input: {
   issueIdentifier?: string;
   branchTemplate?: string | null;
   baseBranch?: string | null;
+  onCacheUnavailable?: (error: RepositoryCacheUnavailableError) => void;
 }): Promise<string> {
   const repositoryDirectory = join(input.issueWorkspacePath, "repository");
   if (await pathExists(join(repositoryDirectory, ".git"))) {

--- a/packages/orchestrator/src/git.ts
+++ b/packages/orchestrator/src/git.ts
@@ -875,6 +875,27 @@ export async function acquireRepositoryLock(
   }
 }
 
+/** Attempts lock acquisition once; maintenance callers use this to skip busy caches. */
+export async function tryAcquireRepositoryLock(
+  lockDirectory: string
+): Promise<string | null> {
+  const ownerToken = `${process.pid}:${randomUUID()}`;
+  try {
+    await mkdir(lockDirectory);
+    await writeFile(
+      join(lockDirectory, "owner"),
+      `${ownerToken}\n${new Date().toISOString()}\n`,
+      "utf8"
+    );
+    return ownerToken;
+  } catch (error) {
+    if (isAlreadyExistsError(error)) {
+      return null;
+    }
+    throw error;
+  }
+}
+
 export async function releaseRepositoryLock(
   lockDirectory: string,
   ownerToken: string

--- a/packages/orchestrator/src/git.ts
+++ b/packages/orchestrator/src/git.ts
@@ -20,6 +20,7 @@ import {
 } from "@gh-symphony/core";
 import {
   ensureGlobalBareRepositoryCache,
+  RepositoryCacheUnavailableError,
   withGlobalBareRepositoryCache,
 } from "./repository-cache.js";
 import { sanitizeRepositoryCloneUrl } from "./repository-url.js";
@@ -97,19 +98,29 @@ export async function syncRepositoryForRun(input: {
     await rm(tempRepositoryDirectory, { recursive: true, force: true });
 
     try {
-      const bareRepositoryDirectory = await ensureGlobalBareRepositoryCache({
-        repository: input.repository,
-        requiredRef: input.requiredRef,
-      });
-      await runCommand("git", [
-        "clone",
-        "--filter=blob:none",
-        "--reference-if-able",
-        bareRepositoryDirectory,
-        "--dissociate",
-        sanitizeRepositoryCloneUrl(input.repository.cloneUrl),
-        tempRepositoryDirectory,
-      ]);
+      try {
+        const bareRepositoryDirectory = await ensureGlobalBareRepositoryCache({
+          repository: input.repository,
+          requiredRef: input.requiredRef,
+        });
+        await runCommand("git", [
+          "clone",
+          "--filter=blob:none",
+          "--reference-if-able",
+          bareRepositoryDirectory,
+          "--dissociate",
+          sanitizeRepositoryCloneUrl(input.repository.cloneUrl),
+          tempRepositoryDirectory,
+        ]);
+      } catch (error) {
+        if (!(error instanceof RepositoryCacheUnavailableError)) {
+          throw error;
+        }
+        await cloneRepositoryDirectly(
+          input.repository,
+          tempRepositoryDirectory
+        );
+      }
       await rename(tempRepositoryDirectory, repositoryDirectory);
       return {
         repositoryDirectory,
@@ -233,41 +244,73 @@ async function ensureIssueWorkspaceWorktree(input: {
   const repositoryDirectoryExisted = await pathExists(repositoryDirectory);
   await mkdir(input.issueWorkspacePath, { recursive: true });
   try {
-    return await withGlobalBareRepositoryCache(
-      {
-        repository: input.repository,
-        requiredRef: input.pullRequestBranch
-          ? `refs/remotes/origin/${input.pullRequestBranch.headRefName}`
-          : input.baseBranch
-            ? `refs/remotes/origin/${input.baseBranch}`
-            : undefined,
-      },
-      async (bare) => {
-        const baseBranch =
-          input.pullRequestBranch?.headRefName ??
-          input.baseBranch ??
-          (await readOriginDefaultBranch(bare));
-        const baseRef = `refs/remotes/origin/${baseBranch}`;
-        await runGitCommand(["-C", bare, "worktree", "prune"]);
-        await runGitCommand([
-          "-C",
-          bare,
-          "worktree",
-          "add",
-          "-B",
-          branch,
-          repositoryDirectory,
-          baseRef,
-        ]);
-        return repositoryDirectory;
+    try {
+      return await withGlobalBareRepositoryCache(
+        {
+          repository: input.repository,
+          requiredRef: input.pullRequestBranch
+            ? `refs/remotes/origin/${input.pullRequestBranch.headRefName}`
+            : input.baseBranch
+              ? `refs/remotes/origin/${input.baseBranch}`
+              : undefined,
+        },
+        async (bare) => {
+          const baseBranch =
+            input.pullRequestBranch?.headRefName ??
+            input.baseBranch ??
+            (await readOriginDefaultBranch(bare));
+          const baseRef = `refs/remotes/origin/${baseBranch}`;
+          await runGitCommand(["-C", bare, "worktree", "prune"]);
+          await runGitCommand([
+            "-C",
+            bare,
+            "worktree",
+            "add",
+            "-B",
+            branch,
+            repositoryDirectory,
+            baseRef,
+          ]);
+          return repositoryDirectory;
+        }
+      );
+    } catch (error) {
+      if (!(error instanceof RepositoryCacheUnavailableError)) {
+        throw error;
       }
-    );
+      await cloneRepositoryDirectly(input.repository, repositoryDirectory);
+      const baseBranch =
+        input.pullRequestBranch?.headRefName ??
+        input.baseBranch ??
+        (await readOriginDefaultBranch(repositoryDirectory));
+      await runGitCommand([
+        "-C",
+        repositoryDirectory,
+        "checkout",
+        "-B",
+        branch,
+        `refs/remotes/origin/${baseBranch}`,
+      ]);
+      return repositoryDirectory;
+    }
   } catch (error) {
     if (!repositoryDirectoryExisted) {
       await rm(repositoryDirectory, { recursive: true, force: true });
     }
     throw error;
   }
+}
+
+async function cloneRepositoryDirectly(
+  repository: RepositoryRef,
+  targetDirectory: string
+): Promise<void> {
+  await runCommand("git", [
+    "clone",
+    "--filter=blob:none",
+    sanitizeRepositoryCloneUrl(repository.cloneUrl),
+    targetDirectory,
+  ]);
 }
 
 async function ignoreMissingWorktree(command: Promise<void>): Promise<void> {

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -25,6 +25,7 @@ export {
 export type { OrchestratorLogLevel };
 export * from "./runtime-factory.js";
 export * from "./explain.js";
+export * from "./repository-cache.js";
 export {
   findGithubProjectIssue,
   resolveTrackerAdapter,

--- a/packages/orchestrator/src/repository-cache.test.ts
+++ b/packages/orchestrator/src/repository-cache.test.ts
@@ -8,6 +8,7 @@ import {
   globalBareRepositoryLockDirectory,
   inspectGlobalRepositoryCache,
   pruneGlobalRepositoryCache,
+  withGlobalBareRepositoryCache,
 } from "./repository-cache.js";
 
 async function createRemote(root: string, marker: string): Promise<string> {
@@ -129,5 +130,41 @@ describe("global bare repository cache", () => {
     });
     expect(locked.skipped[0]?.reason).toBe("locked");
     await access(bareDirectory);
+  });
+
+  it("prevents pruning while a cache reader operation is active", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "repository-cache-config-"));
+    const root = await mkdtemp(join(tmpdir(), "repository-cache-reader-"));
+    const remote = await createRemote(root, "reader-remote");
+    const repository = { owner: "acme", name: "platform", cloneUrl: remote };
+    let releaseReader: (() => void) | undefined;
+    const readerStarted = new Promise<void>((resolve) => {
+      releaseReader = resolve;
+    });
+    let notifyReaderStarted: (() => void) | undefined;
+    const readerIsActive = new Promise<void>((resolve) => {
+      notifyReaderStarted = resolve;
+    });
+
+    const reader = withGlobalBareRepositoryCache(
+      { repository, configDir },
+      async (bareDirectory) => {
+        notifyReaderStarted?.();
+        await readerStarted;
+        return bareDirectory;
+      }
+    );
+    await readerIsActive;
+
+    const prune = await pruneGlobalRepositoryCache({
+      configDir,
+      maxAgeMs: 0,
+      now: new Date("2027-01-01T00:00:00.000Z"),
+    });
+
+    expect(prune.removed).toHaveLength(0);
+    expect(prune.skipped).toMatchObject([{ reason: "locked" }]);
+    releaseReader?.();
+    await expect(reader).resolves.toContain("platform.git");
   });
 });

--- a/packages/orchestrator/src/repository-cache.test.ts
+++ b/packages/orchestrator/src/repository-cache.test.ts
@@ -169,6 +169,91 @@ describe("global bare repository cache", () => {
     expect(result.skipped[0]?.reason).toBe("recent");
   });
 
+  it("removes an old idle cache in non-dry-run mode", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "repository-cache-config-"));
+    const root = await mkdtemp(join(tmpdir(), "repository-cache-remove-"));
+    const remote = await createRemote(root, "remove-remote");
+    const bareDirectory = await ensureGlobalBareRepositoryCache({
+      repository: { owner: "acme", name: "platform", cloneUrl: remote },
+      configDir,
+      now: new Date("2025-01-01T00:00:00.000Z"),
+    });
+
+    const result = await pruneGlobalRepositoryCache({
+      configDir,
+      maxAgeMs: 1,
+      now: new Date("2026-01-01T00:00:00.000Z"),
+    });
+
+    expect(result.removed).toMatchObject([
+      { repository: "acme/platform", worktrees: 0 },
+    ]);
+    expect(result.reclaimedBytes).toBeGreaterThan(0);
+    await expect(access(bareDirectory)).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  it("preserves an old cache with a linked worktree", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "repository-cache-config-"));
+    const root = await mkdtemp(join(tmpdir(), "repository-cache-worktree-"));
+    const remote = await createRemote(root, "worktree-remote");
+    const bareDirectory = await ensureGlobalBareRepositoryCache({
+      repository: { owner: "acme", name: "platform", cloneUrl: remote },
+      configDir,
+      now: new Date("2025-01-01T00:00:00.000Z"),
+    });
+    const linkedDirectory = join(root, "linked-worktree");
+    execFileSync(
+      "git",
+      [
+        "-C",
+        bareDirectory,
+        "worktree",
+        "add",
+        "--detach",
+        linkedDirectory,
+        "origin/main",
+      ],
+      { stdio: "ignore" }
+    );
+
+    const result = await pruneGlobalRepositoryCache({
+      configDir,
+      maxAgeMs: 1,
+      now: new Date("2026-01-01T00:00:00.000Z"),
+    });
+
+    expect(result.removed).toHaveLength(0);
+    expect(result.skipped).toMatchObject([
+      { repository: "acme/platform", worktrees: 1, reason: "worktrees" },
+    ]);
+    await expect(access(bareDirectory)).resolves.toBeUndefined();
+  });
+
+  it("preserves an old cache when linked worktrees cannot be verified", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "repository-cache-config-"));
+    const bareDirectory = join(configDir, "repos", "acme", "platform.git");
+    await mkdir(bareDirectory, { recursive: true });
+    await writeFile(join(bareDirectory, "not-a-bare-repository"), "broken");
+    await writeFile(
+      join(bareDirectory, ".gh-symphony-last-used"),
+      "2025-01-01T00:00:00.000Z\n"
+    );
+
+    const result = await pruneGlobalRepositoryCache({
+      configDir,
+      maxAgeMs: 1,
+      now: new Date("2026-01-01T00:00:00.000Z"),
+    });
+
+    expect(result.removed).toHaveLength(0);
+    expect(result.skipped).toMatchObject([
+      { repository: "acme/platform", worktrees: null, reason: "worktrees" },
+    ]);
+    await expect(access(bareDirectory)).resolves.toBeUndefined();
+  });
+
   it("prevents pruning while a cache reader operation is active", async () => {
     const configDir = await mkdtemp(join(tmpdir(), "repository-cache-config-"));
     const root = await mkdtemp(join(tmpdir(), "repository-cache-reader-"));

--- a/packages/orchestrator/src/repository-cache.test.ts
+++ b/packages/orchestrator/src/repository-cache.test.ts
@@ -102,6 +102,11 @@ describe("global bare repository cache", () => {
     });
     const old = new Date("2025-01-01T00:00:00.000Z");
     await utimes(bareDirectory, old, old);
+    await writeFile(
+      join(bareDirectory, ".gh-symphony-last-used"),
+      `${old.toISOString()}\n`,
+      "utf8"
+    );
 
     const entries = await inspectGlobalRepositoryCache({ configDir });
     expect(entries).toMatchObject([
@@ -130,6 +135,38 @@ describe("global bare repository cache", () => {
     });
     expect(locked.skipped[0]?.reason).toBe("locked");
     await access(bareDirectory);
+  });
+
+  it("tracks cache reuse independently from the bare directory mtime", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "repository-cache-config-"));
+    const root = await mkdtemp(join(tmpdir(), "repository-cache-used-"));
+    const remote = await createRemote(root, "used-remote");
+    const repository = { owner: "acme", name: "platform", cloneUrl: remote };
+    const firstUse = new Date("2026-01-01T00:00:00.000Z");
+    const lastUse = new Date("2026-01-02T00:00:00.000Z");
+    const bareDirectory = await ensureGlobalBareRepositoryCache({
+      repository,
+      configDir,
+      now: firstUse,
+    });
+    await utimes(bareDirectory, firstUse, firstUse);
+
+    await ensureGlobalBareRepositoryCache({
+      repository,
+      configDir,
+      now: lastUse,
+    });
+
+    const entries = await inspectGlobalRepositoryCache({ configDir });
+    expect(entries[0]?.updatedAt).toBe(lastUse.toISOString());
+    const result = await pruneGlobalRepositoryCache({
+      configDir,
+      maxAgeMs: 12 * 60 * 60 * 1000,
+      now: new Date("2026-01-02T06:00:00.000Z"),
+      dryRun: true,
+    });
+    expect(result.removed).toHaveLength(0);
+    expect(result.skipped[0]?.reason).toBe("recent");
   });
 
   it("prevents pruning while a cache reader operation is active", async () => {
@@ -163,7 +200,9 @@ describe("global bare repository cache", () => {
     });
 
     expect(prune.removed).toHaveLength(0);
-    expect(prune.skipped).toMatchObject([{ reason: "locked" }]);
+    expect(prune.skipped).toMatchObject([
+      { bytes: 0, worktrees: null, reason: "locked" },
+    ]);
     releaseReader?.();
     await expect(reader).resolves.toContain("platform.git");
   });

--- a/packages/orchestrator/src/repository-cache.test.ts
+++ b/packages/orchestrator/src/repository-cache.test.ts
@@ -1,9 +1,14 @@
 import { execFileSync } from "node:child_process";
-import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { access, mkdir, mkdtemp, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { ensureGlobalBareRepositoryCache } from "./repository-cache.js";
+import {
+  ensureGlobalBareRepositoryCache,
+  globalBareRepositoryLockDirectory,
+  inspectGlobalRepositoryCache,
+  pruneGlobalRepositoryCache,
+} from "./repository-cache.js";
 
 async function createRemote(root: string, marker: string): Promise<string> {
   const directory = join(root, "acme-platform");
@@ -83,5 +88,46 @@ describe("global bare repository cache", () => {
 
     expect(bareOrigin(bareDirectory)).toBe(remote);
     expect(bareContent(bareDirectory)).toBe("stable-remote");
+  });
+
+  it("inspects and prunes only old unlocked caches without worktrees", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "repository-cache-config-"));
+    const root = await mkdtemp(join(tmpdir(), "repository-cache-prune-"));
+    const remote = await createRemote(root, "prune-remote");
+    const repository = { owner: "acme", name: "platform", cloneUrl: remote };
+    const bareDirectory = await ensureGlobalBareRepositoryCache({
+      repository,
+      configDir,
+    });
+    const old = new Date("2025-01-01T00:00:00.000Z");
+    await utimes(bareDirectory, old, old);
+
+    const entries = await inspectGlobalRepositoryCache({ configDir });
+    expect(entries).toMatchObject([
+      { repository: "acme/platform", locked: false, worktrees: 0 },
+    ]);
+    expect(entries[0]?.bytes).toBeGreaterThan(0);
+
+    const preview = await pruneGlobalRepositoryCache({
+      configDir,
+      maxAgeMs: 1,
+      now: new Date("2026-01-01T00:00:00.000Z"),
+      dryRun: true,
+    });
+    expect(preview.removed).toHaveLength(1);
+    await expect(access(bareDirectory)).resolves.toBeUndefined();
+
+    const lockDirectory = globalBareRepositoryLockDirectory({
+      repository,
+      configDir,
+    });
+    await mkdir(lockDirectory);
+    const locked = await pruneGlobalRepositoryCache({
+      configDir,
+      maxAgeMs: 1,
+      now: new Date("2026-01-01T00:00:00.000Z"),
+    });
+    expect(locked.skipped[0]?.reason).toBe("locked");
+    await access(bareDirectory);
   });
 });

--- a/packages/orchestrator/src/repository-cache.test.ts
+++ b/packages/orchestrator/src/repository-cache.test.ts
@@ -1,5 +1,11 @@
 import { execFileSync } from "node:child_process";
-import { access, mkdir, mkdtemp, utimes, writeFile } from "node:fs/promises";
+import {
+  access,
+  mkdir,
+  mkdtemp,
+  utimes,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
@@ -290,5 +296,49 @@ describe("global bare repository cache", () => {
     ]);
     releaseReader?.();
     await expect(reader).resolves.toContain("platform.git");
+  });
+
+  it("reclaims an old cache after breaking an abandoned stale lock", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "repository-cache-config-"));
+    const root = await mkdtemp(join(tmpdir(), "repository-cache-stale-lock-"));
+    const remote = await createRemote(root, "stale-lock-remote");
+    const repository = { owner: "acme", name: "platform", cloneUrl: remote };
+    const bareDirectory = await ensureGlobalBareRepositoryCache({
+      repository,
+      configDir,
+      now: new Date("2025-01-01T00:00:00.000Z"),
+    });
+    const lockDirectory = globalBareRepositoryLockDirectory({
+      repository,
+      configDir,
+    });
+    await mkdir(lockDirectory);
+    await writeFile(join(lockDirectory, "owner"), "abandoned\n", "utf8");
+    const stale = new Date(Date.now() - 2 * 60 * 60 * 1000);
+    await utimes(lockDirectory, stale, stale);
+
+    const entries = await inspectGlobalRepositoryCache({ configDir });
+    expect(entries).toMatchObject([
+      {
+        repository: "acme/platform",
+        locked: true,
+        staleLock: true,
+        worktrees: 0,
+      },
+    ]);
+    expect(entries[0]?.bytes).toBeGreaterThan(0);
+
+    const result = await pruneGlobalRepositoryCache({
+      configDir,
+      maxAgeMs: 1,
+      now: new Date("2026-01-01T00:00:00.000Z"),
+    });
+
+    expect(result.removed).toMatchObject([
+      { repository: "acme/platform", staleLock: true },
+    ]);
+    await expect(access(bareDirectory)).rejects.toMatchObject({
+      code: "ENOENT",
+    });
   });
 });

--- a/packages/orchestrator/src/repository-cache.ts
+++ b/packages/orchestrator/src/repository-cache.ts
@@ -14,6 +14,16 @@ const DEFAULT_CONFIG_DIR = join(homedir(), ".gh-symphony");
 const FETCH_TTL_MS = 60_000;
 const LAST_FETCH_MARKER = ".gh-symphony-last-fetch";
 
+export class RepositoryCacheUnavailableError extends Error {
+  constructor(
+    message: string,
+    readonly cause: unknown
+  ) {
+    super(message);
+    this.name = "RepositoryCacheUnavailableError";
+  }
+}
+
 export function resolveGlobalRepositoryCacheRoot(
   configDir = process.env.GH_SYMPHONY_CONFIG_DIR || DEFAULT_CONFIG_DIR
 ): string {
@@ -53,15 +63,23 @@ export async function ensureGlobalBareRepositoryCache(input: {
   const bareDirectory = globalBareRepositoryDirectory(input);
   const lockDirectory = globalBareRepositoryLockDirectory(input);
   const cloneUrl = sanitizeRepositoryCloneUrl(input.repository.cloneUrl);
-  await mkdir(dirname(bareDirectory), { recursive: true });
-
-  const ownerToken = await acquireRepositoryLock(lockDirectory);
+  let ownerToken: string;
   try {
-    return ensureBareRepositoryCacheUnderLock({
-      ...input,
-      bareDirectory,
-      cloneUrl,
-    });
+    await mkdir(dirname(bareDirectory), { recursive: true });
+    ownerToken = await acquireRepositoryLock(lockDirectory);
+  } catch (error) {
+    throw cacheUnavailableError(bareDirectory, error);
+  }
+  try {
+    try {
+      return await ensureBareRepositoryCacheUnderLock({
+        ...input,
+        bareDirectory,
+        cloneUrl,
+      });
+    } catch (error) {
+      throw cacheUnavailableError(bareDirectory, error);
+    }
   } finally {
     await releaseRepositoryLock(lockDirectory, ownerToken);
   }
@@ -80,18 +98,38 @@ export async function withGlobalBareRepositoryCache<T>(
   const bareDirectory = globalBareRepositoryDirectory(input);
   const lockDirectory = globalBareRepositoryLockDirectory(input);
   const cloneUrl = sanitizeRepositoryCloneUrl(input.repository.cloneUrl);
-  await mkdir(dirname(bareDirectory), { recursive: true });
-  const ownerToken = await acquireRepositoryLock(lockDirectory);
+  let ownerToken: string;
   try {
-    await ensureBareRepositoryCacheUnderLock({
-      ...input,
-      bareDirectory,
-      cloneUrl,
-    });
+    await mkdir(dirname(bareDirectory), { recursive: true });
+    ownerToken = await acquireRepositoryLock(lockDirectory);
+  } catch (error) {
+    throw cacheUnavailableError(bareDirectory, error);
+  }
+  try {
+    try {
+      await ensureBareRepositoryCacheUnderLock({
+        ...input,
+        bareDirectory,
+        cloneUrl,
+      });
+    } catch (error) {
+      throw cacheUnavailableError(bareDirectory, error);
+    }
     return await operation(bareDirectory);
   } finally {
     await releaseRepositoryLock(lockDirectory, ownerToken);
   }
+}
+
+function cacheUnavailableError(
+  bareDirectory: string,
+  cause: unknown
+): RepositoryCacheUnavailableError {
+  const detail = cause instanceof Error ? cause.message : String(cause);
+  return new RepositoryCacheUnavailableError(
+    `Global repository cache unavailable at ${bareDirectory}: ${detail}`,
+    cause
+  );
 }
 
 async function ensureBareRepositoryCacheUnderLock(input: {

--- a/packages/orchestrator/src/repository-cache.ts
+++ b/packages/orchestrator/src/repository-cache.ts
@@ -98,7 +98,11 @@ export async function inspectGlobalRepositoryCache(
     for (const name of await safeDirectories(join(root, owner))) {
       if (!name.endsWith(".git")) continue;
       const directory = join(root, owner, name);
-      const lockDirectory = join(root, owner, `${name.slice(0, -4)}.lock`);
+      const repository = { owner, name: name.slice(0, -4) };
+      const lockDirectory = globalBareRepositoryLockDirectory({
+        repository,
+        configDir: input.configDir,
+      });
       const locked = await pathExists(lockDirectory);
       const staleLock = locked
         ? await isRepositoryLockStale(lockDirectory)
@@ -106,7 +110,7 @@ export async function inspectGlobalRepositoryCache(
       const details = await safeStat(directory);
       if (!details) continue;
       entries.push({
-        repository: `${owner}/${name.slice(0, -4)}`,
+        repository: `${repository.owner}/${repository.name}`,
         directory,
         bytes: locked && !staleLock ? 0 : await directorySize(directory),
         updatedAt: await readLastUsedAt(directory, details.mtime),
@@ -147,7 +151,7 @@ export async function pruneGlobalRepositoryCache(input: {
       continue;
     }
     if (!input.dryRun) {
-      const lockDirectory = `${entry.directory.slice(0, -4)}.lock`;
+      const lockDirectory = cacheEntryLockDirectory(entry, input.configDir);
       const ownerToken = await tryAcquireRepositoryLock(lockDirectory, {
         breakStale: true,
       });
@@ -176,6 +180,20 @@ export async function pruneGlobalRepositoryCache(input: {
     result.reclaimedBytes += entry.bytes;
   }
   return result;
+}
+
+function cacheEntryLockDirectory(
+  entry: RepositoryCacheEntry,
+  configDir?: string
+): string {
+  const separator = entry.repository.indexOf("/");
+  return globalBareRepositoryLockDirectory({
+    repository: {
+      owner: entry.repository.slice(0, separator),
+      name: entry.repository.slice(separator + 1),
+    },
+    configDir,
+  });
 }
 
 async function safeDirectories(directory: string): Promise<string[]> {

--- a/packages/orchestrator/src/repository-cache.ts
+++ b/packages/orchestrator/src/repository-cache.ts
@@ -6,6 +6,7 @@ import {
   stat,
   writeFile,
 } from "node:fs/promises";
+import type { Stats } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import type { RepositoryRef } from "@gh-symphony/core";
@@ -22,6 +23,7 @@ import { sanitizeRepositoryCloneUrl } from "./repository-url.js";
 const DEFAULT_CONFIG_DIR = join(homedir(), ".gh-symphony");
 const FETCH_TTL_MS = 60_000;
 const LAST_FETCH_MARKER = ".gh-symphony-last-fetch";
+const LAST_USED_MARKER = ".gh-symphony-last-used";
 const CACHE_LOCK_HEARTBEAT_MS = 60_000;
 
 export class RepositoryCacheUnavailableError extends Error {
@@ -94,15 +96,17 @@ export async function inspectGlobalRepositoryCache(
     for (const name of await safeDirectories(join(root, owner))) {
       if (!name.endsWith(".git")) continue;
       const directory = join(root, owner, name);
-      const details = await stat(directory);
       const lockDirectory = join(root, owner, `${name.slice(0, -4)}.lock`);
+      const locked = await pathExists(lockDirectory);
+      const details = await safeStat(directory);
+      if (!details) continue;
       entries.push({
         repository: `${owner}/${name.slice(0, -4)}`,
         directory,
-        bytes: await directorySize(directory),
-        updatedAt: details.mtime.toISOString(),
-        locked: await pathExists(lockDirectory),
-        worktrees: await countLinkedWorktrees(directory),
+        bytes: locked ? 0 : await directorySize(directory),
+        updatedAt: await readLastUsedAt(directory, details.mtime),
+        locked,
+        worktrees: locked ? null : await countLinkedWorktrees(directory),
       });
     }
   }
@@ -171,13 +175,48 @@ async function safeDirectories(directory: string): Promise<string[]> {
 
 async function directorySize(directory: string): Promise<number> {
   let total = 0;
-  for (const entry of await readdir(directory, { withFileTypes: true })) {
+  let entries;
+  try {
+    entries = await readdir(directory, { withFileTypes: true });
+  } catch (error) {
+    if (isMissing(error)) return 0;
+    throw error;
+  }
+  for (const entry of entries) {
     const path = join(directory, entry.name);
-    total += entry.isDirectory()
-      ? await directorySize(path)
-      : (await stat(path)).size;
+    if (entry.isDirectory()) {
+      total += await directorySize(path);
+      continue;
+    }
+    const details = await safeStat(path);
+    if (details) total += details.size;
   }
   return total;
+}
+
+async function safeStat(path: string): Promise<Stats | null> {
+  try {
+    return await stat(path);
+  } catch (error) {
+    if (isMissing(error)) return null;
+    throw error;
+  }
+}
+
+async function readLastUsedAt(
+  directory: string,
+  fallback: Date
+): Promise<string> {
+  try {
+    const marker = await readFile(join(directory, LAST_USED_MARKER), "utf8");
+    const usedAt = Date.parse(marker.trim());
+    return Number.isFinite(usedAt)
+      ? new Date(usedAt).toISOString()
+      : fallback.toISOString();
+  } catch (error) {
+    if (isMissing(error)) return fallback.toISOString();
+    throw error;
+  }
 }
 
 async function countLinkedWorktrees(directory: string): Promise<number | null> {
@@ -322,6 +361,7 @@ async function ensureBareRepositoryCacheUnderLock(input: {
   const now = input.now ?? new Date();
   if (!(await isBareRepository(input.bareDirectory))) {
     await recreateBareRepository(input.bareDirectory, input.cloneUrl, now);
+    await writeLastUsedMarker(input.bareDirectory, now);
     return input.bareDirectory;
   }
 
@@ -334,6 +374,7 @@ async function ensureBareRepositoryCacheUnderLock(input: {
   const originUrl = await readOriginRemoteUrl(input.bareDirectory);
   if (originUrl === null) {
     await recreateBareRepository(input.bareDirectory, input.cloneUrl, now);
+    await writeLastUsedMarker(input.bareDirectory, now);
     return input.bareDirectory;
   }
   // The cache is keyed by owner/name, so a repository that moved hosts,
@@ -360,6 +401,8 @@ async function ensureBareRepositoryCacheUnderLock(input: {
     await writeLastFetchMarker(input.bareDirectory, now);
     await runGitCommand(["-C", input.bareDirectory, "gc", "--auto"]);
   }
+
+  await writeLastUsedMarker(input.bareDirectory, now);
 
   return input.bareDirectory;
 }
@@ -509,6 +552,17 @@ async function writeLastFetchMarker(
 ): Promise<void> {
   await writeFile(
     join(directory, LAST_FETCH_MARKER),
+    `${now.toISOString()}\n`,
+    "utf8"
+  );
+}
+
+async function writeLastUsedMarker(
+  directory: string,
+  now: Date
+): Promise<void> {
+  await writeFile(
+    join(directory, LAST_USED_MARKER),
     `${now.toISOString()}\n`,
     "utf8"
   );

--- a/packages/orchestrator/src/repository-cache.ts
+++ b/packages/orchestrator/src/repository-cache.ts
@@ -7,12 +7,14 @@ import {
   releaseRepositoryLock,
   runGitCommand,
   runGitCommandCapture,
+  startRepositoryLockHeartbeat,
 } from "./git.js";
 import { sanitizeRepositoryCloneUrl } from "./repository-url.js";
 
 const DEFAULT_CONFIG_DIR = join(homedir(), ".gh-symphony");
 const FETCH_TTL_MS = 60_000;
 const LAST_FETCH_MARKER = ".gh-symphony-last-fetch";
+const CACHE_LOCK_HEARTBEAT_MS = 60_000;
 
 export class RepositoryCacheUnavailableError extends Error {
   constructor(
@@ -71,6 +73,11 @@ export async function ensureGlobalBareRepositoryCache(input: {
     throw cacheUnavailableError(bareDirectory, error);
   }
   try {
+    const heartbeat = startRepositoryLockHeartbeat(
+      lockDirectory,
+      ownerToken,
+      CACHE_LOCK_HEARTBEAT_MS
+    );
     try {
       return await ensureBareRepositoryCacheUnderLock({
         ...input,
@@ -79,6 +86,8 @@ export async function ensureGlobalBareRepositoryCache(input: {
       });
     } catch (error) {
       throw cacheUnavailableError(bareDirectory, error);
+    } finally {
+      await heartbeat.stop();
     }
   } finally {
     await releaseRepositoryLock(lockDirectory, ownerToken);
@@ -106,16 +115,25 @@ export async function withGlobalBareRepositoryCache<T>(
     throw cacheUnavailableError(bareDirectory, error);
   }
   try {
+    const heartbeat = startRepositoryLockHeartbeat(
+      lockDirectory,
+      ownerToken,
+      CACHE_LOCK_HEARTBEAT_MS
+    );
     try {
-      await ensureBareRepositoryCacheUnderLock({
-        ...input,
-        bareDirectory,
-        cloneUrl,
-      });
-    } catch (error) {
-      throw cacheUnavailableError(bareDirectory, error);
+      try {
+        await ensureBareRepositoryCacheUnderLock({
+          ...input,
+          bareDirectory,
+          cloneUrl,
+        });
+      } catch (error) {
+        throw cacheUnavailableError(bareDirectory, error);
+      }
+      return await operation(bareDirectory);
+    } finally {
+      await heartbeat.stop();
     }
-    return await operation(bareDirectory);
   } finally {
     await releaseRepositoryLock(lockDirectory, ownerToken);
   }

--- a/packages/orchestrator/src/repository-cache.ts
+++ b/packages/orchestrator/src/repository-cache.ts
@@ -12,6 +12,7 @@ import { dirname, join } from "node:path";
 import type { RepositoryRef } from "@gh-symphony/core";
 import {
   acquireRepositoryLock,
+  isRepositoryLockStale,
   releaseRepositoryLock,
   runGitCommand,
   runGitCommandCapture,
@@ -42,6 +43,7 @@ export type RepositoryCacheEntry = {
   bytes: number;
   updatedAt: string;
   locked: boolean;
+  staleLock: boolean;
   worktrees: number | null;
 };
 
@@ -98,15 +100,20 @@ export async function inspectGlobalRepositoryCache(
       const directory = join(root, owner, name);
       const lockDirectory = join(root, owner, `${name.slice(0, -4)}.lock`);
       const locked = await pathExists(lockDirectory);
+      const staleLock = locked
+        ? await isRepositoryLockStale(lockDirectory)
+        : false;
       const details = await safeStat(directory);
       if (!details) continue;
       entries.push({
         repository: `${owner}/${name.slice(0, -4)}`,
         directory,
-        bytes: locked ? 0 : await directorySize(directory),
+        bytes: locked && !staleLock ? 0 : await directorySize(directory),
         updatedAt: await readLastUsedAt(directory, details.mtime),
         locked,
-        worktrees: locked ? null : await countLinkedWorktrees(directory),
+        staleLock,
+        worktrees:
+          locked && !staleLock ? null : await countLinkedWorktrees(directory),
       });
     }
   }
@@ -131,7 +138,7 @@ export async function pruneGlobalRepositoryCache(input: {
       result.skipped.push({ ...entry, reason: "recent" });
       continue;
     }
-    if (entry.locked) {
+    if (entry.locked && !entry.staleLock) {
       result.skipped.push({ ...entry, reason: "locked" });
       continue;
     }
@@ -141,12 +148,21 @@ export async function pruneGlobalRepositoryCache(input: {
     }
     if (!input.dryRun) {
       const lockDirectory = `${entry.directory.slice(0, -4)}.lock`;
-      const ownerToken = await tryAcquireRepositoryLock(lockDirectory);
+      const ownerToken = await tryAcquireRepositoryLock(lockDirectory, {
+        breakStale: true,
+      });
       if (!ownerToken) {
         result.skipped.push({ ...entry, locked: true, reason: "locked" });
         continue;
       }
       try {
+        const details = await safeStat(entry.directory);
+        if (!details) continue;
+        const updatedAt = await readLastUsedAt(entry.directory, details.mtime);
+        if (now.getTime() - Date.parse(updatedAt) < input.maxAgeMs) {
+          result.skipped.push({ ...entry, updatedAt, reason: "recent" });
+          continue;
+        }
         if ((await countLinkedWorktrees(entry.directory)) !== 0) {
           result.skipped.push({ ...entry, reason: "worktrees" });
           continue;

--- a/packages/orchestrator/src/repository-cache.ts
+++ b/packages/orchestrator/src/repository-cache.ts
@@ -1,4 +1,11 @@
-import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import {
+  mkdir,
+  readFile,
+  readdir,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import type { RepositoryRef } from "@gh-symphony/core";
@@ -8,6 +15,7 @@ import {
   runGitCommand,
   runGitCommandCapture,
   startRepositoryLockHeartbeat,
+  tryAcquireRepositoryLock,
 } from "./git.js";
 import { sanitizeRepositoryCloneUrl } from "./repository-url.js";
 
@@ -25,6 +33,24 @@ export class RepositoryCacheUnavailableError extends Error {
     this.name = "RepositoryCacheUnavailableError";
   }
 }
+
+export type RepositoryCacheEntry = {
+  repository: string;
+  directory: string;
+  bytes: number;
+  updatedAt: string;
+  locked: boolean;
+  worktrees: number | null;
+};
+
+export type RepositoryCachePruneResult = {
+  removed: RepositoryCacheEntry[];
+  skipped: Array<
+    RepositoryCacheEntry & { reason: "locked" | "worktrees" | "recent" }
+  >;
+  reclaimedBytes: number;
+  dryRun: boolean;
+};
 
 export function resolveGlobalRepositoryCacheRoot(
   configDir = process.env.GH_SYMPHONY_CONFIG_DIR || DEFAULT_CONFIG_DIR
@@ -53,6 +79,142 @@ export function globalBareRepositoryLockDirectory(input: {
     resolveGlobalRepositoryCacheRoot(input.configDir),
     input.repository.owner,
     `${input.repository.name}.lock`
+  );
+}
+
+export async function inspectGlobalRepositoryCache(
+  input: {
+    configDir?: string;
+  } = {}
+): Promise<RepositoryCacheEntry[]> {
+  const root = resolveGlobalRepositoryCacheRoot(input.configDir);
+  const owners = await safeDirectories(root);
+  const entries: RepositoryCacheEntry[] = [];
+  for (const owner of owners) {
+    for (const name of await safeDirectories(join(root, owner))) {
+      if (!name.endsWith(".git")) continue;
+      const directory = join(root, owner, name);
+      const details = await stat(directory);
+      const lockDirectory = join(root, owner, `${name.slice(0, -4)}.lock`);
+      entries.push({
+        repository: `${owner}/${name.slice(0, -4)}`,
+        directory,
+        bytes: await directorySize(directory),
+        updatedAt: details.mtime.toISOString(),
+        locked: await pathExists(lockDirectory),
+        worktrees: await countLinkedWorktrees(directory),
+      });
+    }
+  }
+  return entries.sort((a, b) => a.repository.localeCompare(b.repository));
+}
+
+export async function pruneGlobalRepositoryCache(input: {
+  configDir?: string;
+  maxAgeMs: number;
+  now?: Date;
+  dryRun?: boolean;
+}): Promise<RepositoryCachePruneResult> {
+  const now = input.now ?? new Date();
+  const result: RepositoryCachePruneResult = {
+    removed: [],
+    skipped: [],
+    reclaimedBytes: 0,
+    dryRun: Boolean(input.dryRun),
+  };
+  for (const entry of await inspectGlobalRepositoryCache(input)) {
+    if (now.getTime() - Date.parse(entry.updatedAt) < input.maxAgeMs) {
+      result.skipped.push({ ...entry, reason: "recent" });
+      continue;
+    }
+    if (entry.locked) {
+      result.skipped.push({ ...entry, reason: "locked" });
+      continue;
+    }
+    if (entry.worktrees !== 0) {
+      result.skipped.push({ ...entry, reason: "worktrees" });
+      continue;
+    }
+    if (!input.dryRun) {
+      const lockDirectory = `${entry.directory.slice(0, -4)}.lock`;
+      const ownerToken = await tryAcquireRepositoryLock(lockDirectory);
+      if (!ownerToken) {
+        result.skipped.push({ ...entry, locked: true, reason: "locked" });
+        continue;
+      }
+      try {
+        if ((await countLinkedWorktrees(entry.directory)) !== 0) {
+          result.skipped.push({ ...entry, reason: "worktrees" });
+          continue;
+        }
+        await rm(entry.directory, { recursive: true, force: true });
+      } finally {
+        await releaseRepositoryLock(lockDirectory, ownerToken);
+      }
+    }
+    result.removed.push(entry);
+    result.reclaimedBytes += entry.bytes;
+  }
+  return result;
+}
+
+async function safeDirectories(directory: string): Promise<string[]> {
+  try {
+    return (await readdir(directory, { withFileTypes: true }))
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name);
+  } catch (error) {
+    if (isMissing(error)) return [];
+    throw error;
+  }
+}
+
+async function directorySize(directory: string): Promise<number> {
+  let total = 0;
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    const path = join(directory, entry.name);
+    total += entry.isDirectory()
+      ? await directorySize(path)
+      : (await stat(path)).size;
+  }
+  return total;
+}
+
+async function countLinkedWorktrees(directory: string): Promise<number | null> {
+  try {
+    const output = await runGitCommandCapture([
+      "-C",
+      directory,
+      "worktree",
+      "list",
+      "--porcelain",
+    ]);
+    return Math.max(
+      0,
+      output.split("\n").filter((line) => line.startsWith("worktree ")).length -
+        1
+    );
+  } catch {
+    return null;
+  }
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch (error) {
+    if (isMissing(error)) return false;
+    throw error;
+  }
+}
+
+function isMissing(error: unknown): boolean {
+  return Boolean(
+    error &&
+    typeof error === "object" &&
+    "code" in error &&
+    (error.code === "ENOENT" || error.code === "ENOTDIR")
   );
 }
 

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -2720,6 +2720,11 @@ export class OrchestratorService {
       issueIdentifier: issue.identifier,
       branchTemplate,
       baseBranch,
+      onCacheUnavailable: (error) => {
+        this.writeStderr(
+          `[orchestrator] repository cache unavailable for ${issue.identifier}; using direct clone: ${error.message}`
+        );
+      },
     });
     const agentCommand = resolveWorkflowRuntimeCommand(
       workflowForPopulate.workflow


### PR DESCRIPTION
## Issues

- Closed #588

## TL;DR

Global bare-cache failures no longer block workspace population: the orchestrator falls back to an observable direct clone. Cache operations use heartbeat-protected locks, and operators can inspect or conservatively prune cached repositories through the CLI.

## Change-point diagram

```text
workspace population
  ├─ cache available → heartbeat lock → reference clone/worktree
  └─ cache unavailable/timeout → operator warning → isolated direct clone

gh-symphony cache
  ├─ status → size, last-use, lock/stale-lock, worktree safety
  └─ prune  → age filter → deletion lock → age/worktree recheck → remove
```

## Start here

1. `packages/orchestrator/src/repository-cache.ts` — cache inventory, last-use tracking, stale-lock recovery, and conservative pruning.
2. `packages/orchestrator/src/git.ts` — heartbeat ownership, direct-clone fallback, reader protection, and standalone teardown handling.
3. `packages/cli/src/commands/cache.ts` — `cache status` and `cache prune` operator surface.
4. `packages/orchestrator/src/repository-cache.test.ts` and `packages/orchestrator/src/git.test.ts` — concurrency, fallback, stale-lock, and destructive-path regressions.

## Changes

- Fall back to a direct workspace clone when the shared cache is unavailable or its acquisition times out, with an operator-visible warning.
- Hold heartbeat-refreshed cache locks across large clone/fetch and active reference-reader operations.
- Track cache last use independently, recheck age and worktrees under the deletion lock, and safely recover abandoned stale locks.
- Add `gh-symphony cache status` and conservative `cache prune` commands with JSON/dry-run support and clear locked/unverifiable states.
- Add unit, destructive-path, concurrency, CLI, and Docker black-box coverage plus living documentation.
- Add a minor changeset for `@gh-symphony/cli`.

## Evidence

- `pnpm lint`
- `pnpm test`
- `pnpm typecheck`
- `pnpm build`
- `pnpm changeset status`
- Docker TC-15: rebuilt stack healthy; inventory reported `test-owner/test-repo` (24,814 bytes); dry-run retained it; real prune reclaimed it; final inventory empty; stack removed and fixture restored.
- GitHub checks: `Test` and `Container Smoke` passed on `c5d96284`.

## Risks & rollback

- Direct fallback consumes additional network bandwidth while cache storage or locking is degraded; the service warning makes this detectable.
- Pruning is intentionally conservative for live locks, linked worktrees, and unverifiable repositories; abandoned locks are reclaimed only after the existing 30-minute stale threshold.
- Rollback: revert this PR to restore the previous cache-only population path and remove the maintenance CLI surface. Existing bare caches remain compatible.

## Changed files

- Orchestrator cache/runtime: `packages/orchestrator/src/repository-cache.ts`, `packages/orchestrator/src/git.ts`, `packages/orchestrator/src/service.ts`
- CLI: `packages/cli/src/commands/cache.ts`, command registration/help, and CLI docs
- Tests: orchestrator Git/cache tests, CLI cache tests, and `e2e/scenarios/15-cache-maintenance.md`
- Living docs: `README.md`, `packages/cli/README.md`, `docs/architecture.md`, `docs/configuration.md`, `AGENT_TEST.md`
- Release: `.changeset/fuzzy-caches-rest.md`

## Human validation

- [ ] Confirm cache degradation warnings are visible in the operator log stream.
- [ ] Confirm `cache status` labels live locks, stale locks, and unverifiable entries clearly.
- [ ] Confirm `cache prune --dry-run` output matches the intended retention policy before using real prune in production.

## Post-merge validation

- [ ] Run `gh-symphony cache status --json` against a representative production cache root.
- [ ] Run `gh-symphony cache prune --dry-run --max-age-days 30 --json` and review retained/removal candidates.
