### PR TITLE
fix(config): validate projectDir and hash env cache

### DIFF
--- a/.changeset/secure-workflow-env-cache.md
+++ b/.changeset/secure-workflow-env-cache.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Reject relative standalone project directories and avoid retaining plaintext workflow environment values in cache metadata (#591).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,7 +16,9 @@ must declare `repository.slug`, which is also what distinguishes a standalone
 project from a repository that embeds its own workflow. Configuration is derived
 from the folder on every start and cached under
 `<config-dir>/projects/<project-id>/`, where the project id is a stable function
-of the folder path — there is no registration step and no active-project state. Issue workspaces are
+of the folder path — there is no registration step and no active-project state.
+The cached `projectDir` is always absolute; persisted relative values are
+rejected instead of being resolved against the daemon working directory. Issue workspaces are
 created under the project's `workspace.root` (spec 9.1), resolved relative to
 the project folder and defaulting to `<project-dir>/.runtime/workspaces`; the
 directory is created with mode `0700` when it does not exist. Repo-embedded
@@ -28,7 +30,9 @@ using a worktree. Branches default to
 `symphony/<project-slug>/<sanitized-issue-id>`, so multiple projects may use
 one repository without branch collisions. The project `.env` is loaded first
 for project hooks and workers, then host process values override it; keep it
-mode `0600` and do not commit it. An explicit `--config <dir>` is exported to
+mode `0600` and do not commit it. Workflow reload caching compares a SHA-256
+digest of the effective environment so project and host secret values are not
+retained in plaintext cache metadata. An explicit `--config <dir>` is exported to
 `GH_SYMPHONY_CONFIG_DIR` for the process, so the bare cache and spawned workers
 use the same directory as the rest of the CLI state. The cache is keyed by
 `<owner>/<name>`; when a project's clone URL changes, the cache re-points

--- a/packages/cli/src/config.test.ts
+++ b/packages/cli/src/config.test.ts
@@ -113,6 +113,16 @@ describe("config persistence", () => {
         },
       })
     ).rejects.toThrow('Project "project-1" external workflow source path');
+
+    await expect(
+      saveProjectConfig(configDir, projectId, {
+        projectId,
+        slug: projectId,
+        workspaceDir: "/tmp/project-1",
+        projectDir: "relative/project",
+        tracker: { adapter: "file", bindingId: "project-1" },
+      })
+    ).rejects.toThrow('Project "project-1" project directory');
   });
 
   it("serializes concurrent load-modify-save updates", async () => {

--- a/packages/core/src/contracts/status-surface.ts
+++ b/packages/core/src/contracts/status-surface.ts
@@ -52,6 +52,7 @@ export type OrchestratorProjectConfig = {
 export function normalizeOrchestratorProjectConfig(
   config: OrchestratorProjectConfig
 ): OrchestratorProjectConfig {
+  normalizeProjectDir(config);
   const workflowSource = normalizeWorkflowSource(config);
   const populateStrategy = normalizePopulateStrategy(config);
 
@@ -60,6 +61,17 @@ export function normalizeOrchestratorProjectConfig(
     workflowSource,
     populateStrategy,
   };
+}
+
+function normalizeProjectDir(config: OrchestratorProjectConfig): void {
+  if (config.projectDir === undefined) {
+    return;
+  }
+  if (typeof config.projectDir !== "string" || !isAbsolute(config.projectDir)) {
+    throw new Error(
+      `Project ${JSON.stringify(config.projectId)} project directory ${JSON.stringify(config.projectDir)} must be absolute.`
+    );
+  }
 }
 
 function normalizeWorkflowSource(

--- a/packages/core/src/contracts/status-surface.ts
+++ b/packages/core/src/contracts/status-surface.ts
@@ -52,7 +52,7 @@ export type OrchestratorProjectConfig = {
 export function normalizeOrchestratorProjectConfig(
   config: OrchestratorProjectConfig
 ): OrchestratorProjectConfig {
-  normalizeProjectDir(config);
+  assertAbsoluteProjectDir(config);
   const workflowSource = normalizeWorkflowSource(config);
   const populateStrategy = normalizePopulateStrategy(config);
 
@@ -63,7 +63,7 @@ export function normalizeOrchestratorProjectConfig(
   };
 }
 
-function normalizeProjectDir(config: OrchestratorProjectConfig): void {
+function assertAbsoluteProjectDir(config: OrchestratorProjectConfig): void {
   if (config.projectDir === undefined) {
     return;
   }

--- a/packages/core/src/workflow-loader.test.ts
+++ b/packages/core/src/workflow-loader.test.ts
@@ -857,6 +857,27 @@ Prompt body.
 });
 
 describe("WorkflowConfigStore", () => {
+  it("stores a hash instead of plaintext environment values in cache metadata", async () => {
+    const root = await mkdtemp(join(tmpdir(), "workflow-loader-"));
+    tempDirs.push(root);
+    const workflowPath = join(root, "WORKFLOW.md");
+    const store = new WorkflowConfigStore();
+    const secret = "project-and-host-secret";
+
+    await writeFile(workflowPath, SAMPLE_WORKFLOW, "utf8");
+    await store.load(workflowPath, { SECRET_TOKEN: secret });
+
+    const cache = (
+      store as unknown as {
+        cache: Map<string, { envSignature: string }>;
+      }
+    ).cache;
+    const envSignature = cache.get(workflowPath)?.envSignature;
+
+    expect(envSignature).toMatch(/^[a-f0-9]{64}$/);
+    expect(envSignature).not.toContain(secret);
+  });
+
   it("keeps the last known good workflow after an invalid update", async () => {
     const root = await mkdtemp(join(tmpdir(), "workflow-loader-"));
     tempDirs.push(root);

--- a/packages/core/src/workflow-loader.test.ts
+++ b/packages/core/src/workflow-loader.test.ts
@@ -863,6 +863,7 @@ describe("WorkflowConfigStore", () => {
     const workflowPath = join(root, "WORKFLOW.md");
     const store = new WorkflowConfigStore();
     const secret = "project-and-host-secret";
+    const changedSecret = "changed-project-and-host-secret";
 
     await writeFile(workflowPath, SAMPLE_WORKFLOW, "utf8");
     await store.load(workflowPath, { SECRET_TOKEN: secret });
@@ -874,8 +875,14 @@ describe("WorkflowConfigStore", () => {
     ).cache;
     const envSignature = cache.get(workflowPath)?.envSignature;
 
+    await store.load(workflowPath, { SECRET_TOKEN: changedSecret });
+    const changedEnvSignature = cache.get(workflowPath)?.envSignature;
+
     expect(envSignature).toMatch(/^[a-f0-9]{64}$/);
     expect(envSignature).not.toContain(secret);
+    expect(changedEnvSignature).toMatch(/^[a-f0-9]{64}$/);
+    expect(changedEnvSignature).not.toContain(changedSecret);
+    expect(changedEnvSignature).not.toBe(envSignature);
   });
 
   it("keeps the last known good workflow after an invalid update", async () => {

--- a/packages/core/src/workflow/loader.ts
+++ b/packages/core/src/workflow/loader.ts
@@ -23,14 +23,20 @@ export class WorkflowConfigStore {
     const fileStat = await stat(workflowPath);
     const cached = this.cache.get(workflowPath);
     const markdown = await readFile(workflowPath, "utf8");
-    const fingerprint = `${fileStat.mtimeMs}:${fileStat.size}:${createHash("sha256")
+    const fingerprint = `${fileStat.mtimeMs}:${fileStat.size}:${createHash(
+      "sha256"
+    )
       .update(markdown)
       .digest("hex")}`;
-    const envSignature = JSON.stringify(
-      Object.entries(env).filter(
-        (entry): entry is [string, string] => typeof entry[1] === "string"
+    const envSignature = createHash("sha256")
+      .update(
+        JSON.stringify(
+          Object.entries(env).filter(
+            (entry): entry is [string, string] => typeof entry[1] === "string"
+          )
+        )
       )
-    );
+      .digest("hex");
 
     if (
       cached &&


### PR DESCRIPTION
## TL;DR

- Reject relative standalone `projectDir` values instead of resolving them implicitly from the daemon working directory.
- Hash environment-derived workflow cache identity so project and host secret values are not retained in plaintext cache metadata.
- Preserve and test environment-change invalidation, with a patch changeset for the published CLI runtime behavior.

## Change-point diagram

```text
standalone project config ──> normalizeOrchestratorProjectConfig ──> assertAbsoluteProjectDir
workflow path + env ────────> WorkflowConfigStore ────────────────> SHA-256 cache identity
changed effective env ──────> different digest ───────────────────> workflow re-parse
```

## Start here

- `packages/core/src/contracts/status-surface.ts` — standalone project validation at the shared normalization boundary.
- `packages/core/src/workflow/loader.ts` — hashed workflow environment cache identity.
- `packages/core/src/workflow-loader.test.ts` — plaintext protection and environment-change invalidation coverage.
- `packages/cli/src/config.test.ts` — persisted relative-directory rejection coverage.

## Risks & rollback

- Existing standalone configs with relative `projectDir` values will fail explicitly; using an absolute path restores startup.
- Hashing changes cache identity representation only; equality-based cache hits and changed-environment invalidation remain covered.
- Reverting this PR restores relative-path acceptance and plaintext environment signatures in cache metadata.

## Changed files

- `.changeset/secure-workflow-env-cache.md` — publishes the user-visible behavior as an `@gh-symphony/cli` patch.
- `docs/configuration.md` — documents absolute standalone paths and hashed environment cache metadata.
- `packages/cli/src/config.test.ts` — verifies relative standalone project directories are rejected.
- `packages/core/src/contracts/status-surface.ts` — asserts that persisted standalone project directories are absolute.
- `packages/core/src/workflow-loader.test.ts` — verifies digests exclude plaintext secrets and change when the environment changes.
- `packages/core/src/workflow/loader.ts` — stores a SHA-256 environment signature in workflow cache metadata.

## Evidence

- `pnpm exec vitest run packages/core/src/workflow-loader.test.ts packages/cli/src/config.test.ts` — 56 focused tests passed.
- `pnpm lint` — passed across all workspace packages.
- `pnpm test` — passed across all workspace packages.
- `pnpm typecheck` — passed with strict TypeScript checks.
- `pnpm build` — passed across all workspace packages.
- `pnpm exec prettier --check docs/configuration.md packages/core/src/contracts/status-surface.ts packages/core/src/workflow/loader.ts packages/core/src/workflow-loader.test.ts packages/cli/src/config.test.ts .changeset/secure-workflow-env-cache.md` — passed.
- `git diff --check` — passed.
- Docker E2E — not applicable; this changes Configuration Layer validation/cache internals, not dispatch, lifecycle, tracker, or status integration behavior.
- Spec conformance — conforms to `docs/symphony-spec.md`; no intentional divergence and the upstream spec was not modified.

## Post-merge / human validation

- [ ] Confirm a standalone project configured with an absolute `projectDir` starts normally.
- [ ] Confirm a relative standalone `projectDir` reports a clear validation error.
- [ ] Confirm identical environments retain cache-hit behavior and changed environments trigger workflow re-parsing.

## Issues — Closed #591
