### PR TITLE
fix(cli): resolve active standalone project for diagnostics

### DIFF
--- a/.changeset/tidy-ravens-resolve.md
+++ b/.changeset/tidy-ravens-resolve.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Fix #589 by resolving the active standalone project for multi-project `doctor` and `workflow preview` diagnostics, with standalone-specific selection guidance.

--- a/README.md
+++ b/README.md
@@ -599,6 +599,8 @@ gh-symphony config edit             # Open config in $EDITOR
 
 `gh-symphony doctor` runs a single first-run diagnostic pass and exits non-zero if any required prerequisite is missing. `gh-symphony doctor --fix` adds a remediation pass on top of the same checks. `gh-symphony doctor --smoke` is the recommended final preflight before `gh-symphony repo start --once`: it resolves the active managed project, checks the GitHub Project binding, confirms the repository and target issue are readable through the project, renders `WORKFLOW.md` for that issue, verifies the runtime command, workspace root, and configured hook paths, and exits without dispatching a worker.
 
+When the global registry contains multiple standalone projects, `doctor` and live `workflow preview` diagnostics use its `activeProject`. To inspect a different standalone project explicitly, pass `--project-dir <path>` to `doctor` or `--project-id <projectId>` to `workflow preview`.
+
 Use an explicit issue when you want a deterministic check:
 
 ```bash

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -378,6 +378,8 @@ Without `--issue`, doctor auto-selects one active live issue from the managed pr
 
 `gh-symphony doctor --fix` extends the regular diagnostic flow with safe remediation and guided follow-up:
 
+When multiple standalone projects are registered, diagnostics resolve the registry's `activeProject`. Use `doctor --project-dir <path>` or `workflow preview --project-id <projectId>` to select another project explicitly.
+
 - creates missing config/runtime/workspace directories
 - launches `gh auth login` or `gh auth refresh` when a TTY is available, otherwise prints the exact command to run
 - launches `gh-symphony workflow init` when `WORKFLOW.md` is missing or invalid

--- a/packages/cli/src/commands/doctor.test.ts
+++ b/packages/cli/src/commands/doctor.test.ts
@@ -1066,6 +1066,9 @@ describe("runDoctorDiagnostics", () => {
       summary: expect.stringContaining("repo init"),
       remediation: expect.stringContaining("--project-dir <path>"),
     });
+    expect(
+      report.checks.find((check) => check.id === "managed_project")?.remediation
+    ).not.toContain("run from its project folder");
   });
 
   it("accepts env-token auth when gh CLI is unavailable", async () => {

--- a/packages/cli/src/commands/doctor.test.ts
+++ b/packages/cli/src/commands/doctor.test.ts
@@ -1064,6 +1064,7 @@ describe("runDoctorDiagnostics", () => {
     ).toMatchObject({
       status: "fail",
       summary: expect.stringContaining("repo init"),
+      remediation: expect.stringContaining("--project-dir <path>"),
     });
   });
 

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -1767,7 +1767,7 @@ export async function runDoctorDiagnostics(
         "managed_project",
         "Managed project selection",
         resolvedProjectConfig.message,
-        "For a standalone project, run from its project folder or pass '--project-dir <path>'. For a repository runtime, run 'gh-symphony repo init' from the target repository.",
+        "For a standalone project, pass '--project-dir <path>'. For a repository runtime, run 'gh-symphony repo init' from the target repository.",
         {
           reason: resolvedProjectConfig.kind,
           ...(resolvedProjectConfig.projectId

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -1767,7 +1767,7 @@ export async function runDoctorDiagnostics(
         "managed_project",
         "Managed project selection",
         resolvedProjectConfig.message,
-        "Run 'gh-symphony repo init' from the target repository.",
+        "For a standalone project, run from its project folder or pass '--project-dir <path>'. For a repository runtime, run 'gh-symphony repo init' from the target repository.",
         {
           reason: resolvedProjectConfig.kind,
           ...(resolvedProjectConfig.projectId

--- a/packages/cli/src/project-selection.test.ts
+++ b/packages/cli/src/project-selection.test.ts
@@ -174,7 +174,7 @@ describe("resolveManagedProjectConfig", () => {
 });
 
 describe("inspectManagedProjectSelection", () => {
-  it("requires explicit project selection in non-interactive multi-project mode", async () => {
+  it("uses the active project in non-interactive multi-project mode", async () => {
     const configDir = await createConfigFixture(
       [createProject("tenant-a"), createProject("tenant-b")],
       "tenant-b"
@@ -184,10 +184,25 @@ describe("inspectManagedProjectSelection", () => {
     const result = await inspectManagedProjectSelection({ configDir });
 
     expect(result).toMatchObject({
-      kind: "multiple_projects_require_selection",
-      message:
-        "Multiple repository runtime configs are present. Run 'gh-symphony repo init' from the target repository to refresh the cwd runtime.",
+      kind: "resolved",
+      projectId: "tenant-b",
     });
+  });
+
+  it("reports standalone selection guidance when multiple projects have no active project", async () => {
+    const configDir = await createConfigFixture([
+      createProject("tenant-a"),
+      createProject("tenant-b"),
+    ]);
+    setTty(false, false);
+
+    const result = await inspectManagedProjectSelection({ configDir });
+
+    expect(result).toMatchObject({
+      kind: "multiple_projects_require_selection",
+      message: expect.stringContaining("--project-dir <path>"),
+    });
+    expect(result.message).not.toContain("repo init");
   });
 
   it("uses the active project when one is configured", async () => {

--- a/packages/cli/src/project-selection.test.ts
+++ b/packages/cli/src/project-selection.test.ts
@@ -202,6 +202,7 @@ describe("inspectManagedProjectSelection", () => {
       kind: "multiple_projects_require_selection",
       message: expect.stringContaining("--project-dir <path>"),
     });
+    expect(result.message).toContain("gh-symphony project list");
     expect(result.message).not.toContain("repo init");
   });
 
@@ -232,6 +233,9 @@ describe("inspectManagedProjectSelection", () => {
     expect(result).toMatchObject({
       kind: "active_project_missing",
       projectId: "tenant-a",
+      message:
+        "Active project \"tenant-a\" is configured in config.json but its project config is missing. For a standalone project, run 'gh-symphony project start' from its project folder to refresh the runtime config. For a repository runtime, run 'gh-symphony repo init' from the target repository.",
     });
+    expect(result.message).not.toContain('Active Project "tenant-a"');
   });
 });

--- a/packages/cli/src/project-selection.ts
+++ b/packages/cli/src/project-selection.ts
@@ -39,11 +39,15 @@ function explicitProjectRequiredMessage(): string {
 }
 
 function diagnosticProjectRequiredMessage(): string {
-  return "Multiple managed projects are configured and no active project is set. Pass '--project-id <project-id>' to select one. For standalone diagnostics, pass '--project-dir <path>' to 'gh-symphony doctor'.";
+  return "Multiple managed projects are configured and no active project is set. Pass '--project-id <project-id>' to select one. Run 'gh-symphony project list' to see configured project ids. For standalone diagnostics, pass '--project-dir <path>' to 'gh-symphony doctor'.";
+}
+
+function projectConfigRemediation(): string {
+  return "For a standalone project, run 'gh-symphony project start' from its project folder to refresh the runtime config. For a repository runtime, run 'gh-symphony repo init' from the target repository.";
 }
 
 function missingProjectConfigMessage(projectId: string): string {
-  return `Project "${projectId}" is not configured. For a standalone project, run 'gh-symphony project start' from its project folder to refresh the runtime config. For a repository runtime, run 'gh-symphony repo init' from the target repository.`;
+  return `Project "${projectId}" is not configured. ${projectConfigRemediation()}`;
 }
 
 export async function inspectManagedProjectSelection(
@@ -96,7 +100,7 @@ export async function inspectManagedProjectSelection(
       return {
         kind: "active_project_missing",
         projectId: global.activeProject,
-        message: `Active ${missingProjectConfigMessage(global.activeProject)}`,
+        message: `Active project "${global.activeProject}" is configured in config.json but its project config is missing. ${projectConfigRemediation()}`,
       };
     }
 

--- a/packages/cli/src/project-selection.ts
+++ b/packages/cli/src/project-selection.ts
@@ -38,6 +38,14 @@ function explicitProjectRequiredMessage(): string {
   return "Multiple repository runtime configs are present. Run 'gh-symphony repo init' from the target repository to refresh the cwd runtime.\n";
 }
 
+function diagnosticProjectRequiredMessage(): string {
+  return "Multiple managed projects are configured and no active project is set. Pass '--project-id <project-id>' to select one. For standalone diagnostics, pass '--project-dir <path>' to 'gh-symphony doctor'.";
+}
+
+function missingProjectConfigMessage(projectId: string): string {
+  return `Project "${projectId}" is not configured. For a standalone project, run 'gh-symphony project start' from its project folder to refresh the runtime config. For a repository runtime, run 'gh-symphony repo init' from the target repository.`;
+}
+
 export async function inspectManagedProjectSelection(
   input: ResolveProjectSelectionInput
 ): Promise<ManagedProjectResolution> {
@@ -50,7 +58,7 @@ export async function inspectManagedProjectSelection(
       return {
         kind: "requested_project_missing",
         projectId: input.requestedProjectId,
-        message: `Project "${input.requestedProjectId}" is not configured. Run 'gh-symphony repo init' from the target repository.`,
+        message: missingProjectConfigMessage(input.requestedProjectId),
       };
     }
 
@@ -79,13 +87,6 @@ export async function inspectManagedProjectSelection(
     };
   }
 
-  if (projectIds.length > 1 && !isInteractiveTerminal()) {
-    return {
-      kind: "multiple_projects_require_selection",
-      message: explicitProjectRequiredMessage().trimEnd(),
-    };
-  }
-
   if (global.activeProject) {
     const projectConfig = await loadProjectConfig(
       input.configDir,
@@ -95,7 +96,7 @@ export async function inspectManagedProjectSelection(
       return {
         kind: "active_project_missing",
         projectId: global.activeProject,
-        message: `Active project "${global.activeProject}" is configured in config.json but its project config is missing. Re-run 'gh-symphony repo init'.`,
+        message: `Active ${missingProjectConfigMessage(global.activeProject)}`,
       };
     }
 
@@ -113,7 +114,7 @@ export async function inspectManagedProjectSelection(
       return {
         kind: "configured_project_missing",
         projectId,
-        message: `Configured project "${projectId}" is missing its project config file. Re-run 'gh-symphony repo init'.`,
+        message: missingProjectConfigMessage(projectId),
       };
     }
 
@@ -126,8 +127,7 @@ export async function inspectManagedProjectSelection(
 
   return {
     kind: "multiple_projects_require_selection",
-    message:
-      "Multiple repository runtime configs are present and no active project is set. Re-run 'gh-symphony repo init' from the target repository.",
+    message: diagnosticProjectRequiredMessage(),
   };
 }
 


### PR DESCRIPTION
## Issues

- Closed #589

## TL;DR

- Resolve a configured `activeProject` before rejecting non-interactive multi-project diagnostic commands.
- Give accurate standalone-aware remediation for `doctor` and `workflow preview`, including the rework corrections requested in review.

## Change-point diagram

```text
doctor / workflow preview
          |
          v
inspectManagedProjectSelection
          |
          +-- explicit project id --> selected config
          +-- registry activeProject --> selected config
          +-- one registry entry --> selected config
          `-- ambiguous registry --> project-list / explicit-selector guidance
```

## Start here

Review `packages/cli/src/project-selection.ts` first, then the regression cases in `packages/cli/src/project-selection.test.ts`. The `doctor` remediation correction and its regression assertion are isolated to `packages/cli/src/commands/doctor.ts` and `doctor.test.ts`.

## Changes

- Move `activeProject` resolution ahead of multi-project ambiguity handling in the diagnostic selector.
- Preserve the distinct missing-active-project-config diagnosis when the registry entry exists but `project.json` is missing.
- Direct operators to `gh-symphony project list`, `--project-id`, or `--project-dir` without claiming cwd selection that `doctor` does not implement.
- Preserve explicit and single-project selection behavior without changing project lifecycle commands from #569.
- Document the active standalone diagnostic behavior and include a CLI patch changeset.

## Evidence

- `pnpm --filter @gh-symphony/cli test -- project-selection.test.ts commands/doctor.test.ts commands/workflow.test.ts` — 79 tests passed.
- `pnpm lint` — passed across all workspace packages.
- `pnpm test` — passed across all workspace packages.
- `pnpm typecheck` — passed across all workspace packages.
- `pnpm build` — passed across all workspace packages.
- Targeted Prettier check and `git diff --check` — passed.
- Every inline review comment has a concrete reply; the folder-identity design reconciliation is tracked separately in #619.

## Risks & rollback

- Risk is limited to managed-project selection and diagnostic copy; explicit project IDs and single-project registries retain their existing precedence.
- `activeProject` precedence is intentional for #589; cwd-derived standalone selection remains outside this PR.
- Roll back commits `908dce8` and `f5e477e` to restore the prior selector behavior and messages.

## Changed files

- `packages/cli/src/project-selection.ts` and test
- `packages/cli/src/commands/doctor.ts` and test
- `README.md` and `packages/cli/README.md`
- `.changeset/tidy-ravens-resolve.md`

## Post-merge / human validation

- [ ] Run `gh-symphony doctor` with two registered standalone projects and confirm the active project is selected.
- [ ] Remove the active project's `project.json` and confirm the diagnostic distinguishes the missing project config from an unregistered id.
- [ ] Clear `activeProject` and confirm the diagnostic points to `project list`, `--project-id`, and `--project-dir` without suggesting cwd selection.
