### PR TITLE
feat(orchestrator): honor workspace.root for embedded projects

### DIFF
--- a/.changeset/calm-workspace-roots.md
+++ b/.changeset/calm-workspace-roots.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": minor
+---
+
+Honor repo-embedded `workspace.root` for issue workspaces, keep repository checkout metadata separate, and fail safely with migration guidance for legacy project records (#599).

--- a/.changeset/calm-workspace-roots.md
+++ b/.changeset/calm-workspace-roots.md
@@ -2,4 +2,4 @@
 "@gh-symphony/cli": minor
 ---
 
-Honor repo-embedded `workspace.root` for issue workspaces, keep repository checkout metadata separate, and fail safely with migration guidance for legacy project records (#599).
+Honor repo-embedded `workspace.root` for issue workspaces, default to a dedicated root, keep repository checkout metadata separate, and preserve shutdown access with safe migration guidance for legacy project records (#599).

--- a/AGENT_TEST.md
+++ b/AGENT_TEST.md
@@ -386,6 +386,7 @@ idle → [inject issue + refresh]
 | `e2e/scenarios/16-bounded-finalization-deferral.md`       | Verify persistent unknown final tracker reads emit three durable deferrals and enter failure retry handling               |
 | `e2e/scenarios/16-packaged-runtime-entrypoints.md`        | Verify the built CLI's MCP dispatcher and Git credential helper subprocesses inside Docker                                |
 | `e2e/scenarios/16-planning-phase-prompt.md`               | Verify normalized `planning_states` classification reaches the dispatched prompt                                          |
+| `e2e/scenarios/16-repo-embedded-workspace-root.md`        | Verify repo-embedded issue workspaces use `workspace.root` while workspace records remain in orchestrator state           |
 
 ## TC Writing Guide
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ gh-symphony repo start --once
 
 `doctor --smoke` validates the GitHub Project binding, repository workflow, runtime command, workspace root, and hook paths without dispatching a worker. `repo start --once` then performs startup cleanup plus one poll/reconcile/dispatch tick and exits.
 
-Repo-embedded projects honor `workspace.root` relative to the repository checkout. Their issue worktrees live at `<workspace.root>/<issue-key>`, while orchestrator records remain under `.runtime/orchestrator`; `doctor` reports the configured worktree root. Existing installations should stop the daemon, archive `.runtime/orchestrator`, run `repo init` again, and restart so worktrees are safely re-populated without stale shared-cache registrations. See [Configuration](docs/configuration.md#repo-embedded-workspace-root-migration).
+Repo-embedded projects honor `workspace.root` relative to the repository checkout, defaulting to `.runtime/symphony-workspaces`. Their issue worktrees live at `<workspace.root>/<issue-key>`, while orchestrator records remain under `.runtime/orchestrator`; `repo init` creates the root and `doctor` reports it. Existing installations should stop the daemon, archive `.runtime/orchestrator`, run `repo init` again, and restart so worktrees are safely re-populated without stale shared-cache registrations. See [Configuration](docs/configuration.md#repo-embedded-workspace-root-migration).
 
 Use an explicit issue when you want a deterministic preflight:
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ gh-symphony repo start --once
 
 `doctor --smoke` validates the GitHub Project binding, repository workflow, runtime command, workspace root, and hook paths without dispatching a worker. `repo start --once` then performs startup cleanup plus one poll/reconcile/dispatch tick and exits.
 
+Repo-embedded projects honor `workspace.root` relative to the repository checkout. Their issue worktrees live at `<workspace.root>/<issue-key>`, while orchestrator records remain under `.runtime/orchestrator`; `doctor` reports the configured worktree root. Existing installations should stop the daemon, archive `.runtime/orchestrator`, run `repo init` again, and restart so worktrees are safely re-populated without stale shared-cache registrations. See [Configuration](docs/configuration.md#repo-embedded-workspace-root-migration).
+
 Use an explicit issue when you want a deterministic preflight:
 
 ```bash

--- a/docs/adr/2026-08-13_standalone-project-instance-boundary.md
+++ b/docs/adr/2026-08-13_standalone-project-instance-boundary.md
@@ -25,6 +25,9 @@ stores each checkout at `<workspaceDir>/<sanitized-issue-identifier>`, as
 required by spec §9.1. Repo-embedded projects separately persist
 `repositoryDir` for the source checkout and daemon working directory.
 Standalone projects already keep those concepts separate through `projectDir`.
+Repo-embedded projects default the workspace root to the dedicated
+`.runtime/symphony-workspaces` directory, create it during `repo init`, and
+reject roots that equal or contain the repository checkout.
 
 Workspace records remain in the orchestrator state directory in both modes;
 only the populated workspace moves to `workspace.root`. This keeps operational
@@ -43,5 +46,8 @@ workspace directory part of the control-plane state layout.
   layout until `repo init` writes the split paths. Operators use the documented
   stop/archive/reinitialize procedure when they want to discard orphaned
   worktrees and their shared-cache administration safely.
+- CLI shutdown and diagnostics may read legacy metadata so operators can carry
+  out that procedure; daemon startup rejects the same metadata. Later root
+  changes emit the old and new paths before the persisted record is replaced.
 - This is a repository-local extension: the upstream single-workflow model is
   preserved inside each project instance. It does not modify the upstream spec.

--- a/docs/adr/2026-08-13_standalone-project-instance-boundary.md
+++ b/docs/adr/2026-08-13_standalone-project-instance-boundary.md
@@ -3,7 +3,7 @@
 - **Date**: 2026-08-13
 - **Status**: Accepted
 - **Supersedes**: [`2026-05-04_single-repo-orchestrator.md`](./2026-05-04_single-repo-orchestrator.md)
-- **Related Spec**: `docs/symphony-spec.md` §3.1, §5.1
+- **Related Spec**: `docs/symphony-spec.md` §3.1, §5.1, §9.1
 
 ## Context
 
@@ -20,11 +20,28 @@ Projects may share a repository only when their tracker mappings are disjoint.
 They share one repository-scoped bare cache; project slugs namespace populated
 worktree branches as `symphony/<project-slug>/<sanitized-issue-id>`.
 
+Every project mode uses `workspaceDir` as the normalized `workspace.root` and
+stores each checkout at `<workspaceDir>/<sanitized-issue-identifier>`, as
+required by spec §9.1. Repo-embedded projects separately persist
+`repositoryDir` for the source checkout and daemon working directory.
+Standalone projects already keep those concepts separate through `projectDir`.
+
+Workspace records remain in the orchestrator state directory in both modes;
+only the populated workspace moves to `workspace.root`. This keeps operational
+records, run history, and locks together without making the configured
+workspace directory part of the control-plane state layout.
+
 ## Consequences
 
 - Operators can run independent workflows for one repository without mutating
   the repository itself.
 - Disjoint tracker mappings and branch namespaces prevent competing project
   dispatches and branch collisions.
+- `workspace.root` has the same meaning in repo-embedded and standalone modes;
+  runtime-state filenames no longer reserve ordinary issue workspace keys.
+- Repo-embedded installations created before this decision retain their legacy
+  layout until `repo init` writes the split paths. Operators use the documented
+  stop/archive/reinitialize procedure when they want to discard orphaned
+  worktrees and their shared-cache administration safely.
 - This is a repository-local extension: the upstream single-workflow model is
   preserved inside each project instance. It does not modify the upstream spec.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -38,7 +38,8 @@ touches a layer, check that its slice (and the linked documents) still holds.
 - Layered MCP composition (`.mcp.json` sidecar): `packages/core/src/runtime/mcp-compose.ts` + each runtime adapter
 - CLI global/project config, folder-addressed standalone project derivation, and cwd-first
   diagnostic selection: `packages/cli/src/config.ts`, `packages/cli/src/project-selection.ts`,
-  `commands/project.ts`
+  `commands/project.ts`; `workspaceDir` is the issue-workspace root in both modes, while
+  repo-embedded configs additionally carry `repositoryDir` for daemon CWD/liveness
 - Environment variables and `.env` loading order: [configuration.md](configuration.md)
 
 ### 3. Coordination — the orchestrator
@@ -49,6 +50,7 @@ touches a layer, check that its slice (and the linked documents) still holds.
 - Before dispatch, active candidates carrying an adapter-provided terminal fact are converged to the workflow terminal state and suppressed from worker startup.
 - Filesystem state store (`OrchestratorFsStore`), leases: `packages/orchestrator/src/fs-store.ts`
 - Shared bare clone cache (`<config-dir>/repos/<owner>/<repo>.git`), heartbeat locks, direct-clone degradation, safe inventory/eviction, and worktree populate: `repository-cache.ts`, `git.ts`; operator diagnostics and cleanup: `packages/cli/src/commands/cache.ts`
+- Issue workspace records remain in orchestrator state, while population, quarantine, terminal cleanup, and worktree removal operate on `<workspace.root>/<issue-key>` in repo-embedded and standalone modes.
 - Workflow source resolution (declared external/repo sources): `service.ts` + core workflow config
 
 ### 4. Execution — worker and agent subprocess

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -39,9 +39,9 @@ rejected instead of being resolved against the daemon working directory. Issue w
 created under the project's `workspace.root` (spec 9.1), resolved relative to
 the project folder and defaulting to `<project-dir>/.runtime/workspaces`; the
 directory is created with mode `0700` when it does not exist. Repo-embedded
-projects still keep issue workspaces beside their runtime state and ignore
-`workspace.root`; converging them is tracked in
-[#599](https://github.com/hojinzs/github-symphony/issues/599). Each issue is
+projects apply the same rule relative to the repository checkout. Their
+orchestrator state remains under `.runtime/orchestrator`, while populated issue
+workspaces live at `<workspace.root>/<sanitized-issue-identifier>`. Each issue is
 populated from the shared bare cache at `<config-dir>/repos/<owner>/<repo>.git`
 using a worktree. Branches default to
 `symphony/<project-slug>/<sanitized-issue-id>`, so multiple projects may use
@@ -60,6 +60,27 @@ unavailable or its lock times out, workspace creation uses an isolated direct
 clone. `gh-symphony cache status` inventories cache size and safety state;
 `gh-symphony cache prune` applies an operator-triggered 30-day default age
 policy and skips locked caches, linked worktrees, and unverifiable entries.
+
+### Repo-embedded workspace-root migration
+
+After upgrading an existing repo-embedded installation, re-run
+`gh-symphony repo init` while the daemon is stopped so project metadata records
+the repository checkout and `workspace.root` separately. Existing issue
+worktrees are not moved in place because their administrative paths are also
+recorded in the shared bare cache. Use this recoverable one-time reset:
+
+```bash
+gh-symphony repo stop
+mv .runtime/orchestrator .runtime/orchestrator.pre-workspace-root
+gh-symphony repo init
+gh-symphony repo start
+```
+
+The first dispatch re-populates worktrees beneath the configured root. Keep the
+archived directory until needed branches or uncommitted files have been
+recovered; then remove it. Archiving the state and its cache together avoids
+leaving stale `git worktree` registrations behind. If no reusable workspace
+state exists, simply stopping, re-running `repo init`, and starting is enough.
 
 When a standalone project targets a repository that also commits its own
 `WORKFLOW.md`, the status surface reports a shadow warning naming the

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -67,7 +67,9 @@ After upgrading an existing repo-embedded installation, re-run
 `gh-symphony repo init` while the daemon is stopped so project metadata records
 the repository checkout and `workspace.root` separately. Existing issue
 worktrees are not moved in place because their administrative paths are also
-recorded in the shared bare cache. Use this recoverable one-time reset:
+recorded in the shared bare cache. Startup rejects legacy metadata that still
+uses `workspaceDir` as the repository checkout instead of risking workspace
+population inside that checkout. Use this recoverable one-time reset:
 
 ```bash
 gh-symphony repo stop

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -41,7 +41,10 @@ the project folder and defaulting to `<project-dir>/.runtime/workspaces`; the
 directory is created with mode `0700` when it does not exist. Repo-embedded
 projects apply the same rule relative to the repository checkout. Their
 orchestrator state remains under `.runtime/orchestrator`, while populated issue
-workspaces live at `<workspace.root>/<sanitized-issue-identifier>`. Each issue is
+workspaces live at `<workspace.root>/<sanitized-issue-identifier>`; when omitted,
+`workspace.root` defaults to `.runtime/symphony-workspaces`. `repo init` creates
+the resolved root with mode `0700`, and rejects a root that equals or contains
+the repository checkout. Each issue is
 populated from the shared bare cache at `<config-dir>/repos/<owner>/<repo>.git`
 using a worktree. Branches default to
 `symphony/<project-slug>/<sanitized-issue-id>`, so multiple projects may use
@@ -63,8 +66,8 @@ policy and skips locked caches, linked worktrees, and unverifiable entries.
 
 ### Repo-embedded workspace-root migration
 
-After upgrading an existing repo-embedded installation, re-run
-`gh-symphony repo init` while the daemon is stopped so project metadata records
+After upgrading an existing repo-embedded installation, `repo stop` remains
+available for legacy metadata. Run it before `repo init` so project metadata records
 the repository checkout and `workspace.root` separately. Existing issue
 worktrees are not moved in place because their administrative paths are also
 recorded in the shared bare cache. Startup rejects legacy metadata that still
@@ -83,6 +86,10 @@ archived directory until needed branches or uncommitted files have been
 recovered; then remove it. Archiving the state and its cache together avoids
 leaving stale `git worktree` registrations behind. If no reusable workspace
 state exists, simply stopping, re-running `repo init`, and starting is enough.
+If `workspace.root` is changed again later, dispatch emits both a structured
+`workspace-root-relocated` event and a stderr warning naming the previous and
+new paths before replacing the workspace record; inspect the previous path for
+work to recover or delete.
 
 When a standalone project targets a repository that also commits its own
 `WORKFLOW.md`, the status surface reports a shadow warning naming the

--- a/e2e/run-e2e.sh
+++ b/e2e/run-e2e.sh
@@ -300,10 +300,40 @@ if [ "$SCENARIO" = "api-progress-unknown" ]; then
   exit 0
 fi
 
-if [ "$SAW_RUNNING" = true ] && [ "$SAW_REDACTED_STATE" = true ]; then
+CONFIGURED_WORKSPACE_ROOT=false
+if docker exec symphony-e2e node --input-type=module -e '
+  import { existsSync, readFileSync } from "node:fs";
+  import { dirname, resolve, sep } from "node:path";
+  import { execFileSync } from "node:child_process";
+  const repoDir = "/e2e/work/test-repo";
+  const stateDir = `${repoDir}/.runtime/orchestrator/projects/repository`;
+  const expectedRoot = `${repoDir}/.runtime/symphony-workspaces`;
+  const project = JSON.parse(readFileSync(`${stateDir}/project.json`, "utf8"));
+  if (project.repositoryDir !== repoDir || project.workspaceDir !== expectedRoot) {
+    throw new Error(`unexpected_project_paths:${JSON.stringify(project)}`);
+  }
+  const records = execFileSync("find", [stateDir, "-name", "workspace.json"], {
+    encoding: "utf8",
+  }).trim().split("\n").filter(Boolean);
+  if (records.length !== 1) throw new Error(`expected_one_workspace_record:${JSON.stringify(records)}`);
+  const record = JSON.parse(readFileSync(records[0], "utf8"));
+  const workspacePath = resolve(record.workspacePath);
+  if (!workspacePath.startsWith(`${resolve(expectedRoot)}${sep}`)) {
+    throw new Error(`workspace_outside_configured_root:${workspacePath}`);
+  }
+  if (existsSync(`${dirname(records[0])}/repository`)) {
+    throw new Error(`workspace_populated_beside_state:${dirname(records[0])}`);
+  }
+'; then
+  CONFIGURED_WORKSPACE_ROOT=true
+  log "Configured repo-embedded workspace root: YES"
+fi
+
+if [ "$SAW_RUNNING" = true ] && [ "$SAW_REDACTED_STATE" = true ] && [ "$CONFIGURED_WORKSPACE_ROOT" = true ]; then
   log "=== Result ==="
   log "  Worker dispatched and ran: YES"
   log "  Routable IDs + redaction:  YES"
+  log "  Configured workspace root: YES"
   log "  Worker entered retry:     $SAW_RETRY"
   log "  Final health:             $HEALTH"
   log "  Elapsed:                  ${ELAPSED}s"
@@ -314,6 +344,7 @@ else
   fail "=== Result ==="
   fail "  Worker reached running:    $SAW_RUNNING"
   fail "  Routable IDs + redaction:  $SAW_REDACTED_STATE"
+  fail "  Configured workspace root: $CONFIGURED_WORKSPACE_ROOT"
   echo ""
   fail "FAILED"
   docker logs symphony-e2e 2>&1 | tail -20

--- a/e2e/scenarios/16-repo-embedded-workspace-root.md
+++ b/e2e/scenarios/16-repo-embedded-workspace-root.md
@@ -1,0 +1,26 @@
+# TC-16: Repo-embedded configured workspace root
+
+## Setup
+
+The Docker seed workflow declares
+`workspace.root: .runtime/symphony-workspaces`. Build and start the standard
+black-box environment:
+
+```bash
+GH_SYMPHONY_HTTP_TOKEN=e2e-http-token ./e2e/run-e2e.sh happy 45
+```
+
+## Assertions
+
+1. Repo initialization persists distinct `repositoryDir` and `workspaceDir`
+   values in the managed project configuration.
+2. Dispatch creates the issue checkout beneath
+   `/e2e/work/test-repo/.runtime/symphony-workspaces/<issue-key>`.
+3. `workspace.json` remains beneath the orchestrator state directory and its
+   `workspacePath` points at the configured root.
+4. No issue checkout is populated beside `runs/`, `cache/`, or project state.
+
+## Expected result
+
+The regular happy-path lifecycle passes, and the runner prints
+`Configured repo-embedded workspace root: YES`.

--- a/e2e/seed/WORKFLOW.md
+++ b/e2e/seed/WORKFLOW.md
@@ -15,6 +15,8 @@ tracker:
     - " ready "
 polling:
   interval_ms: 5000
+workspace:
+  root: .runtime/symphony-workspaces
 agent:
   max_concurrent_agents: 2
   max_turns: 2

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -386,7 +386,7 @@ gh-symphony doctor --project-dir <projectDir>
 
 `gh-symphony doctor` validates the most common first-run prerequisites in one pass. `gh-symphony doctor --smoke` is the recommended final preflight before `gh-symphony repo start --once`: it resolves the active managed project, checks the GitHub Project binding, confirms the repository and target issue are readable through the project, renders `WORKFLOW.md` for that issue, verifies the runtime command, workspace root, and configured hook paths, and exits without dispatching a worker.
 
-For repo-embedded projects, `workspace.root` is resolved relative to the repository checkout and issue worktrees are populated at `<workspace.root>/<issue-key>`. Runtime records remain under `.runtime/orchestrator`, and daemon liveness continues to use the repository checkout. After upgrading an existing installation, stop it, archive `.runtime/orchestrator`, run `gh-symphony repo init` again, and restart to re-populate worktrees without stale shared-cache administration.
+For repo-embedded projects, `workspace.root` is resolved relative to the repository checkout, defaults to `.runtime/symphony-workspaces`, and issue worktrees are populated at `<workspace.root>/<issue-key>`. Runtime records remain under `.runtime/orchestrator`, and daemon liveness continues to use the repository checkout. `repo init` creates the root with mode `0700`. After upgrading an existing installation, stop it, archive `.runtime/orchestrator`, run `gh-symphony repo init` again, and restart to re-populate worktrees without stale shared-cache administration.
 
 Use an explicit issue when you want a deterministic check:
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -386,6 +386,8 @@ gh-symphony doctor --project-dir <projectDir>
 
 `gh-symphony doctor` validates the most common first-run prerequisites in one pass. `gh-symphony doctor --smoke` is the recommended final preflight before `gh-symphony repo start --once`: it resolves the active managed project, checks the GitHub Project binding, confirms the repository and target issue are readable through the project, renders `WORKFLOW.md` for that issue, verifies the runtime command, workspace root, and configured hook paths, and exits without dispatching a worker.
 
+For repo-embedded projects, `workspace.root` is resolved relative to the repository checkout and issue worktrees are populated at `<workspace.root>/<issue-key>`. Runtime records remain under `.runtime/orchestrator`, and daemon liveness continues to use the repository checkout. After upgrading an existing installation, stop it, archive `.runtime/orchestrator`, run `gh-symphony repo init` again, and restart to re-populate worktrees without stale shared-cache administration.
+
 Use an explicit issue when you want a deterministic check:
 
 ```bash

--- a/packages/cli/src/commands/doctor.test.ts
+++ b/packages/cli/src/commands/doctor.test.ts
@@ -1407,6 +1407,47 @@ describe("runDoctorDiagnostics", () => {
     });
   });
 
+  it("checks the issue workspace root instead of the repo-embedded checkout", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "doctor-embedded-root-"));
+    const configDir = join(rootDir, "config");
+    const workspaceDir = join(rootDir, "configured-workspaces");
+    const repositoryDir = join(rootDir, "repository-file");
+    await prepareDoctorPaths(configDir, workspaceDir);
+    await writeFile(repositoryDir, "not a directory", "utf8");
+    const { repoDir } = await createWorkflowFixture();
+
+    const report = await withCwd(repoDir, () =>
+      runDoctorDiagnostics(baseOptions(configDir), [], {
+        ...authDependencies(),
+        inspectManagedProjectSelection: async () => ({
+          kind: "resolved",
+          projectId: "tenant-a",
+          projectConfig: {
+            ...createProjectConfig(workspaceDir),
+            repositoryDir,
+          },
+        }),
+        getProjectDetail: (async () =>
+          ({
+            id: "PVT_test",
+            title: "Acme Platform",
+            url: "https://github.com/orgs/acme/projects/1",
+            statusFields: [],
+            textFields: [],
+            linkedRepositories: [],
+          }) as never) as never,
+        pathEnv: "",
+      })
+    );
+
+    expect(
+      report.checks.find((check) => check.id === "workspace_root")
+    ).toMatchObject({
+      status: "pass",
+      summary: expect.stringContaining(workspaceDir),
+    });
+  });
+
   it("reports token retrieval errors distinctly from auth failures", async () => {
     const configDir = await mkdtemp(join(tmpdir(), "doctor-config-"));
     const workspaceDir = join(configDir, "workspaces");

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -2035,7 +2035,7 @@ export async function runDoctorDiagnostics(
         workspaceDir,
         workspaceState,
         formatEnsureDirectoryCommand(workspaceDir, deps.platform),
-        "Update the managed project workspaceDir to a writable path or fix the filesystem permissions."
+        "Update WORKFLOW.md workspace.root to a writable path, run 'gh-symphony repo init' again for repo-embedded projects, or fix the filesystem permissions."
       )
     );
   } else {

--- a/packages/cli/src/commands/project.ts
+++ b/packages/cli/src/commands/project.ts
@@ -208,7 +208,7 @@ async function findOverlappingProjects(
     const liveness = await resolveDaemonLiveness({
       configDir,
       projectId: existing.projectId,
-      workspaceDir: existing.workspaceDir,
+      workspaceDir: existing.repositoryDir ?? existing.workspaceDir,
     });
     overlaps.push({
       projectId: existing.projectId,

--- a/packages/cli/src/commands/repo.test.ts
+++ b/packages/cli/src/commands/repo.test.ts
@@ -1,5 +1,12 @@
 import { execFileSync } from "node:child_process";
-import { mkdir, mkdtemp, readFile, stat, writeFile } from "node:fs/promises";
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  readFile,
+  stat,
+  writeFile,
+} from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -301,6 +308,33 @@ describe("repo init runtime migration", () => {
     );
     expect(projectConfig.workspaceDir).not.toBe(
       join(repoDir, ".runtime", "orchestrator")
+    );
+  });
+
+  it("enforces private permissions on a pre-existing workspace root", async () => {
+    const repoDir = await createGitRepo();
+    const workspaceDir = join(repoDir, ".runtime", "symphony-workspaces");
+    const { initRepoRuntime } = await loadRepoRuntimeModule();
+    await writeFile(join(repoDir, "WORKFLOW.md"), VALID_WORKFLOW, "utf8");
+    await mkdir(workspaceDir, { recursive: true, mode: 0o755 });
+    await chmod(workspaceDir, 0o755);
+
+    await initRepoRuntime({ repoDir });
+
+    expect((await stat(workspaceDir)).mode & 0o777).toBe(0o700);
+  });
+
+  it("rejects workspace.root when it contains orchestrator state", async () => {
+    const repoDir = await createGitRepo();
+    const { initRepoRuntime } = await loadRepoRuntimeModule();
+    await writeFile(
+      join(repoDir, "WORKFLOW.md"),
+      VALID_WORKFLOW.replace(".runtime/symphony-workspaces", ".runtime"),
+      "utf8"
+    );
+
+    await expect(initRepoRuntime({ repoDir })).rejects.toThrow(
+      "must not equal or contain the orchestrator runtime directory"
     );
   });
 

--- a/packages/cli/src/commands/repo.test.ts
+++ b/packages/cli/src/commands/repo.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, stat, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -14,6 +14,11 @@ async function loadRepoCommand() {
 async function loadRepoModule() {
   vi.resetModules();
   return import("./repo.js");
+}
+
+async function loadRepoRuntimeModule() {
+  vi.resetModules();
+  return import("../repo-runtime.js");
 }
 
 function captureWrites(stream: NodeJS.WriteStream): {
@@ -246,6 +251,8 @@ describe("repo init runtime migration", () => {
     expect(projectConfig.workspaceDir).toBe(
       join(repoDir, ".runtime", "symphony-workspaces")
     );
+    expect((await stat(projectConfig.workspaceDir)).isDirectory()).toBe(true);
+    expect((await stat(projectConfig.workspaceDir)).mode & 0o777).toBe(0o700);
     expect(projectConfig).not.toHaveProperty("repositories");
     expect(stdout.output()).toContain("Repository initialized: acme/platform");
   });
@@ -273,6 +280,46 @@ describe("repo init runtime migration", () => {
     expect(process.exitCode).toBeUndefined();
     expect(stdout.output()).toContain("Repository initialized: acme/platform");
   });
+
+  it("uses a dedicated workspace root when workspace.root is omitted", async () => {
+    const repoDir = await createGitRepo();
+    const { initRepoRuntime } = await loadRepoRuntimeModule();
+    await writeFile(
+      join(repoDir, "WORKFLOW.md"),
+      VALID_WORKFLOW.replace(
+        "workspace:\n  root: .runtime/symphony-workspaces\n",
+        ""
+      ),
+      "utf8"
+    );
+
+    await initRepoRuntime({ repoDir });
+
+    const projectConfig = await readRepoProjectConfig(repoDir);
+    expect(projectConfig.workspaceDir).toBe(
+      join(repoDir, ".runtime", "symphony-workspaces")
+    );
+    expect(projectConfig.workspaceDir).not.toBe(
+      join(repoDir, ".runtime", "orchestrator")
+    );
+  });
+
+  it.each([".", ".."])(
+    "rejects workspace.root %s when it equals or contains the checkout",
+    async (workspaceRoot) => {
+      const repoDir = await createGitRepo();
+      const { initRepoRuntime } = await loadRepoRuntimeModule();
+      await writeFile(
+        join(repoDir, "WORKFLOW.md"),
+        VALID_WORKFLOW.replace(".runtime/symphony-workspaces", workspaceRoot),
+        "utf8"
+      );
+
+      await expect(initRepoRuntime({ repoDir })).rejects.toThrow(
+        "must not equal or contain the repository checkout"
+      );
+    }
+  );
 
   it("prints a friendly remediation when repo init cannot find WORKFLOW.md", async () => {
     const repoDir = await createGitRepo();

--- a/packages/cli/src/commands/repo.test.ts
+++ b/packages/cli/src/commands/repo.test.ts
@@ -242,6 +242,10 @@ describe("repo init runtime migration", () => {
       owner: "acme",
       name: "platform",
     });
+    expect(projectConfig.repositoryDir).toBe(repoDir);
+    expect(projectConfig.workspaceDir).toBe(
+      join(repoDir, ".runtime", "symphony-workspaces")
+    );
     expect(projectConfig).not.toHaveProperty("repositories");
     expect(stdout.output()).toContain("Repository initialized: acme/platform");
   });

--- a/packages/cli/src/commands/setup.test.ts
+++ b/packages/cli/src/commands/setup.test.ts
@@ -301,7 +301,10 @@ describe("setup command", () => {
       readFile(join(cwd, ".gh-symphony", "context.yaml"), "utf8")
     ).rejects.toThrow();
     expect(project.projectId).toBe("repository");
-    expect(project.workspaceDir).toBe(process.cwd());
+    expect(project.workspaceDir).toBe(
+      join(process.cwd(), ".runtime", "symphony-workspaces")
+    );
+    expect(project.repositoryDir).toBe(process.cwd());
     expect(project.repository).toMatchObject({
       owner: "acme",
       name: "repo-a",
@@ -436,7 +439,10 @@ describe("setup command", () => {
       )
     );
 
-    expect(project.workspaceDir).toBe(process.cwd());
+    expect(project.workspaceDir).toBe(
+      join(process.cwd(), ".runtime", "symphony-workspaces")
+    );
+    expect(project.repositoryDir).toBe(process.cwd());
     expect(project.repository?.name).toBe("repo-b");
     expect(p.note).toHaveBeenCalledWith(
       expect.stringContaining("Init dry-run preview"),

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -337,7 +337,7 @@ const handler = async (
       const runtimeStatus = await resolveRuntimeStatus({
         configDir: options.configDir,
         projectId,
-        workspaceDir: projectConfig.workspaceDir,
+        workspaceDir: projectConfig.repositoryDir ?? projectConfig.workspaceDir,
         snapshot,
       });
       if (options.json || !isTTY) {
@@ -409,7 +409,7 @@ const handler = async (
     const runtimeStatus = await resolveRuntimeStatus({
       configDir: options.configDir,
       projectId,
-      workspaceDir: projectConfig.workspaceDir,
+      workspaceDir: projectConfig.repositoryDir ?? projectConfig.workspaceDir,
       snapshot,
     });
     if (options.json) {
@@ -436,7 +436,7 @@ const handler = async (
     const runtimeStatus = await resolveRuntimeStatus({
       configDir: options.configDir,
       projectId,
-      workspaceDir: projectConfig.workspaceDir,
+      workspaceDir: projectConfig.repositoryDir ?? projectConfig.workspaceDir,
       snapshot: null,
     });
     if (options.json) {

--- a/packages/cli/src/commands/stop.ts
+++ b/packages/cli/src/commands/stop.ts
@@ -62,7 +62,7 @@ const handler = async (
   const liveness = await resolveDaemonLiveness({
     configDir: options.configDir,
     projectId: resolvedProjectId,
-    workspaceDir: projectConfig.workspaceDir,
+    workspaceDir: projectConfig.repositoryDir ?? projectConfig.workspaceDir,
   });
   if (!liveness.running && liveness.reason === "missing-pid") {
     process.stderr.write(

--- a/packages/cli/src/config.test.ts
+++ b/packages/cli/src/config.test.ts
@@ -125,6 +125,30 @@ describe("config persistence", () => {
     ).rejects.toThrow('Project "project-1" project directory');
   });
 
+  it("loads legacy repo metadata so stop and diagnostic commands can migrate it", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "cli-legacy-repo-config-"));
+    const projectDir = join(configDir, "projects", "repository");
+    await mkdir(projectDir, { recursive: true });
+    await writeFile(
+      join(projectDir, "project.json"),
+      JSON.stringify({
+        projectId: "repository",
+        slug: "repository",
+        workspaceDir: "/repos/acme",
+        repository: { owner: "acme", name: "platform", path: "/repos/acme" },
+        tracker: { adapter: "file", bindingId: "repository" },
+      }),
+      "utf8"
+    );
+
+    await expect(
+      loadProjectConfig(configDir, "repository")
+    ).resolves.toMatchObject({
+      workspaceDir: "/repos/acme",
+      workflowSource: { type: "repo" },
+    });
+  });
+
   it("serializes concurrent load-modify-save updates", async () => {
     const configDir = await mkdtemp(join(tmpdir(), "cli-config-lock-"));
     await saveGlobalConfig(configDir, {

--- a/packages/cli/src/repo-runtime.ts
+++ b/packages/cli/src/repo-runtime.ts
@@ -28,6 +28,7 @@ export type RepoInitFlags = {
 };
 
 const INTERNAL_PROJECT_ID = "repository";
+const DEFAULT_WORKSPACE_ROOT = join(".runtime", "symphony-workspaces");
 
 export class RepoRuntimeMigrationError extends Error {}
 
@@ -127,7 +128,7 @@ export async function initRepoRuntime(flags: RepoInitFlags): Promise<{
     displayName: `${repository.owner}/${repository.name}`,
     workspaceDir: workflow.workspace.root
       ? resolve(repoDir, workflow.workspace.root)
-      : runtimeRoot,
+      : resolve(repoDir, DEFAULT_WORKSPACE_ROOT),
     repositoryDir: repoDir,
     repository,
     tracker: {
@@ -143,6 +144,7 @@ export async function initRepoRuntime(flags: RepoInitFlags): Promise<{
 
   await mkdir(runtimeRoot, { recursive: true });
   await saveProjectConfig(runtimeRoot, INTERNAL_PROJECT_ID, projectConfig);
+  await mkdir(projectConfig.workspaceDir, { recursive: true, mode: 0o700 });
   await saveGlobalConfig(runtimeRoot, {
     activeProject: INTERNAL_PROJECT_ID,
     projects: [INTERNAL_PROJECT_ID],

--- a/packages/cli/src/repo-runtime.ts
+++ b/packages/cli/src/repo-runtime.ts
@@ -1,5 +1,6 @@
 import { execFileSync } from "node:child_process";
 import {
+  chmod,
   mkdir,
   readdir,
   readFile,
@@ -8,7 +9,14 @@ import {
   stat,
   writeFile,
 } from "node:fs/promises";
-import { basename, dirname, join, resolve } from "node:path";
+import {
+  basename,
+  dirname,
+  isAbsolute,
+  join,
+  relative,
+  resolve,
+} from "node:path";
 import {
   parseWorkflowMarkdown,
   type OrchestratorProjectConfig,
@@ -122,13 +130,31 @@ export async function initRepoRuntime(flags: RepoInitFlags): Promise<{
     trackerSettings.issuesPath =
       process.env.GH_SYMPHONY_FILE_TRACKER_ISSUES_PATH;
   }
+  const workspaceDir = workflow.workspace.root
+    ? resolve(repoDir, workflow.workspace.root)
+    : resolve(repoDir, DEFAULT_WORKSPACE_ROOT);
+  const runtimeRelativeToWorkspace = relative(workspaceDir, runtimeRoot);
+  const repositoryRelativeToWorkspace = relative(workspaceDir, repoDir);
+  const workspaceContainsRepository =
+    repositoryRelativeToWorkspace === "" ||
+    (!repositoryRelativeToWorkspace.startsWith("..") &&
+      !isAbsolute(repositoryRelativeToWorkspace));
+  if (
+    !workspaceContainsRepository &&
+    (runtimeRelativeToWorkspace === "" ||
+      (!runtimeRelativeToWorkspace.startsWith("..") &&
+        !isAbsolute(runtimeRelativeToWorkspace)))
+  ) {
+    throw new Error(
+      `workspace.root ${JSON.stringify(workspaceDir)} must not equal or contain the orchestrator runtime directory ${JSON.stringify(runtimeRoot)}.`
+    );
+  }
+
   const projectConfig: CliProjectConfig = {
     projectId: INTERNAL_PROJECT_ID,
     slug: basename(repoDir) || INTERNAL_PROJECT_ID,
     displayName: `${repository.owner}/${repository.name}`,
-    workspaceDir: workflow.workspace.root
-      ? resolve(repoDir, workflow.workspace.root)
-      : resolve(repoDir, DEFAULT_WORKSPACE_ROOT),
+    workspaceDir,
     repositoryDir: repoDir,
     repository,
     tracker: {
@@ -145,6 +171,7 @@ export async function initRepoRuntime(flags: RepoInitFlags): Promise<{
   await mkdir(runtimeRoot, { recursive: true });
   await saveProjectConfig(runtimeRoot, INTERNAL_PROJECT_ID, projectConfig);
   await mkdir(projectConfig.workspaceDir, { recursive: true, mode: 0o700 });
+  await chmod(projectConfig.workspaceDir, 0o700);
   await saveGlobalConfig(runtimeRoot, {
     activeProject: INTERNAL_PROJECT_ID,
     projects: [INTERNAL_PROJECT_ID],

--- a/packages/cli/src/repo-runtime.ts
+++ b/packages/cli/src/repo-runtime.ts
@@ -125,7 +125,10 @@ export async function initRepoRuntime(flags: RepoInitFlags): Promise<{
     projectId: INTERNAL_PROJECT_ID,
     slug: basename(repoDir) || INTERNAL_PROJECT_ID,
     displayName: `${repository.owner}/${repository.name}`,
-    workspaceDir: repoDir,
+    workspaceDir: workflow.workspace.root
+      ? resolve(repoDir, workflow.workspace.root)
+      : runtimeRoot,
+    repositoryDir: repoDir,
     repository,
     tracker: {
       adapter: trackerAdapter,
@@ -148,7 +151,8 @@ export async function initRepoRuntime(flags: RepoInitFlags): Promise<{
   const orchestratorConfig: OrchestratorProjectConfig = {
     projectId: INTERNAL_PROJECT_ID,
     slug: projectConfig.slug,
-    workspaceDir: repoDir,
+    workspaceDir: projectConfig.workspaceDir,
+    repositoryDir: repoDir,
     repository,
     tracker: projectConfig.tracker,
   };

--- a/packages/core/src/contracts/status-surface.ts
+++ b/packages/core/src/contracts/status-surface.ts
@@ -34,7 +34,10 @@ export type PopulateStrategy = "clone" | "worktree-cache";
 export type OrchestratorProjectConfig = {
   projectId: string;
   slug: string;
+  /** Root directory containing persistent per-issue workspaces. */
   workspaceDir: string;
+  /** Repository checkout used as the daemon cwd for repo-embedded projects. */
+  repositoryDir?: string;
   repository: RepositoryRef;
   tracker: OrchestratorTrackerConfig;
   /** Defaults to the repository-local workflow for legacy project configs. */

--- a/packages/core/src/contracts/status-surface.ts
+++ b/packages/core/src/contracts/status-surface.ts
@@ -1,4 +1,4 @@
-import { isAbsolute } from "node:path";
+import { isAbsolute, resolve } from "node:path";
 import type { RepositoryRef } from "../domain/workspace.js";
 import type {
   WorkflowDefinition,
@@ -58,6 +58,18 @@ export function normalizeOrchestratorProjectConfig(
   assertAbsoluteProjectDir(config);
   const workflowSource = normalizeWorkflowSource(config);
   const populateStrategy = normalizePopulateStrategy(config);
+  const repositoryPath = config.repository?.path;
+
+  if (
+    workflowSource.type === "repo" &&
+    !config.repositoryDir &&
+    repositoryPath &&
+    resolve(config.workspaceDir) === resolve(repositoryPath)
+  ) {
+    throw new Error(
+      `Project ${JSON.stringify(config.projectId)} uses legacy repo-embedded path metadata. Stop the daemon and run 'gh-symphony repo init' again before starting it.`
+    );
+  }
 
   return {
     ...config,

--- a/packages/core/src/contracts/status-surface.ts
+++ b/packages/core/src/contracts/status-surface.ts
@@ -1,4 +1,4 @@
-import { isAbsolute, resolve } from "node:path";
+import { isAbsolute, relative, resolve } from "node:path";
 import type { RepositoryRef } from "../domain/workspace.js";
 import type {
   WorkflowDefinition,
@@ -58,8 +58,34 @@ export function normalizeOrchestratorProjectConfig(
   assertAbsoluteProjectDir(config);
   const workflowSource = normalizeWorkflowSource(config);
   const populateStrategy = normalizePopulateStrategy(config);
-  const repositoryPath = config.repository?.path;
+  if (workflowSource.type === "repo" && config.repositoryDir) {
+    const workspaceRoot = resolve(config.workspaceDir);
+    const repositoryDir = resolve(config.repositoryDir);
+    const repositoryRelativeToRoot = relative(workspaceRoot, repositoryDir);
+    if (
+      repositoryRelativeToRoot === "" ||
+      (!repositoryRelativeToRoot.startsWith("..") &&
+        !isAbsolute(repositoryRelativeToRoot))
+    ) {
+      throw new Error(
+        `Project ${JSON.stringify(config.projectId)} workspace.root ${JSON.stringify(workspaceRoot)} must not equal or contain the repository checkout ${JSON.stringify(repositoryDir)}.`
+      );
+    }
+  }
 
+  return {
+    ...config,
+    workflowSource,
+    populateStrategy,
+  };
+}
+
+/** Rejects legacy repo metadata on daemon startup without blocking CLI migration commands. */
+export function assertDispatchableOrchestratorProjectConfig(
+  config: OrchestratorProjectConfig
+): void {
+  const workflowSource = normalizeWorkflowSource(config);
+  const repositoryPath = config.repository?.path;
   if (
     workflowSource.type === "repo" &&
     !config.repositoryDir &&
@@ -70,12 +96,6 @@ export function normalizeOrchestratorProjectConfig(
       `Project ${JSON.stringify(config.projectId)} uses legacy repo-embedded path metadata. Stop the daemon and run 'gh-symphony repo init' again before starting it.`
     );
   }
-
-  return {
-    ...config,
-    workflowSource,
-    populateStrategy,
-  };
 }
 
 function assertAbsoluteProjectDir(config: OrchestratorProjectConfig): void {

--- a/packages/core/src/core-conformance.test.ts
+++ b/packages/core/src/core-conformance.test.ts
@@ -98,13 +98,19 @@ describe("resolveIssueWorkspaceDirectory", () => {
     ).toThrow("escapes");
   });
 
-  it("rejects reserved flat-layout workspace keys", () => {
-    expect(() =>
-      resolveIssueWorkspaceDirectory("/runtime/orchestrator", "runs")
-    ).toThrow("reserved");
+  it("allows keys formerly reserved by the flat runtime layout", () => {
+    expect(resolveIssueWorkspaceDirectory("/workspaces", "runs")).toBe(
+      "/workspaces/runs"
+    );
+    expect(resolveIssueWorkspaceDirectory("/workspaces", "cache")).toBe(
+      "/workspaces/cache"
+    );
+  });
+
+  it("rejects hidden workspace keys", () => {
     expect(() =>
       resolveIssueWorkspaceDirectory("/runtime/orchestrator", ".lock")
-    ).toThrow("reserved");
+    ).toThrow("hidden");
   });
 
   it("rejects an issue workspace symlink that resolves outside the runtime root", () => {

--- a/packages/core/src/observability/event-formatter.ts
+++ b/packages/core/src/observability/event-formatter.ts
@@ -40,6 +40,8 @@ export function formatEventMessage(event: OrchestratorEvent): string | null {
       return event.error;
     case "workspace-cleanup":
       return event.error ? `${event.outcome}: ${event.error}` : event.outcome;
+    case "workspace-root-relocated":
+      return `Workspace root changed from ${event.previousWorkspacePath} to ${event.configuredWorkspacePath}`;
     case "worker-error":
       return event.error;
     case "turn_started":

--- a/packages/core/src/observability/structured-events.ts
+++ b/packages/core/src/observability/structured-events.ts
@@ -189,6 +189,17 @@ export type WorkspaceCleanupEvent = {
   error?: string | null;
 };
 
+export type WorkspaceRootRelocatedEvent = {
+  at: string;
+  event: "workspace-root-relocated";
+  projectId?: string;
+  workspaceKey: string;
+  issueIdentifier: string;
+  issueId?: string;
+  previousWorkspacePath: string;
+  configuredWorkspacePath: string;
+};
+
 export type WorkerErrorEvent = {
   at: string;
   event: "worker-error";
@@ -301,6 +312,7 @@ export type OrchestratorEvent =
   | HookExecutedEvent
   | HookFailedEvent
   | WorkspaceCleanupEvent
+  | WorkspaceRootRelocatedEvent
   | WorkerErrorEvent
   | TurnStartedEvent
   | TurnCompletedEvent

--- a/packages/core/src/workspace/identity.ts
+++ b/packages/core/src/workspace/identity.ts
@@ -3,14 +3,6 @@ import { createHash } from "node:crypto";
 import type { IssueSubjectIdentity } from "../domain/issue.js";
 import { isPathWithinRoot } from "./path-safety.js";
 
-const RESERVED_WORKSPACE_KEYS = new Set([
-  "cache",
-  "issues.json",
-  "project.json",
-  "runs",
-  "status.json",
-]);
-
 /**
  * Derive a stable workspace key from a canonical issue identifier.
  *
@@ -79,17 +71,11 @@ export function resolveIssueWorkspaceDirectory(
     );
   }
 
-  if (isReservedWorkspaceKey(workspaceKey)) {
-    throw new Error("Issue workspace key is reserved by the runtime layout.");
+  if (workspaceKey.startsWith(".")) {
+    throw new Error("Issue workspace key cannot be hidden.");
   }
 
   return candidate;
-}
-
-function isReservedWorkspaceKey(workspaceKey: string): boolean {
-  return (
-    workspaceKey.startsWith(".") || RESERVED_WORKSPACE_KEYS.has(workspaceKey)
-  );
 }
 
 export function resolveIssueRepositoryPath(

--- a/packages/orchestrator/src/fs-store.test.ts
+++ b/packages/orchestrator/src/fs-store.test.ts
@@ -82,6 +82,28 @@ describe("OrchestratorFsStore.loadRecentRunEvents", () => {
     );
   });
 
+  it("rejects legacy repo configs that use workspaceDir as the checkout", async () => {
+    const runtimeRoot = await mkdtemp(join(tmpdir(), "orchestrator-store-"));
+    const store = new OrchestratorFsStore(runtimeRoot);
+    const projectDir = store.projectDir("project-1");
+    await mkdir(projectDir, { recursive: true });
+    await writeFile(
+      join(projectDir, "project.json"),
+      JSON.stringify({
+        projectId: "project-1",
+        slug: "project-1",
+        workspaceDir: "/repos/acme",
+        repository: { owner: "acme", name: "repo", path: "/repos/acme" },
+        tracker: { adapter: "file", bindingId: "file-project-1" },
+      }),
+      "utf8"
+    );
+
+    await expect(store.loadProjectConfig("project-1")).rejects.toThrow(
+      "legacy repo-embedded path metadata"
+    );
+  });
+
   it("round-trips standalone project configuration", async () => {
     const runtimeRoot = await mkdtemp(join(tmpdir(), "orchestrator-store-"));
     const store = new OrchestratorFsStore(runtimeRoot);

--- a/packages/orchestrator/src/fs-store.ts
+++ b/packages/orchestrator/src/fs-store.ts
@@ -3,6 +3,7 @@ import { chmod, mkdir, open, rm, stat } from "node:fs/promises";
 import { join, relative, resolve } from "node:path";
 import {
   deriveIssueWorkspaceKeyFromIdentifier,
+  assertDispatchableOrchestratorProjectConfig,
   isFileMissing,
   type IssueOrchestrationRecord,
   type IssueWorkspaceRecord,
@@ -82,7 +83,12 @@ export class OrchestratorFsStore implements OrchestratorStateStore {
           )
         : null);
 
-    return config ? normalizeOrchestratorProjectConfig(config) : null;
+    if (!config) {
+      return null;
+    }
+    const normalized = normalizeOrchestratorProjectConfig(config);
+    assertDispatchableOrchestratorProjectConfig(normalized);
+    return normalized;
   }
 
   async saveProjectConfig(config: OrchestratorProjectConfig): Promise<void> {

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -12442,6 +12442,65 @@ Workspace prompt.
     );
   });
 
+  it("re-populates a legacy workspace record under the configured root", async () => {
+    process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
+    const tempRoot = await mkdtemp(
+      join(tmpdir(), "orchestrator-migrated-embedded-workspace-root-")
+    );
+    const repository = await createRepositoryFixture(
+      tempRoot,
+      "acme",
+      "platform"
+    );
+    const store = new OrchestratorFsStore(tempRoot);
+    const workspaceRoot = join(tempRoot, "configured-workspaces");
+    const projectConfig = {
+      ...createProjectConfig(tempRoot, repository, workspaceRoot),
+      repositoryDir: repository.path,
+    };
+    await store.saveProjectConfig(projectConfig);
+
+    const workspaceKey = "acme_platform_1";
+    const legacyWorkspacePath = join(
+      store.projectDir(projectConfig.projectId),
+      workspaceKey
+    );
+    await store.saveIssueWorkspace({
+      workspaceKey,
+      projectId: projectConfig.projectId,
+      adapter: "github-project",
+      issueSubjectId: "issue-1",
+      issueIdentifier: "acme/platform#1",
+      workspacePath: legacyWorkspacePath,
+      repositoryPath: join(legacyWorkspacePath, "repository"),
+      status: "active",
+      createdAt: "2026-03-08T00:00:00.000Z",
+      updatedAt: "2026-03-08T00:00:00.000Z",
+      lastError: null,
+    });
+
+    const service = new OrchestratorService(store, projectConfig, {
+      fetchImpl: vi.fn().mockResolvedValue(createTrackerResponse(repository)),
+      spawnImpl: vi
+        .fn()
+        .mockReturnValue({ pid: 5304, unref: vi.fn() }) as never,
+      now: () => new Date("2026-03-08T00:00:00.000Z"),
+    });
+
+    await service.runOnce();
+    const migratedRecord = await store.loadIssueWorkspace(
+      projectConfig.projectId,
+      workspaceKey
+    );
+
+    expect(migratedRecord?.workspacePath).toBe(
+      join(workspaceRoot, workspaceKey)
+    );
+    expect(migratedRecord?.repositoryPath).toBe(
+      join(workspaceRoot, workspaceKey, "repository")
+    );
+  });
+
   it("loads only an external workflow and warns when it shadows the repository workflow", async () => {
     process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
     const tempRoot = await mkdtemp(

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -12374,7 +12374,7 @@ Workspace prompt.
     expect((await stat(workspaceRoot)).mode & 0o777).toBe(0o700);
   });
 
-  it("keeps repo-embedded issue workspaces beside the project state", async () => {
+  it("places repo-embedded issue workspaces under the configured workspace root", async () => {
     process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
     const tempRoot = await mkdtemp(
       join(tmpdir(), "orchestrator-embedded-workspace-root-")
@@ -12385,8 +12385,40 @@ Workspace prompt.
       "platform"
     );
     const store = new OrchestratorFsStore(tempRoot);
-    // repo-embedded registration stores the repository checkout here, which
-    // must never be used as a workspace root.
+    const workspaceRoot = join(tempRoot, "configured-workspaces");
+    const projectConfig = {
+      ...createProjectConfig(tempRoot, repository, workspaceRoot),
+      repositoryDir: repository.path,
+    };
+    await store.saveProjectConfig(projectConfig);
+
+    const spawnImpl = vi.fn().mockReturnValue({ pid: 5302, unref: vi.fn() });
+    const service = new OrchestratorService(store, projectConfig, {
+      fetchImpl: vi.fn().mockResolvedValue(createTrackerResponse(repository)),
+      spawnImpl: spawnImpl as never,
+      now: () => new Date("2026-03-08T00:00:00.000Z"),
+    });
+
+    await service.runOnce();
+    const [workspaceRecord] = await store.loadIssueWorkspaces("tenant-1");
+
+    expect(workspaceRecord?.workspacePath).toBe(
+      join(workspaceRoot, workspaceRecord!.workspaceKey)
+    );
+    expect((await stat(workspaceRoot)).mode & 0o777).toBe(0o700);
+  });
+
+  it("keeps legacy repo-embedded workspaces beside project state", async () => {
+    process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
+    const tempRoot = await mkdtemp(
+      join(tmpdir(), "orchestrator-legacy-embedded-workspace-root-")
+    );
+    const repository = await createRepositoryFixture(
+      tempRoot,
+      "acme",
+      "platform"
+    );
+    const store = new OrchestratorFsStore(tempRoot);
     const projectConfig = createProjectConfig(
       tempRoot,
       repository,
@@ -12394,10 +12426,11 @@ Workspace prompt.
     );
     await store.saveProjectConfig(projectConfig);
 
-    const spawnImpl = vi.fn().mockReturnValue({ pid: 5302, unref: vi.fn() });
     const service = new OrchestratorService(store, projectConfig, {
       fetchImpl: vi.fn().mockResolvedValue(createTrackerResponse(repository)),
-      spawnImpl: spawnImpl as never,
+      spawnImpl: vi
+        .fn()
+        .mockReturnValue({ pid: 5303, unref: vi.fn() }) as never,
       now: () => new Date("2026-03-08T00:00:00.000Z"),
     });
 

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -12480,12 +12480,14 @@ Workspace prompt.
       lastError: null,
     });
 
+    const stderrWrite = vi.fn();
     const service = new OrchestratorService(store, projectConfig, {
       fetchImpl: vi.fn().mockResolvedValue(createTrackerResponse(repository)),
       spawnImpl: vi
         .fn()
         .mockReturnValue({ pid: 5304, unref: vi.fn() }) as never,
       now: () => new Date("2026-03-08T00:00:00.000Z"),
+      stderr: { write: stderrWrite } as never,
     });
 
     await service.runOnce();
@@ -12499,6 +12501,24 @@ Workspace prompt.
     );
     expect(migratedRecord?.repositoryPath).toBe(
       join(workspaceRoot, workspaceKey, "repository")
+    );
+    expect(stderrWrite).toHaveBeenCalledWith(
+      expect.stringContaining(
+        `previous=${legacyWorkspacePath} configured=${join(workspaceRoot, workspaceKey)}\n`
+      )
+    );
+    const run = (await store.loadAllRuns()).find(
+      (candidate) => candidate.projectId === projectConfig.projectId
+    );
+    await expect(
+      store.loadRecentRunEvents(run!.runId, 20, projectConfig.projectId)
+    ).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          event: "workspace-root-relocated",
+          message: expect.stringContaining(legacyWorkspacePath),
+        }),
+      ])
     );
   });
 

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -12408,7 +12408,7 @@ Workspace prompt.
     expect((await stat(workspaceRoot)).mode & 0o777).toBe(0o700);
   });
 
-  it("keeps legacy repo-embedded workspaces beside project state", async () => {
+  it("uses workspaceDir for repo-embedded configs without repositoryDir", async () => {
     process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
     const tempRoot = await mkdtemp(
       join(tmpdir(), "orchestrator-legacy-embedded-workspace-root-")
@@ -12419,10 +12419,11 @@ Workspace prompt.
       "platform"
     );
     const store = new OrchestratorFsStore(tempRoot);
+    const workspaceRoot = join(tempRoot, "legacy-compatible-workspaces");
     const projectConfig = createProjectConfig(
       tempRoot,
       repository,
-      repository.path
+      workspaceRoot
     );
     await store.saveProjectConfig(projectConfig);
 
@@ -12438,7 +12439,7 @@ Workspace prompt.
     const [workspaceRecord] = await store.loadIssueWorkspaces("tenant-1");
 
     expect(workspaceRecord?.workspacePath).toBe(
-      join(store.projectDir("tenant-1"), workspaceRecord!.workspaceKey)
+      join(workspaceRoot, workspaceRecord!.workspaceKey)
     );
   });
 
@@ -13656,7 +13657,7 @@ Prefer focused changes.
 
     const workspaceKey = deriveIssueWorkspaceKey("acme/platform#1");
     const expectedWorkspacePath = resolveIssueWorkspaceDirectory(
-      store.projectDir("tenant-1"),
+      workspaceDir,
       workspaceKey
     );
 
@@ -13775,7 +13776,7 @@ function createProjectConfig(
     name: string;
     cloneUrl: string;
   },
-  workspaceDir = join(root, "workspaces", "tenant-1")
+  workspaceDir = join(root, "projects", "tenant-1")
 ) {
   return {
     projectId: "tenant-1",

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -2637,6 +2637,10 @@ export class OrchestratorService {
       this.resolveIssueWorkspaceRoot(tenant),
       workspaceKey
     );
+    const existingWorkspaceAtConfiguredRoot = Boolean(
+      existingWorkspaceRecord &&
+      resolve(existingWorkspaceRecord.workspacePath) === issueWorkspacePath
+    );
     const pullRequestBranch = resolvePullRequestBranchCheckoutTarget(issue);
 
     // #507: dirty recovery may only reuse the workspace when the dirty state
@@ -2646,7 +2650,7 @@ export class OrchestratorService {
     let workspaceQuarantined = false;
     if (
       recovery?.kind === "incomplete-turn-dirty-workspace" &&
-      existingWorkspaceRecord
+      existingWorkspaceAtConfiguredRoot
     ) {
       const currentBranch = await readGitCurrentBranch(
         join(issueWorkspacePath, "repository")
@@ -2713,7 +2717,7 @@ export class OrchestratorService {
       repository: issue.repository,
       issueWorkspacePath,
       existingWorkspace:
-        Boolean(existingWorkspaceRecord) && !workspaceQuarantined,
+        existingWorkspaceAtConfiguredRoot && !workspaceQuarantined,
       pullRequestBranch,
       allowDirtyExistingWorkspace:
         recovery?.kind === "incomplete-turn-dirty-workspace",
@@ -2733,7 +2737,7 @@ export class OrchestratorService {
     );
     await excludeRuntimeSkillsFromGit(repositoryDirectory, agentCommand);
 
-    if (!existingWorkspaceRecord || workspaceQuarantined) {
+    if (!existingWorkspaceAtConfiguredRoot || workspaceQuarantined) {
       const workspaceRecord: IssueWorkspaceRecord = {
         workspaceKey,
         projectId: tenant.projectId,

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -4729,12 +4729,13 @@ export class OrchestratorService {
 
   /**
    * Per-issue workspaces live under the project's configured `workspace.root`
-   * (spec 9.1). Standalone projects carry that root as `workspaceDir`; the
-   * repo-embedded layout still keeps workspaces beside the project state,
-   * where `workspaceDir` means the repository checkout instead.
+   * (spec 9.1). New project configs carry that root as `workspaceDir` in both
+   * modes. A repo-embedded config without `repositoryDir` predates that split,
+   * so it retains the consolidated state-directory layout until `repo init`
+   * migrates its metadata.
    */
   private resolveIssueWorkspaceRoot(tenant: OrchestratorProjectConfig): string {
-    return tenant.workflowSource?.type === "external" && tenant.workspaceDir
+    return tenant.repositoryDir || tenant.workflowSource?.type === "external"
       ? resolve(tenant.workspaceDir)
       : this.store.projectDir(tenant.projectId);
   }

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -4733,15 +4733,12 @@ export class OrchestratorService {
 
   /**
    * Per-issue workspaces live under the project's configured `workspace.root`
-   * (spec 9.1). New project configs carry that root as `workspaceDir` in both
-   * modes. A repo-embedded config without `repositoryDir` predates that split,
-   * so it retains the consolidated state-directory layout until `repo init`
-   * migrates its metadata.
+   * (spec 9.1), carried as `workspaceDir` in every project mode. Persisted
+   * repo-embedded configs that still use this field for the checkout are
+   * rejected during normalization until `repo init` migrates them.
    */
   private resolveIssueWorkspaceRoot(tenant: OrchestratorProjectConfig): string {
-    return tenant.repositoryDir || tenant.workflowSource?.type === "external"
-      ? resolve(tenant.workspaceDir)
-      : this.store.projectDir(tenant.projectId);
+    return resolve(tenant.workspaceDir);
   }
 
   private resolveWorkflowRepositoryDirectory(

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -2641,6 +2641,21 @@ export class OrchestratorService {
       existingWorkspaceRecord &&
       resolve(existingWorkspaceRecord.workspacePath) === issueWorkspacePath
     );
+    if (existingWorkspaceRecord && !existingWorkspaceAtConfiguredRoot) {
+      this.writeStderr(
+        `[orchestrator] workspace root changed for ${issue.identifier}: previous=${existingWorkspaceRecord.workspacePath} configured=${issueWorkspacePath}`
+      );
+      await this.store.appendRunEvent(runId, {
+        at: now.toISOString(),
+        event: "workspace-root-relocated",
+        projectId: tenant.projectId,
+        issueId: issue.id,
+        issueIdentifier: issue.identifier,
+        workspaceKey,
+        previousWorkspacePath: existingWorkspaceRecord.workspacePath,
+        configuredWorkspacePath: issueWorkspacePath,
+      });
+    }
     const pullRequestBranch = resolvePullRequestBranchCheckoutTarget(issue);
 
     // #507: dirty recovery may only reuse the workspace when the dirty state


### PR DESCRIPTION
## Issues — Closed #599

- Fixes #599

## TL;DR

- Repo-embedded projects now honor `workspace.root` for every issue-workspace lifecycle path, matching Symphony spec §9.1.
- Repository checkout metadata (`repositoryDir`) is separate from the issue-workspace root (`workspaceDir`); omitted roots use `.runtime/symphony-workspaces`.
- Rework enforces private root permissions, rejects roots containing checkout or orchestrator state, preserves legacy shutdown access, and reports root relocation.

## Change-point diagram

```text
WORKFLOW.md workspace.root ──► repo init ──► project.workspaceDir
          (or dedicated default)    │                  │
                                    ├─ mkdir + chmod   ▼
repository checkout ─────────► repositoryDir    workspace lifecycle
                                                    ├─ populate / guard
                                                    ├─ quarantine / cleanup
                                                    └─ relocation event
```

## Start here

1. `packages/core/src/contracts/status-surface.ts` — checkout containment validation and dispatch-only legacy guard.
2. `packages/cli/src/repo-runtime.ts` — dedicated default, split checkout metadata, state containment, and `0700` enforcement.
3. `packages/orchestrator/src/fs-store.ts` — fails closed on legacy metadata at daemon config load.
4. `packages/orchestrator/src/service.ts` — configured-root lifecycle and relocation warning/event.
5. `docs/adr/2026-08-13_standalone-project-instance-boundary.md` — shared layout and migration decision.

## Changes

- Route repo-embedded population, startup cleanup, dirty quarantine, removal, and path containment through the configured workspace root.
- Keep `workspace.json` and control-plane state under `.runtime/orchestrator` while issue workspaces live beneath `workspace.root`.
- Default omitted repo-embedded roots to `.runtime/symphony-workspaces`; create or normalize the root to mode `0700` during `repo init`.
- Reject roots that equal or contain the repository checkout or orchestrator runtime state.
- Allow CLI stop/status/doctor paths to read legacy metadata while daemon startup rejects it.
- Emit stderr and structured `workspace-root-relocated` evidence before replacing a stale workspace record.
- Remove obsolete flat-state workspace-key reservations and cover behavior with unit tests and Docker TC-16.

## Evidence

- `pnpm lint` — passed on final pushed head `8647d767`.
- `pnpm test` — passed across all workspace packages on final pushed head `8647d767`.
- `pnpm typecheck` — passed across all workspace packages.
- `pnpm build` — passed across all workspace packages.
- `pnpm exec vitest run packages/cli/src/commands/repo.test.ts` — passed (27 tests), including existing-root permissions and runtime-root containment.
- `GH_SYMPHONY_HTTP_TOKEN=e2e-http-token ./e2e/run-e2e.sh happy 45` — Docker TC-16 passed in 12s on cycle 3.
- `git diff --check` and `bash -n e2e/run-e2e.sh` — passed.
- GitHub `Test` and `Container Smoke` — passed on `8647d767`.

## Risks & rollback

- Existing repo-embedded installations must stop the daemon, archive legacy state, and rerun `gh-symphony repo init`; CLI shutdown remains usable after upgrade, while daemon startup rejects ambiguous legacy metadata.
- A later root change leaves the old tree for deliberate operator recovery or deletion and reports both paths; rollback requires stopping the daemon and restoring the previous binary/layout after preserving local work.

## Changed files

- Core metadata, identity, and observability: `packages/core/src/contracts/status-surface.ts`, `packages/core/src/workspace/identity.ts`, structured event files.
- CLI initialization and diagnostics: `packages/cli/src/repo-runtime.ts`, repo/status/stop/project/doctor commands and tests.
- Orchestrator lifecycle: `packages/orchestrator/src/service.ts`, filesystem store, and tests.
- Operator guidance and architecture: README files, configuration, architecture, ADR, migration changeset.
- Black-box coverage: `e2e/scenarios/16-repo-embedded-workspace-root.md`, E2E runner/seed, and `AGENT_TEST.md`.

## Post-merge / human validation

- [ ] Confirm a repo-embedded project with custom and omitted `workspace.root` values creates issue workspaces beneath the reported dedicated root.
- [ ] Confirm `gh-symphony doctor` passes immediately after `repo init` and reports workspace root and repository checkout independently.
- [ ] Confirm the stop/archive/re-init migration and relocation warning are operationally clear on an existing daemon.
