### PR TITLE
fix(cli): prefer standalone cwd for diagnostics

### DIFF
--- a/.changeset/calm-diagnostics-follow-cwd.md
+++ b/.changeset/calm-diagnostics-follow-cwd.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Prefer a registered standalone project in the current directory for `doctor` and live `workflow preview` diagnostics before falling back to `activeProject` (#619).

--- a/README.md
+++ b/README.md
@@ -599,7 +599,7 @@ gh-symphony config edit             # Open config in $EDITOR
 
 `gh-symphony doctor` runs a single first-run diagnostic pass and exits non-zero if any required prerequisite is missing. `gh-symphony doctor --fix` adds a remediation pass on top of the same checks. `gh-symphony doctor --smoke` is the recommended final preflight before `gh-symphony repo start --once`: it resolves the active managed project, checks the GitHub Project binding, confirms the repository and target issue are readable through the project, renders `WORKFLOW.md` for that issue, verifies the runtime command, workspace root, and configured hook paths, and exits without dispatching a worker.
 
-When cwd is a registered standalone project folder, `doctor` and live `workflow preview` diagnose that project even if another registry project is active. Explicit `--project-dir <path>` (`doctor`) or `--project-id <projectId>` (`workflow preview`) selection wins over cwd; outside a registered standalone folder, diagnostics fall back to the registry's `activeProject`.
+When cwd is a standalone project folder whose runtime config was cached by `project start`, `doctor` and live `workflow preview` diagnose that project even if another registry project is active. Explicit `--project-dir <path>` (`doctor`) or `--project-id <projectId>` (`workflow preview`) selection wins over cwd; outside such a standalone folder, diagnostics fall back to the registry's `activeProject`.
 
 Use an explicit issue when you want a deterministic check:
 

--- a/README.md
+++ b/README.md
@@ -599,7 +599,7 @@ gh-symphony config edit             # Open config in $EDITOR
 
 `gh-symphony doctor` runs a single first-run diagnostic pass and exits non-zero if any required prerequisite is missing. `gh-symphony doctor --fix` adds a remediation pass on top of the same checks. `gh-symphony doctor --smoke` is the recommended final preflight before `gh-symphony repo start --once`: it resolves the active managed project, checks the GitHub Project binding, confirms the repository and target issue are readable through the project, renders `WORKFLOW.md` for that issue, verifies the runtime command, workspace root, and configured hook paths, and exits without dispatching a worker.
 
-When the global registry contains multiple standalone projects, `doctor` and live `workflow preview` diagnostics use its `activeProject`. To inspect a different standalone project explicitly, pass `--project-dir <path>` to `doctor` or `--project-id <projectId>` to `workflow preview`.
+When cwd is a registered standalone project folder, `doctor` and live `workflow preview` diagnose that project even if another registry project is active. Explicit `--project-dir <path>` (`doctor`) or `--project-id <projectId>` (`workflow preview`) selection wins over cwd; outside a registered standalone folder, diagnostics fall back to the registry's `activeProject`.
 
 Use an explicit issue when you want a deterministic check:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -34,7 +34,9 @@ touches a layer, check that its slice (and the linked documents) still holds.
 
 - `WORKFLOW.md` front matter parsing and validation: `packages/core/src/workflow/`
 - Layered MCP composition (`.mcp.json` sidecar): `packages/core/src/runtime/mcp-compose.ts` + each runtime adapter
-- CLI global/project config and folder-addressed standalone project derivation: `packages/cli/src/config.ts`, `commands/project.ts`
+- CLI global/project config, folder-addressed standalone project derivation, and cwd-first
+  diagnostic selection: `packages/cli/src/config.ts`, `packages/cli/src/project-selection.ts`,
+  `commands/project.ts`
 - Environment variables and `.env` loading order: [configuration.md](configuration.md)
 
 ### 3. Coordination — the orchestrator

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,7 +16,11 @@ must declare `repository.slug`, which is also what distinguishes a standalone
 project from a repository that embeds its own workflow. Configuration is derived
 from the folder on every start and cached under
 `<config-dir>/projects/<project-id>/`, where the project id is a stable function
-of the folder path — there is no registration step and no active-project state.
+of the folder path — there is no registration step, and folder-addressed lifecycle does not rely
+on active-project state.
+Folder-addressed lifecycle commands do not consult `activeProject`. Diagnostics have a separate
+selection rule: an explicit selector wins, then an exact registered `projectDir` match for the
+working directory, then the global registry's `activeProject` as a fallback.
 The cached `projectDir` is always absolute; persisted relative values are
 rejected instead of being resolved against the daemon working directory. Issue workspaces are
 created under the project's `workspace.root` (spec 9.1), resolved relative to

--- a/docs/designs/2026-08-11-standalone-project-model-design.md
+++ b/docs/designs/2026-08-11-standalone-project-model-design.md
@@ -16,6 +16,9 @@ Issues [#562](https://github.com/hojinzs/github-symphony/issues/562) through
 command with a folder-addressed model:
 
 - `gh-symphony project start|status|stop` use the current directory or `--project-dir <path>`.
+- `gh-symphony doctor` and live `workflow preview` use a registered standalone project when cwd
+  is that project's folder. Explicit project selectors still win; outside a registered project
+  folder, diagnostics fall back to the global registry's `activeProject`.
 - `project start` re-derives configuration from the folder's `WORKFLOW.md` on every start and caches
   only the runtime state needed by `status` and `stop`; `project add` is not part of the shipped CLI.
 - Tracker-mapping overlap is validated under a config-wide lock when a project starts. Running
@@ -71,7 +74,9 @@ A "project" is an **orchestration execution unit** bundling WORKFLOW.md policy +
 - **The project folder is the source of truth; `<configDir>/projects/<projectId>/project.json` is
   cached runtime state derived at start.** The top-level `config.json` remains the global registry;
   folder identity, rather than a registration command or `activeProject`, selects the standalone
-  project.
+  project for folder-addressed lifecycle commands and diagnostics. Diagnostic commands retain
+  `activeProject` only as a fallback when cwd does not identify a registered standalone project;
+  explicit selectors take precedence over both.
 - The `workspaces/` state directory naming collides with the spec's Workspace (§4.1.4, per-issue directory) — separate cleanup item.
 
 ### D3. The workflow source is a mode declaration, not a priority contest

--- a/docs/designs/2026-08-11-standalone-project-model-design.md
+++ b/docs/designs/2026-08-11-standalone-project-model-design.md
@@ -16,7 +16,7 @@ Issues [#562](https://github.com/hojinzs/github-symphony/issues/562) through
 command with a folder-addressed model:
 
 - `gh-symphony project start|status|stop` use the current directory or `--project-dir <path>`.
-- `gh-symphony doctor` and live `workflow preview` use a registered standalone project when cwd
+- `gh-symphony doctor` and live `workflow preview` use a cached standalone project when cwd
   is that project's folder. Explicit project selectors still win; outside a registered project
   folder, diagnostics fall back to the global registry's `activeProject`.
 - `project start` re-derives configuration from the folder's `WORKFLOW.md` on every start and caches
@@ -75,7 +75,7 @@ A "project" is an **orchestration execution unit** bundling WORKFLOW.md policy +
   cached runtime state derived at start.** The top-level `config.json` remains the global registry;
   folder identity, rather than a registration command or `activeProject`, selects the standalone
   project for folder-addressed lifecycle commands and diagnostics. Diagnostic commands retain
-  `activeProject` only as a fallback when cwd does not identify a registered standalone project;
+  `activeProject` only as a fallback when cwd does not identify a cached standalone project;
   explicit selectors take precedence over both.
 - The `workspaces/` state directory naming collides with the spec's Workspace (§4.1.4, per-issue directory) — separate cleanup item.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -378,7 +378,7 @@ Without `--issue`, doctor auto-selects one active live issue from the managed pr
 
 `gh-symphony doctor --fix` extends the regular diagnostic flow with safe remediation and guided follow-up:
 
-When multiple standalone projects are registered, diagnostics resolve the registry's `activeProject`. Use `doctor --project-dir <path>` or `workflow preview --project-id <projectId>` to select another project explicitly.
+When cwd is a registered standalone project folder, diagnostics resolve that project before the registry's `activeProject`. Explicit `doctor --project-dir <path>` or `workflow preview --project-id <projectId>` selection wins over cwd; outside a registered standalone folder, `activeProject` remains the fallback.
 
 - creates missing config/runtime/workspace directories
 - launches `gh auth login` or `gh auth refresh` when a TTY is available, otherwise prints the exact command to run

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -378,7 +378,7 @@ Without `--issue`, doctor auto-selects one active live issue from the managed pr
 
 `gh-symphony doctor --fix` extends the regular diagnostic flow with safe remediation and guided follow-up:
 
-When cwd is a registered standalone project folder, diagnostics resolve that project before the registry's `activeProject`. Explicit `doctor --project-dir <path>` or `workflow preview --project-id <projectId>` selection wins over cwd; outside a registered standalone folder, `activeProject` remains the fallback.
+When cwd is a standalone project folder whose runtime config was cached by `project start`, diagnostics resolve that project before the registry's `activeProject`. Explicit `doctor --project-dir <path>` or `workflow preview --project-id <projectId>` selection wins over cwd; outside such a standalone folder, `activeProject` remains the fallback.
 
 - creates missing config/runtime/workspace directories
 - launches `gh auth login` or `gh auth refresh` when a TTY is available, otherwise prints the exact command to run

--- a/packages/cli/src/commands/doctor.test.ts
+++ b/packages/cli/src/commands/doctor.test.ts
@@ -1068,7 +1068,7 @@ describe("runDoctorDiagnostics", () => {
     });
     expect(
       report.checks.find((check) => check.id === "managed_project")?.remediation
-    ).not.toContain("run from its project folder");
+    ).toContain("registered project folder");
   });
 
   it("accepts env-token auth when gh CLI is unavailable", async () => {

--- a/packages/cli/src/commands/doctor.test.ts
+++ b/packages/cli/src/commands/doctor.test.ts
@@ -1068,7 +1068,7 @@ describe("runDoctorDiagnostics", () => {
     });
     expect(
       report.checks.find((check) => check.id === "managed_project")?.remediation
-    ).toContain("registered project folder");
+    ).toContain("project start");
   });
 
   it("accepts env-token auth when gh CLI is unavailable", async () => {

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -1767,7 +1767,7 @@ export async function runDoctorDiagnostics(
         "managed_project",
         "Managed project selection",
         resolvedProjectConfig.message,
-        "For a standalone project, run this command from its registered project folder or pass '--project-dir <path>'. For a repository runtime, run 'gh-symphony repo init' from the target repository.",
+        "For a standalone project, run 'gh-symphony project start' from its project folder to refresh the runtime config, then run this command from that folder or pass '--project-dir <path>'. For a repository runtime, run 'gh-symphony repo init' from the target repository.",
         {
           reason: resolvedProjectConfig.kind,
           ...(resolvedProjectConfig.projectId

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -1767,7 +1767,7 @@ export async function runDoctorDiagnostics(
         "managed_project",
         "Managed project selection",
         resolvedProjectConfig.message,
-        "For a standalone project, pass '--project-dir <path>'. For a repository runtime, run 'gh-symphony repo init' from the target repository.",
+        "For a standalone project, run this command from its registered project folder or pass '--project-dir <path>'. For a repository runtime, run 'gh-symphony repo init' from the target repository.",
         {
           reason: resolvedProjectConfig.kind,
           ...(resolvedProjectConfig.projectId

--- a/packages/cli/src/commands/project.ts
+++ b/packages/cli/src/commands/project.ts
@@ -1,4 +1,3 @@
-import { createHash } from "node:crypto";
 import { readFile, readdir } from "node:fs/promises";
 import { basename, resolve } from "node:path";
 import * as p from "@clack/prompts";
@@ -18,6 +17,9 @@ import {
   withConfigLock,
 } from "../config.js";
 import { resolveDaemonLiveness } from "../daemon-liveness.js";
+import { standaloneProjectId } from "../standalone-project.js";
+
+export { standaloneProjectId } from "../standalone-project.js";
 
 type PickupLabels = { include: string[]; exclude: string[] };
 
@@ -57,7 +59,7 @@ export async function deriveStandaloneProject(
       "WORKFLOW.md tracker configuration requires project_id or project_slug."
     );
   }
-  const projectId = projectIdentifier(projectDir);
+  const projectId = standaloneProjectId(projectDir);
   const config: CliProjectConfig = {
     projectId,
     slug: slugify(basename(projectDir)) || projectId,
@@ -118,10 +120,6 @@ export async function deriveStandaloneProject(
  * The identifier is a pure function of the folder path, so a project can be
  * addressed without reading its configuration first.
  */
-export function standaloneProjectId(projectDirInput: string): string {
-  return projectIdentifier(resolve(projectDirInput));
-}
-
 async function listStandaloneProjects(
   configDir: string
 ): Promise<CliProjectConfig[]> {
@@ -344,10 +342,6 @@ function parseRepository(value: Record<string, unknown> | null): RepositoryRef {
         ? value.cloneUrl
         : `https://github.com/${owner}/${name}.git`;
   return { owner, name, cloneUrl };
-}
-
-function projectIdentifier(projectDir: string): string {
-  return `${slugify(basename(projectDir)) || "project"}-${createHash("sha256").update(projectDir).digest("hex").slice(0, 8)}`;
 }
 
 function slugify(value: string): string {

--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -412,8 +412,10 @@ Prompt {{ issue.identifier }}
 
     await writeFile(workflowPath, LINEAR_WORKFLOW, "utf8");
 
-    setWorkflowCommandDependenciesForTest({
-      loadActiveProjectConfig: vi.fn().mockResolvedValue({
+    const resolveManagedProjectSelection = vi.fn().mockResolvedValue({
+      kind: "resolved",
+      projectId: "repository",
+      projectConfig: {
         projectId: "repository",
         slug: "api",
         workspaceDir: root,
@@ -429,17 +431,30 @@ Prompt {{ issue.identifier }}
             projectSlug: "symphony-0c79b11b75ea",
           },
         },
-      }),
+      },
+    });
+    setWorkflowCommandDependenciesForTest({
+      resolveManagedProjectSelection,
       resolveTrackerAdapter,
     });
 
     try {
-      await workflowCommand(["preview", "--file", workflowPath, "ENG-123"], {
-        configDir: root,
-        verbose: false,
-        json: false,
-        noColor: false,
-      });
+      await workflowCommand(
+        [
+          "preview",
+          "--file",
+          workflowPath,
+          "--project-id",
+          "tenant-a",
+          "ENG-123",
+        ],
+        {
+          configDir: root,
+          verbose: false,
+          json: false,
+          noColor: false,
+        }
+      );
     } finally {
       stdout.restore();
     }
@@ -453,6 +468,10 @@ Prompt {{ issue.identifier }}
         }),
       })
     );
+    expect(resolveManagedProjectSelection).toHaveBeenCalledWith({
+      configDir: root,
+      requestedProjectId: "tenant-a",
+    });
     expect(fetchIssueStatesByIds).toHaveBeenCalledWith(
       expect.objectContaining({
         repository: expect.objectContaining({
@@ -478,20 +497,24 @@ Prompt {{ issue.identifier }}
     await writeFile(workflowPath, LINEAR_WORKFLOW, "utf8");
 
     setWorkflowCommandDependenciesForTest({
-      loadActiveProjectConfig: vi.fn().mockResolvedValue({
+      resolveManagedProjectSelection: vi.fn().mockResolvedValue({
+        kind: "resolved",
         projectId: "tenant-a",
-        slug: "tenant-a",
-        workspaceDir: root,
-        repository: {
-          owner: "acme",
-          name: "api",
-          cloneUrl: "https://github.com/acme/api.git",
-        },
-        tracker: {
-          adapter: "github-project",
-          bindingId: "PVT_project_123",
-          settings: {
-            projectId: "PVT_project_123",
+        projectConfig: {
+          projectId: "tenant-a",
+          slug: "tenant-a",
+          workspaceDir: root,
+          repository: {
+            owner: "acme",
+            name: "api",
+            cloneUrl: "https://github.com/acme/api.git",
+          },
+          tracker: {
+            adapter: "github-project",
+            bindingId: "PVT_project_123",
+            settings: {
+              projectId: "PVT_project_123",
+            },
           },
         },
       }),

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -9,7 +9,7 @@ import {
 } from "@gh-symphony/core";
 import { resolveTrackerAdapter } from "@gh-symphony/orchestrator";
 import { fetchGithubProjectIssueByRepositoryAndNumber } from "@gh-symphony/tracker-github";
-import { loadActiveProjectConfig, type CliProjectConfig } from "../config.js";
+import { type CliProjectConfig } from "../config.js";
 import {
   createClient,
   findLinkedRepository,
@@ -61,7 +61,6 @@ type WorkflowCommandDependencies = {
   fetchLiveIssue: typeof fetchGithubProjectIssueByRepositoryAndNumber;
   getGitHubProjectDetail: typeof getProjectDetail;
   getGitHubTokenWithSource: typeof getGhTokenWithSource;
-  loadActiveProjectConfig: typeof loadActiveProjectConfig;
   resolveManagedProjectSelection: typeof inspectManagedProjectSelection;
   resolveTrackerAdapter: typeof resolveTrackerAdapter;
   validateGitHubToken: typeof validateGitHubToken;
@@ -156,7 +155,6 @@ const workflowCommandDependencies: WorkflowCommandDependencies = {
   fetchLiveIssue: fetchGithubProjectIssueByRepositoryAndNumber,
   getGitHubProjectDetail: getProjectDetail,
   getGitHubTokenWithSource: getGhTokenWithSource,
-  loadActiveProjectConfig,
   resolveManagedProjectSelection: inspectManagedProjectSelection,
   resolveTrackerAdapter,
   validateGitHubToken,
@@ -174,7 +172,6 @@ export function resetWorkflowCommandDependenciesForTest(): void {
     fetchGithubProjectIssueByRepositoryAndNumber;
   workflowCommandDependencies.getGitHubProjectDetail = getProjectDetail;
   workflowCommandDependencies.getGitHubTokenWithSource = getGhTokenWithSource;
-  workflowCommandDependencies.loadActiveProjectConfig = loadActiveProjectConfig;
   workflowCommandDependencies.resolveManagedProjectSelection =
     inspectManagedProjectSelection;
   workflowCommandDependencies.resolveTrackerAdapter = resolveTrackerAdapter;
@@ -702,16 +699,22 @@ function isLinearIssueIdentifier(value: string): boolean {
 
 async function loadLinearIssue(
   issueIdentifier: string,
+  projectId: string | undefined,
   workflow: ReturnType<typeof parseWorkflowMarkdown>,
   options: GlobalOptions
 ): Promise<{
   issue: TrackedIssue;
   sampleSource: string;
 }> {
-  const projectConfig =
-    await workflowCommandDependencies.loadActiveProjectConfig(
-      options.configDir
-    );
+  const selection =
+    await workflowCommandDependencies.resolveManagedProjectSelection({
+      configDir: options.configDir,
+      requestedProjectId: projectId,
+    });
+  if (selection.kind !== "resolved") {
+    throw new Error(selection.message);
+  }
+  const projectConfig = selection.projectConfig;
 
   if (!projectConfig?.repository) {
     throw new Error(
@@ -926,7 +929,7 @@ async function runPreview(
   }
   const { issue, sampleSource } = flags.issue
     ? workflow.tracker.kind === "linear"
-      ? await loadLinearIssue(flags.issue, workflow, options)
+      ? await loadLinearIssue(flags.issue, flags.projectId, workflow, options)
       : await loadLiveIssue(flags.issue, flags.projectId, workflow, options)
     : await loadSampleIssue(flags.sample);
   const renderedPrompt = renderIssueWorkflowPreview({

--- a/packages/cli/src/project-selection.test.ts
+++ b/packages/cli/src/project-selection.test.ts
@@ -38,12 +38,14 @@ const {
 
 function createProject(
   projectId: string,
-  displayName?: string
+  displayName?: string,
+  projectDir?: string
 ): CliProjectConfig {
   return {
     projectId,
     slug: projectId,
     displayName,
+    ...(projectDir ? { projectDir } : {}),
     workspaceDir: join("/tmp", projectId),
     tracker: {
       adapter: "github-project",
@@ -174,6 +176,51 @@ describe("resolveManagedProjectConfig", () => {
 });
 
 describe("inspectManagedProjectSelection", () => {
+  it("prefers the registered standalone cwd over a different active project", async () => {
+    const projectADir = await mkdtemp(join(tmpdir(), "standalone-a-"));
+    const projectBDir = await mkdtemp(join(tmpdir(), "standalone-b-"));
+    const configDir = await createConfigFixture(
+      [
+        createProject("tenant-a", "Alpha", projectADir),
+        createProject("tenant-b", "Beta", projectBDir),
+      ],
+      "tenant-b"
+    );
+
+    const result = await inspectManagedProjectSelection({
+      configDir,
+      cwd: projectADir,
+    });
+
+    expect(result).toMatchObject({
+      kind: "resolved",
+      projectId: "tenant-a",
+    });
+  });
+
+  it("keeps an explicit selector ahead of the registered standalone cwd", async () => {
+    const projectADir = await mkdtemp(join(tmpdir(), "standalone-a-"));
+    const projectBDir = await mkdtemp(join(tmpdir(), "standalone-b-"));
+    const configDir = await createConfigFixture(
+      [
+        createProject("tenant-a", "Alpha", projectADir),
+        createProject("tenant-b", "Beta", projectBDir),
+      ],
+      "tenant-b"
+    );
+
+    const result = await inspectManagedProjectSelection({
+      configDir,
+      requestedProjectId: "tenant-b",
+      cwd: projectADir,
+    });
+
+    expect(result).toMatchObject({
+      kind: "resolved",
+      projectId: "tenant-b",
+    });
+  });
+
   it("uses the active project in non-interactive multi-project mode", async () => {
     const configDir = await createConfigFixture(
       [createProject("tenant-a"), createProject("tenant-b")],

--- a/packages/cli/src/project-selection.test.ts
+++ b/packages/cli/src/project-selection.test.ts
@@ -250,6 +250,9 @@ describe("inspectManagedProjectSelection", () => {
       message: expect.stringContaining("--project-dir <path>"),
     });
     expect(result.message).toContain("gh-symphony project list");
+    expect(result.message).toContain(
+      "Run the diagnostic from a registered standalone project folder"
+    );
     expect(result.message).not.toContain("repo init");
   });
 
@@ -281,7 +284,7 @@ describe("inspectManagedProjectSelection", () => {
       kind: "active_project_missing",
       projectId: "tenant-a",
       message:
-        "Active project \"tenant-a\" is configured in config.json but its project config is missing. For a standalone project, run 'gh-symphony project start' from its project folder to refresh the runtime config. For a repository runtime, run 'gh-symphony repo init' from the target repository.",
+        "Active project \"tenant-a\" is configured in config.json but its project config is missing. For a standalone project, run 'gh-symphony project start' from its project folder to refresh the runtime config, then run diagnostics from that folder or select it explicitly. For a repository runtime, run 'gh-symphony repo init' from the target repository.",
     });
     expect(result.message).not.toContain('Active Project "tenant-a"');
   });

--- a/packages/cli/src/project-selection.test.ts
+++ b/packages/cli/src/project-selection.test.ts
@@ -7,6 +7,7 @@ import {
   saveProjectConfig,
   type CliProjectConfig,
 } from "./config.js";
+import { standaloneProjectId } from "./standalone-project.js";
 
 const selectMock = vi.fn();
 const cancelMock = vi.fn();
@@ -176,15 +177,17 @@ describe("resolveManagedProjectConfig", () => {
 });
 
 describe("inspectManagedProjectSelection", () => {
-  it("prefers the registered standalone cwd over a different active project", async () => {
+  it("prefers the cached standalone cwd over a different active project", async () => {
     const projectADir = await mkdtemp(join(tmpdir(), "standalone-a-"));
-    const projectBDir = await mkdtemp(join(tmpdir(), "standalone-b-"));
+    const projectAId = standaloneProjectId(projectADir);
     const configDir = await createConfigFixture(
-      [
-        createProject("tenant-a", "Alpha", projectADir),
-        createProject("tenant-b", "Beta", projectBDir),
-      ],
+      [createProject("tenant-b", "Beta")],
       "tenant-b"
+    );
+    await saveProjectConfig(
+      configDir,
+      projectAId,
+      createProject(projectAId, "Alpha", projectADir)
     );
 
     const result = await inspectManagedProjectSelection({
@@ -194,19 +197,42 @@ describe("inspectManagedProjectSelection", () => {
 
     expect(result).toMatchObject({
       kind: "resolved",
-      projectId: "tenant-a",
+      projectId: projectAId,
     });
   });
 
-  it("keeps an explicit selector ahead of the registered standalone cwd", async () => {
+  it("resolves a cached standalone cwd without a global config", async () => {
     const projectADir = await mkdtemp(join(tmpdir(), "standalone-a-"));
-    const projectBDir = await mkdtemp(join(tmpdir(), "standalone-b-"));
+    const projectAId = standaloneProjectId(projectADir);
+    const configDir = await mkdtemp(join(tmpdir(), "project-selection-"));
+    await saveProjectConfig(
+      configDir,
+      projectAId,
+      createProject(projectAId, "Alpha", projectADir)
+    );
+
+    const result = await inspectManagedProjectSelection({
+      configDir,
+      cwd: projectADir,
+    });
+
+    expect(result).toMatchObject({
+      kind: "resolved",
+      projectId: projectAId,
+    });
+  });
+
+  it("keeps an explicit selector ahead of the cached standalone cwd", async () => {
+    const projectADir = await mkdtemp(join(tmpdir(), "standalone-a-"));
+    const projectAId = standaloneProjectId(projectADir);
     const configDir = await createConfigFixture(
-      [
-        createProject("tenant-a", "Alpha", projectADir),
-        createProject("tenant-b", "Beta", projectBDir),
-      ],
+      [createProject("tenant-b", "Beta")],
       "tenant-b"
+    );
+    await saveProjectConfig(
+      configDir,
+      projectAId,
+      createProject(projectAId, "Alpha", projectADir)
     );
 
     const result = await inspectManagedProjectSelection({
@@ -250,9 +276,7 @@ describe("inspectManagedProjectSelection", () => {
       message: expect.stringContaining("--project-dir <path>"),
     });
     expect(result.message).toContain("gh-symphony project list");
-    expect(result.message).toContain(
-      "Run the diagnostic from a registered standalone project folder"
-    );
+    expect(result.message).toContain("run the diagnostic from that folder");
     expect(result.message).not.toContain("repo init");
   });
 

--- a/packages/cli/src/project-selection.ts
+++ b/packages/cli/src/project-selection.ts
@@ -41,11 +41,11 @@ function explicitProjectRequiredMessage(): string {
 }
 
 function diagnosticProjectRequiredMessage(): string {
-  return "Multiple managed projects are configured and no active project is set. Pass '--project-id <project-id>' to select one. Run 'gh-symphony project list' to see configured project ids. For standalone diagnostics, pass '--project-dir <path>' to 'gh-symphony doctor'.";
+  return "Multiple managed projects are configured, cwd is not a registered standalone project folder, and no active project is set. Run the diagnostic from a registered standalone project folder or pass '--project-id <project-id>' to select one. Run 'gh-symphony project list' to see configured project ids. For doctor, you can also pass '--project-dir <path>'.";
 }
 
 function projectConfigRemediation(): string {
-  return "For a standalone project, run 'gh-symphony project start' from its project folder to refresh the runtime config. For a repository runtime, run 'gh-symphony repo init' from the target repository.";
+  return "For a standalone project, run 'gh-symphony project start' from its project folder to refresh the runtime config, then run diagnostics from that folder or select it explicitly. For a repository runtime, run 'gh-symphony repo init' from the target repository.";
 }
 
 function missingProjectConfigMessage(projectId: string): string {

--- a/packages/cli/src/project-selection.ts
+++ b/packages/cli/src/project-selection.ts
@@ -6,6 +6,7 @@ import {
   type CliProjectConfig,
 } from "./config.js";
 import { writeCliError } from "./cli-error.js";
+import { standaloneProjectId } from "./standalone-project.js";
 
 type ResolveProjectSelectionInput = {
   configDir: string;
@@ -41,7 +42,7 @@ function explicitProjectRequiredMessage(): string {
 }
 
 function diagnosticProjectRequiredMessage(): string {
-  return "Multiple managed projects are configured, cwd is not a registered standalone project folder, and no active project is set. Run the diagnostic from a registered standalone project folder or pass '--project-id <project-id>' to select one. Run 'gh-symphony project list' to see configured project ids. For doctor, you can also pass '--project-dir <path>'.";
+  return "Multiple managed projects are configured, cwd has no cached standalone runtime config, and no active project is set. Run 'gh-symphony project start' from the standalone project folder to refresh its runtime config, run the diagnostic from that folder, or pass '--project-id <project-id>' to select one. Run 'gh-symphony project list' to see configured project ids. For doctor, you can also pass '--project-dir <path>'.";
 }
 
 function projectConfigRemediation(): string {
@@ -52,20 +53,18 @@ function missingProjectConfigMessage(projectId: string): string {
   return `Project "${projectId}" is not configured. ${projectConfigRemediation()}`;
 }
 
-async function loadRegisteredStandaloneProjectFromCwd(
+async function loadStandaloneProjectFromCwd(
   configDir: string,
-  projectIds: string[],
   cwd: string
 ): Promise<{ projectId: string; projectConfig: CliProjectConfig } | null> {
   const resolvedCwd = resolve(cwd);
-  for (const projectId of projectIds) {
-    const projectConfig = await loadProjectConfig(configDir, projectId);
-    if (
-      projectConfig?.projectDir &&
-      resolve(projectConfig.projectDir) === resolvedCwd
-    ) {
-      return { projectId, projectConfig };
-    }
+  const projectId = standaloneProjectId(resolvedCwd);
+  const projectConfig = await loadProjectConfig(configDir, projectId);
+  if (
+    projectConfig?.projectDir &&
+    resolve(projectConfig.projectDir) === resolvedCwd
+  ) {
+    return { projectId, projectConfig };
   }
   return null;
 }
@@ -93,6 +92,14 @@ export async function inspectManagedProjectSelection(
     };
   }
 
+  const cwdProject = await loadStandaloneProjectFromCwd(
+    input.configDir,
+    input.cwd ?? process.cwd()
+  );
+  if (cwdProject) {
+    return { kind: "resolved", ...cwdProject };
+  }
+
   const global = await loadGlobalConfig(input.configDir);
   if (!global) {
     return {
@@ -109,15 +116,6 @@ export async function inspectManagedProjectSelection(
       message:
         "No repository runtime config is configured. Run 'gh-symphony repo init' first.",
     };
-  }
-
-  const cwdProject = await loadRegisteredStandaloneProjectFromCwd(
-    input.configDir,
-    projectIds,
-    input.cwd ?? process.cwd()
-  );
-  if (cwdProject) {
-    return { kind: "resolved", ...cwdProject };
   }
 
   if (global.activeProject) {

--- a/packages/cli/src/project-selection.ts
+++ b/packages/cli/src/project-selection.ts
@@ -1,4 +1,5 @@
 import * as p from "@clack/prompts";
+import { resolve } from "node:path";
 import {
   loadGlobalConfig,
   loadProjectConfig,
@@ -9,6 +10,7 @@ import { writeCliError } from "./cli-error.js";
 type ResolveProjectSelectionInput = {
   configDir: string;
   requestedProjectId?: string;
+  cwd?: string;
   json?: boolean;
 };
 
@@ -50,6 +52,24 @@ function missingProjectConfigMessage(projectId: string): string {
   return `Project "${projectId}" is not configured. ${projectConfigRemediation()}`;
 }
 
+async function loadRegisteredStandaloneProjectFromCwd(
+  configDir: string,
+  projectIds: string[],
+  cwd: string
+): Promise<{ projectId: string; projectConfig: CliProjectConfig } | null> {
+  const resolvedCwd = resolve(cwd);
+  for (const projectId of projectIds) {
+    const projectConfig = await loadProjectConfig(configDir, projectId);
+    if (
+      projectConfig?.projectDir &&
+      resolve(projectConfig.projectDir) === resolvedCwd
+    ) {
+      return { projectId, projectConfig };
+    }
+  }
+  return null;
+}
+
 export async function inspectManagedProjectSelection(
   input: ResolveProjectSelectionInput
 ): Promise<ManagedProjectResolution> {
@@ -89,6 +109,15 @@ export async function inspectManagedProjectSelection(
       message:
         "No repository runtime config is configured. Run 'gh-symphony repo init' first.",
     };
+  }
+
+  const cwdProject = await loadRegisteredStandaloneProjectFromCwd(
+    input.configDir,
+    projectIds,
+    input.cwd ?? process.cwd()
+  );
+  if (cwdProject) {
+    return { kind: "resolved", ...cwdProject };
   }
 
   if (global.activeProject) {

--- a/packages/cli/src/standalone-project.ts
+++ b/packages/cli/src/standalone-project.ts
@@ -1,0 +1,15 @@
+import { createHash } from "node:crypto";
+import { basename, resolve } from "node:path";
+
+function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+/** Derives the stable cache identifier for a standalone project folder. */
+export function standaloneProjectId(projectDirInput: string): string {
+  const projectDir = resolve(projectDirInput);
+  return `${slugify(basename(projectDir)) || "project"}-${createHash("sha256").update(projectDir).digest("hex").slice(0, 8)}`;
+}


### PR DESCRIPTION
## Issues — Closed #619

- Closes #619

## TL;DR

- `doctor` and GitHub/Linear live `workflow preview` derive a cached standalone project directly from cwd before falling back to the registry's `activeProject`.
- Explicit project selectors remain highest precedence; standalone-only operation works without a global `config.json`.

## Change-point diagram

```text
explicit selector
       │
       ▼
deterministic standalone ID from cwd → cached project config
       │ no match
       ▼
registry activeProject
       │ unavailable
       ▼
existing single-project / selection diagnostics
```

## Start here

- `packages/cli/src/standalone-project.ts` — shared deterministic folder identity.
- `packages/cli/src/project-selection.ts` — shared diagnostic selection precedence.
- `packages/cli/src/project-selection.test.ts` — production-shaped project A cwd vs active B and no-global-config regressions.
- `packages/cli/src/commands/workflow.ts` — shared selection for GitHub and Linear live previews.

## Changes

- Derive and load the standalone cwd cache in O(1), after explicit selection and before global registry loading.
- Avoid scanning unrelated project configs, so malformed registry entries cannot abort cwd diagnostics.
- Route Linear live preview and `--project-id` through the shared managed-project selector.
- Align remediation copy and living/design documentation with the cache-based, no-registration standalone model.
- Retain the existing `@gh-symphony/cli` patch changeset.

## Evidence

- `pnpm --filter @gh-symphony/cli test -- project-selection.test.ts commands/workflow.test.ts commands/doctor.test.ts` — 82 tests pass.
- `pnpm lint` — pass.
- `pnpm test` — pass (all workspace suites; CLI 544 tests).
- `pnpm typecheck` — pass.
- `pnpm build` — pass.
- CI `Test` and `Container Smoke` — pass on `e279e8a`.
- Docker E2E: N/A; this is local CLI selection/remediation behavior and does not change orchestrator dispatch, worker lifecycle, tracker adapters, or status APIs.

## Risks & rollback

- Risk: implicit diagnostics from a cached standalone folder intentionally select that folder instead of a different globally active project.
- Explicit selectors remain deterministic overrides. Reverting the selector/helper change and its docs/tests restores the former precedence.

## Changed files

- Identity/selection: `packages/cli/src/standalone-project.ts`, `packages/cli/src/project-selection.ts`, `packages/cli/src/commands/project.ts`.
- Preview/doctor behavior and tests: `packages/cli/src/commands/workflow.ts`, `packages/cli/src/commands/workflow.test.ts`, `packages/cli/src/commands/doctor.ts`, `packages/cli/src/commands/doctor.test.ts`, `packages/cli/src/project-selection.test.ts`.
- Living/design docs: `README.md`, `packages/cli/README.md`, `docs/architecture.md`, `docs/configuration.md`, `docs/designs/2026-08-11-standalone-project-model-design.md`.
- Release note: `.changeset/calm-diagnostics-follow-cwd.md`.

## Human validation

- [ ] From cached standalone project A, confirm `doctor` and GitHub/Linear live preview select A while registry project B is active.
- [ ] Confirm explicit project selectors still win over cwd.
- [ ] Confirm a standalone cache works when global `config.json` is absent.

## Post-merge validation

- No deployment or external smoke validation is required.
