### PR TITLE
fix(cli): publish runtime helper entrypoints

### DIFF
--- a/.changeset/tidy-ravens-package-entrypoints.md
+++ b/.changeset/tidy-ravens-package-entrypoints.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Fix #613 by publishing the built-in MCP server and Git credential helper runtime entry points.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Run tests with coverage
         run: npx vitest run --coverage.enabled --coverage.reporter=json-summary --coverage.reporter=json
 
+      - name: Package entrypoint smoke test
+        run: pnpm --filter @gh-symphony/cli test:package
+
       - name: Coverage Report
         uses: davelosert/vitest-coverage-report-action@v2
         if: always()

--- a/AGENT_TEST.md
+++ b/AGENT_TEST.md
@@ -382,6 +382,7 @@ idle → [inject issue + refresh]
 | `e2e/scenarios/15-terminal-candidate-reconciliation.md`   | Verify a closed issue in active Project status converges to `Done` without worker dispatch                                |
 | `e2e/scenarios/15-cache-maintenance.md`                   | Verify cache inventory, dry-run eviction, and active-worktree preservation                                                |
 | `e2e/scenarios/16-bounded-finalization-deferral.md`       | Verify persistent unknown final tracker reads emit three durable deferrals and enter failure retry handling               |
+| `e2e/scenarios/16-packaged-runtime-entrypoints.md`        | Verify the built CLI's MCP dispatcher and Git credential helper subprocesses inside Docker                                |
 
 ## TC Writing Guide
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,11 @@ Verify the installation:
 gh-symphony --version
 ```
 
+The npm package also ships the internal `dist/mcp-server.js` and
+`dist/git-credential-helper.js` subprocess entry points used by worker runtimes.
+They are implementation details of the CLI and are validated from the packed
+tarball during release testing.
+
 Validate the local prerequisites before setup:
 
 ```bash

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -70,7 +70,11 @@ touches a layer, check that its slice (and the linked documents) still holds.
 ## Package dependency graph
 
 `packages/cli` is the published entrypoint that bundles the rest at build time
-(referenced via devDependencies).
+(referenced via devDependencies). In addition to `dist/index.js` and the worker
+entry, its package build emits `dist/mcp-server.js`, which dispatches exactly one
+built-in GraphQL MCP implementation from an explicit server argument, and
+`dist/git-credential-helper.js`, which supplies runtime-scoped GitHub credentials
+to Git subprocesses.
 
 ```
 cli (bundles: orchestrator, worker, control-plane, dashboard, runtime-claude, tracker-github, core)

--- a/e2e/scenarios/16-packaged-runtime-entrypoints.md
+++ b/e2e/scenarios/16-packaged-runtime-entrypoints.md
@@ -1,0 +1,26 @@
+# TC-16: Packaged runtime entry points
+
+## Setup
+
+Build and start `docker-compose.e2e.yml` so the production CLI bundle and its
+workspace dependencies are available under `/app/packages/cli`.
+
+## Steps
+
+1. Send an MCP `initialize` request to `dist/mcp-server.js --server github`.
+2. Send the same request to `dist/mcp-server.js --server linear`.
+3. Send a Git HTTPS credential request to `dist/git-credential-helper.js` with
+   `GITHUB_GRAPHQL_TOKEN` set.
+4. Inspect each subprocess response.
+
+## Expected
+
+- The GitHub process emits exactly one initialize response whose server name is
+  `github-symphony-graphql`.
+- The Linear process emits exactly one initialize response whose server name is
+  `github-symphony-linear-graphql`.
+- The credential helper returns the configured token for `github.com`.
+
+## Cleanup
+
+Stop the Compose environment with `docker compose -f docker-compose.e2e.yml down`.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -33,6 +33,11 @@ Verify the installation:
 gh-symphony --version
 ```
 
+The package includes internal `dist/mcp-server.js` and
+`dist/git-credential-helper.js` executables. Worker runtimes select one built-in
+MCP implementation with `--server github` or `--server linear`; these entry
+points are not standalone user-facing commands.
+
 Validate the machine and repo prerequisites before first use:
 
 ```bash

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -38,6 +38,7 @@
     "build": "tsup",
     "lint": "eslint src --ext .ts",
     "test": "vitest run --passWithNoTests",
+    "test:package": "pnpm build && node scripts/package-smoke.mjs",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -52,7 +52,10 @@
     "@gh-symphony/dashboard": "workspace:*",
     "@gh-symphony/orchestrator": "workspace:*",
     "@gh-symphony/runtime-claude": "workspace:*",
+    "@gh-symphony/runtime-codex": "workspace:*",
     "@gh-symphony/tracker-github": "workspace:*",
+    "@gh-symphony/tool-github-graphql": "workspace:*",
+    "@gh-symphony/tool-linear-graphql": "workspace:*",
     "@gh-symphony/worker": "workspace:*",
     "tsup": "^8.5.1"
   }

--- a/packages/cli/scripts/package-smoke.mjs
+++ b/packages/cli/scripts/package-smoke.mjs
@@ -1,0 +1,85 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+
+const temporaryDirectory = mkdtempSync(join(tmpdir(), "gh-symphony-pack-"));
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    encoding: "utf8",
+    ...options,
+  });
+
+  if (result.status !== 0) {
+    throw new Error(
+      `${command} ${args.join(" ")} failed:\n${result.stderr || result.stdout}`
+    );
+  }
+
+  return result.stdout;
+}
+
+try {
+  const packOutput = JSON.parse(
+    run("npm", ["pack", "--json", "--pack-destination", temporaryDirectory])
+  );
+  const packagedFiles = new Set(packOutput[0].files.map(({ path }) => path));
+
+  for (const requiredFile of [
+    "dist/mcp-server.js",
+    "dist/git-credential-helper.js",
+  ]) {
+    if (!packagedFiles.has(requiredFile)) {
+      throw new Error(`Published package is missing ${requiredFile}`);
+    }
+  }
+
+  const packageRoot = process.cwd();
+  const initializeRequest = `${JSON.stringify({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "initialize",
+    params: {},
+  })}\n`;
+
+  for (const [server, expectedName] of [
+    ["github", "github-symphony-graphql"],
+    ["linear", "github-symphony-linear-graphql"],
+  ]) {
+    const output = run(
+      process.execPath,
+      [join(packageRoot, "dist/mcp-server.js"), "--server", server],
+      { input: initializeRequest }
+    );
+    const responses = output
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+    const initializeResponses = responses.filter(({ id }) => id === 1);
+
+    if (
+      initializeResponses.length !== 1 ||
+      initializeResponses[0].result?.serverInfo?.name !== expectedName
+    ) {
+      throw new Error(`${server} MCP package smoke test returned ${output}`);
+    }
+  }
+
+  const credentialOutput = run(
+    process.execPath,
+    [join(packageRoot, "dist/git-credential-helper.js")],
+    {
+      input: "protocol=https\nhost=github.com\n\n",
+      env: { ...process.env, GITHUB_GRAPHQL_TOKEN: "ghs_package_smoke" },
+    }
+  );
+
+  if (!credentialOutput.includes("password=ghs_package_smoke")) {
+    throw new Error("Packaged Git credential helper did not return its token");
+  }
+
+  process.stdout.write("Packaged runtime entrypoint smoke tests passed.\n");
+} finally {
+  rmSync(temporaryDirectory, { recursive: true, force: true });
+}

--- a/packages/cli/scripts/package-smoke.mjs
+++ b/packages/cli/scripts/package-smoke.mjs
@@ -11,6 +11,10 @@ function run(command, args, options = {}) {
     ...options,
   });
 
+  if (result.error) {
+    throw result.error;
+  }
+
   if (result.status !== 0) {
     throw new Error(
       `${command} ${args.join(" ")} failed:\n${result.stderr || result.stdout}`

--- a/packages/cli/src/git-credential-helper.ts
+++ b/packages/cli/src/git-credential-helper.ts
@@ -1,0 +1,9 @@
+import { runGitCredentialHelper } from "@gh-symphony/runtime-codex";
+
+if (import.meta.url === new URL(process.argv[1] ?? "", "file:").href) {
+  runGitCredentialHelper().catch((error: unknown) => {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    process.stderr.write(`${message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/packages/cli/src/mcp-server.test.ts
+++ b/packages/cli/src/mcp-server.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { parseBuiltInMcpServer } from "./mcp-server.js";
+
+describe("parseBuiltInMcpServer", () => {
+  it.each([
+    [["--server", "github"], "github"],
+    [["--server", "linear"], "linear"],
+  ] as const)("selects %s", (args, expected) => {
+    expect(parseBuiltInMcpServer([...args])).toBe(expected);
+  });
+
+  it("rejects missing and unsupported server selections", () => {
+    expect(() => parseBuiltInMcpServer([])).toThrow(
+      "Expected --server <github|linear>"
+    );
+    expect(() => parseBuiltInMcpServer(["--server", "other"])).toThrow(
+      "Expected --server <github|linear>"
+    );
+  });
+});

--- a/packages/cli/src/mcp-server.test.ts
+++ b/packages/cli/src/mcp-server.test.ts
@@ -5,6 +5,8 @@ describe("parseBuiltInMcpServer", () => {
   it.each([
     [["--server", "github"], "github"],
     [["--server", "linear"], "linear"],
+    [["--server=github"], "github"],
+    [["--server=linear"], "linear"],
   ] as const)("selects %s", (args, expected) => {
     expect(parseBuiltInMcpServer([...args])).toBe(expected);
   });
@@ -14,7 +16,7 @@ describe("parseBuiltInMcpServer", () => {
       "Expected --server <github|linear>"
     );
     expect(() => parseBuiltInMcpServer(["--server", "other"])).toThrow(
-      "Expected --server <github|linear>"
+      "received other"
     );
   });
 });

--- a/packages/cli/src/mcp-server.ts
+++ b/packages/cli/src/mcp-server.ts
@@ -1,0 +1,36 @@
+import { runGitHubGraphQLMcpServer } from "@gh-symphony/tool-github-graphql";
+import { runLinearGraphQLMcpServer } from "@gh-symphony/tool-linear-graphql";
+
+export type BuiltInMcpServer = "github" | "linear";
+
+export function parseBuiltInMcpServer(args: string[]): BuiltInMcpServer {
+  const serverFlagIndex = args.indexOf("--server");
+  const server = serverFlagIndex === -1 ? undefined : args[serverFlagIndex + 1];
+
+  if (server === "github" || server === "linear") {
+    return server;
+  }
+
+  throw new Error(
+    "Expected --server <github|linear> when starting the built-in MCP server."
+  );
+}
+
+export async function runBuiltInMcpServer(args: string[]): Promise<void> {
+  const server = parseBuiltInMcpServer(args);
+
+  if (server === "github") {
+    await runGitHubGraphQLMcpServer();
+    return;
+  }
+
+  await runLinearGraphQLMcpServer();
+}
+
+if (import.meta.url === new URL(process.argv[1] ?? "", "file:").href) {
+  runBuiltInMcpServer(process.argv.slice(2)).catch((error: unknown) => {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    process.stderr.write(`${message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/packages/cli/src/mcp-server.ts
+++ b/packages/cli/src/mcp-server.ts
@@ -5,14 +5,18 @@ export type BuiltInMcpServer = "github" | "linear";
 
 export function parseBuiltInMcpServer(args: string[]): BuiltInMcpServer {
   const serverFlagIndex = args.indexOf("--server");
-  const server = serverFlagIndex === -1 ? undefined : args[serverFlagIndex + 1];
+  const inlineServer = args
+    .find((arg) => arg.startsWith("--server="))
+    ?.slice("--server=".length);
+  const server =
+    serverFlagIndex === -1 ? inlineServer : args[serverFlagIndex + 1];
 
   if (server === "github" || server === "linear") {
     return server;
   }
 
   throw new Error(
-    "Expected --server <github|linear> when starting the built-in MCP server."
+    `Expected --server <github|linear> when starting the built-in MCP server, received ${server ?? "nothing"}.`
   );
 }
 

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -9,6 +9,8 @@ export default defineConfig({
   entry: {
     index: "src/index.ts",
     "worker-entry": "src/worker-entry.ts",
+    "mcp-server": "src/mcp-server.ts",
+    "git-credential-helper": "src/git-credential-helper.ts",
   },
   format: ["esm"],
   target: "node24",

--- a/packages/runtime-claude/src/mcp-compose.test.ts
+++ b/packages/runtime-claude/src/mcp-compose.test.ts
@@ -60,7 +60,11 @@ describe("composeClaudeMcpConfig", () => {
       mcpServers: {
         github_graphql: {
           command: "node",
-          args: [expect.stringContaining("mcp-server.js")],
+          args: [
+            expect.stringContaining("mcp-server.js"),
+            "--server",
+            "github",
+          ],
           env: {
             GITHUB_GRAPHQL_API_URL: "https://api.github.com/graphql",
             GITHUB_GRAPHQL_TOKEN: "token-1",
@@ -139,7 +143,11 @@ describe("composeClaudeMcpConfig", () => {
         },
         github_graphql: {
           command: "node",
-          args: [expect.stringContaining("mcp-server.js")],
+          args: [
+            expect.stringContaining("mcp-server.js"),
+            "--server",
+            "github",
+          ],
           env: {
             GITHUB_GRAPHQL_API_URL: "https://api.github.com/graphql",
             GITHUB_GRAPHQL_TOKEN: "token-2",
@@ -163,14 +171,22 @@ describe("composeClaudeMcpConfig", () => {
       mcpServers: {
         github_graphql: {
           command: "node",
-          args: [expect.stringContaining("mcp-server.js")],
+          args: [
+            expect.stringContaining("mcp-server.js"),
+            "--server",
+            "github",
+          ],
           env: {
             GITHUB_GRAPHQL_API_URL: "https://api.github.com/graphql",
           },
         },
         linear_graphql: {
           command: "node",
-          args: [expect.stringContaining("mcp-server.js")],
+          args: [
+            expect.stringContaining("mcp-server.js"),
+            "--server",
+            "linear",
+          ],
           env: {
             LINEAR_GRAPHQL_URL: "https://api.linear.app/graphql",
           },
@@ -230,7 +246,7 @@ describe("composeClaudeMcpConfig", () => {
       },
       github_graphql: {
         command: "node",
-        args: [expect.stringContaining("mcp-server.js")],
+        args: [expect.stringContaining("mcp-server.js"), "--server", "github"],
         env: {
           GITHUB_GRAPHQL_API_URL: "https://api.github.com/graphql",
         },
@@ -282,7 +298,11 @@ describe("composeClaudeMcpConfig", () => {
         },
         github_graphql: {
           command: "node",
-          args: [expect.stringContaining("mcp-server.js")],
+          args: [
+            expect.stringContaining("mcp-server.js"),
+            "--server",
+            "github",
+          ],
           env: {
             GITHUB_GRAPHQL_API_URL: "https://api.github.com/graphql",
             GITHUB_GRAPHQL_TOKEN: "token-3",
@@ -373,7 +393,11 @@ describe("composeClaudeMcpConfig", () => {
       mcpServers: {
         github_graphql: {
           command: "node",
-          args: [expect.stringContaining("mcp-server.js")],
+          args: [
+            expect.stringContaining("mcp-server.js"),
+            "--server",
+            "github",
+          ],
           env: {
             GITHUB_GRAPHQL_API_URL: "https://api.github.com/graphql",
           },

--- a/packages/runtime-codex/src/git-credential-helper.ts
+++ b/packages/runtime-codex/src/git-credential-helper.ts
@@ -87,7 +87,7 @@ async function readStdin(): Promise<string> {
   return Buffer.concat(chunks).toString("utf8");
 }
 
-async function main(): Promise<void> {
+export async function runGitCredentialHelper(): Promise<void> {
   const request = parseGitCredentialRequest(await readStdin());
   const response = await resolveGitCredential(request, {
     token: process.env.GITHUB_GRAPHQL_TOKEN,
@@ -102,7 +102,7 @@ async function main(): Promise<void> {
 }
 
 if (import.meta.url === new URL(process.argv[1] ?? "", "file:").href) {
-  main().catch((error: unknown) => {
+  runGitCredentialHelper().catch((error: unknown) => {
     const message = error instanceof Error ? error.message : "Unknown error";
     process.stderr.write(`${message}\n`);
     process.exitCode = 1;

--- a/packages/tool-github-graphql/src/mcp-entry.ts
+++ b/packages/tool-github-graphql/src/mcp-entry.ts
@@ -33,7 +33,7 @@ export function createGitHubGraphQLMcpServerEntry(
 
   return {
     command: "node",
-    args: [resolveGitHubGraphQLMcpServerEntryPoint()],
+    args: [resolveGitHubGraphQLMcpServerEntryPoint(), "--server", "github"],
     env: {
       GITHUB_GRAPHQL_API_URL: githubGraphqlApiUrl,
       ...(options.githubToken

--- a/packages/tool-github-graphql/src/mcp-server.ts
+++ b/packages/tool-github-graphql/src/mcp-server.ts
@@ -13,10 +13,7 @@ import { fileURLToPath } from "node:url";
  *   client → tools/call  → server calls github-graphql-tool, returns result
  */
 
-import {
-  executeGitHubGraphQL,
-  type GitHubGraphQLInvocation,
-} from "./tool.js";
+import { executeGitHubGraphQL, type GitHubGraphQLInvocation } from "./tool.js";
 
 const TOOL_SCHEMA = {
   name: "github_graphql",
@@ -160,7 +157,7 @@ async function handleRequest(msg: {
   }
 }
 
-async function main(): Promise<void> {
+export async function runGitHubGraphQLMcpServer(): Promise<void> {
   process.stdin.setEncoding("utf8");
 
   process.stdin.on("data", (chunk: string) => {
@@ -194,7 +191,7 @@ async function main(): Promise<void> {
 }
 
 if (import.meta.url === new URL(process.argv[1] ?? "", "file:").href) {
-  main().catch((err: unknown) => {
+  runGitHubGraphQLMcpServer().catch((err: unknown) => {
     process.stderr.write(
       `[github-graphql-mcp] fatal: ${err instanceof Error ? err.message : String(err)}\n`
     );

--- a/packages/tool-github-graphql/src/mcp-server.ts
+++ b/packages/tool-github-graphql/src/mcp-server.ts
@@ -190,6 +190,9 @@ export async function runGitHubGraphQLMcpServer(): Promise<void> {
   });
 }
 
+// Keep this compatibility entry self-starting for direct package consumers.
+// The CLI package smoke test must remain enabled in CI because bundling this
+// module directly into its shared MCP entry could otherwise start two servers.
 if (import.meta.url === new URL(process.argv[1] ?? "", "file:").href) {
   runGitHubGraphQLMcpServer().catch((err: unknown) => {
     process.stderr.write(

--- a/packages/tool-github-graphql/src/tool.test.ts
+++ b/packages/tool-github-graphql/src/tool.test.ts
@@ -555,7 +555,7 @@ describe("createGitHubGraphQLMcpServerEntry", () => {
   it("creates a default MCP server entry without optional env keys", () => {
     expect(createGitHubGraphQLMcpServerEntry()).toEqual({
       command: "node",
-      args: [expect.stringContaining("mcp-server.js")],
+      args: [expect.stringContaining("mcp-server.js"), "--server", "github"],
       env: {
         GITHUB_GRAPHQL_API_URL: DEFAULT_GITHUB_GRAPHQL_API_URL,
       },
@@ -574,7 +574,7 @@ describe("createGitHubGraphQLMcpServerEntry", () => {
       })
     ).toEqual({
       command: "node",
-      args: [expect.stringContaining("mcp-server.js")],
+      args: [expect.stringContaining("mcp-server.js"), "--server", "github"],
       env: {
         GITHUB_GRAPHQL_API_URL: "https://api.github.com/graphql",
         GITHUB_GRAPHQL_TOKEN: "ghs_token",

--- a/packages/tool-linear-graphql/src/mcp-entry.ts
+++ b/packages/tool-linear-graphql/src/mcp-entry.ts
@@ -21,7 +21,7 @@ export function createLinearGraphQLMcpServerEntry(
 
   return {
     command: "node",
-    args: [resolveLinearGraphQLMcpServerEntryPoint()],
+    args: [resolveLinearGraphQLMcpServerEntryPoint(), "--server", "linear"],
     env: {
       LINEAR_GRAPHQL_URL: linearGraphqlUrl,
     },

--- a/packages/tool-linear-graphql/src/mcp-server.ts
+++ b/packages/tool-linear-graphql/src/mcp-server.ts
@@ -170,6 +170,9 @@ export async function runLinearGraphQLMcpServer(): Promise<void> {
   });
 }
 
+// Keep this compatibility entry self-starting for direct package consumers.
+// The CLI package smoke test must remain enabled in CI because bundling this
+// module directly into its shared MCP entry could otherwise start two servers.
 if (import.meta.url === new URL(process.argv[1] ?? "", "file:").href) {
   runLinearGraphQLMcpServer().catch((err: unknown) => {
     process.stderr.write(

--- a/packages/tool-linear-graphql/src/mcp-server.ts
+++ b/packages/tool-linear-graphql/src/mcp-server.ts
@@ -137,7 +137,7 @@ async function handleRequest(msg: {
   }
 }
 
-async function main(): Promise<void> {
+export async function runLinearGraphQLMcpServer(): Promise<void> {
   process.stdin.setEncoding("utf8");
 
   process.stdin.on("data", (chunk: string) => {
@@ -171,7 +171,7 @@ async function main(): Promise<void> {
 }
 
 if (import.meta.url === new URL(process.argv[1] ?? "", "file:").href) {
-  main().catch((err: unknown) => {
+  runLinearGraphQLMcpServer().catch((err: unknown) => {
     process.stderr.write(
       `[linear-graphql-mcp] fatal: ${err instanceof Error ? err.message : String(err)}\n`
     );

--- a/packages/tool-linear-graphql/src/tool.test.ts
+++ b/packages/tool-linear-graphql/src/tool.test.ts
@@ -238,7 +238,7 @@ describe("createLinearGraphQLMcpServerEntry", () => {
   it("creates a default MCP server entry without optional auth env", () => {
     expect(createLinearGraphQLMcpServerEntry()).toEqual({
       command: "node",
-      args: [expect.stringContaining("mcp-server.js")],
+      args: [expect.stringContaining("mcp-server.js"), "--server", "linear"],
       env: {
         LINEAR_GRAPHQL_URL: DEFAULT_LINEAR_GRAPHQL_API_URL,
       },
@@ -252,7 +252,7 @@ describe("createLinearGraphQLMcpServerEntry", () => {
       })
     ).toEqual({
       command: "node",
-      args: [expect.stringContaining("mcp-server.js")],
+      args: [expect.stringContaining("mcp-server.js"), "--server", "linear"],
       env: {
         LINEAR_GRAPHQL_URL: "https://api.linear.app/graphql",
       },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,15 @@ importers:
       '@gh-symphony/runtime-claude':
         specifier: workspace:*
         version: link:../runtime-claude
+      '@gh-symphony/runtime-codex':
+        specifier: workspace:*
+        version: link:../runtime-codex
+      '@gh-symphony/tool-github-graphql':
+        specifier: workspace:*
+        version: link:../tool-github-graphql
+      '@gh-symphony/tool-linear-graphql':
+        specifier: workspace:*
+        version: link:../tool-linear-graphql
       '@gh-symphony/tracker-github':
         specifier: workspace:*
         version: link:../tracker-github


### PR DESCRIPTION
## Issues

- Closed #613

## TL;DR

- Publish the `dist/mcp-server.js` and `dist/git-credential-helper.js` executables referenced by worker runtime plans.
- Dispatch the shared MCP executable to exactly one built-in server through `--server github|linear`.
- Smoke-test the actual npm tarball contents and both subprocess protocols.
- Declare every workspace package bundled by the new CLI entries and enforce the package smoke in CI.

## Change-point diagram

```text
GitHub MCP plan ──> dist/mcp-server.js --server github ──> github_graphql only
Linear MCP plan ──> dist/mcp-server.js --server linear ──> linear_graphql only
Git subprocess ──> dist/git-credential-helper.js ──> runtime-scoped GitHub token
```

## Start here

- `packages/cli/tsup.config.ts` declares the two additional published build entries.
- `packages/cli/src/mcp-server.ts` validates explicit server selection and starts one MCP implementation.
- `packages/cli/scripts/package-smoke.mjs` verifies npm tarball membership and executable behavior.

## Changes

- Export the existing MCP and credential-helper runners for dedicated CLI wrappers.
- Add explicit server-selection arguments to both runtime-neutral MCP entry definitions.
- Add unit coverage, npm packing smoke coverage, and Docker TC-16.
- Run the packed-entrypoint smoke in the pull-request Test job and improve subprocess/parser diagnostics.
- Document the internal package artifacts and architecture mapping.
- Add a patch changeset for `@gh-symphony/cli` only.

## Evidence

- `pnpm lint`
- `pnpm test`
- `pnpm typecheck`
- `pnpm build`
- `pnpm --filter @gh-symphony/cli test:package`
- `pnpm install --frozen-lockfile` locally and during a clean Docker image build
- `docker compose -f docker-compose.e2e.yml up -d --build`, followed by TC-16 MCP and credential-helper subprocess probes in `symphony-e2e`

## Risks & rollback

- Risk is limited to bundled runtime entrypoint selection and credential-helper startup; both Codex and Claude MCP config expectations were updated, and CI now probes the packed executables.
- Roll back commits `4037143d` and `5e8a5bde` if packaged subprocess startup regresses.

## Changed files

- `packages/cli/tsup.config.ts`, `packages/cli/src/{mcp-server,git-credential-helper}.ts` — published executable entries.
- `packages/tool-{github,linear}-graphql/src/` and `packages/runtime-codex/src/` — exported runners and runtime arguments.
- `packages/cli/scripts/package-smoke.mjs` plus unit/runtime tests — regression coverage.
- `.github/workflows/ci.yml`, `packages/cli/package.json`, `pnpm-lock.yaml` — mandatory smoke execution and clean-install bundle dependencies.
- `README.md`, `packages/cli/README.md`, `docs/architecture.md`, `AGENT_TEST.md`, `e2e/scenarios/16-packaged-runtime-entrypoints.md` — living documentation and Docker TC.
- `.changeset/tidy-ravens-package-entrypoints.md` — patch release metadata.

## Post-merge / human validation

- [ ] Confirm the released npm tarball contains both internal executable files.
- [ ] Confirm a globally installed CLI starts both built-in MCP integrations in a real worker session.
