### PR TITLE
fix(cli): preserve standalone lock through confirmation

### DIFF
--- a/.changeset/standalone-lock-confirmation.md
+++ b/.changeset/standalone-lock-confirmation.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Keep standalone project-start serialization intact while an operator confirms an overlapping mapping (#607).

--- a/packages/cli/src/commands/project.test.ts
+++ b/packages/cli/src/commands/project.test.ts
@@ -1,7 +1,15 @@
-import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
+
+const { confirmMock } = vi.hoisted(() => ({ confirmMock: vi.fn() }));
+
+vi.mock("@clack/prompts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@clack/prompts")>();
+  return { ...actual, confirm: confirmMock };
+});
+
 import { loadProjectConfig } from "../config.js";
 import { deriveStandaloneProject, standaloneProjectId } from "./project.js";
 import projectCommand from "./project.js";
@@ -157,6 +165,64 @@ describe("deriveStandaloneProject", () => {
     expect(
       results.filter((result) => result.status === "rejected")
     ).toHaveLength(1);
+  });
+
+  it("keeps an aged live lock through overlap confirmation", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "cli-standalone-config-"));
+    const existing = await mkdtemp(join(tmpdir(), "cli-standalone-project-"));
+    const first = await mkdtemp(join(tmpdir(), "cli-standalone-project-"));
+    const second = await mkdtemp(join(tmpdir(), "cli-standalone-project-"));
+    await Promise.all(
+      [existing, first, second].map((projectDir) =>
+        writeFile(join(projectDir, "WORKFLOW.md"), workflow, "utf8")
+      )
+    );
+    await deriveStandaloneProject(existing, { configDir });
+
+    const originalIsTTY = Object.getOwnPropertyDescriptor(
+      process.stdin,
+      "isTTY"
+    );
+    Object.defineProperty(process.stdin, "isTTY", {
+      configurable: true,
+      value: true,
+    });
+    let resolveConfirmation!: (value: boolean) => void;
+    const confirmation = new Promise<boolean>((resolve) => {
+      resolveConfirmation = resolve;
+    });
+    confirmMock
+      .mockImplementationOnce(() => confirmation)
+      .mockResolvedValue(false);
+
+    try {
+      const firstStart = deriveStandaloneProject(first, { configDir });
+      await vi.waitFor(() => expect(confirmMock).toHaveBeenCalledTimes(1));
+
+      const lockPath = join(configDir, ".config.lock");
+      const lock = JSON.parse(await readFile(lockPath, "utf8")) as {
+        startedAt: string;
+      };
+      lock.startedAt = new Date(Date.now() - 31_000).toISOString();
+      await writeFile(lockPath, JSON.stringify(lock), "utf8");
+
+      const secondStart = deriveStandaloneProject(second, { configDir });
+      await new Promise((resolve) => setTimeout(resolve, 75));
+      expect(confirmMock).toHaveBeenCalledTimes(1);
+
+      resolveConfirmation(true);
+      await expect(firstStart).resolves.toBeDefined();
+      await expect(secondStart).rejects.toThrow(
+        "Standalone project start cancelled"
+      );
+    } finally {
+      confirmMock.mockReset();
+      if (originalIsTTY) {
+        Object.defineProperty(process.stdin, "isTTY", originalIsTTY);
+      } else {
+        delete (process.stdin as { isTTY?: boolean }).isTTY;
+      }
+    }
   });
 
   it("preserves Linear label filters and normalizes overlapping states", async () => {

--- a/packages/cli/src/commands/project.ts
+++ b/packages/cli/src/commands/project.ts
@@ -109,6 +109,22 @@ export async function deriveStandaloneProject(
           "Standalone project start cancelled because tracker mappings overlap."
         );
       }
+
+      // Confirmation can take an arbitrary amount of time. The config lock
+      // remains held while waiting, but re-check before persisting so the
+      // decision is based on the state that exists at commit time.
+      const confirmedOverlap = await findOverlappingProjects(
+        options.configDir,
+        config
+      );
+      const runningAfterConfirmation = confirmedOverlap.filter(
+        (entry) => entry.running
+      );
+      if (runningAfterConfirmation.length > 0) {
+        throw new Error(
+          `Tracker mapping overlaps running project(s): ${describe(runningAfterConfirmation)}. Stop them or make the mappings disjoint with tracker.pickup_labels.`
+        );
+      }
     }
 
     await saveProjectConfigWithinLock(options.configDir, projectId, config);

--- a/packages/cli/src/commands/project.ts
+++ b/packages/cli/src/commands/project.ts
@@ -110,15 +110,12 @@ export async function deriveStandaloneProject(
         );
       }
 
-      // Confirmation can take an arbitrary amount of time. The config lock
-      // remains held while waiting, but re-check before persisting so the
-      // decision is based on the state that exists at commit time.
-      const confirmedOverlap = await findOverlappingProjects(
+      // Project mappings cannot change while the config lock is held, but a
+      // daemon can start while the operator is deciding. Refresh only that
+      // liveness state before persisting the confirmed configuration.
+      const runningAfterConfirmation = await runningOverlaps(
         options.configDir,
-        config
-      );
-      const runningAfterConfirmation = confirmedOverlap.filter(
-        (entry) => entry.running
+        overlap
       );
       if (runningAfterConfirmation.length > 0) {
         throw new Error(
@@ -199,6 +196,7 @@ type OverlappingProject = {
   projectId: string;
   label: string;
   running: boolean;
+  workspaceDir: string;
 };
 
 /**
@@ -230,9 +228,29 @@ async function findOverlappingProjects(
       projectId: existing.projectId,
       label: existing.projectDir ?? existing.projectId,
       running: liveness.running,
+      workspaceDir: existing.repositoryDir ?? existing.workspaceDir,
     });
   }
   return overlaps;
+}
+
+async function runningOverlaps(
+  configDir: string,
+  overlaps: OverlappingProject[]
+): Promise<OverlappingProject[]> {
+  const refreshed = await Promise.all(
+    overlaps.map(async (overlap) => ({
+      ...overlap,
+      running: (
+        await resolveDaemonLiveness({
+          configDir,
+          projectId: overlap.projectId,
+          workspaceDir: overlap.workspaceDir,
+        })
+      ).running,
+    }))
+  );
+  return refreshed.filter((overlap) => overlap.running);
 }
 
 function mappingFor(config: CliProjectConfig): Mapping {

--- a/packages/cli/src/config.test.ts
+++ b/packages/cli/src/config.test.ts
@@ -19,6 +19,7 @@ import {
   saveGlobalConfig,
   saveProjectConfig,
   updateGlobalConfig,
+  withConfigLock,
 } from "./config.js";
 
 const originalCwd = process.cwd();
@@ -191,6 +192,48 @@ describe("config persistence", () => {
       projects: ["project-1"],
     });
     expect(await readdir(configDir)).toEqual(["config.json"]);
+  });
+
+  it("reclaims an aged lock whose live owner cannot be identified", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "cli-config-lock-"));
+    const lockPath = join(configDir, ".config.lock");
+    await writeFile(
+      lockPath,
+      JSON.stringify({
+        ownerToken: "unverifiable-owner",
+        pid: process.pid,
+        startedAt: new Date(Date.now() - 31_000).toISOString(),
+        processIdentity: null,
+      }),
+      "utf8"
+    );
+    const expired = new Date(Date.now() - 31_000);
+    await utimes(lockPath, expired, expired);
+
+    await expect(
+      withConfigLock(configDir, async () => "acquired")
+    ).resolves.toBe("acquired");
+  });
+
+  it("reclaims an aged lock whose owner process is gone", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "cli-config-lock-"));
+    const lockPath = join(configDir, ".config.lock");
+    await writeFile(
+      lockPath,
+      JSON.stringify({
+        ownerToken: "dead-owner",
+        pid: 999_999_999,
+        startedAt: new Date(Date.now() - 31_000).toISOString(),
+        processIdentity: null,
+      }),
+      "utf8"
+    );
+    const expired = new Date(Date.now() - 31_000);
+    await utimes(lockPath, expired, expired);
+
+    await expect(
+      withConfigLock(configDir, async () => "acquired")
+    ).resolves.toBe("acquired");
   });
 
   it("reads structured and legacy daemon PID records", () => {

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -403,8 +403,7 @@ async function isStaleConfigLock(path: string): Promise<boolean> {
     ) {
       return isExpiredConfigLockFile(path);
     }
-    const ageMs = Math.abs(Date.now() - Date.parse(record.startedAt));
-    if (!Number.isFinite(ageMs) || ageMs > CONFIG_LOCK_TTL_MS) {
+    if (!Number.isFinite(Date.parse(record.startedAt))) {
       return true;
     }
     try {

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -409,19 +409,24 @@ async function isStaleConfigLock(path: string): Promise<boolean> {
     try {
       process.kill(record.pid!, 0);
     } catch (error) {
-      return Boolean(
+      const processIsGone = Boolean(
         error &&
         typeof error === "object" &&
         "code" in error &&
         error.code === "ESRCH"
       );
+      return processIsGone || (await isExpiredConfigLockFile(path));
     }
     const actualIdentity = getProcessIdentity(record.pid!);
-    return Boolean(
-      record.processIdentity &&
-      actualIdentity &&
-      record.processIdentity !== actualIdentity
-    );
+    if (record.processIdentity && actualIdentity) {
+      return record.processIdentity !== actualIdentity;
+    }
+
+    // A process that is positively identified as the original owner can hold
+    // the lock through an arbitrarily long interactive confirmation. When
+    // identity is unavailable, retain the TTL recovery path for orphaned or
+    // recycled-PID locks instead of wedging the config directory forever.
+    return isExpiredConfigLockFile(path);
   } catch (error) {
     if (isFileMissing(error)) {
       return false;


### PR DESCRIPTION
## TL;DR

- Keep a positively verified live standalone-start config lock exclusively held beyond 30 seconds while an operator waits at confirmation.
- Retain TTL recovery for expired locks whose ownership cannot be verified, and refresh only daemon liveness after confirmation.

## Change-point diagram

```text
project start A ── acquire config lock ── overlap prompt ── confirm ── refresh daemon liveness ── persist
                                      │
project start B ── sees aged verified-live lock ┴─ waits; cannot enter the critical section

unverifiable aged lock ── TTL recovery ── acquire
```

## Start here

- `packages/cli/src/config.ts` — distinguishes verified-live locks from inconclusive ownership and preserves recovery.
- `packages/cli/src/commands/project.ts` — refreshes liveness over the locked overlap set after confirmation.
- `packages/cli/src/config.test.ts` and `packages/cli/src/commands/project.test.ts` — recovery and concurrent-start regressions.

## Risks & rollback

- A lock is retained beyond its TTL only when its PID and process identity both match; unavailable identity retains the prior expiration fallback.
- Reverting this PR restores the former age-first lock behavior.

## Changed files

- `packages/cli/src/config.ts`
- `packages/cli/src/config.test.ts`
- `packages/cli/src/commands/project.ts`
- `packages/cli/src/commands/project.test.ts`
- `.changeset/standalone-lock-confirmation.md`

## Evidence

- `pnpm --filter @gh-symphony/cli test -- --run src/config.test.ts src/commands/project.test.ts` — 21 passed
- `pnpm test` — pass
- `pnpm lint` — pass
- `pnpm typecheck` — pass
- `pnpm build` — pass
- `pnpm exec changeset status --since=origin/main` — `@gh-symphony/cli` patch only
- Docker E2E not run: this changes local CLI lock handling only; it does not alter orchestrator dispatch, worker lifecycle, tracker adapters, or status APIs.

## Issues — Closed #607

Fixes #607

## Post-merge / human validation

- [ ] Confirm an operator can wait at an interactive standalone overlap confirmation while a second start remains blocked.
- [ ] Confirm expired locks with unverifiable ownership are recovered rather than wedging subsequent CLI commands.
