### PR TITLE
fix(cli): align subpath GHES REST mapping

### DIFF
--- a/.changeset/quiet-ghes-subpath.md
+++ b/.changeset/quiet-ghes-subpath.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Map subpath-hosted GHES GraphQL endpoints to their `/api/v3` REST base URL (#602).

--- a/packages/cli/src/github/client.test.ts
+++ b/packages/cli/src/github/client.test.ts
@@ -24,6 +24,18 @@ describe("deriveGitHubRestApiUrl", () => {
       "https://github.example/api/v3"
     );
   });
+
+  it("preserves a GHES subpath when mapping /api/graphql to /api/v3", () => {
+    expect(
+      deriveGitHubRestApiUrl("https://github.example/gh/api/graphql")
+    ).toBe("https://github.example/gh/api/v3");
+  });
+
+  it("preserves an existing GHES /api/v3/graphql endpoint", () => {
+    expect(
+      deriveGitHubRestApiUrl("https://github.example/gh/api/v3/graphql")
+    ).toBe("https://github.example/gh/api/v3");
+  });
 });
 
 describe("discoverUserProjects", () => {

--- a/packages/cli/src/github/client.ts
+++ b/packages/cli/src/github/client.ts
@@ -151,14 +151,13 @@ export function deriveGitHubRestApiUrl(graphqlApiUrl: string): string {
     if (url.hostname.toLowerCase() === "api.github.com") {
       return REST_API_URL;
     }
-    if (normalizedPath === "/api/graphql") {
-      url.pathname = "/api/v3";
-      url.search = "";
-      url.hash = "";
-      return url.toString().replace(/\/$/, "");
-    }
     if (normalizedPath.endsWith("/graphql")) {
-      url.pathname = normalizedPath.slice(0, -"/graphql".length) || "/";
+      const pathSegments = normalizedPath.split("/").filter(Boolean);
+      pathSegments.pop();
+      if (pathSegments.at(-1) === "api") {
+        pathSegments.push("v3");
+      }
+      url.pathname = `/${pathSegments.join("/")}`;
       url.search = "";
       url.hash = "";
       return url.toString().replace(/\/$/, "");


### PR DESCRIPTION
## TL;DR

Align the CLI's GHES REST endpoint mapping with the tracker adapter for subpath-hosted GitHub Enterprise Server instances.

## Change-point diagram

`GHES GraphQL URL` → `deriveGitHubRestApiUrl` → `GHES REST base URL` → repository and token REST requests

## Start here

- `packages/cli/src/github/client.ts` contains endpoint normalization.
- `packages/cli/src/github/client.test.ts` covers public GitHub, canonical GHES, subpath-hosted GHES, and existing `/api/v3/graphql` URLs.

## Risks & rollback

The mapping changes only the REST base derived from custom GraphQL endpoints. Revert this change to restore the prior URL derivation.

## Changed files

- `packages/cli/src/github/client.ts`
- `packages/cli/src/github/client.test.ts`
- `.changeset/quiet-ghes-subpath.md`

## Issues — Closed #602

Fixes #602

## Evidence

- `pnpm --filter @gh-symphony/cli test -- client.test.ts` — passed (7 tests).
- `pnpm lint` — passed.
- `pnpm build` — passed.
- `pnpm test` — passed after building workspace package entrypoints.
- `pnpm typecheck` — passed.

## Post-merge / human validation

- [ ] Verify CLI repository validation against a subpath-hosted GHES instance, if available.
