### PR TITLE
fix(orchestrator): guard worker lifecycle ownership

### DIFF
--- a/.changeset/owner-liveness-recovery.md
+++ b/.changeset/owner-liveness-recovery.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Fix #639 by preserving live foreign workers during reconciliation while allowing dead-owner and legacy runs to recover safely.

--- a/packages/cli/src/commands/logs.test.ts
+++ b/packages/cli/src/commands/logs.test.ts
@@ -353,7 +353,7 @@ describe("logs command", () => {
         issueIdentifier: "acme/platform#4",
         issueId: "issue-4",
         operation: "signal",
-        reason: "owner-token-mismatch",
+        reason: "owner-alive",
       },
     ]);
     const stdout = captureWrites(process.stdout);
@@ -375,7 +375,7 @@ describe("logs command", () => {
       "run-finalization-deferred acme/platform#3 Finalization deferred 2/3 (tracker-read-failed)"
     );
     expect(output).toContain(
-      "run-ownership-skipped acme/platform#4 Skipped signal (owner-token-mismatch)"
+      "run-ownership-skipped acme/platform#4 Skipped signal (owner-alive)"
     );
     expect(output).not.toContain("hook-failed");
   });

--- a/packages/cli/src/commands/logs.test.ts
+++ b/packages/cli/src/commands/logs.test.ts
@@ -345,6 +345,16 @@ describe("logs command", () => {
         maxDeferrals: 3,
         exhausted: false,
       },
+      {
+        at: "2026-03-16T00:03:00.000Z",
+        event: "run-ownership-skipped",
+        projectId: "tenant-a",
+        runId: "run-1",
+        issueIdentifier: "acme/platform#4",
+        issueId: "issue-4",
+        operation: "signal",
+        reason: "owner-token-mismatch",
+      },
     ]);
     const stdout = captureWrites(process.stdout);
 
@@ -363,6 +373,9 @@ describe("logs command", () => {
     expect(output).toContain("run-suppressed acme/platform#2");
     expect(output).toContain(
       "run-finalization-deferred acme/platform#3 Finalization deferred 2/3 (tracker-read-failed)"
+    );
+    expect(output).toContain(
+      "run-ownership-skipped acme/platform#4 Skipped signal (owner-token-mismatch)"
     );
     expect(output).not.toContain("hook-failed");
   });

--- a/packages/cli/src/commands/logs.ts
+++ b/packages/cli/src/commands/logs.ts
@@ -241,6 +241,7 @@ function getLevel(event: LoggedEvent): LogLevel {
     case "run-suppressed":
     case "run-retried":
     case "run-finalization-deferred":
+    case "run-ownership-skipped":
       return "warn";
     default:
       return "info";

--- a/packages/cli/src/commands/start.test.ts
+++ b/packages/cli/src/commands/start.test.ts
@@ -768,6 +768,12 @@ describe("start command foreground locking", () => {
       activeProject: "tenant-a",
       projects: [createProject("tenant-a", "acme", "platform")],
     });
+    acquireProjectLock.mockResolvedValue({
+      lockPath: join(configDir, ".lock"),
+      ownerToken: "owner",
+      pid: 1234,
+      startedAt: "2026-03-17T00:00:00.000Z",
+    });
     run.mockResolvedValue(undefined);
 
     await startModule.default([], {

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -985,6 +985,7 @@ const handler = async (
     const service = new OrchestratorService(store, projectConfig, {
       logLevel,
       assignedOnly: parsed.assignedOnly,
+      ownerToken: projectLock.ownerToken,
       onTick: async (snapshot) => {
         try {
           if (authShutdownRequested) {

--- a/packages/core/src/contracts/status-surface.ts
+++ b/packages/core/src/contracts/status-surface.ts
@@ -233,6 +233,8 @@ export type OrchestratorRunRecord = {
   processId: number | null;
   /** Stable process start-time identity used to reject PID reuse. */
   processIdentity?: string | null;
+  /** Project-lock owner identity of the orchestrator instance that spawned this run. */
+  ownerInstanceId?: string | null;
   port: number | null;
   workingDirectory: string;
   issueWorkspaceKey: string | null;

--- a/packages/core/src/observability/event-formatter.test.ts
+++ b/packages/core/src/observability/event-formatter.test.ts
@@ -62,6 +62,19 @@ describe("event-formatter", () => {
 
     expect(
       formatEventMessage({
+        at: "2026-03-16T00:01:30.000Z",
+        event: "run-ownership-skipped",
+        projectId: "project-1",
+        runId: "run-1",
+        issueIdentifier: "acme/repo#1",
+        issueId: "issue-1",
+        operation: "signal",
+        reason: "owner-token-mismatch",
+      })
+    ).toBe("Skipped signal (owner-token-mismatch)");
+
+    expect(
+      formatEventMessage({
         at: "2026-03-16T00:02:00.000Z",
         event: "workspace-cleanup",
         workspaceKey: "workspace-2",

--- a/packages/core/src/observability/event-formatter.test.ts
+++ b/packages/core/src/observability/event-formatter.test.ts
@@ -69,9 +69,9 @@ describe("event-formatter", () => {
         issueIdentifier: "acme/repo#1",
         issueId: "issue-1",
         operation: "signal",
-        reason: "owner-token-mismatch",
+        reason: "owner-alive",
       })
-    ).toBe("Skipped signal (owner-token-mismatch)");
+    ).toBe("Skipped signal (owner-alive)");
 
     expect(
       formatEventMessage({

--- a/packages/core/src/observability/event-formatter.ts
+++ b/packages/core/src/observability/event-formatter.ts
@@ -30,6 +30,8 @@ export function formatEventMessage(event: OrchestratorEvent): string | null {
       return event.lastError;
     case "run-suppressed":
       return event.reason;
+    case "run-ownership-skipped":
+      return `Skipped ${event.operation} (${event.reason})`;
     case "convergence-lock-expired":
       return `Convergence lock expired after ${event.ttlMs}ms`;
     case "recovery-quarantined":

--- a/packages/core/src/observability/structured-events.ts
+++ b/packages/core/src/observability/structured-events.ts
@@ -119,6 +119,17 @@ export type RunSuppressedEvent = {
   reason: string;
 };
 
+export type RunOwnershipSkippedEvent = {
+  at: string;
+  event: "run-ownership-skipped";
+  projectId: string;
+  runId: string;
+  issueIdentifier: string;
+  issueId: string;
+  operation: "signal" | "claim-release" | "workspace-cleanup";
+  reason: "owner-token-missing" | "owner-token-mismatch";
+};
+
 export type RunFinalizationDeferredEvent = {
   at: string;
   event: "run-finalization-deferred";
@@ -306,6 +317,7 @@ export type OrchestratorEvent =
   | RunRetriedEvent
   | RunFailedEvent
   | RunSuppressedEvent
+  | RunOwnershipSkippedEvent
   | RunFinalizationDeferredEvent
   | ConvergenceLockExpiredEvent
   | RecoveryQuarantinedEvent

--- a/packages/core/src/observability/structured-events.ts
+++ b/packages/core/src/observability/structured-events.ts
@@ -127,7 +127,7 @@ export type RunOwnershipSkippedEvent = {
   issueIdentifier: string;
   issueId: string;
   operation: "signal" | "claim-release" | "workspace-cleanup";
-  reason: "owner-token-missing" | "owner-token-mismatch";
+  reason: "owner-alive";
 };
 
 export type RunFinalizationDeferredEvent = {

--- a/packages/orchestrator/src/index.test.ts
+++ b/packages/orchestrator/src/index.test.ts
@@ -9,6 +9,7 @@ import type { OrchestratorService } from "./service.js";
 
 function createMockService(): OrchestratorService {
   return {
+    setOwnerToken: vi.fn(),
     run: vi.fn().mockResolvedValue(undefined),
     runOnce: vi.fn().mockResolvedValue({
       projectId: "tenant-1",

--- a/packages/orchestrator/src/index.test.ts
+++ b/packages/orchestrator/src/index.test.ts
@@ -409,6 +409,22 @@ describe("orchestrator CLI", () => {
     }
   );
 
+  it.each(["run", "run-once", "dispatch", "recover"])(
+    "assigns a process-scoped owner token for an unscoped %s mutation",
+    async (command) => {
+      const runtimeRoot = await mkdtemp(join(tmpdir(), "orchestrator-cli-"));
+      const service = createMockService();
+
+      await runCli([command, "--runtime-root", runtimeRoot], {
+        createService: () => service,
+      });
+
+      expect(service.setOwnerToken).toHaveBeenCalledWith(
+        expect.stringMatching(new RegExp(`^${process.pid}:`))
+      );
+    }
+  );
+
   it("rejects a concurrent run-once while another mutation owns the lease", async () => {
     const runtimeRoot = await mkdtemp(join(tmpdir(), "orchestrator-cli-"));
     const firstService = createMockService();

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -114,6 +114,7 @@ export async function runCli(
       projectId: parsed.projectId,
     });
     try {
+      service.setOwnerToken(lock.ownerToken);
       return await action();
     } finally {
       await (dependencies.releaseLock ?? releaseProjectLock)(lock);
@@ -176,6 +177,7 @@ export async function runCli(
             runtimeRoot,
             projectId: parsed.projectId,
           });
+          service.setOwnerToken(lock.ownerToken);
         }
 
         signalTarget.once("SIGINT", sigintHandler);

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { pathToFileURL } from "node:url";
 import { resolve } from "node:path";
 import { formatErrorForTerminal, hasVerboseFlag } from "@gh-symphony/core";
@@ -102,10 +103,14 @@ export async function runCli(
   const stdout = dependencies.stdout ?? process.stdout;
   const exitProcess = dependencies.exitProcess ?? process.exit;
   const signalTarget = dependencies.signalTarget ?? process;
+  const setUnscopedOwnerToken = (): void => {
+    service.setOwnerToken(`${process.pid}:${randomUUID()}`);
+  };
   const withProjectMutationLock = async <T>(
     action: () => Promise<T>
   ): Promise<T> => {
     if (!parsed.projectId) {
+      setUnscopedOwnerToken();
       return action();
     }
 
@@ -178,6 +183,8 @@ export async function runCli(
             projectId: parsed.projectId,
           });
           service.setOwnerToken(lock.ownerToken);
+        } else {
+          setUnscopedOwnerToken();
         }
 
         signalTarget.once("SIGINT", sigintHandler);

--- a/packages/orchestrator/src/lock.test.ts
+++ b/packages/orchestrator/src/lock.test.ts
@@ -14,11 +14,32 @@ import {
   acquireProjectLock,
   getProcessCwd,
   getProcessStartIdentity,
+  isProcessRunning,
   releaseProjectLock,
   renewProjectLock,
 } from "./lock.js";
 
 describe("project lock", () => {
+  it("treats only ESRCH as a non-running process probe", () => {
+    const kill = vi.spyOn(process, "kill");
+    kill.mockImplementation(() => {
+      const error = new Error(
+        "operation not permitted"
+      ) as NodeJS.ErrnoException;
+      error.code = "EPERM";
+      throw error;
+    });
+    expect(isProcessRunning(4321)).toBe(true);
+
+    kill.mockImplementation(() => {
+      const error = new Error("no such process") as NodeJS.ErrnoException;
+      error.code = "ESRCH";
+      throw error;
+    });
+    expect(isProcessRunning(4321)).toBe(false);
+    kill.mockRestore();
+  });
+
   it("resolves the current process working directory", () => {
     expect(getProcessCwd(process.pid)).toBe(resolve(process.cwd()));
     expect(getProcessStartIdentity(process.pid)).not.toBeNull();

--- a/packages/orchestrator/src/lock.ts
+++ b/packages/orchestrator/src/lock.ts
@@ -457,7 +457,7 @@ export function getProcessCwd(pid: number): string | null {
   }
 }
 
-function isProcessRunning(pid: number): boolean {
+export function isProcessRunning(pid: number): boolean {
   try {
     process.kill(pid, 0);
     return true;

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -1,4 +1,4 @@
-import { execSync } from "node:child_process";
+import { execSync, spawn as spawnChild } from "node:child_process";
 import { EventEmitter } from "node:events";
 import { readFileSync } from "node:fs";
 import {
@@ -67,6 +67,7 @@ describe("OrchestratorService", () => {
         ownerToken: "4102:instance-b",
         killImpl,
         isProcessRunning: vi.fn().mockReturnValue(true),
+        isOwnerProcessRunning: vi.fn().mockReturnValue(true),
         getProcessStartIdentity: vi.fn().mockReturnValue("worker-current"),
       }
     );
@@ -95,7 +96,7 @@ describe("OrchestratorService", () => {
       expect.objectContaining({
         event: "run-ownership-skipped",
         operation: "signal",
-        reason: "owner-token-mismatch",
+        reason: "owner-alive",
       })
     );
 
@@ -127,7 +128,7 @@ describe("OrchestratorService", () => {
       expect.objectContaining({
         event: "run-ownership-skipped",
         operation: "claim-release",
-        reason: "owner-token-mismatch",
+        reason: "owner-alive",
       })
     );
 
@@ -144,12 +145,15 @@ describe("OrchestratorService", () => {
   it("recovers dead-owner and legacy runs without signalling a live foreign owner", async () => {
     const killImpl = vi.fn();
     const service = new OrchestratorService(
-      { appendRunEvent: vi.fn().mockResolvedValue(undefined) } as unknown as OrchestratorFsStore,
+      {
+        appendRunEvent: vi.fn().mockResolvedValue(undefined),
+      } as unknown as OrchestratorFsStore,
       {} as OrchestratorProjectConfig,
       {
         ownerToken: "5100:current",
         killImpl,
         isProcessRunning: (pid) => pid === 5101,
+        isOwnerProcessRunning: () => false,
         getProcessStartIdentity: vi.fn().mockReturnValue("worker-current"),
       }
     );
@@ -175,6 +179,40 @@ describe("OrchestratorService", () => {
     run.ownerInstanceId = null;
     await expect(signalRunProcess(run, "SIGTERM")).resolves.toBe("signaled");
     expect(killImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("protects a live foreign owner with the default direct-PID probe", async () => {
+    const child = spawnChild(process.execPath, [
+      "-e",
+      "setInterval(() => {}, 1000)",
+    ]);
+    await new Promise<void>((resolve, reject) => {
+      child.once("spawn", () => resolve());
+      child.once("error", reject);
+    });
+    try {
+      const service = new OrchestratorService(
+        {
+          appendRunEvent: vi.fn().mockResolvedValue(undefined),
+        } as unknown as OrchestratorFsStore,
+        {} as OrchestratorProjectConfig,
+        { ownerToken: "5200:current" }
+      );
+      const isRunProtectedByLiveOwner = (
+        service as unknown as {
+          isRunProtectedByLiveOwner(run: OrchestratorRunRecord): boolean;
+        }
+      ).isRunProtectedByLiveOwner.bind(service);
+
+      expect(
+        isRunProtectedByLiveOwner({
+          ownerInstanceId: `${child.pid}:foreign`,
+        } as OrchestratorRunRecord)
+      ).toBe(true);
+    } finally {
+      child.kill();
+      await new Promise<void>((resolve) => child.once("exit", () => resolve()));
+    }
   });
 
   it("gives confirmed tracker progress a bounded clean-exit grace", () => {
@@ -8626,6 +8664,7 @@ Prefer focused changes.
       killImpl,
       ownerToken: "4108:current-owner",
       isProcessRunning: (pid) => pid === 4106 || pid === 4107,
+      isOwnerProcessRunning: (pid) => pid === 4107,
       now: () => new Date("2026-03-08T00:05:00.000Z"),
     });
 
@@ -8642,7 +8681,7 @@ Prefer focused changes.
       expect.arrayContaining([
         expect.objectContaining({
           event: "run-ownership-skipped",
-          message: "Skipped signal (owner-token-mismatch)",
+          message: "Skipped signal (owner-alive)",
         }),
       ])
     );
@@ -12350,6 +12389,49 @@ Handle Linear issue.`,
       remaining: 1496,
       resource: "graphql",
     });
+  });
+
+  it("releases a non-actionable claim when its run record is missing", async () => {
+    process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
+    const tempRoot = await mkdtemp(
+      join(tmpdir(), "orchestrator-missing-run-reconciliation-")
+    );
+    const repository = await createRepositoryFixture(
+      tempRoot,
+      "acme",
+      "platform"
+    );
+    const store = new OrchestratorFsStore(tempRoot);
+    const projectConfig = createProjectConfig(tempRoot, repository);
+    await store.saveProjectConfig(projectConfig);
+    await store.saveProjectIssueOrchestrations("tenant-1", [
+      {
+        issueId: "issue-1",
+        identifier: "acme/platform#1",
+        workspaceKey: "acme_platform_1",
+        completedOnce: false,
+        failureRetryCount: 0,
+        state: "claimed",
+        currentRunId: null,
+        retryEntry: null,
+        updatedAt: "2026-03-08T00:00:00.000Z",
+      },
+    ]);
+
+    const service = new OrchestratorService(store, projectConfig, {
+      fetchImpl: vi
+        .fn()
+        .mockResolvedValue(
+          createTrackerResponseWithState(repository, "Done")
+        ) as never,
+      now: () => new Date("2026-03-08T00:05:00.000Z"),
+    });
+
+    await service.runOnce();
+
+    expect(
+      (await store.loadProjectIssueOrchestrations("tenant-1"))[0]
+    ).toMatchObject({ state: "released", currentRunId: null });
   });
 
   it("stops active runs when the tracker issue is deleted or moved out of scope", async () => {

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -12476,6 +12476,87 @@ Handle Linear issue.`,
     ).toMatchObject({ state: "released", currentRunId: null });
   });
 
+  it("releases a non-actionable claim whose worker process is dead", async () => {
+    process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
+    const tempRoot = await mkdtemp(
+      join(tmpdir(), "orchestrator-dead-worker-release-")
+    );
+    const repository = await createRepositoryFixture(
+      tempRoot,
+      "acme",
+      "platform"
+    );
+    const store = new OrchestratorFsStore(tempRoot);
+    const projectConfig = createProjectConfig(tempRoot, repository);
+    await store.saveProjectConfig(projectConfig);
+    await store.saveProjectIssueOrchestrations("tenant-1", [
+      {
+        issueId: "issue-1",
+        identifier: "acme/platform#1",
+        workspaceKey: "acme_platform_1",
+        completedOnce: false,
+        failureRetryCount: 0,
+        state: "claimed",
+        currentRunId: "run-1",
+        retryEntry: null,
+        updatedAt: "2026-03-08T00:00:00.000Z",
+      },
+    ]);
+    await store.saveRun({
+      runId: "run-1",
+      projectId: "tenant-1",
+      projectSlug: "tenant-1",
+      issueId: "issue-1",
+      issueSubjectId: "issue-1",
+      issueIdentifier: "acme/platform#1",
+      issueState: "Todo",
+      repository,
+      status: "running",
+      attempt: 1,
+      processId: 999001,
+      processIdentity: "worker-x",
+      ownerInstanceId: "4100:instance-a",
+      port: 4601,
+      workingDirectory: join(tempRoot, "active-run"),
+      issueWorkspaceKey: "acme_platform_1",
+      workspaceRuntimeDir: join(tempRoot, "active-run", "workspace-runtime"),
+      workflowPath: null,
+      createdAt: "2026-03-08T00:00:00.000Z",
+      updatedAt: "2026-03-08T00:00:00.000Z",
+      startedAt: "2026-03-08T00:00:00.000Z",
+      completedAt: null,
+      lastError: null,
+    } as OrchestratorRunRecord);
+
+    const killImpl = vi.fn();
+    const service = new OrchestratorService(store, projectConfig, {
+      fetchImpl: vi
+        .fn()
+        .mockResolvedValue(
+          createTrackerResponseWithState(repository, "Done")
+        ) as never,
+      spawnImpl: vi.fn() as never,
+      killImpl,
+      ownerToken: "4200:instance-b",
+      isProcessRunning: () => false,
+      isOwnerProcessRunning: () => false,
+      now: () => new Date("2026-03-08T00:05:00.000Z"),
+    });
+
+    for (let tick = 0; tick < 4; tick += 1) {
+      await service.runOnce();
+    }
+
+    expect(killImpl).not.toHaveBeenCalled();
+    expect(
+      (await store.loadProjectIssueOrchestrations("tenant-1"))[0]
+    ).toMatchObject({ state: "released", currentRunId: null });
+    expect(await store.loadRun("run-1")).toMatchObject({
+      status: "suppressed",
+      runPhase: "canceled_by_reconciliation",
+    });
+  });
+
   it("stops active runs when the tracker issue is deleted or moved out of scope", async () => {
     process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
     const tempRoot = await mkdtemp(

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -64,7 +64,7 @@ describe("OrchestratorService", () => {
       { appendRunEvent } as unknown as OrchestratorFsStore,
       {} as OrchestratorProjectConfig,
       {
-        ownerToken: "instance-b",
+        ownerToken: "4102:instance-b",
         killImpl,
         isProcessRunning: vi.fn().mockReturnValue(true),
         getProcessStartIdentity: vi.fn().mockReturnValue("worker-current"),
@@ -75,7 +75,7 @@ describe("OrchestratorService", () => {
         signalRunProcess(
           run: OrchestratorRunRecord,
           signal: NodeJS.Signals
-        ): Promise<boolean>;
+        ): Promise<"signaled" | "not-running" | "protected">;
       }
     ).signalRunProcess.bind(service);
     const run = {
@@ -85,10 +85,10 @@ describe("OrchestratorService", () => {
       issueIdentifier: "acme/platform#1",
       processId: 4101,
       processIdentity: "worker-current",
-      ownerInstanceId: "instance-a",
+      ownerInstanceId: "4100:instance-a",
     } as OrchestratorRunRecord;
 
-    await expect(signalRunProcess(run, "SIGTERM")).resolves.toBe(false);
+    await expect(signalRunProcess(run, "SIGTERM")).resolves.toBe("protected");
     expect(killImpl).not.toHaveBeenCalled();
     expect(appendRunEvent).toHaveBeenCalledWith(
       "run-1",
@@ -131,14 +131,50 @@ describe("OrchestratorService", () => {
       })
     );
 
-    run.ownerInstanceId = "instance-b";
+    run.ownerInstanceId = "4102:instance-b";
     run.processIdentity = "worker-reused";
-    await expect(signalRunProcess(run, "SIGTERM")).resolves.toBe(false);
+    await expect(signalRunProcess(run, "SIGTERM")).resolves.toBe("not-running");
     expect(killImpl).not.toHaveBeenCalled();
 
     run.processIdentity = "worker-current";
-    await expect(signalRunProcess(run, "SIGTERM")).resolves.toBe(true);
+    await expect(signalRunProcess(run, "SIGTERM")).resolves.toBe("signaled");
     expect(killImpl).toHaveBeenCalledWith(4101, "SIGTERM");
+  });
+
+  it("recovers dead-owner and legacy runs without signalling a live foreign owner", async () => {
+    const killImpl = vi.fn();
+    const service = new OrchestratorService(
+      { appendRunEvent: vi.fn().mockResolvedValue(undefined) } as unknown as OrchestratorFsStore,
+      {} as OrchestratorProjectConfig,
+      {
+        ownerToken: "5100:current",
+        killImpl,
+        isProcessRunning: (pid) => pid === 5101,
+        getProcessStartIdentity: vi.fn().mockReturnValue("worker-current"),
+      }
+    );
+    const signalRunProcess = (
+      service as unknown as {
+        signalRunProcess(
+          run: OrchestratorRunRecord,
+          signal: NodeJS.Signals
+        ): Promise<"signaled" | "not-running" | "protected">;
+      }
+    ).signalRunProcess.bind(service);
+    const run = {
+      runId: "run-1",
+      projectId: "tenant-1",
+      issueId: "issue-1",
+      issueIdentifier: "acme/platform#1",
+      processId: 5101,
+      processIdentity: "worker-current",
+      ownerInstanceId: "5102:dead-owner",
+    } as OrchestratorRunRecord;
+
+    await expect(signalRunProcess(run, "SIGTERM")).resolves.toBe("signaled");
+    run.ownerInstanceId = null;
+    await expect(signalRunProcess(run, "SIGTERM")).resolves.toBe("signaled");
+    expect(killImpl).toHaveBeenCalledTimes(2);
   });
 
   it("gives confirmed tracker progress a bounded clean-exit grace", () => {
@@ -8516,7 +8552,7 @@ Prefer focused changes.
     expect(loadRetryPolicySpy).toHaveBeenCalled();
   });
 
-  it("terminates a running worker when lastEventAt exceeds the workflow stall timeout", async () => {
+  it("does not retry a stalled worker protected by a live foreign owner", async () => {
     process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
     const tempRoot = await mkdtemp(join(tmpdir(), "orchestrator-stall-"));
     const repository = await createRepositoryFixture(
@@ -8557,6 +8593,7 @@ Prefer focused changes.
       status: "running",
       attempt: 1,
       processId: 4106,
+      ownerInstanceId: "4107:foreign-owner",
       port: 4601,
       workingDirectory: join(tempRoot, "active-run"),
       issueWorkspaceKey: null,
@@ -8587,17 +8624,28 @@ Prefer focused changes.
         unref: vi.fn(),
       }) as never,
       killImpl,
-      isProcessRunning: (pid) => pid === 4106,
+      ownerToken: "4108:current-owner",
+      isProcessRunning: (pid) => pid === 4106 || pid === 4107,
       now: () => new Date("2026-03-08T00:05:00.000Z"),
     });
 
     await service.runOnce();
     const updatedRun = await store.loadRun("run-1");
 
-    expect(killImpl).toHaveBeenCalledWith(4106, "SIGTERM");
-    expect(updatedRun?.status).toBe("retrying");
-    expect(updatedRun?.nextRetryAt).toBe("2026-03-08T00:05:01.000Z");
-    expect(updatedRun?.retryKind).toBe("continuation");
+    expect(killImpl).not.toHaveBeenCalled();
+    expect(updatedRun?.status).toBe("running");
+    expect(updatedRun?.nextRetryAt).toBeNull();
+    expect(updatedRun?.retryKind).toBeNull();
+    expect(
+      await store.loadRecentRunEvents("run-1", 10, "tenant-1")
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          event: "run-ownership-skipped",
+          message: "Skipped signal (owner-token-mismatch)",
+        }),
+      ])
+    );
   });
 
   it("formats stall detection as a structured verbose log when enabled", async () => {
@@ -12384,10 +12432,10 @@ Handle Linear issue.`,
     expect(
       (
         service as unknown as {
-          isRunOwnedByCurrentInstance(run: OrchestratorRunRecord): boolean;
+          isRunProtectedByLiveOwner(run: OrchestratorRunRecord): boolean;
         }
-      ).isRunOwnedByCurrentInstance((await store.loadRun("run-1"))!)
-    ).toBe(true);
+      ).isRunProtectedByLiveOwner((await store.loadRun("run-1"))!)
+    ).toBe(false);
 
     const snapshot = await service.runOnce();
     const updatedRun = await store.loadRun("run-1");

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -12423,7 +12423,6 @@ Handle Linear issue.`,
       now: () => new Date("2026-03-08T00:05:00.000Z"),
       killImpl,
       isProcessRunning: vi.fn().mockReturnValue(true),
-      ownerInstanceId: "owner-a",
     });
     service.setOwnerToken("owner-a");
     expect(await store.loadRun("run-1")).toMatchObject({

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -57,6 +57,90 @@ describe("OrchestratorService", () => {
     expect(clampPollInterval(30_000)).toBe(30_000);
   });
 
+  it("guards worker signals by owner and process identity", async () => {
+    const appendRunEvent = vi.fn().mockResolvedValue(undefined);
+    const killImpl = vi.fn();
+    const service = new OrchestratorService(
+      { appendRunEvent } as unknown as OrchestratorFsStore,
+      {} as OrchestratorProjectConfig,
+      {
+        ownerToken: "instance-b",
+        killImpl,
+        isProcessRunning: vi.fn().mockReturnValue(true),
+        getProcessStartIdentity: vi.fn().mockReturnValue("worker-current"),
+      }
+    );
+    const signalRunProcess = (
+      service as unknown as {
+        signalRunProcess(
+          run: OrchestratorRunRecord,
+          signal: NodeJS.Signals
+        ): Promise<boolean>;
+      }
+    ).signalRunProcess.bind(service);
+    const run = {
+      runId: "run-1",
+      projectId: "tenant-1",
+      issueId: "issue-1",
+      issueIdentifier: "acme/platform#1",
+      processId: 4101,
+      processIdentity: "worker-current",
+      ownerInstanceId: "instance-a",
+    } as OrchestratorRunRecord;
+
+    await expect(signalRunProcess(run, "SIGTERM")).resolves.toBe(false);
+    expect(killImpl).not.toHaveBeenCalled();
+    expect(appendRunEvent).toHaveBeenCalledWith(
+      "run-1",
+      expect.objectContaining({
+        event: "run-ownership-skipped",
+        operation: "signal",
+        reason: "owner-token-mismatch",
+      })
+    );
+
+    const releaseRunIssueOrchestration = (
+      service as unknown as {
+        releaseRunIssueOrchestration(
+          issueRecords: IssueOrchestrationRecord[],
+          run: OrchestratorRunRecord,
+          now: Date
+        ): Promise<IssueOrchestrationRecord[]>;
+      }
+    ).releaseRunIssueOrchestration.bind(service);
+    const issueRecords = [
+      {
+        issueId: "issue-1",
+        identifier: "acme/platform#1",
+        workspaceKey: "workspace-1",
+        state: "running",
+        currentRunId: "run-1",
+        retryEntry: null,
+        updatedAt: "2026-08-26T00:00:00.000Z",
+      },
+    ];
+    await expect(
+      releaseRunIssueOrchestration(issueRecords, run, new Date())
+    ).resolves.toEqual(issueRecords);
+    expect(appendRunEvent).toHaveBeenCalledWith(
+      "run-1",
+      expect.objectContaining({
+        event: "run-ownership-skipped",
+        operation: "claim-release",
+        reason: "owner-token-mismatch",
+      })
+    );
+
+    run.ownerInstanceId = "instance-b";
+    run.processIdentity = "worker-reused";
+    await expect(signalRunProcess(run, "SIGTERM")).resolves.toBe(false);
+    expect(killImpl).not.toHaveBeenCalled();
+
+    run.processIdentity = "worker-current";
+    await expect(signalRunProcess(run, "SIGTERM")).resolves.toBe(true);
+    expect(killImpl).toHaveBeenCalledWith(4101, "SIGTERM");
+  });
+
   it("gives confirmed tracker progress a bounded clean-exit grace", () => {
     const run = {
       issueState: "Done",
@@ -12258,6 +12342,7 @@ Handle Linear issue.`,
       status: "running",
       attempt: 1,
       processId: 4208,
+      ownerInstanceId: "owner-a",
       port: 4603,
       workingDirectory: join(tempRoot, "active-run"),
       issueWorkspaceKey: null,
@@ -12290,7 +12375,19 @@ Handle Linear issue.`,
       now: () => new Date("2026-03-08T00:05:00.000Z"),
       killImpl,
       isProcessRunning: vi.fn().mockReturnValue(true),
+      ownerInstanceId: "owner-a",
     });
+    service.setOwnerToken("owner-a");
+    expect(await store.loadRun("run-1")).toMatchObject({
+      ownerInstanceId: "owner-a",
+    });
+    expect(
+      (
+        service as unknown as {
+          isRunOwnedByCurrentInstance(run: OrchestratorRunRecord): boolean;
+        }
+      ).isRunOwnedByCurrentInstance((await store.loadRun("run-1"))!)
+    ).toBe(true);
 
     const snapshot = await service.runOnce();
     const updatedRun = await store.loadRun("run-1");

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -482,29 +482,63 @@ describe("OrchestratorService", () => {
 
   it("queues a non-exhausted restart failure with backoff", async () => {
     const now = new Date("2026-03-08T00:00:00.000Z");
-    const tempRoot = await mkdtemp(join(tmpdir(), "orchestrator-restart-backoff-"));
-    const repository = await createRepositoryFixture(tempRoot, "acme", "platform", {
-      maxFailureRetries: 3,
-      retryBaseDelayMs: 1000,
-      retryMaxDelayMs: 1000,
-    });
+    const tempRoot = await mkdtemp(
+      join(tmpdir(), "orchestrator-restart-backoff-")
+    );
+    const repository = await createRepositoryFixture(
+      tempRoot,
+      "acme",
+      "platform",
+      {
+        maxFailureRetries: 3,
+        retryBaseDelayMs: 1000,
+        retryMaxDelayMs: 1000,
+      }
+    );
     const store = new OrchestratorFsStore(tempRoot);
     const projectConfig = createProjectConfig(tempRoot, repository);
     const run = {
-      runId: "run-retry", projectId: "tenant-1", projectSlug: "tenant-1",
-      issueId: "retry-issue", issueSubjectId: "retry-issue", issueIdentifier: "acme/platform#1",
-      issueState: "Todo", repository, status: "retrying", attempt: 2, processId: null,
-      port: 4601, workingDirectory: tempRoot, issueWorkspaceKey: "retry-issue",
-      workspaceRuntimeDir: tempRoot, workflowPath: null, retryKind: "failure",
-      createdAt: now.toISOString(), updatedAt: now.toISOString(), startedAt: now.toISOString(),
-      completedAt: null, lastError: "Worker process exited unexpectedly.", nextRetryAt: now.toISOString(),
-    } as OrchestratorRunRecord;
-    const issueRecords = [{
-      issueId: "retry-issue", identifier: "acme/platform#1", workspaceKey: "retry-issue",
-      completedOnce: false, failureRetryCount: 1, state: "running" as const,
-      currentRunId: run.runId, retryEntry: { attempt: 2, dueAt: now.toISOString(), error: run.lastError },
+      runId: "run-retry",
+      projectId: "tenant-1",
+      projectSlug: "tenant-1",
+      issueId: "retry-issue",
+      issueSubjectId: "retry-issue",
+      issueIdentifier: "acme/platform#1",
+      issueState: "Todo",
+      repository,
+      status: "retrying",
+      attempt: 2,
+      processId: null,
+      port: 4601,
+      workingDirectory: tempRoot,
+      issueWorkspaceKey: "retry-issue",
+      workspaceRuntimeDir: tempRoot,
+      workflowPath: null,
+      retryKind: "failure",
+      createdAt: now.toISOString(),
       updatedAt: now.toISOString(),
-    }];
+      startedAt: now.toISOString(),
+      completedAt: null,
+      lastError: "Worker process exited unexpectedly.",
+      nextRetryAt: now.toISOString(),
+    } as OrchestratorRunRecord;
+    const issueRecords = [
+      {
+        issueId: "retry-issue",
+        identifier: "acme/platform#1",
+        workspaceKey: "retry-issue",
+        completedOnce: false,
+        failureRetryCount: 1,
+        state: "running" as const,
+        currentRunId: run.runId,
+        retryEntry: {
+          attempt: 2,
+          dueAt: now.toISOString(),
+          error: run.lastError,
+        },
+        updatedAt: now.toISOString(),
+      },
+    ];
     await store.saveProjectIssueOrchestrations("tenant-1", issueRecords);
     vi.spyOn(trackerAdapters, "resolveTrackerAdapter").mockReturnValue({
       reviveIssue: vi.fn().mockReturnValue({}),
@@ -518,16 +552,26 @@ describe("OrchestratorService", () => {
     );
 
     const outcome = await (service as never).restartRun(
-      projectConfig, run, issueRecords, now
+      projectConfig,
+      run,
+      issueRecords,
+      now
     );
 
     expect(outcome.recovered).toBe(false);
-    expect(outcome.issueRecords).toEqual(expect.arrayContaining([
-      expect.objectContaining({
-        issueId: "retry-issue", state: "retry_queued", failureRetryCount: 2,
-        retryEntry: expect.objectContaining({ attempt: 3, dueAt: "2026-03-08T00:00:01.000Z" }),
-      }),
-    ]));
+    expect(outcome.issueRecords).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          issueId: "retry-issue",
+          state: "retry_queued",
+          failureRetryCount: 2,
+          retryEntry: expect.objectContaining({
+            attempt: 3,
+            dueAt: "2026-03-08T00:00:01.000Z",
+          }),
+        }),
+      ])
+    );
   });
 
   it("suppresses an exhausted restart failure and dispatches healthy candidates", async () => {
@@ -5095,7 +5139,7 @@ Prefer focused changes.
     });
   });
 
-  it("releases due retrying runs when a Todo issue becomes blocked before restart", async () => {
+  it("releases a non-running retrying run when its issue becomes non-actionable", async () => {
     process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
     const tempRoot = await mkdtemp(
       join(tmpdir(), "orchestrator-retry-blocked-release-")
@@ -8675,9 +8719,7 @@ Prefer focused changes.
     expect(updatedRun?.status).toBe("running");
     expect(updatedRun?.nextRetryAt).toBeNull();
     expect(updatedRun?.retryKind).toBeNull();
-    expect(
-      await store.loadRecentRunEvents("run-1", 10, "tenant-1")
-    ).toEqual(
+    expect(await store.loadRecentRunEvents("run-1", 10, "tenant-1")).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           event: "run-ownership-skipped",

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -413,6 +413,7 @@ export class OrchestratorService {
   private reconcileRequested = false;
   private workerOrchestratorUrl: string | null = null;
   private workerOrchestratorToken: string | null = null;
+  private ownerToken: string | null = null;
 
   constructor(
     readonly store: OrchestratorStateStore,
@@ -439,8 +440,15 @@ export class OrchestratorService {
       onTick?: OrchestratorTickHandler;
       assignedOnly?: boolean;
       rmImpl?: typeof rm;
+      ownerToken?: string;
     } = {}
-  ) {}
+  ) {
+    this.ownerToken = dependencies.ownerToken ?? null;
+  }
+
+  setOwnerToken(ownerToken: string): void {
+    this.ownerToken = ownerToken;
+  }
 
   setWorkerOrchestratorUrl(url: string, apiToken?: string): void {
     this.workerOrchestratorUrl = url;
@@ -1743,16 +1751,12 @@ export class OrchestratorService {
           ) ?? persistedRun;
         const issue = trackedIssuesByIdentifier.get(issueRecord.identifier);
         if (!issue) {
-          if (
-            !activeRun ||
-            activeRun.processId === null ||
-            !this.isRunProcessRunning(activeRun)
-          ) {
+          if (!activeRun || activeRun.processId === null) {
             continue;
           }
-          const activeWorkerPid = activeRun.processId;
-          this.sendSignal(activeWorkerPid, "SIGTERM");
-          this.retireWorkerPid(activeWorkerPid);
+          if (!(await this.signalRunProcess(activeRun, "SIGTERM"))) {
+            continue;
+          }
           const recovery = await this.classifyIncompleteTurnDirtyWorkspace(
             tenant,
             activeRun,
@@ -1787,9 +1791,9 @@ export class OrchestratorService {
           this.logVerbose(
             `[run-completed] ${suppressedRun.runId} status=${suppressedRun.status}`
           );
-          issueRecords = releaseIssueOrchestration(
+          issueRecords = await this.releaseRunIssueOrchestration(
             issueRecords,
-            issueRecord.issueId,
+            activeRun,
             now
           );
           suppressed += 1;
@@ -1809,9 +1813,11 @@ export class OrchestratorService {
           continue;
         }
 
-        if (activeRun?.processId) {
-          this.sendSignal(activeRun.processId, "SIGTERM");
-          this.retireWorkerPid(activeRun.processId);
+        if (
+          activeRun?.processId &&
+          !(await this.signalRunProcess(activeRun, "SIGTERM"))
+        ) {
+          continue;
         }
         if (activeRun) {
           const issueLifecycle = await resolveTrackedIssueLifecycle(issue);
@@ -1858,11 +1864,13 @@ export class OrchestratorService {
             `[run-completed] ${suppressedRun.runId} status=${suppressedRun.status}`
           );
         }
-        issueRecords = releaseIssueOrchestration(
-          issueRecords,
-          issueRecord.issueId,
-          now
-        );
+        if (activeRun) {
+          issueRecords = await this.releaseRunIssueOrchestration(
+            issueRecords,
+            activeRun,
+            now
+          );
+        }
         suppressed += 1;
       }
 
@@ -1983,6 +1991,16 @@ export class OrchestratorService {
     if (workspaceRecords.length === 0) {
       return;
     }
+    const activeRunsByWorkspace = new Map(
+      (await this.store.loadAllRuns())
+        .filter(
+          (run) =>
+            run.projectId === tenant.projectId &&
+            isActiveRunRecordStatus(run.status) &&
+            run.issueWorkspaceKey
+        )
+        .map((run) => [run.issueWorkspaceKey!, run])
+    );
 
     const trackerAdapter = resolveTrackerAdapter(tenant.tracker);
     const workflowCache = new Map<string, Promise<ProjectWorkflowResolution>>();
@@ -2010,6 +2028,12 @@ export class OrchestratorService {
 
     for (const workspaceRecord of workspaceRecords) {
       if (workspaceRecord.status === "removed") {
+        continue;
+      }
+
+      const activeRun = activeRunsByWorkspace.get(workspaceRecord.workspaceKey);
+      if (activeRun && !this.isRunOwnedByCurrentInstance(activeRun)) {
+        await this.recordOwnershipSkip(activeRun, "workspace-cleanup");
         continue;
       }
 
@@ -2864,6 +2888,7 @@ export class OrchestratorService {
       attempt: 1,
       processId,
       processIdentity,
+      ownerInstanceId: this.ownerToken,
       port: null,
       workingDirectory: repositoryDirectory,
       issueWorkspaceKey: workspaceKey,
@@ -3115,10 +3140,7 @@ export class OrchestratorService {
     );
 
     if (issueRecord?.currentRunId && issueRecord.currentRunId !== run.runId) {
-      if (this.isRunProcessRunning(run)) {
-        this.sendSignal(run.processId!, "SIGTERM");
-        this.retireWorkerPid(run.processId);
-      }
+      await this.signalRunProcess(run, "SIGTERM");
       const supersededRun: OrchestratorRunRecord = {
         ...run,
         status: "failed",
@@ -3178,7 +3200,7 @@ export class OrchestratorService {
             `[orchestrator] stuck worker detected for ${run.runId} (elapsed ${elapsedSeconds}s > ${timeoutSeconds}s) — sending SIGTERM`
           );
         }
-        this.sendSignal(run.processId!, "SIGTERM");
+        await this.signalRunProcess(run, "SIGTERM");
         // Fall through: treat as a normal exit and retry.
       } else {
         const runningRecord: OrchestratorRunRecord = {
@@ -3367,7 +3389,11 @@ export class OrchestratorService {
         `[run-completed] ${completedRun.runId} status=${completedRun.status}`
       );
       return {
-        issueRecords: releaseIssueOrchestration(issueRecords, run.issueId, now),
+        issueRecords: await this.releaseRunIssueOrchestration(
+          issueRecords,
+          run,
+          now
+        ),
         recovered: false,
       };
     }
@@ -3407,9 +3433,9 @@ export class OrchestratorService {
           `[run-completed] ${completedRun.runId} status=${completedRun.status}`
         );
         return {
-          issueRecords: releaseIssueOrchestration(
+          issueRecords: await this.releaseRunIssueOrchestration(
             issueRecords,
-            run.issueId,
+            run,
             now
           ),
           recovered: false,
@@ -4656,7 +4682,11 @@ export class OrchestratorService {
     );
 
     return {
-      issueRecords: releaseIssueOrchestration(issueRecords, run.issueId, now),
+      issueRecords: await this.releaseRunIssueOrchestration(
+        issueRecords,
+        run,
+        now
+      ),
       recovered: false,
     };
   }
@@ -4918,6 +4948,74 @@ export class OrchestratorService {
       return true;
     }
     return liveLeaderIdentity === run.processIdentity;
+  }
+
+  private isRunOwnedByCurrentInstance(run: OrchestratorRunRecord): boolean {
+    // Programmatic service construction predates project-lock ownership. The
+    // CLI always injects an owner identity; retain the legacy behavior only
+    // for callers that have not opted into that lock contract.
+    if (!this.ownerToken) {
+      return true;
+    }
+    return Boolean(
+      run.ownerInstanceId && run.ownerInstanceId === this.ownerToken
+    );
+  }
+
+  private ownershipSkipReason(
+    run: OrchestratorRunRecord
+  ): "owner-token-missing" | "owner-token-mismatch" {
+    return !run.ownerInstanceId
+      ? "owner-token-missing"
+      : "owner-token-mismatch";
+  }
+
+  private async recordOwnershipSkip(
+    run: OrchestratorRunRecord,
+    operation: "signal" | "claim-release" | "workspace-cleanup"
+  ): Promise<void> {
+    const reason = this.ownershipSkipReason(run);
+    await this.store.appendRunEvent(run.runId, {
+      at: this.now().toISOString(),
+      event: "run-ownership-skipped",
+      projectId: run.projectId,
+      runId: run.runId,
+      issueIdentifier: run.issueIdentifier,
+      issueId: run.issueId,
+      operation,
+      reason,
+    });
+    this.logVerbose(
+      `[run-ownership-skipped] ${run.runId} operation=${operation} reason=${reason}`
+    );
+  }
+
+  private async signalRunProcess(
+    run: OrchestratorRunRecord,
+    signal: NodeJS.Signals
+  ): Promise<boolean> {
+    if (!this.isRunOwnedByCurrentInstance(run)) {
+      await this.recordOwnershipSkip(run, "signal");
+      return false;
+    }
+    if (!this.isRunProcessRunning(run)) {
+      return false;
+    }
+    this.sendSignal(run.processId!, signal);
+    this.retireWorkerPid(run.processId);
+    return true;
+  }
+
+  private async releaseRunIssueOrchestration(
+    issueRecords: IssueOrchestrationRecord[],
+    run: OrchestratorRunRecord,
+    now: Date
+  ): Promise<IssueOrchestrationRecord[]> {
+    if (!this.isRunOwnedByCurrentInstance(run)) {
+      await this.recordOwnershipSkip(run, "claim-release");
+      return issueRecords;
+    }
+    return releaseIssueOrchestration(issueRecords, run.issueId, now);
   }
 
   private sendSignal(processId: number, signal: NodeJS.Signals): void {

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -1754,7 +1754,10 @@ export class OrchestratorService {
           if (!activeRun || activeRun.processId === null) {
             continue;
           }
-          if (!(await this.signalRunProcess(activeRun, "SIGTERM"))) {
+          if (
+            (await this.signalRunProcess(activeRun, "SIGTERM")) ===
+            "protected"
+          ) {
             continue;
           }
           const recovery = await this.classifyIncompleteTurnDirtyWorkspace(
@@ -1815,7 +1818,7 @@ export class OrchestratorService {
 
         if (
           activeRun?.processId &&
-          !(await this.signalRunProcess(activeRun, "SIGTERM"))
+          (await this.signalRunProcess(activeRun, "SIGTERM")) === "protected"
         ) {
           continue;
         }
@@ -2032,8 +2035,10 @@ export class OrchestratorService {
       }
 
       const activeRun = activeRunsByWorkspace.get(workspaceRecord.workspaceKey);
-      if (activeRun && !this.isRunOwnedByCurrentInstance(activeRun)) {
-        await this.recordOwnershipSkip(activeRun, "workspace-cleanup");
+      if (activeRun && this.isRunProcessRunning(activeRun)) {
+        if (this.isRunProtectedByLiveOwner(activeRun)) {
+          await this.recordOwnershipSkip(activeRun, "workspace-cleanup");
+        }
         continue;
       }
 
@@ -3140,7 +3145,9 @@ export class OrchestratorService {
     );
 
     if (issueRecord?.currentRunId && issueRecord.currentRunId !== run.runId) {
-      await this.signalRunProcess(run, "SIGTERM");
+      if ((await this.signalRunProcess(run, "SIGTERM")) === "protected") {
+        return { issueRecords, recovered: false };
+      }
       const supersededRun: OrchestratorRunRecord = {
         ...run,
         status: "failed",
@@ -3200,7 +3207,9 @@ export class OrchestratorService {
             `[orchestrator] stuck worker detected for ${run.runId} (elapsed ${elapsedSeconds}s > ${timeoutSeconds}s) — sending SIGTERM`
           );
         }
-        await this.signalRunProcess(run, "SIGTERM");
+        if ((await this.signalRunProcess(run, "SIGTERM")) === "protected") {
+          return { issueRecords, recovered: false };
+        }
         // Fall through: treat as a normal exit and retry.
       } else {
         const runningRecord: OrchestratorRunRecord = {
@@ -4950,16 +4959,18 @@ export class OrchestratorService {
     return liveLeaderIdentity === run.processIdentity;
   }
 
-  private isRunOwnedByCurrentInstance(run: OrchestratorRunRecord): boolean {
+  private isRunProtectedByLiveOwner(run: OrchestratorRunRecord): boolean {
     // Programmatic service construction predates project-lock ownership. The
     // CLI always injects an owner identity; retain the legacy behavior only
     // for callers that have not opted into that lock contract.
     if (!this.ownerToken) {
-      return true;
+      return false;
     }
-    return Boolean(
-      run.ownerInstanceId && run.ownerInstanceId === this.ownerToken
-    );
+    if (!run.ownerInstanceId || run.ownerInstanceId === this.ownerToken) {
+      return false;
+    }
+    const ownerPid = parseOwnerProcessId(run.ownerInstanceId);
+    return ownerPid === null || this.isProcessRunning(ownerPid);
   }
 
   private ownershipSkipReason(
@@ -4993,17 +5004,17 @@ export class OrchestratorService {
   private async signalRunProcess(
     run: OrchestratorRunRecord,
     signal: NodeJS.Signals
-  ): Promise<boolean> {
-    if (!this.isRunOwnedByCurrentInstance(run)) {
+  ): Promise<"signaled" | "not-running" | "protected"> {
+    if (this.isRunProtectedByLiveOwner(run)) {
       await this.recordOwnershipSkip(run, "signal");
-      return false;
+      return "protected";
     }
     if (!this.isRunProcessRunning(run)) {
-      return false;
+      return "not-running";
     }
     this.sendSignal(run.processId!, signal);
     this.retireWorkerPid(run.processId);
-    return true;
+    return "signaled";
   }
 
   private async releaseRunIssueOrchestration(
@@ -5011,7 +5022,7 @@ export class OrchestratorService {
     run: OrchestratorRunRecord,
     now: Date
   ): Promise<IssueOrchestrationRecord[]> {
-    if (!this.isRunOwnedByCurrentInstance(run)) {
+    if (this.isRunProtectedByLiveOwner(run)) {
       await this.recordOwnershipSkip(run, "claim-release");
       return issueRecords;
     }
@@ -5265,6 +5276,12 @@ function isWorkflowHookExecutionAllowed(env: Record<string, string>): boolean {
   const value =
     env[WORKFLOW_HOOK_APPROVAL_ENV] ?? process.env[WORKFLOW_HOOK_APPROVAL_ENV];
   return value === "1" || value?.toLowerCase() === "true";
+}
+
+function parseOwnerProcessId(ownerToken: string): number | null {
+  const separator = ownerToken.indexOf(":");
+  const pid = Number(ownerToken.slice(0, separator));
+  return separator > 0 && Number.isSafeInteger(pid) && pid > 0 ? pid : null;
 }
 
 function parseCommaSeparatedEnvList(value: string | undefined): string[] {

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -429,6 +429,7 @@ export class OrchestratorService {
       maxAttempts?: number;
       killImpl?: (pid: number, signal?: NodeJS.Signals) => void;
       isProcessRunning?: (pid: number) => boolean;
+      isOwnerProcessRunning?: (pid: number) => boolean;
       getProcessStartIdentity?: (pid: number) => string | null;
       waitImpl?: (ms: number) => Promise<void>;
       stderr?: Pick<NodeJS.WriteStream, "write">;
@@ -1816,9 +1817,18 @@ export class OrchestratorService {
           continue;
         }
 
+        if (!activeRun) {
+          issueRecords = releaseIssueOrchestration(
+            issueRecords,
+            issueRecord.issueId,
+            now
+          );
+          suppressed += 1;
+          continue;
+        }
+
         if (
-          activeRun?.processId &&
-          (await this.signalRunProcess(activeRun, "SIGTERM")) === "protected"
+          (await this.signalRunProcess(activeRun, "SIGTERM")) !== "signaled"
         ) {
           continue;
         }
@@ -1867,13 +1877,11 @@ export class OrchestratorService {
             `[run-completed] ${suppressedRun.runId} status=${suppressedRun.status}`
           );
         }
-        if (activeRun) {
-          issueRecords = await this.releaseRunIssueOrchestration(
-            issueRecords,
-            activeRun,
-            now
-          );
-        }
+        issueRecords = await this.releaseRunIssueOrchestration(
+          issueRecords,
+          activeRun,
+          now
+        );
         suppressed += 1;
       }
 
@@ -4970,22 +4978,26 @@ export class OrchestratorService {
       return false;
     }
     const ownerPid = parseOwnerProcessId(run.ownerInstanceId);
-    return ownerPid === null || this.isProcessRunning(ownerPid);
+    return ownerPid !== null && this.isOwnerProcessRunning(ownerPid);
   }
 
-  private ownershipSkipReason(
-    run: OrchestratorRunRecord
-  ): "owner-token-missing" | "owner-token-mismatch" {
-    return !run.ownerInstanceId
-      ? "owner-token-missing"
-      : "owner-token-mismatch";
+  private isOwnerProcessRunning(processId: number): boolean {
+    if (this.dependencies.isOwnerProcessRunning) {
+      return this.dependencies.isOwnerProcessRunning(processId);
+    }
+    try {
+      process.kill(processId, 0);
+      return true;
+    } catch {
+      return false;
+    }
   }
 
   private async recordOwnershipSkip(
     run: OrchestratorRunRecord,
     operation: "signal" | "claim-release" | "workspace-cleanup"
   ): Promise<void> {
-    const reason = this.ownershipSkipReason(run);
+    const reason = "owner-alive";
     await this.store.appendRunEvent(run.runId, {
       at: this.now().toISOString(),
       event: "run-ownership-skipped",

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -4968,9 +4968,9 @@ export class OrchestratorService {
   }
 
   private isRunProtectedByLiveOwner(run: OrchestratorRunRecord): boolean {
-    // Programmatic service construction predates project-lock ownership. The
-    // CLI always injects an owner identity; retain the legacy behavior only
-    // for callers that have not opted into that lock contract.
+    // CLI entry points inject a process-scoped token even when they do not
+    // acquire a project lock. Programmatic callers without a token retain the
+    // legacy behavior because they cannot establish ownership safely.
     if (!this.ownerToken) {
       return false;
     }

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -69,7 +69,10 @@ import {
 import { globalBareRepositoryDirectory } from "./repository-cache.js";
 import { excludeRuntimeSkillsFromGit, injectLayeredSkills } from "./skills.js";
 import { OrchestratorFsStore } from "./fs-store.js";
-import { getProcessStartIdentity } from "./lock.js";
+import {
+  getProcessStartIdentity,
+  isProcessRunning as isDirectProcessRunning,
+} from "./lock.js";
 import { PersistentIssueCommentCache } from "./issue-comment-cache.js";
 import { resolveTrackerAdapter } from "./tracker-adapters.js";
 import {
@@ -1756,8 +1759,7 @@ export class OrchestratorService {
             continue;
           }
           if (
-            (await this.signalRunProcess(activeRun, "SIGTERM")) ===
-            "protected"
+            (await this.signalRunProcess(activeRun, "SIGTERM")) === "protected"
           ) {
             continue;
           }
@@ -1828,55 +1830,53 @@ export class OrchestratorService {
         }
 
         if (
-          (await this.signalRunProcess(activeRun, "SIGTERM")) !== "signaled"
+          (await this.signalRunProcess(activeRun, "SIGTERM")) === "protected"
         ) {
           continue;
         }
-        if (activeRun) {
-          const issueLifecycle = await resolveTrackedIssueLifecycle(issue);
-          const terminalState =
-            !isArchivedProjectItem(issue) &&
-            issueLifecycle !== null &&
-            isStateTerminal(issue.state, issueLifecycle);
-          const recovery = terminalState
-            ? null
-            : await this.classifyIncompleteTurnDirtyWorkspace(
-                tenant,
-                activeRun,
-                now
-              );
-          const suppressedRun: OrchestratorRunRecord = {
-            ...activeRun,
-            status: "suppressed",
-            processId: null,
-            completedAt: now.toISOString(),
-            updatedAt: now.toISOString(),
-            runPhase: "canceled_by_reconciliation",
-            runtimeSession: recovery
-              ? buildRuntimeSession(
-                  activeRun.runtimeSession,
-                  recovery.sessionId,
-                  recovery.threadId,
-                  "completed",
-                  activeRun.runtimeSession?.startedAt ??
-                    activeRun.startedAt ??
-                    now.toISOString(),
+        const issueLifecycle = await resolveTrackedIssueLifecycle(issue);
+        const terminalState =
+          !isArchivedProjectItem(issue) &&
+          issueLifecycle !== null &&
+          isStateTerminal(issue.state, issueLifecycle);
+        const recovery = terminalState
+          ? null
+          : await this.classifyIncompleteTurnDirtyWorkspace(
+              tenant,
+              activeRun,
+              now
+            );
+        const suppressedRun: OrchestratorRunRecord = {
+          ...activeRun,
+          status: "suppressed",
+          processId: null,
+          completedAt: now.toISOString(),
+          updatedAt: now.toISOString(),
+          runPhase: "canceled_by_reconciliation",
+          runtimeSession: recovery
+            ? buildRuntimeSession(
+                activeRun.runtimeSession,
+                recovery.sessionId,
+                recovery.threadId,
+                "completed",
+                activeRun.runtimeSession?.startedAt ??
+                  activeRun.startedAt ??
                   now.toISOString(),
-                  "incomplete-turn-dirty-workspace"
-                )
-              : activeRun.runtimeSession,
-            recovery,
-            lastError: recovery
-              ? "Run suppressed with recoverable incomplete-turn dirty workspace."
-              : terminalState
-                ? "Run suppressed because the tracker issue moved to a terminal state."
-                : "Run suppressed because the tracker state is no longer actionable.",
-          };
-          await this.store.saveRun(suppressedRun);
-          this.logVerbose(
-            `[run-completed] ${suppressedRun.runId} status=${suppressedRun.status}`
-          );
-        }
+                now.toISOString(),
+                "incomplete-turn-dirty-workspace"
+              )
+            : activeRun.runtimeSession,
+          recovery,
+          lastError: recovery
+            ? "Run suppressed with recoverable incomplete-turn dirty workspace."
+            : terminalState
+              ? "Run suppressed because the tracker issue moved to a terminal state."
+              : "Run suppressed because the tracker state is no longer actionable.",
+        };
+        await this.store.saveRun(suppressedRun);
+        this.logVerbose(
+          `[run-completed] ${suppressedRun.runId} status=${suppressedRun.status}`
+        );
         issueRecords = await this.releaseRunIssueOrchestration(
           issueRecords,
           activeRun,
@@ -4985,12 +4985,7 @@ export class OrchestratorService {
     if (this.dependencies.isOwnerProcessRunning) {
       return this.dependencies.isOwnerProcessRunning(processId);
     }
-    try {
-      process.kill(processId, 0);
-      return true;
-    } catch {
-      return false;
-    }
+    return isDirectProcessRunning(processId);
   }
 
   private async recordOwnershipSkip(


### PR DESCRIPTION
## TL;DR

- Prevents an orchestrator from terminating or releasing claims for a live worker owned by another instance.
- Preserves reconciliation recovery for dead, non-running, and legacy runs while treating only `ESRCH` as a dead owner process.
- Gives unscoped CLI mutations a process-scoped owner token so `run`, `run-once`, `dispatch`, and `recover` retain the same protection.

## Change-point diagram

```text
run lifecycle action
  ├─ live foreign owner → emit ownership skip; no signal, release, retry, or cleanup
  └─ own/dead/legacy/non-running → identity-guarded signal or safe reconciliation release
```

## Start here

- `packages/orchestrator/src/{index,service}.ts` — persisted ownership, CLI token wiring, centralized signal/claim guards, reconciliation, and startup cleanup.
- `packages/orchestrator/src/lock.ts` — canonical direct-PID liveness predicate.
- `packages/orchestrator/src/{service,lock}.test.ts` — foreign-owner, PID reuse, non-running release, legacy, and `EPERM` regression coverage.

## Risks & rollback

- The direct owner probe is intentionally fail-closed for errors other than `ESRCH`.
- Owner PID reuse remains conservatively protected while live-owner identity hardening is tracked in #647.

## Changed files

- `packages/orchestrator/src/service.ts`
- `packages/orchestrator/src/lock.ts`
- `packages/orchestrator/src/index.ts`
- `packages/orchestrator/src/service.test.ts`
- `packages/orchestrator/src/lock.test.ts`
- `packages/orchestrator/src/index.test.ts`

## Evidence

- `pnpm lint`
- `pnpm test`
- `pnpm typecheck`
- `pnpm build`
- Docker E2E: rebuilt stack dispatched the stub worker; after fixture removal, the status API reported `health: "idle"`, `activeRuns: 0`, and `lastError: null`.
- Focused regression: `pnpm --filter @gh-symphony/orchestrator exec vitest run src/index.test.ts src/service.test.ts -t 'assigns a process-scoped owner token|releases a non-actionable claim whose worker process is dead'`

## Issues — Closed #639

## Post-merge / human validation

- [ ] Review `run-ownership-skipped` warnings during a multi-instance incident.
