### PR TITLE
fix(worker): handle codex protocol termination

### DIFF
--- a/.changeset/codex-protocol-terminal-guards.md
+++ b/.changeset/codex-protocol-terminal-guards.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Fix #657 by failing Codex worker turns immediately when the app-server exits, bounding protocol lines, and sending the rendered prompt once.

--- a/packages/worker/src/codex-protocol-guard.test.ts
+++ b/packages/worker/src/codex-protocol-guard.test.ts
@@ -5,6 +5,7 @@ import {
   createCodexProtocolLineFramer,
   createCodexProtocolProcessError,
   MAX_CODEX_PROTOCOL_LINE_BYTES,
+  shouldFailOnCodexChildExit,
 } from "./codex-protocol-guard.js";
 import { buildCodexTurnInput } from "./codex-turn-input.js";
 
@@ -34,6 +35,27 @@ describe("codex protocol guard", () => {
     expect(
       createCodexProtocolProcessError(new Error("stdin EPIPE")).message
     ).toBe("port_exit: stdin EPIPE");
+  });
+
+  it("does not reclassify worker-requested or terminal child exits", () => {
+    expect(
+      shouldFailOnCodexChildExit({
+        terminationRequested: true,
+        runPhase: "streaming_turn",
+      })
+    ).toBe(false);
+    expect(
+      shouldFailOnCodexChildExit({
+        terminationRequested: false,
+        runPhase: "timed_out",
+      })
+    ).toBe(false);
+    expect(
+      shouldFailOnCodexChildExit({
+        terminationRequested: false,
+        runPhase: "streaming_turn",
+      })
+    ).toBe(true);
   });
 
   it("rejects a line larger than 10 MiB before unbounded buffering", () => {

--- a/packages/worker/src/codex-protocol-guard.test.ts
+++ b/packages/worker/src/codex-protocol-guard.test.ts
@@ -31,9 +31,9 @@ describe("codex protocol guard", () => {
     expect(createCodexProtocolProcessError(missing).message).toBe(
       "codex_not_found: spawn codex ENOENT"
     );
-    expect(createCodexProtocolProcessError(new Error("stdin EPIPE")).message).toBe(
-      "port_exit: stdin EPIPE"
-    );
+    expect(
+      createCodexProtocolProcessError(new Error("stdin EPIPE")).message
+    ).toBe("port_exit: stdin EPIPE");
   });
 
   it("rejects a line larger than 10 MiB before unbounded buffering", () => {
@@ -51,6 +51,9 @@ describe("codex protocol guard", () => {
         message: `response_error: codex stdout line exceeded ${MAX_CODEX_PROTOCOL_LINE_BYTES} bytes`,
       })
     );
+
+    frame(Buffer.from("another oversized chunk"));
+    expect(onFailure).toHaveBeenCalledExactlyOnceWith(expect.any(Error));
   });
 
   it("delivers the rendered prompt only in the first turn", () => {

--- a/packages/worker/src/codex-protocol-guard.test.ts
+++ b/packages/worker/src/codex-protocol-guard.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createCodexProtocolExitError,
+  createCodexProtocolFailureGate,
+  createCodexProtocolLineFramer,
+  createCodexProtocolProcessError,
+  MAX_CODEX_PROTOCOL_LINE_BYTES,
+} from "./codex-protocol-guard.js";
+import { buildCodexTurnInput } from "./codex-turn-input.js";
+
+describe("codex protocol guard", () => {
+  it("fails once, terminates the child, and rejects work submitted after exit", () => {
+    const onFailure = vi.fn();
+    const terminate = vi.fn();
+    const gate = createCodexProtocolFailureGate({ onFailure, terminate });
+    const exitError = createCodexProtocolExitError(1, null);
+
+    gate.fail(exitError);
+    gate.fail(createCodexProtocolExitError(2, null));
+
+    expect(gate.failure()).toBe(exitError);
+    expect(onFailure).toHaveBeenCalledExactlyOnceWith(exitError);
+    expect(terminate).toHaveBeenCalledExactlyOnceWith();
+  });
+
+  it("maps spawn ENOENT to codex_not_found and other child failures to port_exit", () => {
+    const missing = Object.assign(new Error("spawn codex ENOENT"), {
+      code: "ENOENT",
+    });
+
+    expect(createCodexProtocolProcessError(missing).message).toBe(
+      "codex_not_found: spawn codex ENOENT"
+    );
+    expect(createCodexProtocolProcessError(new Error("stdin EPIPE")).message).toBe(
+      "port_exit: stdin EPIPE"
+    );
+  });
+
+  it("rejects a line larger than 10 MiB before unbounded buffering", () => {
+    const onFailure = vi.fn();
+    const frame = createCodexProtocolLineFramer({
+      onMessage: vi.fn(),
+      onNonJson: vi.fn(),
+      onFailure,
+    });
+
+    frame(Buffer.alloc(MAX_CODEX_PROTOCOL_LINE_BYTES + 1, "x"));
+
+    expect(onFailure).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({
+        message: `response_error: codex stdout line exceeded ${MAX_CODEX_PROTOCOL_LINE_BYTES} bytes`,
+      })
+    );
+  });
+
+  it("delivers the rendered prompt only in the first turn", () => {
+    const renderedPrompt = "assigned issue prompt";
+
+    expect(
+      buildCodexTurnInput({
+        isFirstTurn: true,
+        renderedPrompt,
+        issueIdentifier: "hojinzs/github-symphony#657",
+        issueTitle: "Fix worker protocol",
+        continuationGuidance: "Continue the assigned issue.",
+        cumulativeTurnCount: 0,
+      })
+    ).toBe(renderedPrompt);
+    expect(
+      buildCodexTurnInput({
+        isFirstTurn: false,
+        renderedPrompt,
+        issueIdentifier: "hojinzs/github-symphony#657",
+        issueTitle: "Fix worker protocol",
+        continuationGuidance: "Continue the assigned issue.",
+        cumulativeTurnCount: 1,
+      })
+    ).not.toContain(renderedPrompt);
+  });
+});

--- a/packages/worker/src/codex-protocol-guard.ts
+++ b/packages/worker/src/codex-protocol-guard.ts
@@ -1,0 +1,93 @@
+export const MAX_CODEX_PROTOCOL_LINE_BYTES = 10 * 1024 * 1024;
+
+export function createCodexProtocolExitError(
+  code: number | null,
+  signal: NodeJS.Signals | null
+): Error {
+  return new Error(
+    `port_exit: codex app-server exited with ${signal ?? code ?? "unknown"}`
+  );
+}
+
+export function createCodexProtocolProcessError(cause: Error): Error {
+  return new Error(
+    (cause as NodeJS.ErrnoException).code === "ENOENT"
+      ? `codex_not_found: ${cause.message}`
+      : `port_exit: ${cause.message}`
+  );
+}
+
+export function createCodexProtocolFrameError(): Error {
+  return new Error(
+    `response_error: codex stdout line exceeded ${MAX_CODEX_PROTOCOL_LINE_BYTES} bytes`
+  );
+}
+
+export function createCodexProtocolFailureGate({
+  onFailure,
+  terminate,
+}: {
+  onFailure: (error: Error) => void;
+  terminate: () => void;
+}): {
+  fail: (error: Error) => void;
+  failure: () => Error | null;
+} {
+  let protocolFailure: Error | null = null;
+
+  return {
+    fail(error: Error): void {
+      if (protocolFailure) {
+        return;
+      }
+      protocolFailure = error;
+      onFailure(error);
+      try {
+        terminate();
+      } catch {
+        // A terminal failure can race with normal child-process cleanup.
+      }
+    },
+    failure(): Error | null {
+      return protocolFailure;
+    },
+  };
+}
+
+export function createCodexProtocolLineFramer({
+  onMessage,
+  onNonJson,
+  onFailure,
+}: {
+  onMessage: (message: Record<string, unknown>) => void;
+  onNonJson: (line: string) => void;
+  onFailure: (error: Error) => void;
+}): (chunk: Buffer) => void {
+  let lineBuffer = "";
+
+  return (chunk: Buffer): void => {
+    lineBuffer += chunk.toString("utf8");
+    const lines = lineBuffer.split("\n");
+    lineBuffer = lines.pop() ?? "";
+
+    for (const line of lines) {
+      if (Buffer.byteLength(line, "utf8") > MAX_CODEX_PROTOCOL_LINE_BYTES) {
+        onFailure(createCodexProtocolFrameError());
+        return;
+      }
+      const trimmed = line.trim();
+      if (!trimmed) {
+        continue;
+      }
+      try {
+        onMessage(JSON.parse(trimmed) as Record<string, unknown>);
+      } catch {
+        onNonJson(trimmed);
+      }
+    }
+
+    if (Buffer.byteLength(lineBuffer, "utf8") > MAX_CODEX_PROTOCOL_LINE_BYTES) {
+      onFailure(createCodexProtocolFrameError());
+    }
+  };
+}

--- a/packages/worker/src/codex-protocol-guard.ts
+++ b/packages/worker/src/codex-protocol-guard.ts
@@ -64,15 +64,28 @@ export function createCodexProtocolLineFramer({
   onFailure: (error: Error) => void;
 }): (chunk: Buffer) => void {
   let lineBuffer = "";
+  let failed = false;
+
+  function fail(error: Error): void {
+    if (failed) {
+      return;
+    }
+    failed = true;
+    lineBuffer = "";
+    onFailure(error);
+  }
 
   return (chunk: Buffer): void => {
+    if (failed) {
+      return;
+    }
     lineBuffer += chunk.toString("utf8");
     const lines = lineBuffer.split("\n");
     lineBuffer = lines.pop() ?? "";
 
     for (const line of lines) {
       if (Buffer.byteLength(line, "utf8") > MAX_CODEX_PROTOCOL_LINE_BYTES) {
-        onFailure(createCodexProtocolFrameError());
+        fail(createCodexProtocolFrameError());
         return;
       }
       const trimmed = line.trim();
@@ -87,7 +100,7 @@ export function createCodexProtocolLineFramer({
     }
 
     if (Buffer.byteLength(lineBuffer, "utf8") > MAX_CODEX_PROTOCOL_LINE_BYTES) {
-      onFailure(createCodexProtocolFrameError());
+      fail(createCodexProtocolFrameError());
     }
   };
 }

--- a/packages/worker/src/codex-protocol-guard.ts
+++ b/packages/worker/src/codex-protocol-guard.ts
@@ -1,4 +1,17 @@
+import type { RunAttemptPhase } from "@gh-symphony/core";
+import { isTerminalRunPhase } from "./run-phase.js";
+
 export const MAX_CODEX_PROTOCOL_LINE_BYTES = 10 * 1024 * 1024;
+
+export function shouldFailOnCodexChildExit({
+  terminationRequested,
+  runPhase,
+}: {
+  terminationRequested: boolean;
+  runPhase: RunAttemptPhase | null;
+}): boolean {
+  return !terminationRequested && !isTerminalRunPhase(runPhase);
+}
 
 export function createCodexProtocolExitError(
   code: number | null,

--- a/packages/worker/src/codex-turn-input.ts
+++ b/packages/worker/src/codex-turn-input.ts
@@ -1,0 +1,34 @@
+import { buildIssueIdentityHeader } from "@gh-symphony/core";
+import { buildContinuationTurnInput } from "./thread-resume.js";
+
+export function buildCodexTurnInput({
+  isFirstTurn,
+  renderedPrompt,
+  issueIdentifier,
+  issueTitle,
+  continuationGuidance,
+  cumulativeTurnCount,
+}: {
+  isFirstTurn: boolean;
+  renderedPrompt: string;
+  issueIdentifier: string;
+  issueTitle: string | null | undefined;
+  continuationGuidance: string | null;
+  cumulativeTurnCount: number;
+}): string {
+  if (isFirstTurn) {
+    return renderedPrompt;
+  }
+
+  return [
+    buildIssueIdentityHeader({
+      issueIdentifier: issueIdentifier || "the assigned issue",
+      issueTitle: issueTitle ?? null,
+    }),
+    "",
+    buildContinuationTurnInput({
+      continuationGuidance,
+      cumulativeTurnCount,
+    }),
+  ].join("\n");
+}

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -48,7 +48,7 @@ import {
   type WorkerNonCodexRuntimeAdapter,
   type WorkerNonCodexTurnResult,
 } from "./non-codex-runtime.js";
-import { resolveExitRunPhase } from "./run-phase.js";
+import { isTerminalRunPhase, resolveExitRunPhase } from "./run-phase.js";
 import {
   resolveClaudePreflightAuthMode,
   shouldExposeLinearGraphQLTool,
@@ -1087,6 +1087,16 @@ async function runCodexClientProtocol(
   let consecutiveNonProductiveTurns = 0;
   let consecutiveRefreshFailures = 0;
   let convergenceDetected = false;
+  let terminationRequested = false;
+
+  function requestChildTermination(): void {
+    terminationRequested = true;
+    try {
+      child.kill("SIGTERM");
+    } catch {
+      // A terminal failure can race with normal child-process cleanup.
+    }
+  }
 
   function resolvePendingTurnCompletion(): void {
     if (turnCompletedResolve) {
@@ -1166,9 +1176,7 @@ async function runCodexClientProtocol(
       rejectPendingRequests(error);
       markTurnTerminalFailure("failed", error.message);
     },
-    terminate() {
-      child.kill("SIGTERM");
-    },
+    terminate: requestChildTermination,
   });
 
   function failProtocol(error: Error): void {
@@ -1176,9 +1184,8 @@ async function runCodexClientProtocol(
   }
 
   function sendMessage(msg: Record<string, unknown>): void {
-    const failure = protocolFailureGate.failure();
-    if (failure) {
-      throw failure;
+    if (protocolFailureGate.failure()) {
+      return;
     }
     const line = JSON.stringify(msg) + "\n";
     child.stdin?.write(line);
@@ -1251,13 +1258,7 @@ async function runCodexClientProtocol(
         process.stderr.write(
           `[worker] turn_timeout: turn exceeded ${turnTimeoutMs}ms — killing codex process\n`
         );
-        if (child.pid) {
-          try {
-            process.kill(child.pid, "SIGTERM");
-          } catch {
-            // Already gone.
-          }
-        }
+        requestChildTermination();
         reject(new Error("turn_timeout: turn exceeded time limit"));
       }, turnTimeoutMs);
 
@@ -1368,13 +1369,7 @@ async function runCodexClientProtocol(
     if (runtimeState.run) {
       runtimeState.run.lastError = reason;
     }
-    if (child.pid) {
-      try {
-        process.kill(child.pid, "SIGTERM");
-      } catch {
-        // Already gone.
-      }
-    }
+    requestChildTermination();
     if (activeTurnTelemetry) {
       emitTurnFailedEvent(
         activeTurnTelemetry,
@@ -1405,7 +1400,11 @@ async function runCodexClientProtocol(
           event.payload.threadId,
           event.payload.turnId,
           event.payload.arguments
-        );
+        ).catch((error: unknown) => {
+          process.stderr.write(
+            `[worker] dynamic tool call ${event.payload.callId} dispatch failed: ${error instanceof Error ? error.message : String(error)}\n`
+          );
+        });
         emitObservedAgentEvent(event);
         return true;
       case "agent.inputRequired":
@@ -1526,11 +1525,7 @@ async function runCodexClientProtocol(
       process.stderr.write(`[worker] ${reason}\n`);
       emitOrchestratorChannelEvent("worker_identity_violation");
       markTurnTerminalFailure("failed", reason);
-      try {
-        child.kill("SIGTERM");
-      } catch {
-        // The codex process may already be gone.
-      }
+      requestChildTermination();
       return;
     }
 
@@ -1575,7 +1570,7 @@ async function runCodexClientProtocol(
   });
 
   child.on("exit", (code: number | null, signal: NodeJS.Signals | null) => {
-    if (runtimeState.runPhase === "finishing" || runtimeState.runPhase === "succeeded") {
+    if (terminationRequested || isTerminalRunPhase(runtimeState.runPhase)) {
       return;
     }
     const error = createCodexProtocolExitError(code, signal);

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -48,7 +48,7 @@ import {
   type WorkerNonCodexRuntimeAdapter,
   type WorkerNonCodexTurnResult,
 } from "./non-codex-runtime.js";
-import { isTerminalRunPhase, resolveExitRunPhase } from "./run-phase.js";
+import { resolveExitRunPhase } from "./run-phase.js";
 import {
   resolveClaudePreflightAuthMode,
   shouldExposeLinearGraphQLTool,
@@ -77,6 +77,7 @@ import {
   createCodexProtocolFailureGate,
   createCodexProtocolLineFramer,
   createCodexProtocolProcessError,
+  shouldFailOnCodexChildExit,
 } from "./codex-protocol-guard.js";
 
 const launcherEnv = loadLauncherEnvironment(process.env);
@@ -165,6 +166,7 @@ console.log(
 );
 
 let childProcess: ChildProcess | null = null;
+let workerTerminationRequested = false;
 let runtimeAdapter: AgentRuntimeAdapter | null = null;
 let shutdownPromise: Promise<void> | null = null;
 let orchestratorChannelDrainPending = false;
@@ -199,6 +201,7 @@ function shutdown(signal: NodeJS.Signals) {
 
   shutdownPromise = (async () => {
     if (childProcess?.pid) {
+      workerTerminationRequested = true;
       try {
         process.kill(childProcess.pid, "SIGTERM");
       } catch {
@@ -1091,6 +1094,7 @@ async function runCodexClientProtocol(
 
   function requestChildTermination(): void {
     terminationRequested = true;
+    workerTerminationRequested = true;
     try {
       child.kill("SIGTERM");
     } catch {
@@ -1570,7 +1574,12 @@ async function runCodexClientProtocol(
   });
 
   child.on("exit", (code: number | null, signal: NodeJS.Signals | null) => {
-    if (terminationRequested || isTerminalRunPhase(runtimeState.runPhase)) {
+    if (
+      !shouldFailOnCodexChildExit({
+        terminationRequested: terminationRequested || workerTerminationRequested,
+        runPhase: runtimeState.runPhase,
+      })
+    ) {
       return;
     }
     const error = createCodexProtocolExitError(code, signal);

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -2,7 +2,6 @@ import { spawn, type ChildProcess } from "node:child_process";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import {
-  buildIssueIdentityHeader,
   classifySessionExit,
   DEFAULT_AGENT_INPUT_REQUIRED_REASON,
   parseWorkflowMarkdown,
@@ -55,7 +54,7 @@ import {
   shouldExposeLinearGraphQLTool,
   resolveWorkerRuntimeRoute,
 } from "./runtime-routing.js";
-import { buildContinuationTurnInput } from "./thread-resume.js";
+import { buildCodexTurnInput } from "./codex-turn-input.js";
 import { runWorkerIdentityPreflight } from "./identity-preflight.js";
 import {
   findCwdBoundaryViolation,
@@ -73,6 +72,12 @@ import {
   updateRefreshFailureCount,
 } from "./turn-lease.js";
 import { persistTokenUsageArtifact, type TokenUsage } from "./token-usage.js";
+import {
+  createCodexProtocolExitError,
+  createCodexProtocolFailureGate,
+  createCodexProtocolLineFramer,
+  createCodexProtocolProcessError,
+} from "./codex-protocol-guard.js";
 
 const launcherEnv = loadLauncherEnvironment(process.env);
 type TokenUsageSnapshot = TokenUsage;
@@ -168,8 +173,6 @@ let orchestratorHeartbeatTimer: NodeJS.Timeout | null = null;
 const MAX_PENDING_ORCHESTRATOR_CHANNEL_PAYLOADS = 16;
 const ORCHESTRATOR_CHANNEL_FLUSH_TIMEOUT_MS = 250;
 const ORCHESTRATOR_CHANNEL_HEARTBEAT_INTERVAL_MS = 10_000;
-const MAX_CODEX_PROTOCOL_LINE_BYTES = 10 * 1024 * 1024;
-
 function composeTurnTitle(
   issueIdentifierValue: string | undefined,
   issueTitleValue: string | undefined
@@ -1059,10 +1062,6 @@ async function runCodexClientProtocol(
   // Pipe codex stderr to our stderr for observability
   child.stderr?.pipe(process.stderr);
 
-  // Buffer to accumulate incomplete lines from codex stdout
-  let lineBuffer = "";
-  let protocolFailure: Error | null = null;
-
   // Accumulate streaming delta events so they log as a single line
   let deltaBuffer: { itemId: string; text: string } | null = null;
 
@@ -1162,16 +1161,25 @@ async function runCodexClientProtocol(
     pendingRequests.clear();
   }
 
+  const protocolFailureGate = createCodexProtocolFailureGate({
+    onFailure(error) {
+      rejectPendingRequests(error);
+      markTurnTerminalFailure("failed", error.message);
+    },
+    terminate() {
+      child.kill("SIGTERM");
+    },
+  });
+
   function failProtocol(error: Error): void {
-    if (protocolFailure) {
-      return;
-    }
-    protocolFailure = error;
-    rejectPendingRequests(error);
-    markTurnTerminalFailure("failed", error.message);
+    protocolFailureGate.fail(error);
   }
 
   function sendMessage(msg: Record<string, unknown>): void {
+    const failure = protocolFailureGate.failure();
+    if (failure) {
+      throw failure;
+    }
     const line = JSON.stringify(msg) + "\n";
     child.stdin?.write(line);
   }
@@ -1181,6 +1189,10 @@ async function runCodexClientProtocol(
     method: string,
     params: Record<string, unknown>
   ): Promise<unknown> {
+    const failure = protocolFailureGate.failure();
+    if (failure) {
+      return Promise.reject(failure);
+    }
     return new Promise((resolve, reject) => {
       pendingRequests.set(id, { resolve, reject });
       sendMessage({ jsonrpc: "2.0", id, method, params });
@@ -1548,63 +1560,34 @@ async function runCodexClientProtocol(
     }
   }
 
-  // Wire up line-delimited JSON parsing from codex stdout
+  // Wire up line-delimited JSON parsing from codex stdout.
+  const frameCodexStdout = createCodexProtocolLineFramer({
+    onMessage: handleServerMessage,
+    onNonJson: (line) => {
+      process.stderr.write(`[worker] codex stdout (non-JSON): ${line}\n`);
+    },
+    onFailure: failProtocol,
+  });
   child.stdout.on("data", (chunk: Buffer) => {
-    if (protocolFailure) {
-      return;
-    }
-    lineBuffer += chunk.toString("utf8");
-    const lines = lineBuffer.split("\n");
-    lineBuffer = lines.pop() ?? "";
-
-    for (const line of lines) {
-      if (Buffer.byteLength(line, "utf8") > MAX_CODEX_PROTOCOL_LINE_BYTES) {
-        failProtocol(
-          new Error(
-            `protocol_error: codex stdout line exceeded ${MAX_CODEX_PROTOCOL_LINE_BYTES} bytes`
-          )
-        );
-        return;
-      }
-      const trimmed = line.trim();
-      if (!trimmed) continue;
-      try {
-        const msg = JSON.parse(trimmed) as Record<string, unknown>;
-        handleServerMessage(msg);
-      } catch {
-        // Non-JSON output from codex (e.g. startup logs); ignore
-        process.stderr.write(`[worker] codex stdout (non-JSON): ${trimmed}\n`);
-      }
-    }
-
-    if (Buffer.byteLength(lineBuffer, "utf8") > MAX_CODEX_PROTOCOL_LINE_BYTES) {
-      failProtocol(
-        new Error(
-          `protocol_error: codex stdout line exceeded ${MAX_CODEX_PROTOCOL_LINE_BYTES} bytes`
-        )
-      );
+    if (!protocolFailureGate.failure()) {
+      frameCodexStdout(chunk);
     }
   });
 
   child.on("exit", (code: number | null, signal: NodeJS.Signals | null) => {
-    const error = new Error(
-      `port_exit: codex app-server exited with ${signal ?? code ?? "unknown"}`
-    );
-    process.stderr.write(`[worker] ${error.message}\n`);
-    rejectPendingRequests(error);
-    if (runtimeState.runPhase === "streaming_turn") {
-      failProtocol(error);
+    if (runtimeState.runPhase === "finishing" || runtimeState.runPhase === "succeeded") {
+      return;
     }
+    const error = createCodexProtocolExitError(code, signal);
+    process.stderr.write(`[worker] ${error.message}\n`);
+    failProtocol(error);
   });
 
   child.on("error", (cause: Error) => {
-    const error = new Error(
-      (cause as NodeJS.ErrnoException).code === "ENOENT"
-        ? `codex_not_found: ${cause.message}`
-        : `port_exit: ${cause.message}`
-    );
-    rejectPendingRequests(error);
-    failProtocol(error);
+    failProtocol(createCodexProtocolProcessError(cause));
+  });
+  child.stdin.on("error", (cause: Error) => {
+    failProtocol(createCodexProtocolProcessError(cause));
   });
 
   try {
@@ -1746,19 +1729,14 @@ async function runCodexClientProtocol(
 
       // #507: continuation turns carry the engine-owned identity header so
       // the agent never loses its issue binding after the initial prompt.
-      const turnInput = isFirstTurn
-        ? renderedPrompt
-        : [
-            buildIssueIdentityHeader({
-              issueIdentifier: issueIdentifier || "the assigned issue",
-              issueTitle: env.SYMPHONY_ISSUE_TITLE ?? null,
-            }),
-            "",
-            buildContinuationTurnInput({
-              continuationGuidance,
-              cumulativeTurnCount: turn,
-            }),
-          ].join("\n");
+      const turnInput = buildCodexTurnInput({
+        isFirstTurn,
+        renderedPrompt,
+        issueIdentifier,
+        issueTitle: env.SYMPHONY_ISSUE_TITLE,
+        continuationGuidance,
+        cumulativeTurnCount: turn,
+      });
 
       process.stderr.write(
         `[worker] starting codex turn ${turnCount}/${maxTurns}${isFirstTurn ? " (initial)" : " (continuation)"}\n`
@@ -1990,7 +1968,8 @@ async function runCodexClientProtocol(
       }
     } else if (
       errMsg.startsWith("port_exit:") ||
-      errMsg.startsWith("protocol_error:")
+      errMsg.startsWith("response_error:") ||
+      errMsg.startsWith("codex_not_found:")
     ) {
       if (runtimeState.run) {
         runtimeState.run.lastError = errMsg;

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -168,6 +168,7 @@ let orchestratorHeartbeatTimer: NodeJS.Timeout | null = null;
 const MAX_PENDING_ORCHESTRATOR_CHANNEL_PAYLOADS = 16;
 const ORCHESTRATOR_CHANNEL_FLUSH_TIMEOUT_MS = 250;
 const ORCHESTRATOR_CHANNEL_HEARTBEAT_INTERVAL_MS = 10_000;
+const MAX_CODEX_PROTOCOL_LINE_BYTES = 10 * 1024 * 1024;
 
 function composeTurnTitle(
   issueIdentifierValue: string | undefined,
@@ -627,7 +628,10 @@ async function startAssignedRun() {
       runtimeState.runPhase = "failed";
 
       if (runtimeState.run) {
-        runtimeState.run.lastError = error.message;
+        runtimeState.run.lastError =
+          (error as NodeJS.ErrnoException).code === "ENOENT"
+            ? `codex_not_found: ${error.message}`
+            : error.message;
       }
       void persistSessionTokenUsageArtifact(launcherEnv);
     });
@@ -1057,6 +1061,7 @@ async function runCodexClientProtocol(
 
   // Buffer to accumulate incomplete lines from codex stdout
   let lineBuffer = "";
+  let protocolFailure: Error | null = null;
 
   // Accumulate streaming delta events so they log as a single line
   let deltaBuffer: { itemId: string; text: string } | null = null;
@@ -1148,6 +1153,22 @@ async function runCodexClientProtocol(
       emitTurnFailedEvent(activeTurnTelemetry, lastError);
       activeTurnTelemetry = null;
     }
+  }
+
+  function rejectPendingRequests(error: Error): void {
+    for (const pending of pendingRequests.values()) {
+      pending.reject(error);
+    }
+    pendingRequests.clear();
+  }
+
+  function failProtocol(error: Error): void {
+    if (protocolFailure) {
+      return;
+    }
+    protocolFailure = error;
+    rejectPendingRequests(error);
+    markTurnTerminalFailure("failed", error.message);
   }
 
   function sendMessage(msg: Record<string, unknown>): void {
@@ -1529,11 +1550,22 @@ async function runCodexClientProtocol(
 
   // Wire up line-delimited JSON parsing from codex stdout
   child.stdout.on("data", (chunk: Buffer) => {
+    if (protocolFailure) {
+      return;
+    }
     lineBuffer += chunk.toString("utf8");
     const lines = lineBuffer.split("\n");
     lineBuffer = lines.pop() ?? "";
 
     for (const line of lines) {
+      if (Buffer.byteLength(line, "utf8") > MAX_CODEX_PROTOCOL_LINE_BYTES) {
+        failProtocol(
+          new Error(
+            `protocol_error: codex stdout line exceeded ${MAX_CODEX_PROTOCOL_LINE_BYTES} bytes`
+          )
+        );
+        return;
+      }
       const trimmed = line.trim();
       if (!trimmed) continue;
       try {
@@ -1544,6 +1576,35 @@ async function runCodexClientProtocol(
         process.stderr.write(`[worker] codex stdout (non-JSON): ${trimmed}\n`);
       }
     }
+
+    if (Buffer.byteLength(lineBuffer, "utf8") > MAX_CODEX_PROTOCOL_LINE_BYTES) {
+      failProtocol(
+        new Error(
+          `protocol_error: codex stdout line exceeded ${MAX_CODEX_PROTOCOL_LINE_BYTES} bytes`
+        )
+      );
+    }
+  });
+
+  child.on("exit", (code: number | null, signal: NodeJS.Signals | null) => {
+    const error = new Error(
+      `port_exit: codex app-server exited with ${signal ?? code ?? "unknown"}`
+    );
+    process.stderr.write(`[worker] ${error.message}\n`);
+    rejectPendingRequests(error);
+    if (runtimeState.runPhase === "streaming_turn") {
+      failProtocol(error);
+    }
+  });
+
+  child.on("error", (cause: Error) => {
+    const error = new Error(
+      (cause as NodeJS.ErrnoException).code === "ENOENT"
+        ? `codex_not_found: ${cause.message}`
+        : `port_exit: ${cause.message}`
+    );
+    rejectPendingRequests(error);
+    failProtocol(error);
   });
 
   try {
@@ -1570,7 +1631,6 @@ async function runCodexClientProtocol(
 
     const baseThreadParams = {
       cwd: plan.cwd,
-      developerInstructions: renderedPrompt,
       approvalPolicy,
       sandbox: threadSandbox,
       config: {
@@ -1925,6 +1985,13 @@ async function runCodexClientProtocol(
       }
     } else if (errMsg.startsWith("turn_timeout:")) {
       runtimeState.runPhase = "timed_out";
+      if (runtimeState.run) {
+        runtimeState.run.lastError = errMsg;
+      }
+    } else if (
+      errMsg.startsWith("port_exit:") ||
+      errMsg.startsWith("protocol_error:")
+    ) {
       if (runtimeState.run) {
         runtimeState.run.lastError = errMsg;
       }

--- a/packages/worker/src/run-phase.test.ts
+++ b/packages/worker/src/run-phase.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { resolveExitRunPhase } from "./run-phase.js";
+import { isTerminalRunPhase, resolveExitRunPhase } from "./run-phase.js";
 
 describe("resolveExitRunPhase", () => {
   it("marks successful exits as succeeded from non-terminal phases", () => {
@@ -18,5 +18,12 @@ describe("resolveExitRunPhase", () => {
     expect(
       resolveExitRunPhase("timed_out", { code: 1, signal: "SIGTERM" })
     ).toBe("timed_out");
+  });
+
+  it("recognizes every terminal phase before a child exit is handled", () => {
+    expect(isTerminalRunPhase("failed")).toBe(true);
+    expect(isTerminalRunPhase("timed_out")).toBe(true);
+    expect(isTerminalRunPhase("canceled_by_reconciliation")).toBe(true);
+    expect(isTerminalRunPhase("streaming_turn")).toBe(false);
   });
 });

--- a/packages/worker/src/run-phase.ts
+++ b/packages/worker/src/run-phase.ts
@@ -8,6 +8,12 @@ const TERMINAL_RUN_PHASES = new Set<RunAttemptPhase>([
   "canceled_by_reconciliation",
 ]);
 
+export function isTerminalRunPhase(
+  runPhase: RunAttemptPhase | null
+): runPhase is RunAttemptPhase {
+  return runPhase !== null && TERMINAL_RUN_PHASES.has(runPhase);
+}
+
 export function resolveExitRunPhase(
   currentRunPhase: RunAttemptPhase | null,
   exit: {
@@ -15,7 +21,7 @@ export function resolveExitRunPhase(
     signal: NodeJS.Signals | null;
   }
 ): RunAttemptPhase {
-  if (currentRunPhase && TERMINAL_RUN_PHASES.has(currentRunPhase)) {
+  if (isTerminalRunPhase(currentRunPhase)) {
     return currentRunPhase;
   }
 

--- a/packages/worker/src/worker-protocol.test.ts
+++ b/packages/worker/src/worker-protocol.test.ts
@@ -58,16 +58,11 @@ function createFakeChild(): {
   child: ChildProcessWithoutNullStreams;
   stdout: PassThrough;
   stdin: PassThrough;
-  emitExit: (code: number | null, signal: string | null) => void;
-  emitError: (error: Error) => void;
-  killed: boolean;
 } {
   const stdin = new PassThrough();
   const stdout = new PassThrough();
   const stderr = new PassThrough();
   const emitter = new EventEmitter();
-  let killed = false;
-
   const child = {
     pid: 12345,
     stdin,
@@ -76,20 +71,13 @@ function createFakeChild(): {
     once: emitter.once.bind(emitter),
     on: emitter.on.bind(emitter),
     emit: emitter.emit.bind(emitter),
-    kill: () => {
-      killed = true;
-    },
+    kill: () => {},
   } as unknown as ChildProcessWithoutNullStreams;
 
   return {
     child,
     stdout,
     stdin,
-    emitExit: (code, signal) => emitter.emit("exit", code, signal),
-    emitError: (error) => emitter.emit("error", error),
-    get killed() {
-      return killed;
-    },
   };
 }
 

--- a/packages/worker/src/worker-protocol.test.ts
+++ b/packages/worker/src/worker-protocol.test.ts
@@ -50,8 +50,6 @@ type ActiveTurnTelemetry = {
   tokenUsageBaseline: TokenUsageSnapshot;
 };
 
-const MAX_CODEX_PROTOCOL_LINE_BYTES = 10 * 1024 * 1024;
-
 /**
  * Minimal fake child process for testing: provides stdin/stdout/stderr streams
  * and basic process lifecycle (pid, kill, exit events).
@@ -138,8 +136,6 @@ function createProtocolContext(options: {
   const pendingOrchestratorChannelPayloads: string[] = [];
   const maxPendingOrchestratorChannelPayloads = 16;
   let activeTurnTelemetry: ActiveTurnTelemetry | null = null;
-  let protocolFailure: Error | null = null;
-  let lineBuffer = "";
 
   const defaultOrchestratorChannelWriter = {
     write(chunk: string): boolean {
@@ -758,22 +754,6 @@ function createProtocolContext(options: {
     }
   }
 
-  function rejectPendingRequests(error: Error): void {
-    for (const pending of pendingRequests.values()) {
-      pending.reject(error);
-    }
-    pendingRequests.clear();
-  }
-
-  function failProtocol(error: Error): void {
-    if (protocolFailure) {
-      return;
-    }
-    protocolFailure = error;
-    rejectPendingRequests(error);
-    markTurnTerminalFailure("failed", error.message);
-  }
-
   function finalizeRunState(): void {
     runtimeState.runPhase = "finishing";
     runtimeState.status =
@@ -946,63 +926,6 @@ function createProtocolContext(options: {
     );
   }
 
-  function handleStdoutChunk(chunk: Buffer): void {
-    if (protocolFailure) {
-      return;
-    }
-
-    lineBuffer += chunk.toString("utf8");
-    const lines = lineBuffer.split("\n");
-    lineBuffer = lines.pop() ?? "";
-
-    for (const line of lines) {
-      if (Buffer.byteLength(line, "utf8") > MAX_CODEX_PROTOCOL_LINE_BYTES) {
-        failProtocol(
-          new Error(
-            `protocol_error: codex stdout line exceeded ${MAX_CODEX_PROTOCOL_LINE_BYTES} bytes`
-          )
-        );
-        return;
-      }
-      const trimmed = line.trim();
-      if (!trimmed) continue;
-      try {
-        handleServerMessage(JSON.parse(trimmed) as Record<string, unknown>);
-      } catch {
-        logs.push(`[worker] codex stdout (non-JSON): ${trimmed}`);
-      }
-    }
-
-    if (Buffer.byteLength(lineBuffer, "utf8") > MAX_CODEX_PROTOCOL_LINE_BYTES) {
-      failProtocol(
-        new Error(
-          `protocol_error: codex stdout line exceeded ${MAX_CODEX_PROTOCOL_LINE_BYTES} bytes`
-        )
-      );
-    }
-  }
-
-  fake.child.on(
-    "exit",
-    (code: number | null, signal: NodeJS.Signals | null) => {
-      const error = new Error(
-        `port_exit: codex app-server exited with ${signal ?? code ?? "unknown"}`
-      );
-      rejectPendingRequests(error);
-      failProtocol(error);
-    }
-  );
-
-  fake.child.on("error", (cause: Error) => {
-    const error = new Error(
-      (cause as NodeJS.ErrnoException).code === "ENOENT"
-        ? `codex_not_found: ${cause.message}`
-        : `port_exit: ${cause.message}`
-    );
-    rejectPendingRequests(error);
-    failProtocol(error);
-  });
-
   return {
     fake,
     pendingRequests,
@@ -1013,7 +936,6 @@ function createProtocolContext(options: {
     waitForTurnCompletion,
     waitForTurnWithTimeout,
     handleServerMessage,
-    handleStdoutChunk,
     emitOrchestratorHeartbeat,
     waitForPendingOrchestratorChannelFlush,
     resolveTerminalOrchestratorChannelFlushTimeoutMs,
@@ -1815,46 +1737,6 @@ describe("turn timeout (3.6)", () => {
     );
   });
 
-  it("fails an active turn immediately when the codex port exits and rejects pending requests", async () => {
-    const ctx = createProtocolContext({ turnTimeoutMs: 5000 });
-    const turnWait = ctx.waitForTurnWithTimeout();
-    const pendingRequest = ctx.sendRequest("tool-1", "tool/list", {});
-    const pendingRejection = expect(pendingRequest).rejects.toThrow(
-      "port_exit: codex app-server exited with 1"
-    );
-
-    ctx.fake.emitExit(1, null);
-
-    await turnWait;
-    await pendingRejection;
-    expect(ctx.runtimeState.status).toBe("failed");
-    expect(ctx.runtimeState.runPhase).toBe("failed");
-    expect(ctx.runtimeState.run.lastError).toBe(
-      "port_exit: codex app-server exited with 1"
-    );
-    expect(ctx.pendingRequests.size).toBe(0);
-  });
-
-  it("maps a missing codex executable to codex_not_found", async () => {
-    const ctx = createProtocolContext({ turnTimeoutMs: 5000 });
-    const turnWait = ctx.waitForTurnWithTimeout();
-    const pendingRequest = ctx.sendRequest("init-1", "initialize", {});
-    const pendingRejection = expect(pendingRequest).rejects.toThrow(
-      "codex_not_found: spawn codex ENOENT"
-    );
-    const error = Object.assign(new Error("spawn codex ENOENT"), {
-      code: "ENOENT",
-    });
-
-    ctx.fake.emitError(error);
-
-    await turnWait;
-    await pendingRejection;
-    expect(ctx.runtimeState.run.lastError).toBe(
-      "codex_not_found: spawn codex ENOENT"
-    );
-  });
-
   it("resolves pending turn wait when turn/cancelled is received", async () => {
     const ctx = createProtocolContext({ turnTimeoutMs: 5000 });
 
@@ -1940,27 +1822,6 @@ describe("turn timeout (3.6)", () => {
     expect(ctx.runtimeState.runPhase).toBe("failed");
     expect(ctx.runtimeState.run.lastError).toBe(
       "turn_failed: tool execution failed"
-    );
-  });
-});
-
-describe("codex stdout framing", () => {
-  it("fails the protocol when an unterminated stdout line exceeds 10 MiB", async () => {
-    const ctx = createProtocolContext({});
-    const pendingRequest = ctx.sendRequest("thread-1", "thread/start", {});
-    const pendingRejection = expect(pendingRequest).rejects.toThrow(
-      "protocol_error: codex stdout line exceeded 10485760 bytes"
-    );
-
-    ctx.handleStdoutChunk(
-      Buffer.alloc(MAX_CODEX_PROTOCOL_LINE_BYTES + 1, 0x61)
-    );
-
-    await pendingRejection;
-    expect(ctx.runtimeState.status).toBe("failed");
-    expect(ctx.runtimeState.runPhase).toBe("failed");
-    expect(ctx.runtimeState.run.lastError).toBe(
-      "protocol_error: codex stdout line exceeded 10485760 bytes"
     );
   });
 });

--- a/packages/worker/src/worker-protocol.test.ts
+++ b/packages/worker/src/worker-protocol.test.ts
@@ -50,6 +50,8 @@ type ActiveTurnTelemetry = {
   tokenUsageBaseline: TokenUsageSnapshot;
 };
 
+const MAX_CODEX_PROTOCOL_LINE_BYTES = 10 * 1024 * 1024;
+
 /**
  * Minimal fake child process for testing: provides stdin/stdout/stderr streams
  * and basic process lifecycle (pid, kill, exit events).
@@ -59,6 +61,7 @@ function createFakeChild(): {
   stdout: PassThrough;
   stdin: PassThrough;
   emitExit: (code: number | null, signal: string | null) => void;
+  emitError: (error: Error) => void;
   killed: boolean;
 } {
   const stdin = new PassThrough();
@@ -85,6 +88,7 @@ function createFakeChild(): {
     stdout,
     stdin,
     emitExit: (code, signal) => emitter.emit("exit", code, signal),
+    emitError: (error) => emitter.emit("error", error),
     get killed() {
       return killed;
     },
@@ -134,6 +138,8 @@ function createProtocolContext(options: {
   const pendingOrchestratorChannelPayloads: string[] = [];
   const maxPendingOrchestratorChannelPayloads = 16;
   let activeTurnTelemetry: ActiveTurnTelemetry | null = null;
+  let protocolFailure: Error | null = null;
+  let lineBuffer = "";
 
   const defaultOrchestratorChannelWriter = {
     write(chunk: string): boolean {
@@ -752,6 +758,22 @@ function createProtocolContext(options: {
     }
   }
 
+  function rejectPendingRequests(error: Error): void {
+    for (const pending of pendingRequests.values()) {
+      pending.reject(error);
+    }
+    pendingRequests.clear();
+  }
+
+  function failProtocol(error: Error): void {
+    if (protocolFailure) {
+      return;
+    }
+    protocolFailure = error;
+    rejectPendingRequests(error);
+    markTurnTerminalFailure("failed", error.message);
+  }
+
   function finalizeRunState(): void {
     runtimeState.runPhase = "finishing";
     runtimeState.status =
@@ -924,6 +946,63 @@ function createProtocolContext(options: {
     );
   }
 
+  function handleStdoutChunk(chunk: Buffer): void {
+    if (protocolFailure) {
+      return;
+    }
+
+    lineBuffer += chunk.toString("utf8");
+    const lines = lineBuffer.split("\n");
+    lineBuffer = lines.pop() ?? "";
+
+    for (const line of lines) {
+      if (Buffer.byteLength(line, "utf8") > MAX_CODEX_PROTOCOL_LINE_BYTES) {
+        failProtocol(
+          new Error(
+            `protocol_error: codex stdout line exceeded ${MAX_CODEX_PROTOCOL_LINE_BYTES} bytes`
+          )
+        );
+        return;
+      }
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      try {
+        handleServerMessage(JSON.parse(trimmed) as Record<string, unknown>);
+      } catch {
+        logs.push(`[worker] codex stdout (non-JSON): ${trimmed}`);
+      }
+    }
+
+    if (Buffer.byteLength(lineBuffer, "utf8") > MAX_CODEX_PROTOCOL_LINE_BYTES) {
+      failProtocol(
+        new Error(
+          `protocol_error: codex stdout line exceeded ${MAX_CODEX_PROTOCOL_LINE_BYTES} bytes`
+        )
+      );
+    }
+  }
+
+  fake.child.on(
+    "exit",
+    (code: number | null, signal: NodeJS.Signals | null) => {
+      const error = new Error(
+        `port_exit: codex app-server exited with ${signal ?? code ?? "unknown"}`
+      );
+      rejectPendingRequests(error);
+      failProtocol(error);
+    }
+  );
+
+  fake.child.on("error", (cause: Error) => {
+    const error = new Error(
+      (cause as NodeJS.ErrnoException).code === "ENOENT"
+        ? `codex_not_found: ${cause.message}`
+        : `port_exit: ${cause.message}`
+    );
+    rejectPendingRequests(error);
+    failProtocol(error);
+  });
+
   return {
     fake,
     pendingRequests,
@@ -934,6 +1013,7 @@ function createProtocolContext(options: {
     waitForTurnCompletion,
     waitForTurnWithTimeout,
     handleServerMessage,
+    handleStdoutChunk,
     emitOrchestratorHeartbeat,
     waitForPendingOrchestratorChannelFlush,
     resolveTerminalOrchestratorChannelFlushTimeoutMs,
@@ -1011,13 +1091,12 @@ function sendStartupRequestsForEnv(
 
   void ctx.sendRequest("thread-1", "thread/start", {
     cwd: "/tmp",
-    developerInstructions: "test prompt",
     approvalPolicy,
     sandbox: threadSandbox,
   });
   void ctx.sendRequest("turn-1", "turn/start", {
     threadId: "thread-1",
-    input: [{ type: "text", text: "continue" }],
+    input: [{ type: "text", text: "test prompt" }],
     cwd: "/tmp",
     title: composeTurnTitle(
       env.SYMPHONY_ISSUE_IDENTIFIER,
@@ -1061,7 +1140,6 @@ async function sendStartupHandshake(
 
   const threadPromise = ctx.sendRequestWithTimeout("thread-1", "thread/start", {
     cwd: "/tmp",
-    developerInstructions: "test prompt",
     approvalPolicy,
     sandbox: threadSandbox,
   });
@@ -1077,7 +1155,7 @@ async function sendStartupHandshake(
 
   void ctx.sendRequest("turn-1", "turn/start", {
     threadId,
-    input: [{ type: "text", text: "continue" }],
+    input: [{ type: "text", text: "test prompt" }],
     cwd: "/tmp",
     title: composeTurnTitle(
       env.SYMPHONY_ISSUE_IDENTIFIER,
@@ -1431,7 +1509,6 @@ describe("read timeout (3.5)", () => {
         method: "thread/start",
         params: {
           cwd: "/tmp",
-          developerInstructions: "test prompt",
           approvalPolicy: "on-request",
           sandbox: "workspace-write",
         },
@@ -1442,7 +1519,7 @@ describe("read timeout (3.5)", () => {
         method: "turn/start",
         params: {
           threadId: "thread-1",
-          input: [{ type: "text", text: "continue" }],
+          input: [{ type: "text", text: "test prompt" }],
           cwd: "/tmp",
           title: "acme/repo#1: Test issue",
           approvalPolicy: "on-request",
@@ -1486,7 +1563,6 @@ describe("read timeout (3.5)", () => {
         method: "thread/start",
         params: {
           cwd: "/tmp",
-          developerInstructions: "test prompt",
           approvalPolicy: "on-request",
           sandbox: "workspace-write",
         },
@@ -1497,7 +1573,7 @@ describe("read timeout (3.5)", () => {
         method: "turn/start",
         params: {
           threadId: "thread-from-server",
-          input: [{ type: "text", text: "continue" }],
+          input: [{ type: "text", text: "test prompt" }],
           cwd: "/tmp",
           title: "acme/repo#1: Test issue",
           approvalPolicy: "on-request",
@@ -1525,7 +1601,6 @@ describe("read timeout (3.5)", () => {
       method: "thread/start",
       params: {
         cwd: "/tmp",
-        developerInstructions: "test prompt",
         approvalPolicy: "never",
         sandbox: "danger-full-access",
       },
@@ -1536,7 +1611,7 @@ describe("read timeout (3.5)", () => {
       method: "turn/start",
       params: {
         threadId: "thread-1",
-        input: [{ type: "text", text: "continue" }],
+        input: [{ type: "text", text: "test prompt" }],
         cwd: "/tmp",
         title: "Untitled issue",
         approvalPolicy: "never",
@@ -1560,11 +1635,10 @@ describe("read timeout (3.5)", () => {
       method: "turn/start",
       params: {
         threadId: "thread-1",
-        input: [{ type: "text", text: "continue" }],
+        input: [{ type: "text", text: "test prompt" }],
         cwd: "/tmp",
         title: "acme/repo#1: Test issue",
         approvalPolicy: "never",
-        sandboxPolicy: undefined,
       },
     });
   });
@@ -1586,11 +1660,10 @@ describe("read timeout (3.5)", () => {
       method: "turn/start",
       params: {
         threadId: "thread-1",
-        input: [{ type: "text", text: "continue" }],
+        input: [{ type: "text", text: "test prompt" }],
         cwd: "/tmp",
         title: "acme/repo#1",
         approvalPolicy: "never",
-        sandboxPolicy: undefined,
       },
     });
 
@@ -1608,11 +1681,10 @@ describe("read timeout (3.5)", () => {
       method: "turn/start",
       params: {
         threadId: "thread-1",
-        input: [{ type: "text", text: "continue" }],
+        input: [{ type: "text", text: "test prompt" }],
         cwd: "/tmp",
         title: "Test issue",
         approvalPolicy: "never",
-        sandboxPolicy: undefined,
       },
     });
   });
@@ -1743,6 +1815,46 @@ describe("turn timeout (3.6)", () => {
     );
   });
 
+  it("fails an active turn immediately when the codex port exits and rejects pending requests", async () => {
+    const ctx = createProtocolContext({ turnTimeoutMs: 5000 });
+    const turnWait = ctx.waitForTurnWithTimeout();
+    const pendingRequest = ctx.sendRequest("tool-1", "tool/list", {});
+    const pendingRejection = expect(pendingRequest).rejects.toThrow(
+      "port_exit: codex app-server exited with 1"
+    );
+
+    ctx.fake.emitExit(1, null);
+
+    await turnWait;
+    await pendingRejection;
+    expect(ctx.runtimeState.status).toBe("failed");
+    expect(ctx.runtimeState.runPhase).toBe("failed");
+    expect(ctx.runtimeState.run.lastError).toBe(
+      "port_exit: codex app-server exited with 1"
+    );
+    expect(ctx.pendingRequests.size).toBe(0);
+  });
+
+  it("maps a missing codex executable to codex_not_found", async () => {
+    const ctx = createProtocolContext({ turnTimeoutMs: 5000 });
+    const turnWait = ctx.waitForTurnWithTimeout();
+    const pendingRequest = ctx.sendRequest("init-1", "initialize", {});
+    const pendingRejection = expect(pendingRequest).rejects.toThrow(
+      "codex_not_found: spawn codex ENOENT"
+    );
+    const error = Object.assign(new Error("spawn codex ENOENT"), {
+      code: "ENOENT",
+    });
+
+    ctx.fake.emitError(error);
+
+    await turnWait;
+    await pendingRejection;
+    expect(ctx.runtimeState.run.lastError).toBe(
+      "codex_not_found: spawn codex ENOENT"
+    );
+  });
+
   it("resolves pending turn wait when turn/cancelled is received", async () => {
     const ctx = createProtocolContext({ turnTimeoutMs: 5000 });
 
@@ -1828,6 +1940,27 @@ describe("turn timeout (3.6)", () => {
     expect(ctx.runtimeState.runPhase).toBe("failed");
     expect(ctx.runtimeState.run.lastError).toBe(
       "turn_failed: tool execution failed"
+    );
+  });
+});
+
+describe("codex stdout framing", () => {
+  it("fails the protocol when an unterminated stdout line exceeds 10 MiB", async () => {
+    const ctx = createProtocolContext({});
+    const pendingRequest = ctx.sendRequest("thread-1", "thread/start", {});
+    const pendingRejection = expect(pendingRequest).rejects.toThrow(
+      "protocol_error: codex stdout line exceeded 10485760 bytes"
+    );
+
+    ctx.handleStdoutChunk(
+      Buffer.alloc(MAX_CODEX_PROTOCOL_LINE_BYTES + 1, 0x61)
+    );
+
+    await pendingRejection;
+    expect(ctx.runtimeState.status).toBe("failed");
+    expect(ctx.runtimeState.runPhase).toBe("failed");
+    expect(ctx.runtimeState.run.lastError).toBe(
+      "protocol_error: codex stdout line exceeded 10485760 bytes"
     );
   });
 });


### PR DESCRIPTION
## Issues — Closed #657

## TL;DR

- Codex subprocess exits, spawn failures, stdin EPIPE, and oversized stdout frames now end the protocol immediately through shared production guards.
- Pending and subsequent JSON-RPC requests reject with the preserved terminal category; active turn waits are released so the worker exits for orchestrator retry.
- Worker-requested shutdown and established terminal phases are excluded from `port_exit` reclassification.

## Change-point diagram

```text
Unexpected Codex exit / ENOENT / stdin EPIPE / >10 MiB stdout frame
  -> port_exit / codex_not_found / response_error
  -> reject pending and future requests; release active turn wait
  -> terminate child; worker exits non-zero; orchestrator retries

Worker-requested SIGTERM / terminal run phase
  -> preserve the existing classification and observability record
```

## Start here

- `packages/worker/src/codex-protocol-guard.ts` owns normalized errors, bounded framing, and the exit-decision predicate.
- `packages/worker/src/index.ts` wires the guard into app-server lifecycle and shutdown handling.
- `packages/worker/src/codex-protocol-guard.test.ts` imports the production helpers for terminal, framing, and prompt-injection regressions.

## Risks & rollback

- Frames larger than 10 MiB are intentionally rejected rather than retained indefinitely. Reverting this PR restores prior behavior.
- The Docker environment uses a stub worker; actual Codex app-server termination remains covered by unit tests.

## Changed files

- `.changeset/codex-protocol-terminal-guards.md`
- `packages/worker/src/index.ts`
- `packages/worker/src/codex-protocol-guard.ts`
- `packages/worker/src/codex-protocol-guard.test.ts`
- `packages/worker/src/codex-turn-input.ts`
- `packages/worker/src/run-phase.ts`
- `packages/worker/src/run-phase.test.ts`
- `packages/worker/src/worker-protocol.test.ts`

## Evidence

- `pnpm --filter @gh-symphony/worker test -- codex-protocol-guard.test.ts worker-protocol.test.ts run-phase.test.ts` — 69 tests passed.
- `pnpm lint` — passed.
- `pnpm test` — passed.
- `pnpm typecheck` — passed.
- `pnpm build` — passed.
- `bash e2e/run-e2e.sh happy 60` — passed; isolated Docker worker dispatch, continuation retry, and cleanup reached idle.
- Upstream conformance: aligns with Symphony §§10.1, 10.3, and 10.6. Oversized frames use normalized `response_error`; no intentional divergence.

## Post-merge / human validation

- [ ] Confirm a production worker schedules a retry after a deliberately terminated Codex app-server.

## Issues

- Closes #657
