### PR TITLE
test(orchestrator): align ownership-skip event reason

### DIFF
--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -8719,11 +8719,19 @@ Prefer focused changes.
     expect(updatedRun?.status).toBe("running");
     expect(updatedRun?.nextRetryAt).toBeNull();
     expect(updatedRun?.retryKind).toBeNull();
-    expect(await store.loadRecentRunEvents("run-1", 10, "tenant-1")).toEqual(
+    const events = (await readFile(
+      join(store.runDir("run-1", "tenant-1"), "events.ndjson"),
+      "utf8"
+    ))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+
+    expect(events).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           event: "run-ownership-skipped",
-          message: "Skipped signal (owner-alive)",
+          reason: "owner-alive",
         }),
       ])
     );

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -8719,6 +8719,15 @@ Prefer focused changes.
     expect(updatedRun?.status).toBe("running");
     expect(updatedRun?.nextRetryAt).toBeNull();
     expect(updatedRun?.retryKind).toBeNull();
+    expect(await store.loadRecentRunEvents("run-1", 10, "tenant-1")).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          event: "run-ownership-skipped",
+          message: "Skipped signal (owner-alive)",
+        }),
+      ])
+    );
+
     const events = (await readFile(
       join(store.runDir("run-1", "tenant-1"), "events.ndjson"),
       "utf8"
@@ -8731,6 +8740,7 @@ Prefer focused changes.
       expect.arrayContaining([
         expect.objectContaining({
           event: "run-ownership-skipped",
+          operation: "signal",
           reason: "owner-alive",
         }),
       ])


### PR DESCRIPTION
## TL;DR

- The ownership-liveness regression preserves the formatted store-reader assertion and adds an additive persisted-event assertion for structured metadata.
- The test now proves the ownership skip is recorded for the `signal` operation with `reason: "owner-alive"`.

## Change-point diagram

```text
ownership check → recordOwnershipSkip(operation="signal", reason="owner-alive")
                         │
               ┌─────────┴─────────┐
               ▼                   ▼
 store reader: formatted message   persisted NDJSON: structured metadata
               │                   │
               └─────────┬─────────┘
                         ▼
               service.test.ts regression
```

## Start here

- `packages/orchestrator/src/service.test.ts` — ownership-skip lifecycle regression assertion.

## Changes

- Preserve the store-reader assertion for the formatted ownership-skip message and integrity path.
- Add a complementary persisted-event assertion for `operation: "signal"` and `reason: "owner-alive"`.

## Evidence

- `pnpm exec vitest run packages/orchestrator/src/service.test.ts -t 'does not retry a stalled worker protected by a live foreign owner' --reporter=dot` — pass (1 test).
- `pnpm exec vitest run packages/orchestrator/src/service.test.ts --reporter=dot` — pass (177 tests).
- `pnpm lint` — pass.
- `pnpm test` — pass.
- `pnpm typecheck` — pass.
- `pnpm build` — pass.
- `git diff --check` — pass.
- Docker E2E: N/A; this is a test-only event-contract assertion change and does not alter orchestrator runtime behavior.

## Risks & rollback

- Low risk: test-only coverage. Reverting the added assertions restores the previous test behavior.

## Changed files

- `packages/orchestrator/src/service.test.ts`.

## Human validation

- [ ] Confirm the ownership-skip event remains persisted with `operation: "signal"` and `reason: "owner-alive"`.

## Post-merge validation

- No deployment or external smoke validation is required.

## Issues — Closed #649

Closes #649
