### PR TITLE
feat(core): strict front-matter validation

### DIFF
--- a/.changeset/strict-workflow-frontmatter.md
+++ b/.changeset/strict-workflow-frontmatter.md
@@ -1,0 +1,6 @@
+---
+"@gh-symphony/cli": minor
+---
+
+Reject invalid WORKFLOW.md front matter before runtime execution with typed
+diagnostics for workflow validation errors (#667).

--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ Lower numbers dispatch first. If an issue has multiple configured priority label
 
 Legacy `tracker.priority_field: Priority` remains supported for existing workflows, but it is deprecated because it uses live Project option order. Project field definitions are cached for the process lifetime, so field creation, removal, and option changes take effect after the daemon restarts. To migrate, replace it with `tracker.priority.source: project-field`, copy the exact field name, and write explicit option-name-to-number mappings. If both legacy and explicit config are present, explicit `tracker.priority` wins and diagnostics warn about the conflict.
 
-`gh-symphony workflow validate` reports local config errors and legacy priority warnings. `gh-symphony doctor` additionally checks live Project/repository drift: missing fields, missing labels, unmapped live options, stale configured mappings, and active issues that currently resolve to `priority = null` because their priority-like value is unmapped.
+`gh-symphony workflow validate` reports local config errors and legacy priority warnings. Strict front-matter failures use stable workflow error codes; with `--json`, `workflow validate` includes both `error.code` and `error.path`. `gh-symphony doctor` additionally checks live Project/repository drift: missing fields, missing labels, unmapped live options, stale configured mappings, and active issues that currently resolve to `priority = null` because their priority-like value is unmapped.
 
 ### Token-Only Setup
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -34,21 +34,23 @@ same metadata for automation.
 ## WORKFLOW.md Front-matter Validation
 
 `gh-symphony workflow validate` and `gh-symphony repo doctor` use the same
-strict parser as workflow loading. Failures include a stable error code and a
-field path so automation can distinguish malformed YAML from a policy error.
+strict parser as workflow loading. Failures include a stable error code; the
+`workflow validate --json` error also exposes its field path separately.
 
-| Rule | Required value | Error code/path |
-| --- | --- | --- |
-| Front matter syntax | A valid YAML mapping | `workflow_parse_error` or `workflow_front_matter_not_a_map` at `front_matter` |
-| Numeric fields | YAML integers; quoted numeric strings and fractions are rejected | `workflow_validation_error` at the field path |
-| `hooks.timeout_ms` | A positive integer when provided | `workflow_validation_error` at `hooks.timeout_ms` |
-| `agent.max_turns` | A positive integer when provided | `workflow_validation_error` at `agent.max_turns` |
-| `codex.command` | A non-empty string when provided | `workflow_validation_error` at `codex.command` |
-| `tracker.kind` | One of `github-project`, `linear`, or `file` | `workflow_validation_error` at `tracker.kind` |
+| Rule                | Required value                                                                                                             | Error code/path                                                               |
+| ------------------- | -------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| Front matter syntax | A valid YAML mapping                                                                                                       | `workflow_parse_error` or `workflow_front_matter_not_a_map` at `front_matter` |
+| Numeric fields      | YAML integers; quoted numeric strings and fractions are rejected, including priority maps and per-state concurrency values | `workflow_validation_error` at the field path                                 |
+| `hooks.timeout_ms`  | A positive integer when provided                                                                                           | `workflow_validation_error` at `hooks.timeout_ms`                             |
+| `agent.max_turns`   | A positive integer when provided                                                                                           | `workflow_validation_error` at `agent.max_turns`                              |
+| `codex.command`     | A non-empty string when provided                                                                                           | `workflow_validation_error` at `codex.command`                                |
+| `tracker.kind`      | One of `github-project`, `linear`, or `file`                                                                               | `workflow_validation_error` at `tracker.kind`                                 |
 
 Omitted optional values retain their documented defaults. Per-state concurrency
 maps remain supported through `agent.max_concurrent_agents_by_state` and their
-values also must be YAML integers.
+values must be positive YAML integers. This repository intentionally rejects an
+invalid override rather than ignoring it, so invalid configuration cannot silently
+disable dispatch for a state.
 
 ## Workflow Lifecycle Policy
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -31,6 +31,25 @@ Human-readable `gh-symphony repo status`, `gh-symphony project status`, and
 their `--watch` dashboards show the applied revision; `--json` exposes the
 same metadata for automation.
 
+## WORKFLOW.md Front-matter Validation
+
+`gh-symphony workflow validate` and `gh-symphony repo doctor` use the same
+strict parser as workflow loading. Failures include a stable error code and a
+field path so automation can distinguish malformed YAML from a policy error.
+
+| Rule | Required value | Error code/path |
+| --- | --- | --- |
+| Front matter syntax | A valid YAML mapping | `workflow_parse_error` or `workflow_front_matter_not_a_map` at `front_matter` |
+| Numeric fields | YAML integers; quoted numeric strings and fractions are rejected | `workflow_validation_error` at the field path |
+| `hooks.timeout_ms` | A positive integer when provided | `workflow_validation_error` at `hooks.timeout_ms` |
+| `agent.max_turns` | A positive integer when provided | `workflow_validation_error` at `agent.max_turns` |
+| `codex.command` | A non-empty string when provided | `workflow_validation_error` at `codex.command` |
+| `tracker.kind` | One of `github-project`, `linear`, or `file` | `workflow_validation_error` at `tracker.kind` |
+
+Omitted optional values retain their documented defaults. Per-state concurrency
+maps remain supported through `agent.max_concurrent_agents_by_state` and their
+values also must be YAML integers.
+
 ## Workflow Lifecycle Policy
 
 `tracker.blocker_check_states` selects the workflow states where unresolved

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -180,7 +180,7 @@ tracker:
 
 Legacy `tracker.priority_field: Priority` still works, but it is deprecated because it derives numeric priority from the live Project option order. Project field definitions are cached for the process lifetime, so field creation, removal, and option changes take effect after the daemon restarts. Migrate by copying the field name into `tracker.priority.field` and writing each option display name under `values` with the intended number. If both keys are present, `tracker.priority` wins and `gh-symphony doctor` reports a warning.
 
-Run `gh-symphony workflow validate` for local schema errors and `gh-symphony doctor` for live drift warnings such as missing Project fields, missing labels, unmapped live options, stale mappings, and active issues whose priority-like value resolves to `priority = null`.
+Run `gh-symphony workflow validate` for local schema errors and `gh-symphony doctor` for live drift warnings such as missing Project fields, missing labels, unmapped live options, stale mappings, and active issues whose priority-like value resolves to `priority = null`. Strict front-matter failures use stable workflow error codes; `workflow validate --json` also emits the failing `error.path`.
 
 ### Linear Tracker Repositories
 

--- a/packages/cli/src/cli-error.ts
+++ b/packages/cli/src/cli-error.ts
@@ -16,6 +16,7 @@ export type CliErrorCode =
 export function writeCliError(input: {
   code: CliErrorCode;
   message: string;
+  path?: string;
   json?: boolean;
   exitCode?: number;
   usage?: string;
@@ -27,6 +28,7 @@ export function writeCliError(input: {
         {
           error: {
             code: input.code,
+            ...(input.path ? { path: input.path } : {}),
             message: input.message,
           },
         },

--- a/packages/cli/src/cli-error.ts
+++ b/packages/cli/src/cli-error.ts
@@ -1,6 +1,9 @@
 export type CliErrorCode =
   | "invalid_arguments"
   | "missing_workflow_file"
+  | "workflow_parse_error"
+  | "workflow_front_matter_not_a_map"
+  | "workflow_validation_error"
   | "repository_initialization_failed"
   | "missing_repository_runtime_config"
   | "status_snapshot_unavailable"

--- a/packages/cli/src/commands/doctor.test.ts
+++ b/packages/cli/src/commands/doctor.test.ts
@@ -1252,6 +1252,9 @@ describe("runDoctorDiagnostics", () => {
     ).toMatchObject({
       status: "fail",
       summary: "WORKFLOW.md could not be parsed.",
+      details: expect.objectContaining({
+        error: expect.stringContaining("workflow_parse_error"),
+      }),
     });
     expect(
       report.checks.find((check) => check.id === "runtime_command")

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -4,6 +4,7 @@ import { access, mkdir, readFile, stat } from "node:fs/promises";
 import { isAbsolute, join, resolve } from "node:path";
 import {
   parseWorkflowMarkdown,
+  WorkflowValidationError,
   redactObservabilitySecrets,
   redactObservabilityText,
   type ParsedWorkflow,
@@ -712,9 +713,11 @@ async function checkWorkflow(
       remediation:
         "Fix the WORKFLOW.md front matter or re-run 'gh-symphony workflow init' to regenerate it.",
       error:
-        error instanceof Error
-          ? error.message
-          : "Unknown workflow parse error.",
+        error instanceof WorkflowValidationError
+          ? `${error.code} (${error.path}): ${error.message}`
+          : error instanceof Error
+            ? error.message
+            : "Unknown workflow parse error.",
     };
   }
 }

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -17,6 +17,7 @@ import {
   resolveRuntimeCommandBinary,
   type ClaudePreflightCheck,
 } from "@gh-symphony/runtime-claude";
+import { getSupportedTrackerKinds } from "@gh-symphony/orchestrator";
 import {
   fetchGithubProjectIssueByRepositoryAndNumber,
   fetchGithubProjectIssues,
@@ -696,7 +697,9 @@ async function checkWorkflow(
   }
 
   try {
-    const parsed = deps.parseWorkflowMarkdown(markdown, process.env);
+    const parsed = deps.parseWorkflowMarkdown(markdown, process.env, {
+      supportedTrackerKinds: getSupportedTrackerKinds(),
+    });
     return {
       status: "pass",
       command: parsed.agentCommand,

--- a/packages/cli/src/commands/repo.test.ts
+++ b/packages/cli/src/commands/repo.test.ts
@@ -644,7 +644,7 @@ Handle {{issue.identifier}}.
 
     expect(process.exitCode).toBe(1);
     expect(stderr.output()).toContain(
-      "Workflow front matter requires environment variable LINEAR_API_KEY"
+      'Workflow front matter field "tracker.api_key" requires environment variable LINEAR_API_KEY'
     );
   });
 

--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -73,6 +73,29 @@ afterEach(() => {
 });
 
 describe("workflow command handler", () => {
+  it("prints typed front-matter errors from workflow validate", async () => {
+    const root = await mkdtemp(join(tmpdir(), "workflow-validate-error-"));
+    const workflowPath = join(root, "WORKFLOW.md");
+    const stdout = captureWrites(process.stdout);
+
+    await writeFile(workflowPath, "---\n- tracker\n---\nPrompt", "utf8");
+
+    try {
+      await workflowCommand(["validate", "--file", workflowPath], {
+        configDir: root,
+        verbose: false,
+        json: true,
+        noColor: false,
+      });
+    } finally {
+      stdout.restore();
+    }
+
+    expect(JSON.parse(stdout.output())).toMatchObject({
+      error: { code: "workflow_front_matter_not_a_map" },
+    });
+  });
+
   it("validates a workflow file with strict prompt and continuation rendering", async () => {
     const root = await mkdtemp(join(tmpdir(), "workflow-validate-"));
     const workflowPath = join(root, "WORKFLOW.md");

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -4,6 +4,7 @@ import {
   buildPromptVariables,
   type OrchestratorProjectConfig,
   parseWorkflowMarkdown,
+  WorkflowValidationError,
   renderPrompt,
   resolveWorkflowExecutionPhase,
   type TrackedIssue,
@@ -23,6 +24,7 @@ import {
   validateGitHubToken,
 } from "../github/gh-auth.js";
 import type { GlobalOptions } from "../index.js";
+import { writeCliError } from "../cli-error.js";
 import {
   buildPriorityConfigDiagnostics,
   type PriorityDiagnostic,
@@ -1035,6 +1037,14 @@ const handler = async (
         return;
     }
   } catch (error) {
+    if (error instanceof WorkflowValidationError) {
+      writeCliError({
+        code: error.code,
+        message: `${error.path}: ${error.message}`,
+        json: options.json,
+      });
+      return;
+    }
     const message = error instanceof Error ? error.message : String(error);
     process.stderr.write(`Workflow command failed: ${message}\n`);
     process.exitCode = 1;

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -1040,6 +1040,7 @@ const handler = async (
     if (error instanceof WorkflowValidationError) {
       writeCliError({
         code: error.code,
+        path: error.path,
         message: `${error.path}: ${error.message}`,
         json: options.json,
       });

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -9,7 +9,10 @@ import {
   resolveWorkflowExecutionPhase,
   type TrackedIssue,
 } from "@gh-symphony/core";
-import { resolveTrackerAdapter } from "@gh-symphony/orchestrator";
+import {
+  getSupportedTrackerKinds,
+  resolveTrackerAdapter,
+} from "@gh-symphony/orchestrator";
 import { fetchGithubProjectIssueByRepositoryAndNumber } from "@gh-symphony/tracker-github";
 import { type CliProjectConfig } from "../config.js";
 import {
@@ -805,7 +808,9 @@ function validateWorkflow(
   workflowPath: string,
   markdown: string
 ): WorkflowValidationReport {
-  const workflow = parseWorkflowMarkdown(markdown);
+  const workflow = parseWorkflowMarkdown(markdown, process.env, {
+    supportedTrackerKinds: getSupportedTrackerKinds(),
+  });
   const samplePhase = resolveWorkflowExecutionPhase({
     issueState: SAMPLE_ISSUE.state,
     planningStates: workflow.lifecycle.planningStates,
@@ -951,7 +956,9 @@ async function runPreview(
     );
   }
   const { workflowPath, markdown } = await loadWorkflowMarkdown(flags.file);
-  const workflow = parseWorkflowMarkdown(markdown);
+  const workflow = parseWorkflowMarkdown(markdown, process.env, {
+    supportedTrackerKinds: getSupportedTrackerKinds(),
+  });
   if (
     flags.issue &&
     workflow.tracker.kind !== "github-project" &&

--- a/packages/core/src/workflow-loader.test.ts
+++ b/packages/core/src/workflow-loader.test.ts
@@ -106,6 +106,12 @@ describe("parseWorkflowMarkdown", () => {
       "agent.max_turns",
     ],
     [
+      "non-positive global concurrency",
+      "---\ntracker:\n  kind: github-project\nagent:\n  max_concurrent_agents: 0\ncodex:\n  command: codex\n---\nPrompt",
+      "workflow_validation_error",
+      "agent.max_concurrent_agents",
+    ],
+    [
       "empty codex command",
       "---\ntracker:\n  kind: github-project\ncodex:\n  command: '   '\n---\nPrompt",
       "workflow_validation_error",
@@ -173,6 +179,53 @@ Prompt`);
     expect(thrown).toMatchObject({
       code: "workflow_validation_error",
       path: "agent.max_concurrent_agents_by_state.Ready",
+    });
+  });
+
+  it.each([
+    ["a string", "'2'"],
+    ["a decimal", "1.5"],
+  ])("preserves map-entry paths when concurrency is %s", (_name, value) => {
+    let thrown: unknown;
+    try {
+      parseWorkflowMarkdown(`---
+tracker:
+  kind: github-project
+agent:
+  max_concurrent_agents_by_state:
+    Ready: ${value}
+codex:
+  command: codex
+---
+Prompt`);
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toMatchObject({
+      code: "workflow_validation_error",
+      path: "agent.max_concurrent_agents_by_state.Ready",
+    });
+  });
+
+  it("preserves paths for unresolved environment-backed fields", () => {
+    let thrown: unknown;
+    try {
+      parseWorkflowMarkdown(
+        `---
+tracker:
+  kind: github-project
+codex:
+  command: ${"${UNSET_CODEX_COMMAND}"}
+---
+Prompt`,
+        {}
+      );
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toMatchObject({
+      code: "workflow_validation_error",
+      path: "codex.command",
     });
   });
 

--- a/packages/core/src/workflow-loader.test.ts
+++ b/packages/core/src/workflow-loader.test.ts
@@ -3,7 +3,10 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, describe, expect, it } from "vitest";
 import { WorkflowConfigStore } from "./workflow/loader.js";
-import { parseWorkflowMarkdown } from "./workflow/parser.js";
+import {
+  parseWorkflowMarkdown,
+  WorkflowValidationError,
+} from "./workflow/parser.js";
 import { isStateActive } from "./workflow/lifecycle.js";
 import {
   resolveWorkflowRuntimeCommand,
@@ -59,6 +62,41 @@ Prefer focused changes.
 `;
 
 describe("parseWorkflowMarkdown", () => {
+  it.each([
+    ["invalid YAML", "---\ntracker:\n   kind: github-project\n---\nPrompt", "workflow_parse_error", "front_matter"],
+    ["non-map front matter", "---\n- tracker\n---\nPrompt", "workflow_front_matter_not_a_map", "front_matter"],
+    ["unsupported tracker", "---\ntracker:\n  kind: jira\ncodex:\n  command: codex\n---\nPrompt", "workflow_validation_error", "tracker.kind"],
+    ["string integer", "---\ntracker:\n  kind: github-project\nagent:\n  max_turns: '2'\ncodex:\n  command: codex\n---\nPrompt", "workflow_validation_error", "max_turns"],
+    ["non-positive hook timeout", "---\ntracker:\n  kind: github-project\nhooks:\n  timeout_ms: 0\ncodex:\n  command: codex\n---\nPrompt", "workflow_validation_error", "hooks.timeout_ms"],
+    ["non-positive turn limit", "---\ntracker:\n  kind: github-project\nagent:\n  max_turns: -1\ncodex:\n  command: codex\n---\nPrompt", "workflow_validation_error", "agent.max_turns"],
+    ["empty codex command", "---\ntracker:\n  kind: github-project\ncodex:\n  command: '   '\n---\nPrompt", "workflow_validation_error", "codex.command"],
+  ])("returns a typed error for %s", (_name, markdown, code, path) => {
+    try {
+      parseWorkflowMarkdown(markdown);
+      throw new Error("Expected parsing to fail.");
+    } catch (error) {
+      expect(error).toBeInstanceOf(WorkflowValidationError);
+      expect(error).toMatchObject({ code, path });
+    }
+  });
+
+  it("applies defaults and preserves per-state concurrency maps", () => {
+    const workflow = parseWorkflowMarkdown(`---
+tracker:
+  kind: github-project
+agent:
+  max_concurrent_agents_by_state:
+    Ready: 2
+codex:
+  command: codex
+---
+Prompt`);
+
+    expect(workflow.hooks.timeoutMs).toBeGreaterThan(0);
+    expect(workflow.agent.maxTurns).toBeGreaterThan(0);
+    expect(workflow.agent.maxConcurrentAgentsByState).toEqual({ Ready: 2 });
+  });
+
   it("parses spec-shaped yaml front matter and prompt body", () => {
     const workflow = parseWorkflowMarkdown(SAMPLE_WORKFLOW);
 

--- a/packages/core/src/workflow-loader.test.ts
+++ b/packages/core/src/workflow-loader.test.ts
@@ -63,13 +63,54 @@ Prefer focused changes.
 
 describe("parseWorkflowMarkdown", () => {
   it.each([
-    ["invalid YAML", "---\ntracker:\n   kind: github-project\n---\nPrompt", "workflow_parse_error", "front_matter"],
-    ["non-map front matter", "---\n- tracker\n---\nPrompt", "workflow_front_matter_not_a_map", "front_matter"],
-    ["unsupported tracker", "---\ntracker:\n  kind: jira\ncodex:\n  command: codex\n---\nPrompt", "workflow_validation_error", "tracker.kind"],
-    ["string integer", "---\ntracker:\n  kind: github-project\nagent:\n  max_turns: '2'\ncodex:\n  command: codex\n---\nPrompt", "workflow_validation_error", "max_turns"],
-    ["non-positive hook timeout", "---\ntracker:\n  kind: github-project\nhooks:\n  timeout_ms: 0\ncodex:\n  command: codex\n---\nPrompt", "workflow_validation_error", "hooks.timeout_ms"],
-    ["non-positive turn limit", "---\ntracker:\n  kind: github-project\nagent:\n  max_turns: -1\ncodex:\n  command: codex\n---\nPrompt", "workflow_validation_error", "agent.max_turns"],
-    ["empty codex command", "---\ntracker:\n  kind: github-project\ncodex:\n  command: '   '\n---\nPrompt", "workflow_validation_error", "codex.command"],
+    [
+      "invalid YAML",
+      "---\ntracker:\n   kind: github-project\n---\nPrompt",
+      "workflow_parse_error",
+      "front_matter",
+    ],
+    [
+      "non-map front matter",
+      "---\n- tracker\n---\nPrompt",
+      "workflow_front_matter_not_a_map",
+      "front_matter",
+    ],
+    [
+      "scalar front matter",
+      "---\nhello\n---\nPrompt",
+      "workflow_front_matter_not_a_map",
+      "front_matter",
+    ],
+    [
+      "unsupported tracker",
+      "---\ntracker:\n  kind: jira\ncodex:\n  command: codex\n---\nPrompt",
+      "workflow_validation_error",
+      "tracker.kind",
+    ],
+    [
+      "string integer",
+      "---\ntracker:\n  kind: github-project\nagent:\n  max_turns: '2'\ncodex:\n  command: codex\n---\nPrompt",
+      "workflow_validation_error",
+      "agent.max_turns",
+    ],
+    [
+      "non-positive hook timeout",
+      "---\ntracker:\n  kind: github-project\nhooks:\n  timeout_ms: 0\ncodex:\n  command: codex\n---\nPrompt",
+      "workflow_validation_error",
+      "hooks.timeout_ms",
+    ],
+    [
+      "non-positive turn limit",
+      "---\ntracker:\n  kind: github-project\nagent:\n  max_turns: -1\ncodex:\n  command: codex\n---\nPrompt",
+      "workflow_validation_error",
+      "agent.max_turns",
+    ],
+    [
+      "empty codex command",
+      "---\ntracker:\n  kind: github-project\ncodex:\n  command: '   '\n---\nPrompt",
+      "workflow_validation_error",
+      "codex.command",
+    ],
   ])("returns a typed error for %s", (_name, markdown, code, path) => {
     try {
       parseWorkflowMarkdown(markdown);
@@ -95,6 +136,44 @@ Prompt`);
     expect(workflow.hooks.timeoutMs).toBeGreaterThan(0);
     expect(workflow.agent.maxTurns).toBeGreaterThan(0);
     expect(workflow.agent.maxConcurrentAgentsByState).toEqual({ Ready: 2 });
+  });
+
+  it("accepts tracker kinds injected by the adapter boundary", () => {
+    const workflow = parseWorkflowMarkdown(
+      `---
+tracker:
+  kind: custom-tracker
+codex:
+  command: codex
+---
+Prompt`,
+      process.env,
+      { supportedTrackerKinds: ["custom-tracker"] }
+    );
+
+    expect(workflow.tracker.kind).toBe("custom-tracker");
+  });
+
+  it("rejects non-positive per-state concurrency overrides", () => {
+    let thrown: unknown;
+    try {
+      parseWorkflowMarkdown(`---
+tracker:
+  kind: github-project
+agent:
+  max_concurrent_agents_by_state:
+    Ready: -1
+codex:
+  command: codex
+---
+Prompt`);
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toMatchObject({
+      code: "workflow_validation_error",
+      path: "agent.max_concurrent_agents_by_state.Ready",
+    });
   });
 
   it("parses spec-shaped yaml front matter and prompt body", () => {

--- a/packages/core/src/workflow/loader.ts
+++ b/packages/core/src/workflow/loader.ts
@@ -2,7 +2,10 @@ import { createHash } from "node:crypto";
 import { access, readFile, stat } from "node:fs/promises";
 import { constants } from "node:fs";
 import { DEFAULT_WORKFLOW_DEFINITION, type ParsedWorkflow } from "./config.js";
-import { parseWorkflowMarkdown } from "./parser.js";
+import {
+  parseWorkflowMarkdown,
+  WorkflowValidationError,
+} from "./parser.js";
 import type { WorkflowResolution } from "../contracts/status-surface.js";
 
 type WorkflowCacheEntry = {
@@ -79,14 +82,19 @@ export class WorkflowConfigStore {
           isValid: false,
           usedLastKnownGood: true,
           validationError:
-            error instanceof Error
-              ? error.message
-              : "Invalid workflow definition.",
+            formatWorkflowValidationError(error),
         });
       }
       throw error;
     }
   }
+}
+
+export function formatWorkflowValidationError(error: unknown): string {
+  if (error instanceof WorkflowValidationError) {
+    return `${error.code} (${error.path}): ${error.message}`;
+  }
+  return error instanceof Error ? error.message : "Invalid workflow definition.";
 }
 
 export function createDefaultWorkflowResolution(): WorkflowResolution {

--- a/packages/core/src/workflow/loader.ts
+++ b/packages/core/src/workflow/loader.ts
@@ -5,6 +5,7 @@ import { DEFAULT_WORKFLOW_DEFINITION, type ParsedWorkflow } from "./config.js";
 import {
   parseWorkflowMarkdown,
   WorkflowValidationError,
+  type ParseWorkflowOptions,
 } from "./parser.js";
 import type { WorkflowResolution } from "../contracts/status-surface.js";
 
@@ -18,6 +19,8 @@ type WorkflowCacheEntry = {
 
 export class WorkflowConfigStore {
   private readonly cache = new Map<string, WorkflowCacheEntry>();
+
+  constructor(private readonly parseOptions: ParseWorkflowOptions = {}) {}
 
   async load(
     workflowPath: string,
@@ -57,7 +60,7 @@ export class WorkflowConfigStore {
     }
 
     try {
-      const workflow = parseWorkflowMarkdown(markdown, env);
+      const workflow = parseWorkflowMarkdown(markdown, env, this.parseOptions);
       const revision = createWorkflowRevision(workflow);
       const loadedAt = new Date().toISOString();
       this.cache.set(workflowPath, {
@@ -81,8 +84,7 @@ export class WorkflowConfigStore {
           loadedAt: cached.loadedAt,
           isValid: false,
           usedLastKnownGood: true,
-          validationError:
-            formatWorkflowValidationError(error),
+          validationError: formatWorkflowValidationError(error),
         });
       }
       throw error;
@@ -94,7 +96,9 @@ export function formatWorkflowValidationError(error: unknown): string {
   if (error instanceof WorkflowValidationError) {
     return `${error.code} (${error.path}): ${error.message}`;
   }
-  return error instanceof Error ? error.message : "Invalid workflow definition.";
+  return error instanceof Error
+    ? error.message
+    : "Invalid workflow definition.";
 }
 
 export function createDefaultWorkflowResolution(): WorkflowResolution {

--- a/packages/core/src/workflow/parser.ts
+++ b/packages/core/src/workflow/parser.ts
@@ -51,6 +51,7 @@ export class WorkflowValidationError extends Error {
   }
 }
 
+/** Compatibility list for consumers that do not own a tracker-adapter registry. */
 export const DEFAULT_SUPPORTED_TRACKER_KINDS = [
   "github-project",
   "linear",
@@ -68,10 +69,11 @@ export function parseWorkflowMarkdown(
     if (error instanceof WorkflowValidationError) {
       throw error;
     }
-    const message = error instanceof Error ? error.message : "Invalid workflow definition.";
+    const message =
+      error instanceof Error ? error.message : "Invalid workflow definition.";
     throw new WorkflowValidationError(
       "workflow_validation_error",
-      inferWorkflowErrorPath(message),
+      "front_matter",
       message
     );
   }
@@ -137,24 +139,37 @@ function parseWorkflowMarkdownInternal(
 
   const maxConcurrentAgentsByState = readNumberMap(
     agent,
-    "max_concurrent_agents_by_state"
+    "max_concurrent_agents_by_state",
+    "agent.max_concurrent_agents_by_state",
+    { positive: true }
   );
 
   const runtime = hasRuntime ? parseRuntimeConfig(runtimeNode, env) : null;
   const codexConfig = {
-    command: readOptionalNonEmptyString(codex, "command", env) ?? DEFAULT_AGENT_COMMAND,
+    command:
+      readOptionalNonEmptyString(codex, "command", env, "codex.command") ??
+      DEFAULT_AGENT_COMMAND,
     approvalPolicy: readOptionalString(codex, "approval_policy", env),
     threadSandbox: readOptionalString(codex, "thread_sandbox", env),
     turnSandboxPolicy: readOptionalString(codex, "turn_sandbox_policy", env),
     turnTimeoutMs:
-      readOptionalIntegerLike(codex, "turn_timeout_ms") ??
-      DEFAULT_TURN_TIMEOUT_MS,
+      readOptionalIntegerLike(
+        codex,
+        "turn_timeout_ms",
+        "codex.turn_timeout_ms"
+      ) ?? DEFAULT_TURN_TIMEOUT_MS,
     readTimeoutMs:
-      readOptionalIntegerLike(codex, "read_timeout_ms") ??
-      DEFAULT_READ_TIMEOUT_MS,
+      readOptionalIntegerLike(
+        codex,
+        "read_timeout_ms",
+        "codex.read_timeout_ms"
+      ) ?? DEFAULT_READ_TIMEOUT_MS,
     stallTimeoutMs:
-      readOptionalIntegerLike(codex, "stall_timeout_ms") ??
-      DEFAULT_STALL_TIMEOUT_MS,
+      readOptionalIntegerLike(
+        codex,
+        "stall_timeout_ms",
+        "codex.stall_timeout_ms"
+      ) ?? DEFAULT_STALL_TIMEOUT_MS,
   };
   const agentCommand = resolveWorkflowRuntimeCommand({
     runtime,
@@ -190,8 +205,11 @@ function parseWorkflowMarkdownInternal(
     },
     polling: {
       intervalMs:
-        readOptionalIntegerLike(polling, "interval_ms") ??
-        DEFAULT_POLL_INTERVAL_MS,
+        readOptionalIntegerLike(
+          polling,
+          "interval_ms",
+          "polling.interval_ms"
+        ) ?? DEFAULT_POLL_INTERVAL_MS,
     },
     repository: readOptionalExtensionObject(frontMatter, "repository"),
     workspace: {
@@ -208,21 +226,33 @@ function parseWorkflowMarkdownInternal(
     },
     agent: {
       maxConcurrentAgents:
-        readOptionalIntegerLike(agent, "max_concurrent_agents") ??
-        DEFAULT_MAX_CONCURRENT_AGENTS,
+        readOptionalIntegerLike(
+          agent,
+          "max_concurrent_agents",
+          "agent.max_concurrent_agents"
+        ) ?? DEFAULT_MAX_CONCURRENT_AGENTS,
       maxRetryBackoffMs:
-        readOptionalIntegerLike(agent, "max_retry_backoff_ms") ??
-        DEFAULT_MAX_RETRY_BACKOFF_MS,
+        readOptionalIntegerLike(
+          agent,
+          "max_retry_backoff_ms",
+          "agent.max_retry_backoff_ms"
+        ) ?? DEFAULT_MAX_RETRY_BACKOFF_MS,
       maxConcurrentAgentsByState,
       maxFailureRetries:
-        readOptionalIntegerLike(agent, "max_failure_retries") ??
-        DEFAULT_MAX_FAILURE_RETRIES,
+        readOptionalIntegerLike(
+          agent,
+          "max_failure_retries",
+          "agent.max_failure_retries"
+        ) ?? DEFAULT_MAX_FAILURE_RETRIES,
       maxTurns:
         readOptionalPositiveInteger(agent, "max_turns", "agent.max_turns") ??
         DEFAULT_MAX_TURNS,
       retryBaseDelayMs:
-        readOptionalIntegerLike(agent, "retry_base_delay_ms") ??
-        DEFAULT_BASE_DELAY_MS,
+        readOptionalIntegerLike(
+          agent,
+          "retry_base_delay_ms",
+          "agent.retry_base_delay_ms"
+        ) ?? DEFAULT_BASE_DELAY_MS,
     },
     runtime,
     codex: codexConfig,
@@ -376,7 +406,15 @@ function parseFrontMatter(
   const lines = frontMatter.replace(/\r\n/g, "\n").split("\n");
   let value: WorkflowFrontMatterNode;
   try {
-    [value] = parseBlock(lines, 0, 0);
+    const root = lines.find(
+      (line) => line.trim() && !line.trim().startsWith("#")
+    );
+    value =
+      root &&
+      findMappingSeparator(root.trim()) < 0 &&
+      !root.trim().startsWith("- ")
+        ? parseScalar(root)
+        : parseBlock(lines, 0, 0)[0];
   } catch (error) {
     if (error instanceof WorkflowValidationError) {
       throw error;
@@ -397,11 +435,6 @@ function parseFrontMatter(
   }
 
   return value as Record<string, WorkflowFrontMatterNode>;
-}
-
-function inferWorkflowErrorPath(message: string): string {
-  const field = message.match(/field "([^"]+)"/);
-  return field?.[1] ?? "front_matter";
 }
 
 function parseBlock(
@@ -818,16 +851,17 @@ function readRequiredObject(
 function readOptionalString(
   input: Record<string, WorkflowFrontMatterNode>,
   key: string,
-  env: NodeJS.ProcessEnv
+  env: NodeJS.ProcessEnv,
+  path = key
 ): string | null {
   const value = input[key];
   if (value === undefined || value === null) {
     return null;
   }
   if (typeof value !== "string") {
-    throw new Error(`Workflow front matter field "${key}" must be a string.`);
+    throw new Error(`Workflow front matter field "${path}" must be a string.`);
   }
-  return resolveEnvironmentValue(value, env);
+  return resolveEnvironmentValue(value, env, path);
 }
 
 function readOptionalWorkflowString(
@@ -914,7 +948,8 @@ function readOptionalBoolean(
 
 function readOptionalIntegerLike(
   input: Record<string, WorkflowFrontMatterNode>,
-  key: string
+  key: string,
+  path = key
 ): number | null {
   const value = input[key];
   if (value === undefined || value === null) {
@@ -923,7 +958,11 @@ function readOptionalIntegerLike(
   if (typeof value === "number" && Number.isInteger(value)) {
     return value;
   }
-  throw new Error(`Workflow front matter field "${key}" must be an integer.`);
+  throw new WorkflowValidationError(
+    "workflow_validation_error",
+    path,
+    `Workflow front matter field "${path}" must be an integer.`
+  );
 }
 
 function readOptionalPositiveInteger(
@@ -931,7 +970,7 @@ function readOptionalPositiveInteger(
   key: string,
   path: string
 ): number | null {
-  const value = readOptionalIntegerLike(input, key);
+  const value = readOptionalIntegerLike(input, key, path);
   if (value !== null && value <= 0) {
     throw new WorkflowValidationError(
       "workflow_validation_error",
@@ -945,14 +984,15 @@ function readOptionalPositiveInteger(
 function readOptionalNonEmptyString(
   input: Record<string, WorkflowFrontMatterNode>,
   key: string,
-  env: NodeJS.ProcessEnv
+  env: NodeJS.ProcessEnv,
+  path: string
 ): string | null {
-  const value = readOptionalString(input, key, env);
+  const value = readOptionalString(input, key, env, path);
   if (value !== null && value.trim().length === 0) {
     throw new WorkflowValidationError(
       "workflow_validation_error",
-      `codex.${key}`,
-      `Workflow front matter field "codex.${key}" must be a non-empty string when provided.`
+      path,
+      `Workflow front matter field "${path}" must be a non-empty string when provided.`
     );
   }
   return value;
@@ -961,7 +1001,8 @@ function readOptionalNonEmptyString(
 function readNumberMap(
   input: Record<string, WorkflowFrontMatterNode>,
   key: string,
-  path = key
+  path = key,
+  options: { positive?: boolean } = {}
 ): Record<string, number> {
   const value = input[key];
   if (value === undefined || value === null) {
@@ -974,6 +1015,13 @@ function readNumberMap(
   const result: Record<string, number> = {};
   for (const [entryKey, entryValue] of Object.entries(value)) {
     if (typeof entryValue === "number" && Number.isInteger(entryValue)) {
+      if (options.positive && entryValue <= 0) {
+        throw new WorkflowValidationError(
+          "workflow_validation_error",
+          `${path}.${entryKey}`,
+          `Workflow front matter field "${path}.${entryKey}" must be a positive integer.`
+        );
+      }
       result[entryKey] = entryValue;
       continue;
     }
@@ -986,14 +1034,15 @@ function readNumberMap(
 
 function resolveEnvironmentValue(
   value: string,
-  env: NodeJS.ProcessEnv
+  env: NodeJS.ProcessEnv,
+  path: string
 ): string {
   const envTokenMatch = value.match(/^(?:env:)?([A-Z0-9_]+)$/);
   if (value.startsWith("env:") && envTokenMatch) {
     const resolved = env[envTokenMatch[1]];
     if (!resolved) {
       throw new Error(
-        `Workflow front matter requires environment variable ${envTokenMatch[1]}.`
+        `Workflow front matter field "${path}" requires environment variable ${envTokenMatch[1]}.`
       );
     }
     return resolved;
@@ -1004,7 +1053,7 @@ function resolveEnvironmentValue(
     const resolved = env[dollarEnvTokenMatch[1]];
     if (!resolved) {
       throw new Error(
-        `Workflow front matter requires environment variable ${dollarEnvTokenMatch[1]}.`
+        `Workflow front matter field "${path}" requires environment variable ${dollarEnvTokenMatch[1]}.`
       );
     }
     return resolved;
@@ -1014,7 +1063,7 @@ function resolveEnvironmentValue(
     const resolved = env[name];
     if (!resolved) {
       throw new Error(
-        `Workflow front matter requires environment variable ${name}.`
+        `Workflow front matter field "${path}" requires environment variable ${name}.`
       );
     }
     return resolved;

--- a/packages/core/src/workflow/parser.ts
+++ b/packages/core/src/workflow/parser.ts
@@ -31,12 +31,56 @@ type WorkflowFrontMatterNode =
 
 export type ParseWorkflowOptions = {
   compatibilityMode?: "strict" | "legacy";
+  supportedTrackerKinds?: readonly string[];
 };
+
+export type WorkflowValidationErrorCode =
+  | "workflow_parse_error"
+  | "workflow_front_matter_not_a_map"
+  | "workflow_validation_error";
+
+/** A stable, machine-readable error raised while reading WORKFLOW.md. */
+export class WorkflowValidationError extends Error {
+  constructor(
+    public readonly code: WorkflowValidationErrorCode,
+    public readonly path: string,
+    message: string
+  ) {
+    super(message);
+    this.name = "WorkflowValidationError";
+  }
+}
+
+export const DEFAULT_SUPPORTED_TRACKER_KINDS = [
+  "github-project",
+  "linear",
+  "file",
+] as const;
 
 export function parseWorkflowMarkdown(
   markdown: string,
   env: NodeJS.ProcessEnv = process.env,
   options: ParseWorkflowOptions = {}
+): ParsedWorkflow {
+  try {
+    return parseWorkflowMarkdownInternal(markdown, env, options);
+  } catch (error) {
+    if (error instanceof WorkflowValidationError) {
+      throw error;
+    }
+    const message = error instanceof Error ? error.message : "Invalid workflow definition.";
+    throw new WorkflowValidationError(
+      "workflow_validation_error",
+      inferWorkflowErrorPath(message),
+      message
+    );
+  }
+}
+
+function parseWorkflowMarkdownInternal(
+  markdown: string,
+  env: NodeJS.ProcessEnv,
+  options: ParseWorkflowOptions
 ): ParsedWorkflow {
   const compatibilityMode = options.compatibilityMode ?? "strict";
   const frontMatterMatch = markdown.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
@@ -45,7 +89,11 @@ export function parseWorkflowMarkdown(
     if (compatibilityMode === "legacy") {
       return parseLegacyWorkflowMarkdown(markdown);
     }
-    throw new Error("WORKFLOW.md must use YAML front matter.");
+    throw new WorkflowValidationError(
+      "workflow_parse_error",
+      "front_matter",
+      "WORKFLOW.md must use YAML front matter."
+    );
   }
 
   const [, rawFrontMatter, rawPromptTemplate = ""] = frontMatterMatch;
@@ -64,6 +112,15 @@ export function parseWorkflowMarkdown(
     : readRequiredObject(frontMatter, "codex");
 
   const trackerKind = readRequiredString(tracker, "kind", env);
+  const supportedTrackerKinds =
+    options.supportedTrackerKinds ?? DEFAULT_SUPPORTED_TRACKER_KINDS;
+  if (!supportedTrackerKinds.includes(trackerKind)) {
+    throw new WorkflowValidationError(
+      "workflow_validation_error",
+      "tracker.kind",
+      `Unsupported workflow tracker.kind "${trackerKind}". Supported values: ${supportedTrackerKinds.join(", ")}.`
+    );
+  }
   validateTrackerConfig(tracker, trackerKind, env);
   const activeStates =
     readStringList(tracker, "active_states") ??
@@ -85,7 +142,7 @@ export function parseWorkflowMarkdown(
 
   const runtime = hasRuntime ? parseRuntimeConfig(runtimeNode, env) : null;
   const codexConfig = {
-    command: readOptionalString(codex, "command", env) ?? DEFAULT_AGENT_COMMAND,
+    command: readOptionalNonEmptyString(codex, "command", env) ?? DEFAULT_AGENT_COMMAND,
     approvalPolicy: readOptionalString(codex, "approval_policy", env),
     threadSandbox: readOptionalString(codex, "thread_sandbox", env),
     turnSandboxPolicy: readOptionalString(codex, "turn_sandbox_policy", env),
@@ -146,7 +203,8 @@ export function parseWorkflowMarkdown(
       afterRun: readOptionalString(hooks, "after_run", env),
       beforeRemove: readOptionalString(hooks, "before_remove", env),
       timeoutMs:
-        readOptionalIntegerLike(hooks, "timeout_ms") ?? DEFAULT_HOOK_TIMEOUT_MS,
+        readOptionalPositiveInteger(hooks, "timeout_ms", "hooks.timeout_ms") ??
+        DEFAULT_HOOK_TIMEOUT_MS,
     },
     agent: {
       maxConcurrentAgents:
@@ -160,7 +218,8 @@ export function parseWorkflowMarkdown(
         readOptionalIntegerLike(agent, "max_failure_retries") ??
         DEFAULT_MAX_FAILURE_RETRIES,
       maxTurns:
-        readOptionalIntegerLike(agent, "max_turns") ?? DEFAULT_MAX_TURNS,
+        readOptionalPositiveInteger(agent, "max_turns", "agent.max_turns") ??
+        DEFAULT_MAX_TURNS,
       retryBaseDelayMs:
         readOptionalIntegerLike(agent, "retry_base_delay_ms") ??
         DEFAULT_BASE_DELAY_MS,
@@ -315,13 +374,34 @@ function parseFrontMatter(
   frontMatter: string
 ): Record<string, WorkflowFrontMatterNode> {
   const lines = frontMatter.replace(/\r\n/g, "\n").split("\n");
-  const [value] = parseBlock(lines, 0, 0);
+  let value: WorkflowFrontMatterNode;
+  try {
+    [value] = parseBlock(lines, 0, 0);
+  } catch (error) {
+    if (error instanceof WorkflowValidationError) {
+      throw error;
+    }
+    throw new WorkflowValidationError(
+      "workflow_parse_error",
+      "front_matter",
+      error instanceof Error ? error.message : "Invalid YAML front matter."
+    );
+  }
 
   if (!value || Array.isArray(value) || typeof value !== "object") {
-    throw new Error("Workflow front matter must be a YAML object.");
+    throw new WorkflowValidationError(
+      "workflow_front_matter_not_a_map",
+      "front_matter",
+      "Workflow front matter must be a YAML object."
+    );
   }
 
   return value as Record<string, WorkflowFrontMatterNode>;
+}
+
+function inferWorkflowErrorPath(message: string): string {
+  const field = message.match(/field "([^"]+)"/);
+  return field?.[1] ?? "front_matter";
 }
 
 function parseBlock(
@@ -840,13 +920,42 @@ function readOptionalIntegerLike(
   if (value === undefined || value === null) {
     return null;
   }
-  if (typeof value === "number") {
+  if (typeof value === "number" && Number.isInteger(value)) {
     return value;
   }
-  if (typeof value === "string" && /^-?\d+$/.test(value)) {
-    return Number.parseInt(value, 10);
-  }
   throw new Error(`Workflow front matter field "${key}" must be an integer.`);
+}
+
+function readOptionalPositiveInteger(
+  input: Record<string, WorkflowFrontMatterNode>,
+  key: string,
+  path: string
+): number | null {
+  const value = readOptionalIntegerLike(input, key);
+  if (value !== null && value <= 0) {
+    throw new WorkflowValidationError(
+      "workflow_validation_error",
+      path,
+      `Workflow front matter field "${path}" must be a positive integer.`
+    );
+  }
+  return value;
+}
+
+function readOptionalNonEmptyString(
+  input: Record<string, WorkflowFrontMatterNode>,
+  key: string,
+  env: NodeJS.ProcessEnv
+): string | null {
+  const value = readOptionalString(input, key, env);
+  if (value !== null && value.trim().length === 0) {
+    throw new WorkflowValidationError(
+      "workflow_validation_error",
+      `codex.${key}`,
+      `Workflow front matter field "codex.${key}" must be a non-empty string when provided.`
+    );
+  }
+  return value;
 }
 
 function readNumberMap(
@@ -864,12 +973,8 @@ function readNumberMap(
 
   const result: Record<string, number> = {};
   for (const [entryKey, entryValue] of Object.entries(value)) {
-    if (typeof entryValue === "number") {
+    if (typeof entryValue === "number" && Number.isInteger(entryValue)) {
       result[entryKey] = entryValue;
-      continue;
-    }
-    if (typeof entryValue === "string" && /^-?\d+$/.test(entryValue)) {
-      result[entryKey] = Number.parseInt(entryValue, 10);
       continue;
     }
     throw new Error(

--- a/packages/core/src/workflow/parser.ts
+++ b/packages/core/src/workflow/parser.ts
@@ -113,7 +113,7 @@ function parseWorkflowMarkdownInternal(
     ? readObject(frontMatter, "codex")
     : readRequiredObject(frontMatter, "codex");
 
-  const trackerKind = readRequiredString(tracker, "kind", env);
+  const trackerKind = readRequiredString(tracker, "kind", env, "tracker.kind");
   const supportedTrackerKinds =
     options.supportedTrackerKinds ?? DEFAULT_SUPPORTED_TRACKER_KINDS;
   if (!supportedTrackerKinds.includes(trackerKind)) {
@@ -187,19 +187,38 @@ function parseWorkflowMarkdownInternal(
     tracker: {
       kind: trackerKind,
       endpoint:
-        readOptionalString(tracker, "endpoint", env) ??
+        readOptionalString(tracker, "endpoint", env, "tracker.endpoint") ??
         (trackerKind === "linear" ? DEFAULT_LINEAR_GRAPHQL_URL : null),
-      apiKey: readOptionalString(tracker, "api_key", env),
-      projectSlug: readOptionalString(tracker, "project_slug", env),
+      apiKey: readOptionalString(tracker, "api_key", env, "tracker.api_key"),
+      projectSlug: readOptionalString(
+        tracker,
+        "project_slug",
+        env,
+        "tracker.project_slug"
+      ),
       pickupLabels: readPickupLabelsConfig(tracker),
       activeStates,
       terminalStates,
-      projectId: readOptionalString(tracker, "project_id", env),
+      projectId: readOptionalString(
+        tracker,
+        "project_id",
+        env,
+        "tracker.project_id"
+      ),
       stateFieldName:
-        readOptionalString(tracker, "state_field", env) ??
-        DEFAULT_WORKFLOW_TRACKER.stateFieldName,
+        readOptionalString(
+          tracker,
+          "state_field",
+          env,
+          "tracker.state_field"
+        ) ?? DEFAULT_WORKFLOW_TRACKER.stateFieldName,
       priority: readPriorityConfig(tracker, env),
-      priorityFieldName: readOptionalString(tracker, "priority_field", env),
+      priorityFieldName: readOptionalString(
+        tracker,
+        "priority_field",
+        env,
+        "tracker.priority_field"
+      ),
       blockerCheckStates,
       planningStates,
     },
@@ -226,7 +245,7 @@ function parseWorkflowMarkdownInternal(
     },
     agent: {
       maxConcurrentAgents:
-        readOptionalIntegerLike(
+        readOptionalPositiveInteger(
           agent,
           "max_concurrent_agents",
           "agent.max_concurrent_agents"
@@ -292,7 +311,12 @@ function validateTrackerConfig(
     }
   }
 
-  const projectSlug = readOptionalString(tracker, "project_slug", env);
+  const projectSlug = readOptionalString(
+    tracker,
+    "project_slug",
+    env,
+    "tracker.project_slug"
+  );
   if (!projectSlug || projectSlug.trim().length === 0) {
     throw new Error(
       'Workflow front matter field "tracker.project_slug" is required for tracker.kind "linear".'
@@ -300,7 +324,12 @@ function validateTrackerConfig(
   }
 
   if ("endpoint" in tracker) {
-    const endpoint = readOptionalString(tracker, "endpoint", env);
+    const endpoint = readOptionalString(
+      tracker,
+      "endpoint",
+      env,
+      "tracker.endpoint"
+    );
     if (!endpoint || endpoint.trim().length === 0) {
       throw new Error(
         'Workflow front matter field "tracker.endpoint" must be a non-empty string when provided for tracker.kind "linear".'
@@ -879,11 +908,12 @@ function readOptionalWorkflowString(
 function readRequiredString(
   input: Record<string, WorkflowFrontMatterNode>,
   key: string,
-  env: NodeJS.ProcessEnv
+  env: NodeJS.ProcessEnv,
+  path = key
 ): string {
-  const value = readOptionalString(input, key, env);
+  const value = readOptionalString(input, key, env, path);
   if (!value) {
-    throw new Error(`Workflow front matter field "${key}" is required.`);
+    throw new Error(`Workflow front matter field "${path}" is required.`);
   }
   return value;
 }
@@ -1025,7 +1055,9 @@ function readNumberMap(
       result[entryKey] = entryValue;
       continue;
     }
-    throw new Error(
+    throw new WorkflowValidationError(
+      "workflow_validation_error",
+      `${path}.${entryKey}`,
       `Workflow front matter field "${path}.${entryKey}" must be an integer.`
     );
   }
@@ -1041,7 +1073,9 @@ function resolveEnvironmentValue(
   if (value.startsWith("env:") && envTokenMatch) {
     const resolved = env[envTokenMatch[1]];
     if (!resolved) {
-      throw new Error(
+      throw new WorkflowValidationError(
+        "workflow_validation_error",
+        path,
         `Workflow front matter field "${path}" requires environment variable ${envTokenMatch[1]}.`
       );
     }
@@ -1052,7 +1086,9 @@ function resolveEnvironmentValue(
   if (dollarEnvTokenMatch) {
     const resolved = env[dollarEnvTokenMatch[1]];
     if (!resolved) {
-      throw new Error(
+      throw new WorkflowValidationError(
+        "workflow_validation_error",
+        path,
         `Workflow front matter field "${path}" requires environment variable ${dollarEnvTokenMatch[1]}.`
       );
     }
@@ -1062,7 +1098,9 @@ function resolveEnvironmentValue(
   return value.replace(/\$\{([A-Z0-9_]+)\}/g, (_, name: string) => {
     const resolved = env[name];
     if (!resolved) {
-      throw new Error(
+      throw new WorkflowValidationError(
+        "workflow_validation_error",
+        path,
         `Workflow front matter field "${path}" requires environment variable ${name}.`
       );
     }

--- a/packages/orchestrator/src/git.ts
+++ b/packages/orchestrator/src/git.ts
@@ -25,8 +25,11 @@ import {
   withGlobalBareRepositoryCache,
 } from "./repository-cache.js";
 import { sanitizeRepositoryCloneUrl } from "./repository-url.js";
+import { getSupportedTrackerKinds } from "./tracker-adapters.js";
 
-const workflowConfigStore = new WorkflowConfigStore();
+const workflowConfigStore = new WorkflowConfigStore({
+  supportedTrackerKinds: getSupportedTrackerKinds(),
+});
 const LOCK_RETRY_MS = 100;
 const LOCK_STALE_MS = 30 * 60 * 1000;
 const LOCK_TIMEOUT_MS = 2 * 60 * 1000;

--- a/packages/orchestrator/src/git.ts
+++ b/packages/orchestrator/src/git.ts
@@ -15,6 +15,7 @@ import { join } from "node:path";
 import {
   createInvalidWorkflowResolution,
   createDefaultWorkflowResolution,
+  formatWorkflowValidationError,
   WorkflowConfigStore,
   type RepositoryRef,
   type WorkflowResolution,
@@ -501,7 +502,7 @@ export async function loadWorkflowFile(
 
     return createInvalidWorkflowResolution(
       workflowPath,
-      error instanceof Error ? error.message : "workflow_parse_error"
+      formatWorkflowValidationError(error)
     );
   }
 }

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -29,6 +29,7 @@ export * from "./explain.js";
 export * from "./repository-cache.js";
 export {
   findGithubProjectIssue,
+  getSupportedTrackerKinds,
   resolveTrackerAdapter,
 } from "./tracker-adapters.js";
 export {

--- a/packages/orchestrator/src/tracker-adapters.test.ts
+++ b/packages/orchestrator/src/tracker-adapters.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { resolveTrackerAdapter } from "./tracker-adapters.js";
+import {
+  getSupportedTrackerKinds,
+  resolveTrackerAdapter,
+} from "./tracker-adapters.js";
 
 describe("resolveTrackerAdapter", () => {
   it("registers the Linear adapter", () => {
@@ -13,4 +16,10 @@ describe("resolveTrackerAdapter", () => {
 
     expect(adapter.buildWorkerEnvironment).toBeTypeOf("function");
   });
+});
+
+it("exports adapter-owned tracker kinds for workflow validation", () => {
+  expect(getSupportedTrackerKinds()).toEqual(
+    expect.arrayContaining(["github-project", "file", "linear"])
+  );
 });

--- a/packages/orchestrator/src/tracker-adapters.ts
+++ b/packages/orchestrator/src/tracker-adapters.ts
@@ -12,6 +12,11 @@ const localAdapters = new Map<string, OrchestratorTrackerAdapter>([
   ["linear", linearTrackerAdapter],
 ]);
 
+/** Adapter-owned tracker kinds supplied to workflow validation at the boundary. */
+export function getSupportedTrackerKinds(): readonly string[] {
+  return ["github-project", ...localAdapters.keys()];
+}
+
 export function resolveTrackerAdapter(
   tracker: OrchestratorTrackerConfig
 ): OrchestratorTrackerAdapter {


### PR DESCRIPTION
## TL;DR

- Enforce strict `WORKFLOW.md` validation before configuration reaches runtime execution.
- Preserve typed workflow error codes and qualified field paths across parser, loader, `workflow validate`, and `doctor`.
- Keep CLI and daemon tracker-kind preflight aligned with the orchestrator adapter registry.

## Change-point diagram

```text
adapter registry → parser/loader options → typed workflow validation → CLI diagnostics
```

## Start here

- `packages/core/src/workflow/parser.ts` owns typed front-matter validation and field paths.
- `packages/orchestrator/src/tracker-adapters.ts` supplies registered tracker kinds to workflow loading.
- `packages/cli/src/commands/{workflow,doctor}.ts` apply the same supported-kind registry to preflight commands.
- `packages/core/src/workflow-loader.test.ts` covers malformed YAML, scalar roots, strict integer/range checks, defaults, and injected kinds.

## Risks & rollback

- Previously accepted quoted numeric values, non-positive concurrency limits, and invalid configuration now fail early.
- Priority maps and per-state concurrency overrides must use YAML integers; global and per-state concurrency values must be positive.
- Roll back by reverting this PR to restore legacy permissive parsing.

## Changed files

- `packages/core/src/workflow/{parser,loader}.ts`: strict typed validation and parser coverage.
- `packages/orchestrator/src/{git,tracker-adapters}.ts`: adapter-owned supported-kind injection.
- `packages/cli/src/commands/{workflow,doctor,repo.test}.ts`: registry-aligned CLI preflight and diagnostic regression coverage.
- `docs/configuration.md`, `README.md`, `packages/cli/README.md`: validation behavior guidance.

## Issues — Closed #667

## Evidence

- `pnpm lint`
- `pnpm test`
- `pnpm typecheck`
- `pnpm build`
- Docker E2E: rebuilt `symphony-e2e`; `/healthz` returned `{"ok":true}`, refresh succeeded, and `/api/v1/state` reported `health: "idle"` with no `lastError`.

## Post-merge / human validation

- [ ] Confirm invalid workflows expose stable codes and qualified paths in `workflow validate --json`.
- [ ] Confirm `doctor` and `workflow validate` accept registered tracker kinds and reject an unregistered kind before dispatch.
