### PR TITLE
feat(tracker-github): normalize refreshed snapshots

### DIFF
--- a/.changeset/normalized-github-refresh.md
+++ b/.changeset/normalized-github-refresh.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Return complete normalized GitHub Project issue snapshots after ID refreshes, including routing fields and assignees (#662).

--- a/packages/tracker-github/src/adapter.ts
+++ b/packages/tracker-github/src/adapter.ts
@@ -499,8 +499,7 @@ export function normalizeProjectItem(
       item.content.state ?? null,
       linkedPullRequests,
       linkedPullRequestsTruncated,
-      isArchived,
-      normalizeAssigneeLogins(item.content.assignees?.nodes ?? [])
+      isArchived
     ),
     rateLimits,
   };
@@ -2187,6 +2186,18 @@ function normalizeIssueStateLookupNode(
     return null;
   }
 
+  if (projectItem.isArchived !== true) {
+    const fieldValues = extractFieldValues(
+      projectItem.fieldValues?.nodes ?? []
+    );
+    requireProjectItemState(
+      fieldValues,
+      lifecycle,
+      projectItem.id,
+      `${issue.repository.owner.login}/${issue.repository.name}#${issue.number}`
+    );
+  }
+
   const normalized = normalizeRepositoryIssueLookup(
     projectId,
     issue,
@@ -2195,17 +2206,9 @@ function normalizeIssueStateLookupNode(
     priority,
     rateLimits
   );
-  if (normalized || projectItem.isArchived === true) {
+  if (normalized) {
     return normalized;
   }
-
-  const fieldValues = extractFieldValues(projectItem.fieldValues?.nodes ?? []);
-  requireProjectItemState(
-    fieldValues,
-    lifecycle,
-    projectItem.id,
-    `${issue.repository.owner.login}/${issue.repository.name}#${issue.number}`
-  );
   return null;
 }
 
@@ -2306,18 +2309,16 @@ function withIssueMetadata(
   sourceState: string | null,
   linkedPullRequests: GitHubPullRequestMetadata[],
   linkedPullRequestsTruncated = false,
-  isArchived = false,
-  assignees: string[] = []
+  isArchived = false
 ): TrackedIssue["metadata"] {
-  const metadata = assignees.length === 0 ? {} : { assignees };
   if (
     linkedPullRequests.length === 0 &&
     !linkedPullRequestsTruncated &&
     !isArchived
   ) {
     return sourceState === null
-      ? { ...fieldValues, ...metadata }
-      : withGitHubMetadata(fieldValues, { sourceState, ...metadata });
+      ? fieldValues
+      : withGitHubMetadata(fieldValues, { sourceState });
   }
 
   return withGitHubMetadata(fieldValues, {
@@ -2325,14 +2326,7 @@ function withIssueMetadata(
     linkedPullRequests,
     linkedPullRequestsTruncated,
     isArchived,
-    ...metadata,
   });
-}
-
-function normalizeAssigneeLogins(
-  nodes: Array<{ login: string | null } | null>
-): string[] {
-  return nodes.flatMap((node) => (node?.login ? [node.login] : []));
 }
 
 async function resolveIssueProjectItemForStateLookup(

--- a/packages/tracker-github/src/adapter.ts
+++ b/packages/tracker-github/src/adapter.ts
@@ -278,20 +278,13 @@ type GraphQLProjectFieldsResponse = {
   } | null;
 };
 
-type GraphQLIssueStateLookupNode = {
-  __typename: "Issue" | "PullRequest";
-  id: string;
-  number: number;
-  url?: string | null;
-  updatedAt: string | null;
-  headRefName?: string | null;
-  repository: {
-    name: string;
-    url: string;
-    owner: { login: string };
-  };
-  projectItems: GraphQLIssueProjectItemsConnection | null;
-};
+type GraphQLIssueStateLookupNode =
+  | (GraphQLIssueNode & {
+      projectItems: GraphQLIssueProjectItemsConnection | null;
+    })
+  | (GraphQLPullRequestNode & {
+      projectItems: GraphQLIssueProjectItemsConnection | null;
+    });
 
 type GraphQLIssueStatesByIdsResponse = {
   nodes?: Array<GraphQLIssueStateLookupNode | null> | null;
@@ -485,8 +478,8 @@ export function normalizeProjectItem(
     labels: normalizeLabelNames(item.content.labels?.nodes ?? []),
     dispatchable: true,
     assigneeId:
-      item.content.assignees?.nodes?.find((assignee) => assignee?.login)?.login ??
-      null,
+      item.content.assignees?.nodes?.find((assignee) => assignee?.login)
+        ?.login ?? null,
     blockedBy,
     createdAt: item.content.createdAt,
     updatedAt: trackedUpdatedAt,
@@ -506,7 +499,8 @@ export function normalizeProjectItem(
       item.content.state ?? null,
       linkedPullRequests,
       linkedPullRequestsTruncated,
-      isArchived
+      isArchived,
+      normalizeAssigneeLogins(item.content.assignees?.nodes ?? [])
     ),
     rateLimits,
   };
@@ -724,6 +718,14 @@ export async function fetchIssueStatesByIds(
 
   const issues: GitHubTrackedIssue[] = [];
   const cycleConfig = beginGraphQLRateLimitCycle(config);
+  const priorityOptionIds =
+    !config.priority && config.priorityFieldName
+      ? await fetchPriorityOptionOrder(
+          cycleConfig,
+          config.priorityFieldName,
+          fetchImpl
+        )
+      : undefined;
   let latestRateLimits: GitHubRateLimitPayload | null = null;
 
   for (const issueIdBatch of chunkValues([...new Set(issueIds)], 100)) {
@@ -751,6 +753,13 @@ export async function fetchIssueStatesByIds(
         node,
         projectItem,
         config.lifecycle,
+        {
+          explicit: config.priority,
+          legacy: {
+            fieldName: config.priorityFieldName,
+            optionIds: priorityOptionIds,
+          },
+        },
         rateLimits
       );
       if (normalized) {
@@ -2168,6 +2177,7 @@ function normalizeIssueStateLookupNode(
   issue: GraphQLIssueStateLookupNode | null,
   projectItem: GraphQLIssueProjectItemNode | null,
   lifecycle: WorkflowLifecycleConfig = DEFAULT_WORKFLOW_LIFECYCLE,
+  priority: PriorityResolutionInput = {},
   rateLimits: Record<string, unknown> | null = null
 ): GitHubTrackedIssue | null {
   if (issue?.__typename !== "Issue" && issue?.__typename !== "PullRequest") {
@@ -2177,66 +2187,31 @@ function normalizeIssueStateLookupNode(
     return null;
   }
 
-  const fieldValues = extractFieldValues(projectItem.fieldValues?.nodes ?? []);
-  const isArchived = projectItem.isArchived === true;
-  const repository = issue.repository;
-  const identifier = `${repository.owner.login}/${repository.name}#${issue.number}`;
-  const state = isArchived
-    ? ARCHIVED_PROJECT_ITEM_STATE
-    : requireProjectItemState(
-        fieldValues,
-        lifecycle,
-        projectItem.id,
-        identifier
-      );
-  const url =
-    issue.url ??
-    `${repository.url}/${issue.__typename === "PullRequest" ? "pull" : "issues"}/${issue.number}`;
+  const normalized = normalizeRepositoryIssueLookup(
+    projectId,
+    issue,
+    projectItem,
+    lifecycle,
+    priority,
+    rateLimits
+  );
+  if (normalized || projectItem.isArchived === true) {
+    return normalized;
+  }
 
-  return {
-    id: issue.id,
-    identifier,
-    number: issue.number,
-    title: identifier,
-    description: null,
-    priority: null,
-    state,
-    branchName:
-      issue.__typename === "PullRequest" ? (issue.headRefName ?? null) : null,
-    url,
-    labels: [],
-    dispatchable: true,
-    assigneeId: null,
-    blockedBy: [],
-    createdAt: null,
-    updatedAt: projectItem.updatedAt ?? issue.updatedAt,
-    repository: {
-      owner: repository.owner.login,
-      name: repository.name,
-      url: repository.url,
-      cloneUrl: deriveCloneUrl(repository.url),
-    },
-    tracker: {
-      adapter: "github-project",
-      bindingId: projectId,
-      itemId: projectItem.id,
-    },
-    metadata:
-      issue.__typename === "PullRequest"
-        ? withGitHubMetadata(fieldValues, {
-            contentType: "PullRequest",
-            isArchived,
-          })
-        : withGitHubMetadata(fieldValues, {
-            isArchived,
-          }),
-    rateLimits,
-  };
+  const fieldValues = extractFieldValues(projectItem.fieldValues?.nodes ?? []);
+  requireProjectItemState(
+    fieldValues,
+    lifecycle,
+    projectItem.id,
+    `${issue.repository.owner.login}/${issue.repository.name}#${issue.number}`
+  );
+  return null;
 }
 
 function normalizeRepositoryIssueLookup(
   projectId: string,
-  issue: GraphQLRepositoryIssueLookupNode | null,
+  issue: GraphQLIssueStateLookupNode | GraphQLRepositoryIssueLookupNode | null,
   projectItem: GraphQLIssueProjectItemNode | null,
   lifecycle: WorkflowLifecycleConfig = DEFAULT_WORKFLOW_LIFECYCLE,
   priority: PriorityResolutionInput = {},
@@ -2331,16 +2306,18 @@ function withIssueMetadata(
   sourceState: string | null,
   linkedPullRequests: GitHubPullRequestMetadata[],
   linkedPullRequestsTruncated = false,
-  isArchived = false
+  isArchived = false,
+  assignees: string[] = []
 ): TrackedIssue["metadata"] {
+  const metadata = assignees.length === 0 ? {} : { assignees };
   if (
     linkedPullRequests.length === 0 &&
     !linkedPullRequestsTruncated &&
     !isArchived
   ) {
     return sourceState === null
-      ? fieldValues
-      : withGitHubMetadata(fieldValues, { sourceState });
+      ? { ...fieldValues, ...metadata }
+      : withGitHubMetadata(fieldValues, { sourceState, ...metadata });
   }
 
   return withGitHubMetadata(fieldValues, {
@@ -2348,7 +2325,14 @@ function withIssueMetadata(
     linkedPullRequests,
     linkedPullRequestsTruncated,
     isArchived,
+    ...metadata,
   });
+}
+
+function normalizeAssigneeLogins(
+  nodes: Array<{ login: string | null } | null>
+): string[] {
+  return nodes.flatMap((node) => (node?.login ? [node.login] : []));
 }
 
 async function resolveIssueProjectItemForStateLookup(
@@ -3217,13 +3201,48 @@ const ISSUE_STATES_BY_IDS_QUERY = `
       ... on Issue {
         id
         number
+        title
+        body
         url
+        state
+        createdAt
         updatedAt
+        labels(first: 20) {
+          nodes {
+            name
+          }
+        }
+        assignees(first: 20) {
+          nodes {
+            login
+          }
+        }
         repository {
           name
           url
           owner {
             login
+          }
+        }
+        blockedBy(first: 100) {
+          nodes {
+            id
+            number
+            state
+            repository {
+              name
+              owner {
+                login
+              }
+            }
+          }
+        }
+        closedByPullRequestsReferences(first: 20) {
+          nodes {
+            ...PullRequestMetadata
+          }
+          pageInfo {
+            hasNextPage
           }
         }
         projectItems(first: 100, includeArchived: true) {
@@ -3264,18 +3283,7 @@ const ISSUE_STATES_BY_IDS_QUERY = `
         }
       }
       ... on PullRequest {
-        id
-        number
-        url
-        updatedAt
-        headRefName
-        repository {
-          name
-          url
-          owner {
-            login
-          }
-        }
+        ...PullRequestMetadata
         projectItems(first: 100, includeArchived: true) {
           nodes {
             id
@@ -3314,6 +3322,35 @@ const ISSUE_STATES_BY_IDS_QUERY = `
         }
       }
     }
+  }
+
+  fragment PullRequestMetadata on PullRequest {
+    id
+    number
+    title
+    body
+    url
+    state
+    isDraft
+    merged
+    headRefName
+    baseRefName
+    headRepository {
+      name
+      url
+      owner {
+        login
+      }
+    }
+    repository {
+      name
+      url
+      owner {
+        login
+      }
+    }
+    createdAt
+    updatedAt
   }
 `;
 

--- a/packages/tracker-github/src/tracker-github.test.ts
+++ b/packages/tracker-github/src/tracker-github.test.ts
@@ -4906,9 +4906,7 @@ describe("resolveTrackerAdapter", () => {
       ],
       createdAt: "2026-03-13T00:00:00.000Z",
       updatedAt: "2026-03-14T00:00:00.000Z",
-      metadata: {
-        assignees: ["octocat"],
-      },
+      assigneeId: "octocat",
     });
   });
 
@@ -4991,6 +4989,9 @@ describe("resolveTrackerAdapter", () => {
 
           expect(body.query).toContain("... on PullRequest");
           expect(body.query).toContain("headRefName");
+          expect(body.query).toContain("baseRefName");
+          expect(body.query).toContain("headRepository");
+          expect(body.query).toContain("createdAt");
           expect(body.variables.issueIds).toEqual(["pr-1"]);
 
           return new Response(
@@ -5024,6 +5025,27 @@ describe("resolveTrackerAdapter", () => {
     expect(issues[0]?.branchName).toBe("feature/pr-card");
     expect(issues[0]?.url).toBe("https://github.com/acme/platform/pull/42");
     expect(issues[0]?.tracker.itemId).toBe("item-pr-1");
+    expect(issues[0]).toMatchObject({
+      title: "Add refresh normalization",
+      description: "PR body",
+      createdAt: "2026-03-13T00:00:00.000Z",
+      metadata: {
+        contentType: "PullRequest",
+        pullRequest: {
+          title: "Add refresh normalization",
+          body: "PR body",
+          state: "OPEN",
+          isDraft: false,
+          merged: false,
+          baseRefName: "main",
+          headRepository: {
+            owner: "acme",
+            name: "fork",
+          },
+          createdAt: "2026-03-13T00:00:00.000Z",
+        },
+      },
+    });
   });
 
   it("fails loudly when a refreshed Project item omits the state field", async () => {
@@ -5044,18 +5066,24 @@ describe("resolveTrackerAdapter", () => {
     });
     node.projectItems.nodes[0]!.fieldValues.nodes = [];
 
-    await expect(
-      adapter.fetchIssueStatesByIds(makeProjectConfig(), ["issue-1"], {
-        token: "dependencies-token",
-        fetchImpl: async () =>
-          new Response(JSON.stringify({ data: { nodes: [node] } }), {
-            status: 200,
-            headers: { "content-type": "application/json" },
-          }),
-      })
-    ).rejects.toThrow(
-      'github_project_state_field_missing: Project item item-missing-state did not include configured state field "Status". Issue: acme/platform#1.'
-    );
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    try {
+      await expect(
+        adapter.fetchIssueStatesByIds(makeProjectConfig(), ["issue-1"], {
+          token: "dependencies-token",
+          fetchImpl: async () =>
+            new Response(JSON.stringify({ data: { nodes: [node] } }), {
+              status: 200,
+              headers: { "content-type": "application/json" },
+            }),
+        })
+      ).rejects.toThrow(
+        'github_project_state_field_missing: Project item item-missing-state did not include configured state field "Status". Issue: acme/platform#1.'
+      );
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
   });
 
   it("attaches GitHub API rate-limit headers to fetched issue state lookups", async () => {
@@ -5921,6 +5949,11 @@ function makePullRequestStateLookupNode(input: {
   state: string;
   isArchived?: boolean;
   headRefName?: string | null;
+  title?: string;
+  body?: string | null;
+  baseRefName?: string | null;
+  isDraft?: boolean | null;
+  merged?: boolean | null;
   pageInfo?: {
     endCursor: string | null;
     hasNextPage: boolean;
@@ -5930,14 +5963,26 @@ function makePullRequestStateLookupNode(input: {
     __typename: "PullRequest" as const,
     id: input.pullRequestId,
     number: input.number,
+    title: input.title ?? "Add refresh normalization",
+    body: input.body ?? "PR body",
     url: `https://github.com/acme/platform/pull/${input.number}`,
+    state: "OPEN",
+    isDraft: input.isDraft ?? false,
+    merged: input.merged ?? false,
     updatedAt: "2026-03-14T00:00:00.000Z",
     headRefName: input.headRefName ?? null,
+    baseRefName: input.baseRefName ?? "main",
+    headRepository: {
+      name: "fork",
+      url: "https://github.com/acme/fork",
+      owner: { login: "acme" },
+    },
     repository: {
       name: "platform",
       url: "https://github.com/acme/platform",
       owner: { login: "acme" },
     },
+    createdAt: "2026-03-13T00:00:00.000Z",
     projectItems: {
       nodes: [
         {

--- a/packages/tracker-github/src/tracker-github.test.ts
+++ b/packages/tracker-github/src/tracker-github.test.ts
@@ -4804,6 +4804,11 @@ describe("resolveTrackerAdapter", () => {
         tracker: {
           adapter: "github-project",
           bindingId: "project-123",
+          priority: {
+            source: "project-field",
+            field: "Priority",
+            values: { High: 1 },
+          },
           settings: {
             projectId: "project-123",
           },
@@ -4828,9 +4833,9 @@ describe("resolveTrackerAdapter", () => {
           expect(body.query).toContain("isArchived");
           expect(body.query).toContain("... on Issue");
           expect(body.query).toContain("... on PullRequest");
-          expect(body.query).not.toContain("blockedBy(");
-          expect(body.query).not.toContain("labels(");
-          expect(body.query).not.toContain("assignees(");
+          expect(body.query).toContain("blockedBy(first: 100)");
+          expect(body.query).toContain("labels(first: 20)");
+          expect(body.query).toContain("assignees(first: 20)");
           expect(body.variables.issueIds).toEqual(["issue-1", "issue-2"]);
 
           return new Response(
@@ -4844,6 +4849,22 @@ describe("resolveTrackerAdapter", () => {
                     number: 1,
                     title: "First issue",
                     state: "In Progress",
+                    body: "Refresh the normalized snapshot.",
+                    labels: ["routable", "priority-high"],
+                    assignees: ["octocat"],
+                    priorityName: "High",
+                    priorityOptionId: "priority-high",
+                    blockedBy: [
+                      {
+                        id: "issue-9",
+                        number: 9,
+                        state: "OPEN",
+                        repository: {
+                          name: "dependencies",
+                          owner: { login: "acme" },
+                        },
+                      },
+                    ],
                   }),
                   makeIssueStateLookupNode({
                     projectId: "project-123",
@@ -4871,6 +4892,24 @@ describe("resolveTrackerAdapter", () => {
       "acme/platform#2",
     ]);
     expect(issues.map((issue) => issue.state)).toEqual(["In Progress", "Done"]);
+    expect(issues[0]).toMatchObject({
+      title: "First issue",
+      description: "Refresh the normalized snapshot.",
+      priority: 1,
+      labels: ["priority-high", "routable"],
+      blockedBy: [
+        {
+          id: "issue-9",
+          identifier: "acme/dependencies#9",
+          state: null,
+        },
+      ],
+      createdAt: "2026-03-13T00:00:00.000Z",
+      updatedAt: "2026-03-14T00:00:00.000Z",
+      metadata: {
+        assignees: ["octocat"],
+      },
+    });
   });
 
   it("returns archived issue states explicitly from the by-id lookup", async () => {
@@ -4987,7 +5026,7 @@ describe("resolveTrackerAdapter", () => {
     expect(issues[0]?.tracker.itemId).toBe("item-pr-1");
   });
 
-  it("fails loudly when refreshed Project metadata omits the state field", async () => {
+  it("fails loudly when a refreshed Project item omits the state field", async () => {
     const adapter = resolveTrackerAdapter({
       adapter: "github-project",
       bindingId: "project-123",
@@ -5792,6 +5831,17 @@ function makeIssueStateLookupNode(input: {
   number: number;
   title: string;
   state: string;
+  body?: string | null;
+  labels?: string[];
+  assignees?: string[];
+  blockedBy?: Array<{
+    id: string;
+    number: number;
+    state: string | null;
+    repository: { name: string; owner: { login: string } };
+  }>;
+  priorityName?: string;
+  priorityOptionId?: string;
   isArchived?: boolean;
   pageInfo?: {
     endCursor: string | null;
@@ -5802,7 +5852,25 @@ function makeIssueStateLookupNode(input: {
     __typename: "Issue" as const,
     id: input.issueId,
     number: input.number,
+    title: input.title,
+    body: input.body ?? null,
+    url: `https://github.com/acme/platform/issues/${input.number}`,
+    state: "OPEN",
+    createdAt: "2026-03-13T00:00:00.000Z",
     updatedAt: "2026-03-14T00:00:00.000Z",
+    labels: {
+      nodes: (input.labels ?? []).map((name) => ({ name })),
+    },
+    assignees: {
+      nodes: (input.assignees ?? []).map((login) => ({ login })),
+    },
+    blockedBy: {
+      nodes: input.blockedBy ?? [],
+    },
+    closedByPullRequestsReferences: {
+      nodes: [],
+      pageInfo: { hasNextPage: false },
+    },
     repository: {
       name: "platform",
       url: "https://github.com/acme/platform",
@@ -5822,6 +5890,17 @@ function makeIssueStateLookupNode(input: {
                 name: input.state,
                 field: { name: "Status" },
               },
+              ...(input.priorityName
+                ? [
+                    {
+                      __typename:
+                        "ProjectV2ItemFieldSingleSelectValue" as const,
+                      name: input.priorityName,
+                      optionId: input.priorityOptionId,
+                      field: { name: "Priority" },
+                    },
+                  ]
+                : []),
             ],
           },
         },


### PR DESCRIPTION
## TL;DR

`fetchIssueStatesByIds` now returns the same complete normalized snapshots as candidate discovery, including labels, assignee, priority, timestamps, blockers, and PullRequest metadata. Review rework adds fixture-level coverage for the full PullRequest response shape and keeps fail-loud refresh errors free of candidate-only skip telemetry.

## Change-point diagram

```text
GitHub nodes(ids:) response
        |
        v
shared normalizeProjectItem()
        |
        +-- Issue snapshot: labels / assignee / priority / timestamps / blockers
        +-- PullRequest snapshot: title / body / timestamps / pullRequest metadata
```

## Start here

- `packages/tracker-github/src/adapter.ts` — shared by-ID normalization and fail-loud state validation.
- `packages/tracker-github/src/tracker-github.test.ts` — Issue and PullRequest snapshot regressions.

## Risks & rollback

- The GraphQL request remains one request per batch of at most 100 IDs; collection bounds match candidate discovery (labels/assignees 20, blockers 100).
- Roll back this PR to restore the previous by-ID stub behavior if a GitHub GraphQL schema incompatibility is observed.

## Changed files

- `packages/tracker-github/src/adapter.ts`
- `packages/tracker-github/src/tracker-github.test.ts`
- `.changeset/normalized-github-refresh.md`

## Evidence

- `pnpm --filter @gh-symphony/tracker-github test -- --run src/tracker-github.test.ts`
- `pnpm build && pnpm test && pnpm lint && pnpm typecheck`
- Docker E2E happy path: stub worker reached `status=completed`.
- GitHub CI: Test and Container Smoke passed on `a9272ca6`.

## Issues — Closed #662

## Post-merge / human validation

- [ ] Verify a live GitHub Project refresh reflects mid-run label, assignee, and priority edits.
