### PR TITLE
feat(tracker-github): derive dispatchable eligibility

### DIFF
--- a/.changeset/green-items-dispatch.md
+++ b/.changeset/green-items-dispatch.md
@@ -2,4 +2,4 @@
 "@gh-symphony/cli": minor
 ---
 
-Expose GitHub Project dispatch eligibility for unassigned, out-of-scope, label-ineligible, and fork pull request items with explainable reasons (#687).
+Expose GitHub Project dispatch eligibility for unassigned, out-of-scope, label-ineligible, and fork pull request items with explainable reasons (#687). The GitHub eligibility event is now `tracker-dispatchability-derived`, retaining assignment/scope context and a reason breakdown; fork PR Project items are reported as non-dispatchable instead of degrading project status.

--- a/.changeset/green-items-dispatch.md
+++ b/.changeset/green-items-dispatch.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": minor
+---
+
+Expose GitHub Project dispatch eligibility for unassigned, out-of-scope, label-ineligible, and fork pull request items with explainable reasons (#687).

--- a/AGENT_TEST.md
+++ b/AGENT_TEST.md
@@ -406,6 +406,7 @@ idle → [inject issue + refresh]
 | `e2e/scenarios/16-planning-phase-prompt.md`               | Verify normalized `planning_states` classification reaches the dispatched prompt                                          |
 | `e2e/scenarios/16-repo-embedded-workspace-root.md`        | Verify repo-embedded issue workspaces use `workspace.root` while workspace records remain in orchestrator state           |
 | `e2e/scenarios/17-retry-prompt-attempt.md`                | Verify continuation retry attempt reset and prompt rendering are covered by the Docker lifecycle path and unit assertions |
+| `e2e/scenarios/18-dispatchable-eligibility.md`            | Verify non-dispatchable tracker records do not start workers while retaining an explainable reason                         |
 
 ## TC Writing Guide
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -64,7 +64,7 @@ touches a layer, check that its slice (and the linked documents) still holds.
 
 ### 5. Integration — tracker adapters (tracker-specific code lives only here)
 
-- GitHub Project V2: `packages/tracker-github` (including source issue state and linked-PR metadata kept distinct from Project workflow status)
+- GitHub Project V2: `packages/tracker-github` (including source issue state and linked-PR metadata kept distinct from Project workflow status); it returns all active scoped items and derives GitHub assignment, repository-scope, pickup-label, and fork-PR eligibility as `dispatchable` with an explainable reason.
 - Linear: `packages/tracker-linear`
 - File-based (E2E only): `packages/tracker-file`
 - GitHub-specific planning/approval/PR-reporting extensions: `packages/extension-github-workflow`

--- a/docs/designs/2026-07-06-github-project-repo-dispatch-filter-design.md
+++ b/docs/designs/2026-07-06-github-project-repo-dispatch-filter-design.md
@@ -94,7 +94,11 @@ if (config.repositoryFilter) {
 
 ### Component 4 — Observability (`packages/tracker-github/src/adapter.ts`)
 
-Mirror the `emitAssignedOnlyFilterEvent` pattern with an `emitRepositoryFilterEvent` that emits the repo-exclusion count (event: `tracker-repository-filtered`, payload with `projectId`, `repository` (wanted), `excludedCount`).
+Emit `tracker-dispatchability-derived` when assignment or repository eligibility
+rules are active. Its payload retains `projectId`, the active
+`currentUserLogin` and/or repository scope, `includedCount`, and a
+`nonDispatchableByReason` breakdown so operators can triage retained records
+without relying on the removed filter-only events.
 
 ## Backward Compatibility / Change Grade ⚠️
 

--- a/e2e/scenarios/18-dispatchable-eligibility.md
+++ b/e2e/scenarios/18-dispatchable-eligibility.md
@@ -1,0 +1,28 @@
+# Dispatchable eligibility suppression
+
+This black-box regression verifies the orchestration boundary used by GitHub
+Project eligibility: a tracker record with `dispatchable: false` remains
+visible to dispatch evaluation but must not start a worker. The GitHub adapter
+unit suite covers derivation from assignment, repository scope, pickup labels,
+and fork PR heads; this Docker case verifies the adapter-neutral dispatch gate.
+
+## Setup
+
+Start the Docker E2E environment with an empty issue fixture.
+
+## Steps
+
+1. Inject one active `Ready` file-tracker issue with `dispatchable: false` and
+   a non-empty `dispatchReason`.
+2. Trigger `/api/v1/refresh` and wait through one reconciliation interval.
+3. Read `/api/v1/state` and the run event log.
+
+## Expected
+
+- The tracker record is evaluated without starting a worker.
+- `activeRuns` remains `0` and no `run-dispatched` event is written.
+- The same reason is available to the dispatch explain surface for the issue.
+
+## Cleanup
+
+Replace the fixture with `[]` and stop the Compose project.

--- a/packages/core/src/workflow/pickup-labels.test.ts
+++ b/packages/core/src/workflow/pickup-labels.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import type { OrchestratorProjectConfig, TrackedIssue } from "@gh-symphony/core";
+import {
+  filterIssuesByPickupLabels,
+  resolvePickupLabelDispatchReason,
+} from "./pickup-labels.js";
+
+const project = {
+  tracker: {
+    adapter: "file" as const,
+    bindingId: "test",
+    settings: { pickupLabels: { include: ["alpha"], exclude: ["blocked"] } },
+  },
+} as Pick<OrchestratorProjectConfig, "tracker">;
+
+function issue(labels: string[]): TrackedIssue {
+  return {
+    id: labels.join("-") || "unlabeled",
+    identifier: `acme/repo#${labels.join("-") || "1"}`,
+    number: 1,
+    title: "Test issue",
+    description: null,
+    priority: null,
+    state: "Ready",
+    branchName: null,
+    url: null,
+    labels,
+    dispatchable: true,
+    assigneeId: null,
+    blockedBy: [],
+    createdAt: null,
+    updatedAt: null,
+    repository: { owner: "acme", name: "repo", cloneUrl: "" },
+    tracker: { adapter: "file", bindingId: "test", itemId: "test" },
+    metadata: {},
+  };
+}
+
+describe("resolvePickupLabelDispatchReason", () => {
+  it("shares exclude-first pickup policy with filtering", () => {
+    const included = issue(["alpha"]);
+    const excluded = issue(["alpha", "blocked"]);
+    const missing = issue([]);
+
+    expect(resolvePickupLabelDispatchReason(included, project)).toBeNull();
+    expect(resolvePickupLabelDispatchReason(excluded, project)).toBe(
+      'Issue has excluded pickup label "blocked".'
+    );
+    expect(resolvePickupLabelDispatchReason(missing, project)).toBe(
+      "Issue is missing a required pickup label (alpha)."
+    );
+    expect(filterIssuesByPickupLabels([included, excluded, missing], project)).toEqual([
+      included,
+    ]);
+  });
+});

--- a/packages/core/src/workflow/pickup-labels.ts
+++ b/packages/core/src/workflow/pickup-labels.ts
@@ -11,29 +11,45 @@ export function filterIssuesByPickupLabels<T extends TrackedIssue>(
   issues: T[],
   project: Pick<OrchestratorProjectConfig, "tracker">
 ): T[] {
+  return issues.filter(
+    (issue) => resolvePickupLabelDispatchReason(issue, project) === null
+  );
+}
+
+/**
+ * Resolves the workflow-policy reason an issue cannot be picked up. Tracker
+ * adapters may retain such issues for status/explain surfaces without
+ * duplicating pickup-label semantics.
+ */
+export function resolvePickupLabelDispatchReason<T extends TrackedIssue>(
+  issue: T,
+  project: Pick<OrchestratorProjectConfig, "tracker">
+): string | null {
   const pickupLabels = project.tracker.settings?.pickupLabels;
   if (
     !pickupLabels ||
     typeof pickupLabels !== "object" ||
     Array.isArray(pickupLabels)
   ) {
-    return issues;
+    return null;
   }
 
   const config = pickupLabels as Record<string, unknown>;
   const include = readLabelList(config.include);
   const exclude = new Set(readLabelList(config.exclude));
   if (include.length === 0 && exclude.size === 0) {
-    return issues;
+    return null;
   }
 
-  return issues.filter((issue) => {
-    const labels = new Set(issue.labels);
-    return (
-      ![...exclude].some((label) => labels.has(label)) &&
-      (include.length === 0 || include.some((label) => labels.has(label)))
-    );
-  });
+  const labels = new Set(issue.labels);
+  const excludedLabel = [...exclude].find((label) => labels.has(label));
+  if (excludedLabel) {
+    return `Issue has excluded pickup label "${excludedLabel}".`;
+  }
+
+  return include.length === 0 || include.some((label) => labels.has(label))
+    ? null
+    : `Issue is missing a required pickup label (${include.join(", ")}).`;
 }
 
 function readLabelList(value: unknown): string[] {

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -1827,9 +1827,23 @@ describe("OrchestratorService", () => {
       requestFails: false,
       targetIdentifier: "acme/platform#99",
     },
+    {
+      name: "non-dispatchable terminal candidate",
+      metadata: { sourceState: "CLOSED" },
+      terminalFact: "issue_closed",
+      requestFails: false,
+      targetIdentifier: null,
+      dispatchable: false,
+    },
   ])(
     "reconciles a $name to Done without dispatching",
-    async ({ metadata, terminalFact, requestFails, targetIdentifier }) => {
+    async ({
+      metadata,
+      terminalFact,
+      requestFails,
+      targetIdentifier,
+      dispatchable = true,
+    }) => {
       const tempRoot = await mkdtemp(
         join(tmpdir(), "orchestrator-terminal-candidate-")
       );
@@ -1852,7 +1866,7 @@ describe("OrchestratorService", () => {
         branchName: null,
         url: "https://github.com/acme/platform/issues/1",
         labels: [],
-        dispatchable: true,
+        dispatchable,
         assigneeId: null,
         blockedBy: [],
         createdAt: "2026-03-08T00:00:00.000Z",
@@ -1912,7 +1926,7 @@ describe("OrchestratorService", () => {
       expect(result.summary.dispatched).toBe(0);
       expect(result.summary.suppressed).toBe(0);
       expect(spawnImpl).not.toHaveBeenCalled();
-      if (targetIdentifier) {
+      if (targetIdentifier || !dispatchable) {
         expect(requestState).not.toHaveBeenCalled();
         expect(info).not.toHaveBeenCalledWith(
           expect.stringContaining(
@@ -1952,6 +1966,78 @@ describe("OrchestratorService", () => {
       }
     }
   );
+
+  it("does not publish active PR advisories for non-dispatchable items", async () => {
+    const tempRoot = await mkdtemp(
+      join(tmpdir(), "orchestrator-nondispatchable-advisory-")
+    );
+    const repository = await createRepositoryFixture(
+      tempRoot,
+      "acme",
+      "platform"
+    );
+    const store = new OrchestratorFsStore(tempRoot);
+    const projectConfig = createProjectConfig(tempRoot, repository);
+    await store.saveProjectConfig(projectConfig);
+    const issue = {
+      id: "issue-1",
+      identifier: "acme/platform#1",
+      number: 1,
+      title: "Out-of-scope issue",
+      description: null,
+      priority: null,
+      state: "Todo",
+      branchName: null,
+      url: "https://github.com/acme/platform/issues/1",
+      labels: [],
+      dispatchable: false,
+      dispatchReason: "repository does not match the configured scope",
+      assigneeId: null,
+      blockedBy: [],
+      createdAt: "2026-03-08T00:00:00.000Z",
+      updatedAt: "2026-03-08T00:00:00.000Z",
+      repository,
+      tracker: {
+        adapter: "github-project" as const,
+        bindingId: "project-123",
+        itemId: "item-1",
+      },
+      metadata: {
+        sourceState: "OPEN",
+        linkedPullRequests: [
+          {
+            id: "pr-2",
+            number: 2,
+            identifier: "acme/platform#2",
+            url: "https://github.com/acme/platform/pull/2",
+            state: "OPEN",
+            merged: false,
+          },
+        ],
+      },
+    };
+    const issues = Object.assign([issue], {
+      rateLimits: null,
+      skippedItems: [],
+    }) as TrackedIssueList;
+    const upsertIssueComment = vi.fn();
+    vi.spyOn(trackerAdapters, "resolveTrackerAdapter").mockReturnValue({
+      listIssues: vi.fn().mockResolvedValue(issues),
+      listIssuesByStates: vi.fn().mockResolvedValue([]),
+      fetchIssueStatesByIds: vi.fn().mockResolvedValue([]),
+      buildWorkerEnvironment: vi.fn(),
+      reviveIssue: vi.fn(),
+      upsertIssueComment,
+    });
+    const service = new OrchestratorService(store, projectConfig, {
+      spawnImpl: vi.fn() as never,
+      now: () => new Date("2026-03-08T00:00:00.000Z"),
+    });
+
+    await service.runOnce();
+
+    expect(upsertIssueComment).not.toHaveBeenCalled();
+  });
 
   it("passes worktree-cache settings into issue populate", async () => {
     process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
@@ -7051,10 +7137,8 @@ Prefer focused changes.
 
     const result = await service.runOnce();
 
-    expect(result.health).toBe("degraded");
-    expect(result.lastError).toMatch(
-      /fork pull requests are unsupported for automatic checkout\/push \(contributor\/platform -> acme\/platform\)/
-    );
+    expect(result.health).toBe("idle");
+    expect(result.lastError).toBeNull();
     expect(spawnImpl).not.toHaveBeenCalled();
   });
 
@@ -7090,10 +7174,8 @@ Prefer focused changes.
 
     const result = await service.runOnce();
 
-    expect(result.health).toBe("degraded");
-    expect(result.lastError).toMatch(
-      /fork pull requests are unsupported for automatic checkout\/push \(unknown fork -> acme\/platform\)/
-    );
+    expect(result.health).toBe("idle");
+    expect(result.lastError).toBeNull();
     expect(spawnImpl).not.toHaveBeenCalled();
   });
 

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -1306,11 +1306,12 @@ export class OrchestratorService {
         );
       }
       const canonicalIssues = resolveCanonicalSubjectIssues(issues);
-      const terminalCandidateIssues = issueIdentifier
+      const terminalCandidateIssues = (issueIdentifier
         ? canonicalIssues.filter((issue) =>
             matchesTargetIssueIdentifier(issue, issueIdentifier)
           )
-        : canonicalIssues;
+        : canonicalIssues
+      ).filter((issue) => issue.dispatchable);
       const terminalCandidateReconciliation =
         await this.reconcileTerminalCandidates(
           tenant,
@@ -1465,11 +1466,12 @@ export class OrchestratorService {
             matchesTargetIssueIdentifier(issue, issueIdentifier)
           )
         : trackedActionableIssues;
-      const targetedIssues = issueIdentifier
+      const targetedIssues = (issueIdentifier
         ? canonicalIssues.filter((issue: TrackedIssue) =>
             matchesTargetIssueIdentifier(issue, issueIdentifier)
           )
-        : canonicalIssues;
+        : canonicalIssues
+      ).filter((issue) => issue.dispatchable);
       const advisoryRateLimits =
         await this.publishLinkedPullRequestActiveAdvisories(
           tenant,

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -362,6 +362,8 @@ function resolvePullRequestBranchCheckoutTarget(
     const source = headRepository
       ? `${headRepository.owner}/${headRepository.name}`
       : "unknown fork";
+    // PR-content items are excluded earlier by tracker dispatchability; this
+    // remains for issues linked to a fork PR.
     throw new NonRetryableDispatchError(
       `Cannot checkout pull request branch for ${pullRequest.identifier}: fork pull requests are unsupported for automatic checkout/push (${source} -> ${issue.repository.owner}/${issue.repository.name}).`
     );
@@ -1441,8 +1443,11 @@ export class OrchestratorService {
         lifecyclesByIssueIdentifier,
       } = await this.resolveActionableCandidates(
         tenant,
+        // Retained provider-ineligible records are kept for explain/status but
+        // must not load or cache workflow policy for another repository.
         canonicalIssues.filter(
           (issue) =>
+            issue.dispatchable &&
             !terminalCandidateReconciliation.suppressedIdentifiers.has(
               issue.identifier
             )

--- a/packages/tracker-github/README.md
+++ b/packages/tracker-github/README.md
@@ -1,3 +1,16 @@
 # @gh-symphony/tracker-github
 
 GitHub Project polling, issue normalization, and tracker-facing configuration validation that stay behind the core tracker adapter contract.
+
+## Adapter profile
+
+- Candidate polling returns every active, in-scope Project item, including items
+  that cannot be dispatched. GitHub-specific eligibility is expressed through
+  `dispatchable: false` and `dispatchReason`, so `repo explain` can report it.
+- `assigneeId` is the login of the first GitHub issue assignee, or `null` when
+  an issue has no assignee. It is a provider-native identity and is not a
+  cross-tracker identifier.
+- With `--assigned-only`, items assigned to another user stay visible but are
+  non-dispatchable. Repository scope and fork PR heads are handled the same
+  way. Blocker semantics remain outside this adapter until their dedicated
+  migration.

--- a/packages/tracker-github/src/adapter.ts
+++ b/packages/tracker-github/src/adapter.ts
@@ -581,7 +581,7 @@ export async function fetchProjectIssues(
   const currentUserLogin = config.assignedOnly
     ? await fetchCurrentUserLogin(config, fetchImpl)
     : null;
-  let nonDispatchableCount = 0;
+  const nonDispatchableByReason: Record<string, number> = {};
   let latestRateLimits: GitHubRateLimitPayload | null = null;
   const skippedItems: NonNullable<TrackedIssueList["skippedItems"]> = [];
 
@@ -635,7 +635,9 @@ export async function fetchProjectIssues(
         repositoryFilter: config.repositoryFilter,
       });
       if (!issue.dispatchable) {
-        nonDispatchableCount += 1;
+        const reason = getDispatchabilityReasonCategory(issue.dispatchReason);
+        nonDispatchableByReason[reason] =
+          (nonDispatchableByReason[reason] ?? 0) + 1;
       }
       return [issue];
     });
@@ -656,8 +658,10 @@ export async function fetchProjectIssues(
 
   emitDispatchabilityDerivationEvent({
     projectId: config.projectId,
+    currentUserLogin,
+    repository: config.repositoryFilter ?? null,
     includedCount: issues.length,
-    nonDispatchableCount,
+    nonDispatchableByReason,
   });
 
   latestRateLimits = finalizeGraphQLRateLimitCycle(
@@ -1935,7 +1939,7 @@ function getAssignedOnlyDispatchReason(
   }
 
   if (item.content.__typename !== "Issue") {
-    return `Pull request is not assigned to ${currentUserLogin}.`;
+    return "Pull request items are not dispatched under assigned-only mode.";
   }
 
   const isAssigned = (item.content.assignees?.nodes ?? []).some(
@@ -1953,12 +1957,9 @@ function getRepositoryDispatchReason(
   }
 
   const isInScope =
-    issue.repository.owner.localeCompare(repositoryFilter.owner, undefined, {
-      sensitivity: "accent",
-    }) === 0 &&
-    issue.repository.name.localeCompare(repositoryFilter.name, undefined, {
-      sensitivity: "accent",
-    }) === 0;
+    issue.repository.owner.toLowerCase() ===
+      repositoryFilter.owner.toLowerCase() &&
+    issue.repository.name.toLowerCase() === repositoryFilter.name.toLowerCase();
   return isInScope
     ? null
     : `Repository ${issue.repository.owner}/${issue.repository.name} is outside configured repository scope ${repositoryFilter.owner}/${repositoryFilter.name}.`;
@@ -1982,17 +1983,41 @@ function getPullRequestHeadDispatchReason(
     : `Fork pull requests are unsupported for automatic checkout/push (${headRepository ? `${headRepository.owner}/${headRepository.name}` : "unknown fork"} -> ${issue.repository.owner}/${issue.repository.name}).`;
 }
 
+function getDispatchabilityReasonCategory(reason: string | null | undefined): string {
+  if (reason?.startsWith("Issue is not assigned") || reason?.startsWith("Pull request items")) {
+    return "assignment";
+  }
+  if (reason?.startsWith("Repository ")) {
+    return "repository";
+  }
+  return "forkPullRequest";
+}
+
 function emitDispatchabilityDerivationEvent(input: {
   projectId: string;
+  currentUserLogin: string | null;
+  repository: { owner: string; name: string } | null;
   includedCount: number;
-  nonDispatchableCount: number;
+  nonDispatchableByReason: Record<string, number>;
 }): void {
+  if (!input.currentUserLogin && !input.repository) {
+    return;
+  }
+
   console.info(
     JSON.stringify({
       event: "tracker-dispatchability-derived",
       projectId: input.projectId,
+      ...(input.currentUserLogin
+        ? { currentUserLogin: input.currentUserLogin }
+        : {}),
+      ...(input.repository ? { repository: input.repository } : {}),
       includedCount: input.includedCount,
-      nonDispatchableCount: input.nonDispatchableCount,
+      nonDispatchableCount: Object.values(input.nonDispatchableByReason).reduce(
+        (count, value) => count + value,
+        0
+      ),
+      nonDispatchableByReason: input.nonDispatchableByReason,
     })
   );
 }

--- a/packages/tracker-github/src/adapter.ts
+++ b/packages/tracker-github/src/adapter.ts
@@ -581,8 +581,7 @@ export async function fetchProjectIssues(
   const currentUserLogin = config.assignedOnly
     ? await fetchCurrentUserLogin(config, fetchImpl)
     : null;
-  let excludedCount = 0;
-  let repositoryExcludedCount = 0;
+  let nonDispatchableCount = 0;
   let latestRateLimits: GitHubRateLimitPayload | null = null;
   const skippedItems: NonNullable<TrackedIssueList["skippedItems"]> = [];
 
@@ -604,22 +603,6 @@ export async function fetchProjectIssues(
       }
 
       if (!isRepositoryFilterableProjectItem(item)) {
-        if (config.repositoryFilter) {
-          repositoryExcludedCount += 1;
-        }
-        return [];
-      }
-
-      if (currentUserLogin && !isIssueAssignedToLogin(item, currentUserLogin)) {
-        excludedCount += 1;
-        return [];
-      }
-
-      if (
-        config.repositoryFilter &&
-        !isIssueInRepository(item, config.repositoryFilter)
-      ) {
-        repositoryExcludedCount += 1;
         return [];
       }
 
@@ -647,7 +630,14 @@ export async function fetchProjectIssues(
         return [];
       }
 
-      return [normalized];
+      const issue = applyDispatchabilityRules(normalized, item, {
+        currentUserLogin,
+        repositoryFilter: config.repositoryFilter,
+      });
+      if (!issue.dispatchable) {
+        nonDispatchableCount += 1;
+      }
+      return [issue];
     });
 
     issues.push(...pageIssues);
@@ -664,23 +654,11 @@ export async function fetchProjectIssues(
     });
   }
 
-  if (currentUserLogin) {
-    emitAssignedOnlyFilterEvent({
-      projectId: config.projectId,
-      currentUserLogin,
-      includedCount: issues.length,
-      excludedCount,
-    });
-  }
-
-  if (config.repositoryFilter) {
-    emitRepositoryFilterEvent({
-      projectId: config.projectId,
-      repository: `${config.repositoryFilter.owner}/${config.repositoryFilter.name}`,
-      includedCount: issues.length,
-      excludedCount: repositoryExcludedCount,
-    });
-  }
+  emitDispatchabilityDerivationEvent({
+    projectId: config.projectId,
+    includedCount: issues.length,
+    nonDispatchableCount,
+  });
 
   latestRateLimits = finalizeGraphQLRateLimitCycle(
     latestRateLimits,
@@ -1915,19 +1893,6 @@ async function fetchCurrentUserLogin(
   return payload.login;
 }
 
-function isIssueAssignedToLogin(
-  item: GraphQLProjectItem,
-  login: string
-): boolean {
-  if (item.content?.__typename !== "Issue") {
-    return false;
-  }
-
-  return (item.content.assignees?.nodes ?? []).some(
-    (assignee) => assignee?.login === login
-  );
-}
-
 function isRepositoryFilterableProjectItem(
   item: GraphQLProjectItem
 ): item is GraphQLProjectItem & {
@@ -1939,51 +1904,95 @@ function isRepositoryFilterableProjectItem(
   );
 }
 
-function isIssueInRepository(
+function applyDispatchabilityRules(
+  issue: GitHubTrackedIssue,
   item: GraphQLProjectItem & {
     content: GraphQLIssueNode | GraphQLPullRequestNode;
   },
-  repository: { owner: string; name: string }
-): boolean {
-  const itemRepository = item.content.repository;
-  const itemOwner = itemRepository.owner.login.toLowerCase();
-  const itemName = itemRepository.name.toLowerCase();
-  const filterOwner = repository.owner.toLowerCase();
-  const filterName = repository.name.toLowerCase();
+  options: {
+    currentUserLogin: string | null;
+    repositoryFilter: { owner: string; name: string } | null | undefined;
+  }
+): GitHubTrackedIssue {
+  const reason =
+    getAssignedOnlyDispatchReason(item, options.currentUserLogin) ??
+    getRepositoryDispatchReason(issue, options.repositoryFilter) ??
+    getPullRequestHeadDispatchReason(issue);
 
-  return itemOwner === filterOwner && itemName === filterName;
+  return reason
+    ? { ...issue, dispatchable: false, dispatchReason: reason }
+    : issue;
 }
 
-function emitAssignedOnlyFilterEvent(input: {
-  projectId: string;
-  currentUserLogin: string;
-  includedCount: number;
-  excludedCount: number;
-}): void {
-  console.info(
-    JSON.stringify({
-      event: "tracker-assigned-only-filtered",
-      projectId: input.projectId,
-      currentUserLogin: input.currentUserLogin,
-      includedCount: input.includedCount,
-      excludedCount: input.excludedCount,
-    })
+function getAssignedOnlyDispatchReason(
+  item: GraphQLProjectItem & {
+    content: GraphQLIssueNode | GraphQLPullRequestNode;
+  },
+  currentUserLogin: string | null
+): string | null {
+  if (!currentUserLogin) {
+    return null;
+  }
+
+  if (item.content.__typename !== "Issue") {
+    return `Pull request is not assigned to ${currentUserLogin}.`;
+  }
+
+  const isAssigned = (item.content.assignees?.nodes ?? []).some(
+    (assignee) => assignee?.login === currentUserLogin
   );
+  return isAssigned ? null : `Issue is not assigned to ${currentUserLogin}.`;
 }
 
-function emitRepositoryFilterEvent(input: {
+function getRepositoryDispatchReason(
+  issue: GitHubTrackedIssue,
+  repositoryFilter: { owner: string; name: string } | null | undefined
+): string | null {
+  if (!repositoryFilter) {
+    return null;
+  }
+
+  const isInScope =
+    issue.repository.owner.localeCompare(repositoryFilter.owner, undefined, {
+      sensitivity: "accent",
+    }) === 0 &&
+    issue.repository.name.localeCompare(repositoryFilter.name, undefined, {
+      sensitivity: "accent",
+    }) === 0;
+  return isInScope
+    ? null
+    : `Repository ${issue.repository.owner}/${issue.repository.name} is outside configured repository scope ${repositoryFilter.owner}/${repositoryFilter.name}.`;
+}
+
+function getPullRequestHeadDispatchReason(
+  issue: GitHubTrackedIssue
+): string | null {
+  const pullRequest = issue.metadata.pullRequest;
+  if (!pullRequest) {
+    return null;
+  }
+
+  const headRepository = pullRequest.headRepository;
+  const sameRepository =
+    headRepository != null &&
+    headRepository.owner.toLowerCase() === issue.repository.owner.toLowerCase() &&
+    headRepository.name.toLowerCase() === issue.repository.name.toLowerCase();
+  return sameRepository
+    ? null
+    : `Fork pull requests are unsupported for automatic checkout/push (${headRepository ? `${headRepository.owner}/${headRepository.name}` : "unknown fork"} -> ${issue.repository.owner}/${issue.repository.name}).`;
+}
+
+function emitDispatchabilityDerivationEvent(input: {
   projectId: string;
-  repository: string;
   includedCount: number;
-  excludedCount: number;
+  nonDispatchableCount: number;
 }): void {
   console.info(
     JSON.stringify({
-      event: "tracker-repository-filtered",
+      event: "tracker-dispatchability-derived",
       projectId: input.projectId,
-      repository: input.repository,
       includedCount: input.includedCount,
-      excludedCount: input.excludedCount,
+      nonDispatchableCount: input.nonDispatchableCount,
     })
   );
 }

--- a/packages/tracker-github/src/orchestrator-adapter.ts
+++ b/packages/tracker-github/src/orchestrator-adapter.ts
@@ -5,7 +5,6 @@ import type {
   OrchestratorTrackerConfig,
   TrackedIssueList,
 } from "@gh-symphony/core";
-import { filterIssuesByPickupLabels } from "@gh-symphony/core";
 import {
   fetchGithubIssueStatesByIds,
   fetchGithubProjectIssueByRepositoryAndNumber,
@@ -18,15 +17,7 @@ import {
 export const githubProjectTrackerAdapter: OrchestratorTrackerAdapter = {
   async listIssues(project, dependencies = {}) {
     const issues = await listProjectIssues(project, dependencies);
-    const filtered = filterIssuesByPickupLabels(
-      issues,
-      project
-    ) as TrackedIssueList;
-    if (filtered !== issues) {
-      filtered.rateLimits = (issues as TrackedIssueList).rateLimits;
-      filtered.skippedItems = (issues as TrackedIssueList).skippedItems;
-    }
-    return filtered;
+    return applyPickupLabelDispatchability(issues, project);
   },
 
   async listIssuesByStates(project, states, dependencies = {}) {
@@ -163,6 +154,50 @@ export async function findGithubProjectIssue(
     parsed.number,
     dependencies.fetchImpl
   );
+}
+
+function applyPickupLabelDispatchability(
+  issues: TrackedIssueList,
+  project: Parameters<OrchestratorTrackerAdapter["listIssues"]>[0]
+): TrackedIssueList {
+  const pickupLabels = project.tracker.settings?.pickupLabels;
+  if (
+    !pickupLabels ||
+    typeof pickupLabels !== "object" ||
+    Array.isArray(pickupLabels)
+  ) {
+    return issues;
+  }
+
+  const config = pickupLabels as Record<string, unknown>;
+  const include = readPickupLabels(config.include);
+  const exclude = new Set(readPickupLabels(config.exclude));
+  if (include.length === 0 && exclude.size === 0) {
+    return issues;
+  }
+
+  const result = issues.map((issue) => {
+    const labels = new Set(issue.labels);
+    const excludedLabel = [...exclude].find((label) => labels.has(label));
+    const included = include.length === 0 || include.some((label) => labels.has(label));
+    if (!issue.dispatchable || (!excludedLabel && included)) {
+      return issue;
+    }
+
+    const dispatchReason = excludedLabel
+      ? `Issue has excluded pickup label "${excludedLabel}".`
+      : `Issue is missing a required pickup label (${include.join(", ")}).`;
+    return { ...issue, dispatchable: false, dispatchReason };
+  }) as TrackedIssueList;
+  result.rateLimits = issues.rateLimits;
+  result.skippedItems = issues.skippedItems;
+  return result;
+}
+
+function readPickupLabels(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((label): label is string => typeof label === "string")
+    : [];
 }
 
 async function listProjectIssues(

--- a/packages/tracker-github/src/orchestrator-adapter.ts
+++ b/packages/tracker-github/src/orchestrator-adapter.ts
@@ -5,6 +5,7 @@ import type {
   OrchestratorTrackerConfig,
   TrackedIssueList,
 } from "@gh-symphony/core";
+import { resolvePickupLabelDispatchReason } from "@gh-symphony/core";
 import {
   fetchGithubIssueStatesByIds,
   fetchGithubProjectIssueByRepositoryAndNumber,
@@ -160,44 +161,17 @@ function applyPickupLabelDispatchability(
   issues: TrackedIssueList,
   project: Parameters<OrchestratorTrackerAdapter["listIssues"]>[0]
 ): TrackedIssueList {
-  const pickupLabels = project.tracker.settings?.pickupLabels;
-  if (
-    !pickupLabels ||
-    typeof pickupLabels !== "object" ||
-    Array.isArray(pickupLabels)
-  ) {
-    return issues;
-  }
-
-  const config = pickupLabels as Record<string, unknown>;
-  const include = readPickupLabels(config.include);
-  const exclude = new Set(readPickupLabels(config.exclude));
-  if (include.length === 0 && exclude.size === 0) {
-    return issues;
-  }
-
   const result = issues.map((issue) => {
-    const labels = new Set(issue.labels);
-    const excludedLabel = [...exclude].find((label) => labels.has(label));
-    const included = include.length === 0 || include.some((label) => labels.has(label));
-    if (!issue.dispatchable || (!excludedLabel && included)) {
+    const dispatchReason = resolvePickupLabelDispatchReason(issue, project);
+    if (!issue.dispatchable || !dispatchReason) {
       return issue;
     }
 
-    const dispatchReason = excludedLabel
-      ? `Issue has excluded pickup label "${excludedLabel}".`
-      : `Issue is missing a required pickup label (${include.join(", ")}).`;
     return { ...issue, dispatchable: false, dispatchReason };
   }) as TrackedIssueList;
   result.rateLimits = issues.rateLimits;
   result.skippedItems = issues.skippedItems;
   return result;
-}
-
-function readPickupLabels(value: unknown): string[] {
-  return Array.isArray(value)
-    ? value.filter((label): label is string => typeof label === "string")
-    : [];
 }
 
 async function listProjectIssues(

--- a/packages/tracker-github/src/tracker-github.test.ts
+++ b/packages/tracker-github/src/tracker-github.test.ts
@@ -627,6 +627,40 @@ describe("resolveTrackerAdapter", () => {
     });
   });
 
+  it("marks fork pull request Project items non-dispatchable during polling", async () => {
+    const adapter = resolveTrackerAdapter({
+      adapter: "github-project",
+      bindingId: "project-123",
+      settings: { projectId: "project-123" },
+    });
+
+    const issues = await adapter.listIssues(makeProjectConfig(), {
+      token: "dependencies-token",
+      fetchImpl: async () =>
+        makeJsonResponse(
+          makeProjectItemsPayload([
+            makePullRequestProjectItem({
+              itemId: "item-pr-fork",
+              pullRequestId: "pr-fork",
+              number: 9,
+              title: "Forked pull request",
+              headRepository: {
+                name: "platform-fork",
+                url: "https://github.com/contributor/platform-fork",
+                owner: { login: "contributor" },
+              },
+            }),
+          ])
+        ),
+    });
+
+    expect(issues[0]).toMatchObject({
+      dispatchable: false,
+      dispatchReason:
+        "Fork pull requests are unsupported for automatic checkout/push (contributor/platform-fork -> acme/platform).",
+    });
+  });
+
   it("attaches Issue linked pull request metadata from closedByPullRequestsReferences", () => {
     const issue = normalizeGithubProjectItem(
       "project-123",
@@ -2210,7 +2244,7 @@ describe("resolveTrackerAdapter", () => {
     expect(issues.map((issue) => issue.state)).toEqual(["Done"]);
   });
 
-  it("falls back to legacy assignedOnly tracker setting with a deprecation warning", async () => {
+  it("keeps unassigned issues visible but marks them non-dispatchable for assignedOnly", async () => {
     const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
@@ -2296,13 +2330,20 @@ describe("resolveTrackerAdapter", () => {
         }
       );
 
-      expect(issues).toHaveLength(1);
-      expect(issues[0]?.identifier).toBe("acme/platform#1");
+      expect(issues).toHaveLength(2);
+      expect(issues[0]).toMatchObject({
+        identifier: "acme/platform#1",
+        dispatchable: true,
+        assigneeId: "machine-user",
+      });
+      expect(issues[1]).toMatchObject({
+        identifier: "acme/platform#2",
+        dispatchable: false,
+        assigneeId: "someone-else",
+        dispatchReason: "Issue is not assigned to machine-user.",
+      });
       expect(infoSpy).toHaveBeenCalledWith(
-        expect.stringContaining('"event":"tracker-assigned-only-filtered"')
-      );
-      expect(infoSpy).toHaveBeenCalledWith(
-        expect.stringContaining('"excludedCount":1')
+        expect.stringContaining('"event":"tracker-dispatchability-derived"')
       );
       expect(warnSpy).toHaveBeenCalledWith(
         expect.stringContaining("Deprecated tracker.settings.assignedOnly")
@@ -2458,16 +2499,30 @@ describe("resolveTrackerAdapter", () => {
       expect(fetchImpl).toHaveBeenCalledTimes(2);
       expect(platformIssues.map((issue) => issue.identifier)).toEqual([
         "acme/platform#1",
-      ]);
-      expect(webIssues.map((issue) => issue.identifier)).toEqual([
         "acme/web#2",
       ]);
-      const webIssueIds = new Set(webIssues.map((issue) => issue.id));
-      expect(platformIssues.some((issue) => webIssueIds.has(issue.id))).toBe(
-        false
-      );
+      expect(webIssues.map((issue) => issue.identifier)).toEqual([
+        "acme/platform#1",
+        "acme/web#2",
+      ]);
+      expect(platformIssues[1]).toMatchObject({
+        dispatchable: false,
+        dispatchReason:
+          "Repository acme/web is outside configured repository scope acme/platform.",
+      });
+      expect(webIssues[0]).toMatchObject({
+        dispatchable: false,
+        dispatchReason:
+          "Repository acme/platform is outside configured repository scope acme/web.",
+      });
+      expect(platformIssues.filter((issue) => issue.dispatchable)).toEqual([
+        expect.objectContaining({ identifier: "acme/platform#1" }),
+      ]);
+      expect(webIssues.filter((issue) => issue.dispatchable)).toEqual([
+        expect.objectContaining({ identifier: "acme/web#2" }),
+      ]);
       expect(infoSpy).toHaveBeenCalledWith(
-        expect.stringContaining('"event":"tracker-repository-filtered"')
+        expect.stringContaining('"event":"tracker-dispatchability-derived"')
       );
     } finally {
       infoSpy.mockRestore();
@@ -2513,7 +2568,9 @@ describe("resolveTrackerAdapter", () => {
 
     expect(issues.map((issue) => issue.identifier)).toEqual([
       "acme/platform#1",
+      "acme/web#2",
     ]);
+    expect(issues[1]).toMatchObject({ dispatchable: false });
   });
 
   it("allows tracker repository '*' to opt out of repository dispatch scoping", async () => {
@@ -2610,7 +2667,12 @@ describe("resolveTrackerAdapter", () => {
       }
     );
 
-    expect(issues.map((issue) => issue.identifier)).toEqual(["acme/web#2"]);
+    expect(issues.map((issue) => issue.identifier)).toEqual([
+      "acme/platform#1",
+      "acme/web#2",
+    ]);
+    expect(issues[0]).toMatchObject({ dispatchable: false });
+    expect(issues[1]).toMatchObject({ dispatchable: true });
   });
 
   it("matches repository filters case-insensitively", async () => {
@@ -2655,7 +2717,9 @@ describe("resolveTrackerAdapter", () => {
 
     expect(issues.map((issue) => issue.identifier)).toEqual([
       "acme/platform#1",
+      "acme/web#2",
     ]);
+    expect(issues.map((issue) => issue.dispatchable)).toEqual([true, false]);
   });
 
   it("excludes assigned issues from other repositories before dispatch", async () => {
@@ -2703,7 +2767,9 @@ describe("resolveTrackerAdapter", () => {
 
     expect(issues.map((issue) => issue.identifier)).toEqual([
       "acme/platform#1",
+      "acme/web#2",
     ]);
+    expect(issues.map((issue) => issue.dispatchable)).toEqual([true, false]);
   });
 
   it("excludes Project V2 draft items without repository content when scoped", async () => {
@@ -5622,7 +5688,7 @@ describe("pickup label filtering", () => {
     }),
   ]);
 
-  it("lists only issues matching the configured pickup labels", async () => {
+  it("keeps non-matching pickup-label issues visible but non-dispatchable", async () => {
     const config = makeProjectConfig();
     config.tracker.settings = {
       ...config.tracker.settings,
@@ -5636,7 +5702,16 @@ describe("pickup label filtering", () => {
 
     expect(issues.map((issue) => issue.identifier)).toEqual([
       "acme/platform#1",
+      "acme/platform#2",
+      "acme/platform#3",
     ]);
+    expect(issues.map((issue) => issue.dispatchable)).toEqual([true, false, false]);
+    expect(issues[1]?.dispatchReason).toBe(
+      'Issue has excluded pickup label "beta".'
+    );
+    expect(issues[2]?.dispatchReason).toBe(
+      "Issue is missing a required pickup label (alpha)."
+    );
   });
 
   it("keeps every issue when no pickup labels are configured", async () => {
@@ -5666,6 +5741,8 @@ describe("pickup label filtering", () => {
 
     expect(issues.map((issue) => issue.identifier)).toEqual([
       "acme/platform#1",
+      "acme/platform#2",
+      "acme/platform#3",
     ]);
     expect("rateLimits" in issues).toBe(true);
   });


### PR DESCRIPTION
## TL;DR

- GitHub Project polling retains every active in-scope record and exposes provider-derived eligibility to `repo explain`.
- Rework restores invariant repository matching, prevents retained records from resolving foreign workflows, and preserves structured eligibility diagnostics.

## Change-point diagram

Project item → assignment/repository/PR-head/pickup-label policy → `dispatchable` + `dispatchReason` → explain-visible record → dispatch and mutation/workflow gates

## Start here

- `packages/tracker-github/src/adapter.ts`: assignment, repository scope, PR-head eligibility, and operator event derivation.
- `packages/core/src/workflow/pickup-labels.ts`: shared pickup-label reason resolution.
- `packages/orchestrator/src/service.ts`: prevents retained ineligible records from mutation and workflow-resolution paths.
- `packages/core/src/workflow/pickup-labels.test.ts` and tracker/orchestrator tests: regression coverage.

## Risks & rollback

- Eligibility is provider-specific; blocker policy remains deferred to #663.
- Fork PR Project items are now non-dispatchable rather than degrading project status; `repo explain` supplies the reason.
- Rollback: revert this PR to restore the prior GitHub Project filtering behavior.

## Changed files

- GitHub tracker adapter and orchestrator adapter
- Core pickup-label policy and regression test
- Orchestrator workflow-resolution gate
- Architecture/design documentation and CLI changeset

## Issues — Closed #687

## Evidence

- `pnpm lint` — pass
- `pnpm test` — pass
- `pnpm typecheck` — pass
- `pnpm build` — pass
- Docker E2E: a `Ready` non-dispatchable fixture resulted in `health: idle`, `activeRuns: 0`, and no run event directory.

## Post-merge / human validation

- [ ] Confirm `repo explain` reports the GitHub reason for an unassigned Project item under `--assigned-only`.
- [ ] Confirm project logs provide the configured eligibility context and reason breakdown.
