### PR TITLE
ci(e2e): add missing e2e:compose-project-test script (unblocks release PR #648)

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "e2e:init": "bash e2e/seed/init-local.sh",
     "e2e:start": "cd .runtime/e2e/work/test-repo && GH_SYMPHONY_HTTP_TOKEN=\"${GH_SYMPHONY_HTTP_TOKEN:-e2e-http-token}\" GH_SYMPHONY_FILE_TRACKER_ISSUES_PATH=\"$(pwd)/../../../../e2e/fixtures/issues.json\" SYMPHONY_WORKER_COMMAND=\"node $(pwd)/../../../../e2e/dist/stub-worker.js\" node ../../../../packages/cli/dist/index.js repo start --http 4680",
     "e2e:standalone-project": "bash e2e/run-standalone-project-e2e.sh",
+    "e2e:compose-project-test": "bash e2e/lib/compose-project.test.sh",
     "e2e:claude": "bash test/e2e/claude/run-docker-e2e.sh",
     "dev:orchestrator": "pnpm --filter @gh-symphony/orchestrator dev",
     "dev:worker": "pnpm --filter @gh-symphony/worker dev",


### PR DESCRIPTION
## Summary

`main` CI has been red since #693 merged: the workflow step **Compose project helper test** runs `pnpm e2e:compose-project-test`, but #693 never added that script to `package.json` (`ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL Command "e2e:compose-project-test" not found`, exit 254). The changeset release PR #648 is blocked by it.

This registers the script that #693 intended:

```json
"e2e:compose-project-test": "bash e2e/lib/compose-project.test.sh"
```

Verified locally: `pnpm e2e:compose-project-test` → `compose project isolation helpers passed`.

CI/tooling only — no runtime behavior change, no changeset. Refs #692, #693, #648.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TKNuAB3WbG9cJ9Gy4TJSNu
