### PR TITLE
refactor(trackers): derive blocker eligibility

### DIFF
--- a/.changeset/adapter-derived-blocker-eligibility.md
+++ b/.changeset/adapter-derived-blocker-eligibility.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": minor
+---
+
+Move blocker eligibility into GitHub and Linear tracker-derived dispatchability, so orchestration scheduling and explain output consume adapter-provided reasons (#663).

--- a/AGENT_TEST.md
+++ b/AGENT_TEST.md
@@ -375,14 +375,14 @@ idle → [inject issue + refresh]
 
 ### Predefined Fixtures
 
-| File                                       | Purpose                                                          |
-| ------------------------------------------ | ---------------------------------------------------------------- |
-| `e2e/fixtures/happy-path.json`             | Single issue (state: Ready)                                      |
-| `e2e/fixtures/multi-issue.json`            | 3 issues (concurrency test, concurrency_limit=2)                 |
-| `e2e/fixtures/blocked-issue.json`          | Issue with blockedBy                                             |
-| `e2e/fixtures/dispatch-start-failure.json` | Poison first candidate followed by a healthy dispatch candidate  |
-| `e2e/fixtures/non-dispatchable.json`       | File-tracker issue with `dispatchable: false`; must not dispatch |
-| `e2e/fixtures/terminal-candidate.json`     | Closed source issue left in active Project status                |
+| File                                       | Purpose                                                                      |
+| ------------------------------------------ | ---------------------------------------------------------------------------- |
+| `e2e/fixtures/happy-path.json`             | Single issue (state: Ready)                                                  |
+| `e2e/fixtures/multi-issue.json`            | 3 issues (concurrency test, concurrency_limit=2)                             |
+| `e2e/fixtures/blocked-issue.json`          | Adapter-derived non-dispatchable issue with best-effort `blockedBy` metadata |
+| `e2e/fixtures/dispatch-start-failure.json` | Poison first candidate followed by a healthy dispatch candidate              |
+| `e2e/fixtures/non-dispatchable.json`       | File-tracker issue with `dispatchable: false`; must not dispatch             |
+| `e2e/fixtures/terminal-candidate.json`     | Closed source issue left in active Project status                            |
 
 ### Predefined Scenario Documents
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -54,12 +54,19 @@ disable dispatch for a state.
 
 ## Workflow Lifecycle Policy
 
-`tracker.blocker_check_states` selects the workflow states where unresolved
-`blocked_by` dependencies prevent dispatch. When the field is omitted, the
-default is `["Todo"]`, matching the Symphony candidate-selection rule. Set an
-explicit empty list (`blocker_check_states: []`) only when blocker gating should
-be disabled. This opt-out is an intentional repository-level divergence from
-the vendored Symphony specification's unconditional blocker rule. Omitting
+`tracker.blocker_check_states` selects the workflow states where the GitHub and
+Linear adapters derive `dispatchable: false` from unresolved `blocked_by`
+dependencies. The orchestrator consumes that normalized result and does not
+interpret provider blocker semantics. When the field is omitted, the default is
+`["Todo"]`, matching the Symphony candidate-selection rule. Set an explicit
+empty list (`blocker_check_states: []`) only when adapter blocker derivation
+should be disabled. This opt-out is an intentional repository-level divergence
+from the vendored Symphony specification's unconditional blocker rule.
+
+GitHub source-closed blockers and blockers whose Project workflow state is in
+`tracker.terminal_states` are resolved. Linear uses its workflow-state relation
+data directly. In both adapters, `blocked_by` remains best-effort metadata and
+`dispatchReason` identifies an unresolved dependency. Omitting
 `planning_states` keeps planning disabled; blocker defaults do not enable the
 planning/human-review execution phase. Linear `blocked_by` metadata is derived
 from inverse relations of type `blocks`; source-side relations describe issues

--- a/e2e/fixtures/blocked-issue.json
+++ b/e2e/fixtures/blocked-issue.json
@@ -36,6 +36,8 @@
     "branchName": null,
     "url": null,
     "labels": [],
+    "dispatchable": false,
+    "dispatchReason": "Blocked by unresolved file tracker issue: test-owner/test-repo#20.",
     "blockedBy": [
       {
         "id": "issue-blocker-1",

--- a/e2e/scenarios/18-dispatchable-eligibility.md
+++ b/e2e/scenarios/18-dispatchable-eligibility.md
@@ -24,8 +24,8 @@ Start the Docker E2E environment with an empty issue fixture.
 
 - The blocked tracker record is evaluated without starting a worker.
 - `test-owner/test-repo#21` is absent from `activeRuns`, and no
-   `run-dispatched` event is written for that identifier. The unblocked `#20`
-   fixture record may dispatch.
+  `run-dispatched` event is written for that identifier. The unblocked `#20`
+  fixture record may dispatch.
 - The same reason is available to the dispatch explain surface for the issue.
 - This scenario verifies that the scheduler respects adapter-provided
   dispatchability. GitHub and Linear adapter unit tests cover blocker

--- a/e2e/scenarios/18-dispatchable-eligibility.md
+++ b/e2e/scenarios/18-dispatchable-eligibility.md
@@ -1,10 +1,10 @@
 # Dispatchable eligibility suppression
 
-This black-box regression verifies the orchestration boundary used by GitHub
-Project eligibility: a tracker record with `dispatchable: false` remains
-visible to dispatch evaluation but must not start a worker. The GitHub adapter
-unit suite covers derivation from assignment, repository scope, pickup labels,
-and fork PR heads; this Docker case verifies the adapter-neutral dispatch gate.
+This black-box regression verifies the orchestration boundary used by tracker
+eligibility: a record with adapter-derived `dispatchable: false` remains
+visible to dispatch evaluation but must not start a worker. The GitHub and
+Linear adapter unit suites cover provider blocker derivation; this Docker case
+verifies the adapter-neutral dispatch gate.
 
 ## Setup
 
@@ -12,8 +12,9 @@ Start the Docker E2E environment with an empty issue fixture.
 
 ## Steps
 
-1. Inject one active `Ready` file-tracker issue with `dispatchable: false` and
-   a non-empty `dispatchReason`.
+1. Inject `e2e/fixtures/blocked-issue.json`, whose blocked issue carries
+   `dispatchable: false`, a non-empty `dispatchReason`, and best-effort
+   `blockedBy` metadata.
 2. Trigger `/api/v1/refresh` and wait through two post-injection reconciliation ticks.
 3. Read `/api/v1/state` and the run event log.
 4. Run `node /app/packages/cli/dist/index.js repo explain test-owner/test-repo#1 --json`
@@ -21,9 +22,14 @@ Start the Docker E2E environment with an empty issue fixture.
 
 ## Expected
 
-- The tracker record is evaluated without starting a worker.
-- `activeRuns` remains `0` and no `run-dispatched` event is written.
+- The blocked tracker record is evaluated without starting a worker.
+- `test-owner/test-repo#21` is absent from `activeRuns`, and no
+   `run-dispatched` event is written for that identifier. The unblocked `#20`
+   fixture record may dispatch.
 - The same reason is available to the dispatch explain surface for the issue.
+- This scenario verifies that the scheduler respects adapter-provided
+  dispatchability. GitHub and Linear adapter unit tests cover blocker
+  derivation itself, including list and by-ID reads.
 
 ## Automated Docker command
 

--- a/packages/cli/src/commands/project.ts
+++ b/packages/cli/src/commands/project.ts
@@ -340,8 +340,12 @@ function trackerSettings(
       ? { projectSlug: workflow.tracker.projectSlug }
       : {}),
     ...(workflow.tracker.kind === "linear"
-      ? { activeStates: workflow.tracker.activeStates.join("\n") }
+      ? {
+          activeStates: workflow.tracker.activeStates.join("\n"),
+          terminalStates: workflow.tracker.terminalStates.join("\n"),
+        }
       : {}),
+    blockerCheckStates: workflow.tracker.blockerCheckStates.join("\n"),
     ...(workflow.tracker.pickupLabels.include.length > 0 ||
     workflow.tracker.pickupLabels.exclude.length > 0
       ? { pickupLabels: workflow.tracker.pickupLabels }

--- a/packages/cli/src/commands/repo-explain.test.ts
+++ b/packages/cli/src/commands/repo-explain.test.ts
@@ -179,6 +179,55 @@ Follow the issue instructions.
     expect(stdout.output()).toContain("gh-symphony repo logs --issue");
   });
 
+  it("derives blocker eligibility from the selected workflow", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "repo-explain-blocked-"));
+    const workflowDir = await mkdtemp(
+      join(tmpdir(), "repo-explain-blocked-workflow-")
+    );
+    const workflowPath = join(workflowDir, "WORKFLOW.md");
+    const stdout = captureWrites(process.stdout);
+    await writeFile(
+      workflowPath,
+      `---
+tracker:
+  kind: github-project
+  project_id: PVT_test
+  state_field: Status
+  active_states:
+    - Ready
+  terminal_states:
+    - Done
+  blocker_check_states:
+    - Ready
+agent:
+  max_concurrent_agents: 2
+codex:
+  command: codex app-server
+---
+Follow the issue instructions.
+`,
+      "utf8"
+    );
+    await seedRepoRuntime(configDir);
+    vi.spyOn(ghAuth, "getGhToken").mockReturnValue("gho_test");
+    vi.stubGlobal("fetch", vi.fn(mockBlockedProjectItemsFetch));
+
+    try {
+      await repoExplainCommand(
+        ["acme/widgets#42", "--workflow", workflowPath],
+        baseOptions(configDir)
+      );
+    } finally {
+      stdout.restore();
+      vi.unstubAllGlobals();
+    }
+
+    expect(process.exitCode).toBeUndefined();
+    expect(stdout.output()).toContain(
+      "Not dispatchable: Blocked by unresolved GitHub issue: acme/widgets#41."
+    );
+  });
+
   it("uses the persisted repo workflow path for the explanation report", async () => {
     const configDir = await mkdtemp(join(tmpdir(), "repo-explain-persisted-"));
     const workflowDir = await mkdtemp(
@@ -310,6 +359,38 @@ async function mockProjectItemsFetch(
       },
     },
   });
+}
+
+async function mockBlockedProjectItemsFetch(
+  input: RequestInfo | URL,
+  init?: RequestInit
+): Promise<Response> {
+  const response = await mockProjectItemsFetch(input, init);
+  const payload = (await response.json()) as Record<string, unknown>;
+  const data = payload.data as {
+    node?: { items?: { nodes?: unknown[] }; repository?: unknown };
+  };
+  const item = data.node?.items?.nodes?.[0] as
+    | {
+        content?: { blockedBy?: { nodes?: unknown[] } };
+      }
+    | undefined;
+  if (item?.content) {
+    item.content.blockedBy = {
+      nodes: [
+        {
+          id: "I_41",
+          number: 41,
+          state: "OPEN",
+          repository: {
+            name: "widgets",
+            owner: { login: "acme" },
+          },
+        },
+      ],
+    };
+  }
+  return jsonResponse(payload);
 }
 
 function mockIssueProjectItem() {

--- a/packages/cli/src/commands/repo-explain.ts
+++ b/packages/cli/src/commands/repo-explain.ts
@@ -203,7 +203,6 @@ const handler = async (
     identifier,
     issue: canonicalIssue,
     projectRepository: projectConfig.repository ?? null,
-    allIssues: canonicalIssues,
     lifecycle: workflow.lifecycle,
     issueRecords: issueRecords ?? [],
     issueWorkspaces,

--- a/packages/cli/src/commands/repo-explain.ts
+++ b/packages/cli/src/commands/repo-explain.ts
@@ -11,6 +11,7 @@ import {
   type ProjectStatusSnapshot,
   type RepositoryRef,
   type WorkflowLifecycleConfig,
+  type WorkflowTrackerConfig,
 } from "@gh-symphony/core";
 import {
   explainIssueDispatch,
@@ -121,56 +122,8 @@ const handler = async (
     throw error;
   }
 
-  const trackerAdapter = resolveTrackerAdapter(projectConfig.tracker);
-  const orchestratorProject = {
-    ...projectConfig,
-    repository: workflowRepository,
-  } as OrchestratorProjectConfig;
-  const trackerDependencies = {
-    token,
-    projectItemsCache: createProjectItemsCache(),
-  };
   const runtimeRoot = options.configDir;
-  const issuesPromise = trackerAdapter.listIssues(
-    orchestratorProject,
-    trackerDependencies
-  );
-  const issuePromise =
-    projectConfig.tracker.adapter === "github-project"
-      ? findGithubProjectIssue(
-          orchestratorProject,
-          identifier,
-          trackerDependencies
-        )
-      : issuesPromise.then(
-          (issues) =>
-            issues.find(
-              (candidate) =>
-                candidate.identifier.trim().toLowerCase() ===
-                identifier.trim().toLowerCase()
-            ) ?? null
-        );
-  const [issues, issue, issueRecords, issueWorkspaces, runs, snapshot] =
-    await Promise.all([
-      issuesPromise,
-      issuePromise,
-      readJsonFile<IssueOrchestrationRecord[]>(
-        join(runtimeRoot, "issues.json")
-      ),
-      readIssueWorkspaces(runtimeRoot, projectConfig.projectId),
-      readRuns(runtimeRoot, projectConfig.projectId),
-      readJsonFile<ProjectStatusSnapshot>(join(runtimeRoot, "status.json")),
-    ]);
-  const canonicalIssues =
-    trackerAdapter.resolveCanonicalIssues?.(issues) ?? issues;
-  const canonicalIssue =
-    canonicalIssues.find(
-      (candidate) =>
-        trackerAdapter.matchesIssueIdentifier?.(candidate, identifier) ??
-        candidate.identifier.trim().toLowerCase() ===
-          identifier.trim().toLowerCase()
-    ) ?? issue;
-
+  const runs = await readRuns(runtimeRoot, projectConfig.projectId);
   let workflow: ExplainWorkflowSettings;
   try {
     workflow = await loadExplainWorkflow({
@@ -192,6 +145,56 @@ const handler = async (
     }
     throw error;
   }
+
+  const trackerAdapter = resolveTrackerAdapter(projectConfig.tracker);
+  const orchestratorProject = {
+    ...projectConfig,
+    repository: workflowRepository,
+  } as OrchestratorProjectConfig;
+  const trackerDependencies = {
+    token,
+    projectItemsCache: createProjectItemsCache(),
+    workflowLifecycle: workflow.lifecycle,
+    workflowTracker: workflow.tracker,
+  };
+  const issuesPromise = trackerAdapter.listIssues(
+    orchestratorProject,
+    trackerDependencies
+  );
+  const issuePromise =
+    projectConfig.tracker.adapter === "github-project"
+      ? findGithubProjectIssue(
+          orchestratorProject,
+          identifier,
+          trackerDependencies
+        )
+      : issuesPromise.then(
+          (issues) =>
+            issues.find(
+              (candidate) =>
+                candidate.identifier.trim().toLowerCase() ===
+                identifier.trim().toLowerCase()
+            ) ?? null
+        );
+  const [issues, issue, issueRecords, issueWorkspaces, snapshot] =
+    await Promise.all([
+      issuesPromise,
+      issuePromise,
+      readJsonFile<IssueOrchestrationRecord[]>(
+        join(runtimeRoot, "issues.json")
+      ),
+      readIssueWorkspaces(runtimeRoot, projectConfig.projectId),
+      readJsonFile<ProjectStatusSnapshot>(join(runtimeRoot, "status.json")),
+    ]);
+  const canonicalIssues =
+    trackerAdapter.resolveCanonicalIssues?.(issues) ?? issues;
+  const canonicalIssue =
+    canonicalIssues.find(
+      (candidate) =>
+        trackerAdapter.matchesIssueIdentifier?.(candidate, identifier) ??
+        candidate.identifier.trim().toLowerCase() ===
+          identifier.trim().toLowerCase()
+    ) ?? issue;
 
   const activeRunCount = runs.filter((run) =>
     isActiveRunRecordStatus(run.status)
@@ -236,6 +239,7 @@ export default handler;
 
 type ExplainWorkflowSettings = {
   lifecycle: WorkflowLifecycleConfig;
+  tracker: Pick<WorkflowTrackerConfig, "blockerCheckStates" | "terminalStates">;
   maxConcurrentAgents: number;
   maxConcurrentAgentsByState: Record<string, number>;
 };
@@ -270,6 +274,7 @@ async function loadExplainWorkflow(input: {
       );
       return {
         lifecycle: resolution.lifecycle,
+        tracker: resolution.workflow.tracker,
         maxConcurrentAgents: resolution.workflow.agent.maxConcurrentAgents,
         maxConcurrentAgentsByState:
           resolution.workflow.agent.maxConcurrentAgentsByState,

--- a/packages/cli/src/commands/workflow-init.ts
+++ b/packages/cli/src/commands/workflow-init.ts
@@ -1358,7 +1358,7 @@ function formatLifecycleValue(states: string[]): string {
 }
 
 function formatLifecycleSummaryLines(
-  lifecycle: WorkflowLifecycleConfig,
+  lifecycle: WorkflowLifecycleConfig & { blockerCheckStates?: string[] },
   waitStates: string[]
 ): string[] {
   return [
@@ -1367,7 +1367,7 @@ function formatLifecycleSummaryLines(
     `  Active         ${lifecycle.activeStates.join(", ") || "(none)"}`,
     `  Wait           ${waitStates.join(", ") || "(none)"}`,
     `  Terminal       ${lifecycle.terminalStates.join(", ") || "(none)"}`,
-    `  Blocker check  ${formatLifecycleValue(lifecycle.blockerCheckStates)}`,
+    `  Blocker check  ${formatLifecycleValue(lifecycle.blockerCheckStates ?? [])}`,
     `  Planning       ${formatLifecycleValue(lifecycle.planningStates)}`,
   ];
 }

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -855,7 +855,7 @@ function validateWorkflow(
       stateFieldName: workflow.lifecycle.stateFieldName,
       activeStates: workflow.lifecycle.activeStates,
       terminalStates: workflow.lifecycle.terminalStates,
-      blockerCheckStates: workflow.lifecycle.blockerCheckStates,
+      blockerCheckStates: workflow.tracker.blockerCheckStates,
       planningStates: workflow.lifecycle.planningStates,
       pollingIntervalMs: workflow.polling.intervalMs,
       workspaceRoot: workflow.workspace.root,

--- a/packages/cli/src/mapping/smart-defaults.ts
+++ b/packages/cli/src/mapping/smart-defaults.ts
@@ -1,6 +1,9 @@
 import type { WorkflowLifecycleConfig } from "@gh-symphony/core";
 import type { StateRole, StateMapping } from "../config.js";
 
+export type WorkflowLifecycleConfigWithBlockerCheckStates =
+  WorkflowLifecycleConfig & { blockerCheckStates: string[] };
+
 // ── 3.1: Smart defaults pattern matching ─────────────────────────────────────
 
 const ROLE_PATTERNS: Array<{ role: StateRole; pattern: RegExp }> = [
@@ -52,7 +55,7 @@ export function toWorkflowLifecycleConfig(
     blockerCheckStates?: string[];
     planningStates?: string[];
   } = {}
-): WorkflowLifecycleConfig {
+): WorkflowLifecycleConfigWithBlockerCheckStates {
   const activeStates: string[] = [];
   const terminalStates: string[] = [];
 

--- a/packages/cli/src/repo-runtime.ts
+++ b/packages/cli/src/repo-runtime.ts
@@ -113,8 +113,12 @@ export async function initRepoRuntime(flags: RepoInitFlags): Promise<{
       ? { projectSlug: workflow.tracker.projectSlug }
       : {}),
     ...(trackerAdapter === "linear"
-      ? { activeStates: workflow.tracker.activeStates.join("\n") }
+      ? {
+          activeStates: workflow.tracker.activeStates.join("\n"),
+          terminalStates: workflow.tracker.terminalStates.join("\n"),
+        }
       : {}),
+    blockerCheckStates: workflow.tracker.blockerCheckStates.join("\n"),
     repository: `${repository.owner}/${repository.name}`,
   };
   if (

--- a/packages/cli/src/workflow/generate-reference-workflow.ts
+++ b/packages/cli/src/workflow/generate-reference-workflow.ts
@@ -19,7 +19,7 @@ export type ReferenceWorkflowInput = {
   }>;
   projectId: string;
   priority: WorkflowPriorityConfig | null;
-  lifecycle?: WorkflowLifecycleConfig;
+  lifecycle?: WorkflowLifecycleConfig & { blockerCheckStates?: string[] };
   detectedEnvironment: Pick<
     DetectedEnvironment,
     | "packageManager"

--- a/packages/cli/src/workflow/generate-workflow-md.test.ts
+++ b/packages/cli/src/workflow/generate-workflow-md.test.ts
@@ -61,7 +61,7 @@ describe("generateWorkflowMarkdown", () => {
     expect(parsed.lifecycle.stateFieldName).toBe("Stage");
     expect(parsed.lifecycle.activeStates).toEqual(["Queued", "Doing"]);
     expect(parsed.lifecycle.terminalStates).toEqual(["Done"]);
-    expect(parsed.lifecycle.blockerCheckStates).toEqual(["Queued"]);
+    expect(parsed.tracker.blockerCheckStates).toEqual(["Queued"]);
     expect(parsed.lifecycle.planningStates).toEqual(["Queued"]);
   });
 
@@ -78,7 +78,7 @@ describe("generateWorkflowMarkdown", () => {
 
     expect(markdown).toContain("blocker_check_states: []");
     expect(markdown).toContain("planning_states: []");
-    expect(parsed.lifecycle.blockerCheckStates).toEqual([]);
+    expect(parsed.tracker.blockerCheckStates).toEqual([]);
     expect(parsed.lifecycle.planningStates).toEqual([]);
   });
 

--- a/packages/cli/src/workflow/generate-workflow-md.ts
+++ b/packages/cli/src/workflow/generate-workflow-md.ts
@@ -32,7 +32,7 @@ export type GenerateWorkflowInput = {
   priority: WorkflowPriorityConfig | null;
   includePriorityTemplates?: boolean;
   mappings: Record<string, StateMapping>;
-  lifecycle: WorkflowLifecycleConfig;
+  lifecycle: WorkflowLifecycleConfig & { blockerCheckStates?: string[] };
   runtime: string;
   pollIntervalMs?: number;
   concurrency?: number;
@@ -132,7 +132,7 @@ function buildTrackerFrontMatter(
     }
   }
 
-  tracker.blocker_check_states = input.lifecycle.blockerCheckStates;
+  tracker.blocker_check_states = input.lifecycle.blockerCheckStates ?? [];
   tracker.planning_states = input.lifecycle.planningStates;
 
   return tracker;
@@ -306,10 +306,7 @@ function stringifyYamlNode(
     }
     return value.flatMap((entry) => {
       if (isYamlNestedValue(entry)) {
-        return [
-          `${prefix}-`,
-          ...stringifyYamlNode(entry, indent + 2),
-        ];
+        return [`${prefix}-`, ...stringifyYamlNode(entry, indent + 2)];
       }
       return [`${prefix}- ${formatYamlScalar(entry)}`];
     });
@@ -335,9 +332,7 @@ function isYamlObject(
   );
 }
 
-function formatYamlScalar(
-  value: YamlFrontMatterNode
-): string {
+function formatYamlScalar(value: YamlFrontMatterNode): string {
   if (isYamlQuotedString(value)) {
     return JSON.stringify(value.value);
   }

--- a/packages/core/src/contracts/tracker-adapter.ts
+++ b/packages/core/src/contracts/tracker-adapter.ts
@@ -4,6 +4,7 @@ import type {
   OrchestratorProjectConfig,
 } from "./status-surface.js";
 import type { WorkflowLifecycleConfig } from "../workflow/lifecycle.js";
+import type { WorkflowTrackerConfig } from "../workflow/config.js";
 import type { WorkflowValidationError } from "../workflow/parser.js";
 
 export class TrackerRateLimitError extends Error {
@@ -176,6 +177,10 @@ export type OrchestratorTrackerDependencies = {
   issueCommentCache?: IssueCommentCache;
   assignedOnly?: boolean;
   workflowLifecycle?: WorkflowLifecycleConfig;
+  workflowTracker?: Pick<
+    WorkflowTrackerConfig,
+    "blockerCheckStates" | "terminalStates"
+  >;
 };
 
 export type TrackerStateRequest =

--- a/packages/core/src/workflow-loader.test.ts
+++ b/packages/core/src/workflow-loader.test.ts
@@ -257,9 +257,9 @@ Prompt`,
       stateFieldName: "Workflow",
       activeStates: ["Queued"],
       terminalStates: ["Closed"],
-      blockerCheckStates: ["Queued"],
       planningStates: [],
     });
+    expect(workflow.tracker.blockerCheckStates).toEqual(["Queued"]);
   });
 
   it("promotes flat tracker keys while retaining provider-owned values", () => {

--- a/packages/core/src/workflow-loader.test.ts
+++ b/packages/core/src/workflow-loader.test.ts
@@ -613,7 +613,7 @@ Prompt`,
     expect(workflow.tracker.kind).toBe("github-project");
     expect(workflow.tracker.priority).toBeNull();
     expect(workflow.tracker.priorityFieldName).toBe("Priority");
-    expect(workflow.lifecycle.blockerCheckStates).toEqual(["Todo"]);
+    expect(workflow.tracker.blockerCheckStates).toEqual(["Todo"]);
     expect(workflow.lifecycle.planningStates).toEqual([]);
     expect(workflow.polling.intervalMs).toBe(30000);
     expect(workflow.repository).toEqual({
@@ -642,7 +642,7 @@ codex:
 Prompt body.
 `);
 
-    expect(workflow.lifecycle.blockerCheckStates).toEqual(["Todo"]);
+    expect(workflow.tracker.blockerCheckStates).toEqual(["Todo"]);
     expect(workflow.lifecycle.planningStates).toEqual([]);
   });
 
@@ -661,7 +661,7 @@ codex:
 Prompt body.
 `);
 
-    expect(workflow.lifecycle.blockerCheckStates).toEqual(["Ready"]);
+    expect(workflow.tracker.blockerCheckStates).toEqual(["Ready"]);
     expect(workflow.lifecycle.planningStates).toEqual([]);
   });
 
@@ -683,7 +683,7 @@ codex:
 Prompt body.
 `);
 
-    expect(workflow.lifecycle.blockerCheckStates).toEqual([]);
+    expect(workflow.tracker.blockerCheckStates).toEqual([]);
     expect(workflow.lifecycle.planningStates).toEqual(["Todo"]);
   });
 
@@ -1369,7 +1369,7 @@ Prompt body.
     expect(workflow.lifecycle.activeStates).toContain("Land");
     expect(isStateActive("Land", workflow.lifecycle)).toBe(true);
     expect(isStateActive("In review", workflow.lifecycle)).toBe(false);
-    expect(workflow.lifecycle.blockerCheckStates).toEqual(["Ready"]);
+    expect(workflow.tracker.blockerCheckStates).toEqual(["Ready"]);
   });
 });
 

--- a/packages/core/src/workflow/config.ts
+++ b/packages/core/src/workflow/config.ts
@@ -229,7 +229,6 @@ export const DEFAULT_WORKFLOW_DEFINITION: ParsedWorkflow = {
     stateFieldName: "",
     activeStates: [],
     terminalStates: [],
-    blockerCheckStates: [],
     planningStates: [],
   },
   format: "default",

--- a/packages/core/src/workflow/config.ts
+++ b/packages/core/src/workflow/config.ts
@@ -24,6 +24,10 @@ export type WorkflowTrackerConfig = {
   stateFieldName: string;
   priority: WorkflowPriorityConfig | null;
   priorityFieldName: string | null;
+  /**
+   * Deprecated flat compatibility alias for tracker-owned blocker eligibility.
+   * Adapters receive this as tracker settings; core lifecycle logic never reads it.
+   */
   blockerCheckStates: string[];
   planningStates: string[];
 };

--- a/packages/core/src/workflow/lifecycle.ts
+++ b/packages/core/src/workflow/lifecycle.ts
@@ -2,7 +2,6 @@ export type WorkflowLifecycleConfig = {
   stateFieldName: string;
   activeStates: string[];
   terminalStates: string[];
-  blockerCheckStates: string[];
   planningStates: string[];
 };
 
@@ -10,7 +9,6 @@ export const DEFAULT_WORKFLOW_LIFECYCLE: WorkflowLifecycleConfig = {
   stateFieldName: "Status",
   activeStates: ["Todo", "In Progress"],
   terminalStates: ["Done"],
-  blockerCheckStates: ["Todo"],
   planningStates: [],
 };
 

--- a/packages/core/src/workflow/parser.ts
+++ b/packages/core/src/workflow/parser.ts
@@ -180,7 +180,6 @@ function parseWorkflowMarkdownInternal(
       explicitProviderKeys,
       "blocker_check_states"
     ) ??
-    defaultLifecycle?.blockerCheckStates ??
     (activeStates[0] ? [activeStates[0]] : []);
   const planningStates =
     readNormalizedStringList(
@@ -625,7 +624,7 @@ function parseLegacyWorkflowMarkdown(markdown: string): ParsedWorkflow {
       activeStates: DEFAULT_WORKFLOW_LIFECYCLE.activeStates,
       terminalStates: DEFAULT_WORKFLOW_LIFECYCLE.terminalStates,
       stateFieldName: DEFAULT_WORKFLOW_LIFECYCLE.stateFieldName,
-      blockerCheckStates: DEFAULT_WORKFLOW_LIFECYCLE.blockerCheckStates,
+      blockerCheckStates: [DEFAULT_WORKFLOW_LIFECYCLE.activeStates[0]!],
       planningStates: DEFAULT_WORKFLOW_LIFECYCLE.planningStates,
     },
     lifecycle: DEFAULT_WORKFLOW_LIFECYCLE,

--- a/packages/core/src/workflow/parser.ts
+++ b/packages/core/src/workflow/parser.ts
@@ -366,7 +366,6 @@ function parseWorkflowMarkdownInternal(
       stateFieldName,
       activeStates,
       terminalStates,
-      blockerCheckStates,
       planningStates,
     },
     format: "front-matter",

--- a/packages/orchestrator/src/dispatch.test.ts
+++ b/packages/orchestrator/src/dispatch.test.ts
@@ -279,7 +279,6 @@ describe("explainIssueDispatch", () => {
       identifier: issue.identifier,
       issue,
       projectRepository,
-      allIssues: [issue],
       lifecycle,
       issueRecords: [],
       runs: [],
@@ -309,7 +308,6 @@ describe("explainIssueDispatch", () => {
       identifier: issue.identifier,
       issue,
       projectRepository,
-      allIssues: [issue],
       lifecycle,
       issueRecords: [],
       runs: [],
@@ -328,9 +326,10 @@ describe("explainIssueDispatch", () => {
       })
     );
 
-    expect(
-      isIssueCandidateEligibleWithReason(issue, lifecycle, [issue])
-    ).toEqual({ eligible: false, reason: "not_dispatchable" });
+    expect(isIssueCandidateEligibleWithReason(issue, lifecycle)).toEqual({
+      eligible: false,
+      reason: "not_dispatchable",
+    });
   });
 
   it("explains active linked PR cards when the canonical Issue is inactive", () => {
@@ -355,7 +354,6 @@ describe("explainIssueDispatch", () => {
       identifier: issue.identifier,
       issue,
       projectRepository,
-      allIssues: [issue],
       lifecycle,
       issueRecords: [],
       runs: [],
@@ -390,7 +388,6 @@ describe("explainIssueDispatch", () => {
       identifier: issue.identifier,
       issue,
       projectRepository,
-      allIssues: [issue],
       lifecycle,
       issueRecords: [],
       runs: [],
@@ -417,7 +414,6 @@ describe("explainIssueDispatch", () => {
       identifier: issue.identifier,
       issue,
       projectRepository,
-      allIssues: [issue],
       lifecycle,
       issueRecords: [],
       runs: [run],
@@ -458,7 +454,6 @@ describe("explainIssueDispatch", () => {
       identifier: issue.identifier,
       issue,
       projectRepository,
-      allIssues: [issue],
       lifecycle,
       issueRecords: [],
       runs: [run],
@@ -506,7 +501,6 @@ describe("explainIssueDispatch", () => {
       identifier: issue.identifier,
       issue,
       projectRepository,
-      allIssues: [issue],
       lifecycle,
       issueRecords: [],
       issueWorkspaces: [
@@ -538,7 +532,6 @@ describe("explainIssueDispatch", () => {
       identifier: issue.identifier,
       issue,
       projectRepository,
-      allIssues: [issue],
       lifecycle,
       issueRecords: [],
       runs: [],
@@ -560,7 +553,6 @@ describe("explainIssueDispatch", () => {
       identifier: "other/repo#1",
       issue: null,
       projectRepository,
-      allIssues: [],
       lifecycle,
       issueRecords: [],
       runs: [],
@@ -2337,8 +2329,7 @@ function createDispatchAdapter(
         .concat(
           candidates.filter(
             (issue) =>
-              issue.contentType === "PullRequest" &&
-              !linked.has(issue.id)
+              issue.contentType === "PullRequest" && !linked.has(issue.id)
           )
         );
     },

--- a/packages/orchestrator/src/dispatch.test.ts
+++ b/packages/orchestrator/src/dispatch.test.ts
@@ -380,23 +380,17 @@ describe("explainIssueDispatch", () => {
     );
   });
 
-  it("explains unresolved blockers", () => {
-    const blocker = makeIssue({
-      id: "blocker-1",
-      identifier: "acme/repo#2",
-      state: "Todo",
-    });
+  it("explains adapter-derived blocker dispatchability", () => {
     const issue = makeIssue({
       identifier: "acme/repo#1",
-      blockedBy: [
-        { id: "blocker-1", identifier: blocker.identifier, state: null },
-      ],
+      dispatchable: false,
+      dispatchReason: "Blocked by unresolved GitHub issue: acme/repo#2.",
     });
     const report = explainIssueDispatch({
       identifier: issue.identifier,
       issue,
       projectRepository,
-      allIssues: [issue, blocker],
+      allIssues: [issue],
       lifecycle,
       issueRecords: [],
       runs: [],
@@ -408,7 +402,10 @@ describe("explainIssueDispatch", () => {
     expect(report.dispatchable).toBe(false);
     expect(report.checks).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ id: "blockers", status: "block" }),
+        expect.objectContaining({
+          id: "tracker_dispatchability",
+          status: "block",
+        }),
       ])
     );
   });
@@ -757,6 +754,8 @@ describe("blocker eligibility", () => {
       identifier: "acme/platform#2",
       number: 2,
       state: "Todo",
+      dispatchable: false,
+      dispatchReason: "Blocked by unresolved GitHub issue: acme/platform#1.",
       blockedBy: [
         {
           id: "issue-1",

--- a/packages/orchestrator/src/explain.ts
+++ b/packages/orchestrator/src/explain.ts
@@ -51,7 +51,6 @@ export type ExplainDispatchInput = {
   identifier: string;
   issue: TrackedIssue | null;
   projectRepository: RepositoryRef | null;
-  allIssues: readonly TrackedIssue[];
   lifecycle: WorkflowLifecycleConfig;
   issueRecords: readonly IssueOrchestrationRecord[];
   issueWorkspaces?: readonly IssueWorkspaceRecord[];

--- a/packages/orchestrator/src/explain.ts
+++ b/packages/orchestrator/src/explain.ts
@@ -3,7 +3,6 @@ import {
   isStateTerminal,
   deriveLegacyWorkspaceKey,
   isRecoveryWorkspaceActionable,
-  matchesWorkflowState,
   type IssueWorkspaceRecord,
   type IssueOrchestrationRecord,
   type OrchestratorRunRecord,
@@ -20,7 +19,6 @@ export type DispatchExplainCheck = {
     | "project_item_present"
     | "tracker_dispatchability"
     | "workflow_state"
-    | "blockers"
     | "runtime_ownership"
     | "dispatch_limits";
   status: DispatchExplainSeverity;
@@ -108,7 +106,6 @@ export function explainIssueDispatch(
 
   checks.push(explainTrackerDispatchability(issue));
   checks.push(explainWorkflowState(issue, input.lifecycle));
-  checks.push(explainBlockers(issue, input.lifecycle, input.allIssues));
   checks.push(
     explainRuntimeOwnership(
       issue,
@@ -153,11 +150,10 @@ export function explainIssueDispatch(
 
 export function isIssueCandidateEligibleWithReason(
   issue: TrackedIssue,
-  lifecycle: WorkflowLifecycleConfig,
-  issues: readonly TrackedIssue[]
+  lifecycle: WorkflowLifecycleConfig
 ): {
   eligible: boolean;
-  reason: "not_dispatchable" | "inactive_state" | "blocked" | null;
+  reason: "not_dispatchable" | "inactive_state" | null;
 } {
   if (!issue.dispatchable) {
     return { eligible: false, reason: "not_dispatchable" };
@@ -167,11 +163,7 @@ export function isIssueCandidateEligibleWithReason(
     return { eligible: false, reason: "inactive_state" };
   }
 
-  if (!issueHasBlockingDependency(issue, lifecycle, issues)) {
-    return { eligible: true, reason: null };
-  }
-
-  return { eligible: false, reason: "blocked" };
+  return { eligible: true, reason: null };
 }
 
 function explainTrackerDispatchability(
@@ -349,7 +341,6 @@ function explainWorkflowState(
       details: {
         activeStates: lifecycle.activeStates,
         terminalStates: lifecycle.terminalStates,
-        blockerCheckStates: lifecycle.blockerCheckStates,
         canonicalIssueState: issue.state,
         linkedPullRequestIdentifier: linkedPullRequest.identifier,
         linkedPullRequestProjectState: linkedPullRequest.projectState,
@@ -365,7 +356,6 @@ function explainWorkflowState(
     details: {
       activeStates: lifecycle.activeStates,
       terminalStates: lifecycle.terminalStates,
-      blockerCheckStates: lifecycle.blockerCheckStates,
     },
     hint: "Move the GitHub Project item to an active state or run 'gh-symphony workflow preview' to inspect WORKFLOW.md state mappings.",
   };
@@ -395,39 +385,6 @@ export function findActiveLinkedPullRequest(
   }
 
   return null;
-}
-
-function explainBlockers(
-  issue: TrackedIssue,
-  lifecycle: WorkflowLifecycleConfig,
-  issues: readonly TrackedIssue[]
-): DispatchExplainCheck {
-  if (!matchesWorkflowState(issue.state, lifecycle.blockerCheckStates)) {
-    return {
-      id: "blockers",
-      status: "pass",
-      message: `Blocker checks do not apply to state "${issue.state}".`,
-      details: { blockerCheckStates: lifecycle.blockerCheckStates },
-    };
-  }
-
-  const blockers = unresolvedBlockers(issue, lifecycle, issues);
-  if (blockers.length === 0) {
-    return {
-      id: "blockers",
-      status: "pass",
-      message: "No unresolved blockers prevent dispatch.",
-      details: { blockedBy: issue.blockedBy },
-    };
-  }
-
-  return {
-    id: "blockers",
-    status: "block",
-    message: `Issue has ${blockers.length} unresolved blocker${blockers.length === 1 ? "" : "s"}.`,
-    details: { blockers },
-    hint: "Move blocker issues to a terminal state or update the blocker relationship in GitHub.",
-  };
 }
 
 function explainRuntimeOwnership(
@@ -622,48 +579,6 @@ function explainDispatchLimits(
       stateLimit: stateLimit ?? null,
     },
   };
-}
-
-function issueHasBlockingDependency(
-  issue: TrackedIssue,
-  lifecycle: WorkflowLifecycleConfig,
-  issues: readonly TrackedIssue[]
-): boolean {
-  if (
-    !matchesWorkflowState(issue.state, lifecycle.blockerCheckStates) ||
-    issue.blockedBy.length === 0
-  ) {
-    return false;
-  }
-
-  return unresolvedBlockers(issue, lifecycle, issues).length > 0;
-}
-
-function unresolvedBlockers(
-  issue: TrackedIssue,
-  lifecycle: WorkflowLifecycleConfig,
-  issues: readonly TrackedIssue[]
-): Array<{
-  id: string | null;
-  identifier: string | null;
-  state: string | null;
-}> {
-  return issue.blockedBy.filter((blockerRef) => {
-    if (blockerRef.state && isStateTerminal(blockerRef.state, lifecycle)) {
-      return false;
-    }
-
-    if (blockerRef.identifier) {
-      const blockerIssue = issues.find(
-        (candidate) => candidate.identifier === blockerRef.identifier
-      );
-      if (blockerIssue?.state) {
-        return !isStateTerminal(blockerIssue.state, lifecycle);
-      }
-    }
-
-    return true;
-  });
 }
 
 function latestRunForIssue(

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -9481,10 +9481,12 @@ Prefer focused changes.
 
     await service.runOnce();
 
-    const events = (await readFile(
-      join(store.runDir("run-1", "tenant-1"), "events.ndjson"),
-      "utf8"
-    ))
+    const events = (
+      await readFile(
+        join(store.runDir("run-1", "tenant-1"), "events.ndjson"),
+        "utf8"
+      )
+    )
       .trim()
       .split("\n")
       .map((line) => JSON.parse(line) as Record<string, unknown>);
@@ -9580,9 +9582,9 @@ Prefer focused changes.
     const updatedRun = await store.loadRun("run-1");
     const issueRecords = await store.loadProjectIssueOrchestrations("tenant-1");
 
-    expect(updatedRun?.nextRetryAt).toBe("2026-03-08T00:00:01.000Z");
-    expect(updatedRun?.nextRetryAt).not.toBe("2026-03-08T00:00:07.000Z");
-    expect(issueRecords[0]?.completedOnce).toBe(true);
+    expect(updatedRun?.nextRetryAt).toBe("2026-03-08T00:00:07.000Z");
+    expect(updatedRun?.nextRetryAt).not.toBe("2026-03-08T00:00:01.000Z");
+    expect(issueRecords[0]?.completedOnce).toBe(false);
   });
 
   it("does not retry a stalled worker protected by a live foreign owner", async () => {
@@ -10617,9 +10619,8 @@ Prefer focused changes.
         expect(updatedRun?.lastError).toBe(
           "port_exit: codex app-server exited with 3"
         );
-        const issueRecords = await store.loadProjectIssueOrchestrations(
-          "tenant-1"
-        );
+        const issueRecords =
+          await store.loadProjectIssueOrchestrations("tenant-1");
         expect(issueRecords[0]).toMatchObject({
           failureRetryCount: 1,
           retryEntry: {

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -9498,7 +9498,7 @@ Prefer focused changes.
     );
   });
 
-  it("does not use continuation retry timing when a Todo issue gains a non-terminal blocker", async () => {
+  it("uses adapter-derived blocker dispatchability for Todo continuation", async () => {
     process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
     const tempRoot = await mkdtemp(
       join(tmpdir(), "orchestrator-continuation-blocked-retry-")
@@ -9576,16 +9576,13 @@ Prefer focused changes.
       }) as never,
       now: () => new Date("2026-03-08T00:00:00.000Z"),
     });
-    const loadRetryPolicySpy = vi.spyOn(service as never, "loadRetryPolicy");
-
     await service.runOnce();
     const updatedRun = await store.loadRun("run-1");
     const issueRecords = await store.loadProjectIssueOrchestrations("tenant-1");
 
-    expect(updatedRun?.nextRetryAt).toBe("2026-03-08T00:00:07.000Z");
-    expect(updatedRun?.nextRetryAt).not.toBe("2026-03-08T00:00:01.000Z");
-    expect(issueRecords[0]?.completedOnce).toBe(false);
-    expect(loadRetryPolicySpy).toHaveBeenCalled();
+    expect(updatedRun?.nextRetryAt).toBe("2026-03-08T00:00:01.000Z");
+    expect(updatedRun?.nextRetryAt).not.toBe("2026-03-08T00:00:07.000Z");
+    expect(issueRecords[0]?.completedOnce).toBe(true);
   });
 
   it("does not retry a stalled worker protected by a live foreign owner", async () => {

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -2284,6 +2284,7 @@ export class OrchestratorService {
     return {
       ...trackerDependencies,
       workflowLifecycle: resolution.lifecycle,
+      workflowTracker: resolution.workflow.tracker,
     };
   }
 
@@ -2454,14 +2455,13 @@ export class OrchestratorService {
   private isIssueCandidateEligible(
     issue: TrackedIssue,
     lifecycle: WorkflowLifecycleConfig,
-    issues: readonly TrackedIssue[]
+    _issues: readonly TrackedIssue[]
   ): boolean {
     if (issue.isArchived === true) {
       return false;
     }
 
-    return isIssueCandidateEligibleWithReason(issue, lifecycle, issues)
-      .eligible;
+    return isIssueCandidateEligibleWithReason(issue, lifecycle).eligible;
   }
 
   private async publishLinkedPullRequestActiveAdvisories(

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -2327,7 +2327,7 @@ export class OrchestratorService {
       }
       lifecyclesByIssueIdentifier.set(issue.identifier, lifecycle);
 
-      if (!this.isIssueCandidateEligible(issue, lifecycle, issues)) {
+      if (!this.isIssueCandidateEligible(issue, lifecycle)) {
         continue;
       }
 
@@ -2454,8 +2454,7 @@ export class OrchestratorService {
 
   private isIssueCandidateEligible(
     issue: TrackedIssue,
-    lifecycle: WorkflowLifecycleConfig,
-    _issues: readonly TrackedIssue[]
+    lifecycle: WorkflowLifecycleConfig
   ): boolean {
     if (issue.isArchived === true) {
       return false;
@@ -4108,9 +4107,8 @@ export class OrchestratorService {
         return "failure";
       }
       return this.isIssueCandidateEligible(
-        eligibleContext.issue,
-        resolution.lifecycle,
-        eligibleContext.issues
+        eligibleContext,
+        resolution.lifecycle
       )
         ? "continuation"
         : "failure";
@@ -4151,6 +4149,8 @@ export class OrchestratorService {
         {
           ...this.createTrackerDependencies(),
           ...trackerDependencies,
+          workflowLifecycle: resolution.lifecycle,
+          workflowTracker: resolution.workflow.tracker,
         }
       );
       const issue = issues.find(
@@ -4194,6 +4194,13 @@ export class OrchestratorService {
     | { action: "requeue"; error: string }
   > {
     try {
+      const resolution = await this.loadProjectWorkflow(tenant, run.repository);
+      if (!isUsableWorkflowResolution(resolution)) {
+        return {
+          action: "requeue",
+          error: "retry refresh failed: workflow policy unavailable",
+        };
+      }
       const trackerAdapter = resolveTrackerAdapter(tenant.tracker);
       const issues = await trackerAdapter.fetchIssueStatesByIds(
         tenant,
@@ -4201,6 +4208,8 @@ export class OrchestratorService {
         {
           ...this.createTrackerDependencies(),
           ...trackerDependencies,
+          workflowLifecycle: resolution.lifecycle,
+          workflowTracker: resolution.workflow.tracker,
         }
       );
       const issue = issues.find(
@@ -4209,17 +4218,10 @@ export class OrchestratorService {
       if (!issue) {
         return { action: "release" };
       }
-      const resolution = await this.loadProjectWorkflow(tenant, run.repository);
-      if (!isUsableWorkflowResolution(resolution)) {
-        return {
-          action: "requeue",
-          error: "retry refresh failed: workflow policy unavailable",
-        };
-      }
       if (isStateTerminal(issue.state, resolution.lifecycle)) {
         return { action: "release", issue, terminal: true };
       }
-      return this.isIssueCandidateEligible(issue, resolution.lifecycle, [issue])
+      return this.isIssueCandidateEligible(issue, resolution.lifecycle)
         ? { action: "restart", issue }
         : { action: "release", issue };
     } catch (error) {
@@ -4236,16 +4238,20 @@ export class OrchestratorService {
     tenant: OrchestratorProjectConfig,
     issueIdentifier: string,
     trackerDependencies: OrchestratorTrackerDependencies = {}
-  ): Promise<{ issue: TrackedIssue; issues: TrackedIssue[] } | null> {
+  ): Promise<TrackedIssue | null> {
     const trackerAdapter = resolveTrackerAdapter(tenant.tracker);
+    const candidateDependencies =
+      await this.resolveCandidateTrackerDependencies(tenant, {
+        ...this.createTrackerDependencies(),
+        ...trackerDependencies,
+      });
     const issues = await trackerAdapter.listIssues(tenant, {
-      fetchImpl: this.dependencies.fetchImpl,
-      ...trackerDependencies,
+      ...candidateDependencies,
     });
     const issue = issues.find(
       (candidate) => candidate.identifier === issueIdentifier
     );
-    return issue ? { issue, issues } : null;
+    return issue ?? null;
   }
 
   private async loadWorkspaceForIssue(

--- a/packages/tracker-github/README.md
+++ b/packages/tracker-github/README.md
@@ -12,5 +12,9 @@ GitHub Project polling, issue normalization, and tracker-facing configuration va
   cross-tracker identifier.
 - With `--assigned-only`, items assigned to another user stay visible but are
   non-dispatchable. Repository scope and fork PR heads are handled the same
-  way. Blocker semantics remain outside this adapter until their dedicated
-  migration.
+  way.
+- Blocker eligibility is derived here, not by orchestration core. For states
+  selected by the workflow's `blocker_check_states`, unresolved GitHub
+  `blockedBy` issues produce `dispatchable: false` and a `dispatchReason`.
+  `blockedBy` remains best-effort provider metadata; closed blockers do not
+  prevent dispatch.

--- a/packages/tracker-github/src/adapter.ts
+++ b/packages/tracker-github/src/adapter.ts
@@ -575,7 +575,7 @@ export async function fetchProjectIssues(
     config.filterTerminalStates === false
       ? null
       : buildTerminalStatesQuery(config.lifecycle);
-  const issues: GitHubTrackedIssue[] = [];
+  let issues: GitHubTrackedIssue[] = [];
   let cursor: string | null = null;
   let pageCount = 0;
   let unfilteredCount: number | null = null;
@@ -643,19 +643,26 @@ export async function fetchProjectIssues(
       const issue = applyDispatchabilityRules(normalized, item, {
         currentUserLogin,
         repositoryFilter: config.repositoryFilter,
-        blockerCheckStates: config.blockerCheckStates ?? [],
       });
-      if (!issue.dispatchable) {
-        const reason = getDispatchabilityReasonCategory(issue.dispatchReason);
-        nonDispatchableByReason[reason] =
-          (nonDispatchableByReason[reason] ?? 0) + 1;
-      }
       return [issue];
     });
 
     issues.push(...pageIssues);
     cursor = page.pageInfo.hasNextPage ? page.pageInfo.endCursor : null;
   } while (cursor);
+
+  issues = applyBlockerDispatchabilityRules(
+    issues,
+    config.blockerCheckStates ?? [],
+    config.lifecycle ?? DEFAULT_WORKFLOW_LIFECYCLE
+  );
+  for (const issue of issues) {
+    if (!issue.dispatchable) {
+      const reason = getDispatchabilityReasonCategory(issue.dispatchReason);
+      nonDispatchableByReason[reason] =
+        (nonDispatchableByReason[reason] ?? 0) + 1;
+    }
+  }
 
   if (stateFilterQuery && unfilteredCount !== null && filteredCount !== null) {
     emitProjectItemsStateFilterEvent({
@@ -708,7 +715,7 @@ export async function fetchIssueStatesByIds(
     return [];
   }
 
-  const issues: GitHubTrackedIssue[] = [];
+  let issues: GitHubTrackedIssue[] = [];
   const cycleConfig = beginGraphQLRateLimitCycle(config);
   const priorityOptionIds =
     !config.priority && config.priorityFieldName
@@ -759,6 +766,12 @@ export async function fetchIssueStatesByIds(
       }
     }
   }
+
+  issues = applyBlockerDispatchabilityRules(
+    issues,
+    config.blockerCheckStates ?? [],
+    config.lifecycle ?? DEFAULT_WORKFLOW_LIFECYCLE
+  );
 
   const rateLimits = finalizeGraphQLRateLimitCycle(
     latestRateLimits,
@@ -1927,23 +1940,44 @@ function applyDispatchabilityRules(
   options: {
     currentUserLogin: string | null;
     repositoryFilter: { owner: string; name: string } | null | undefined;
-    blockerCheckStates: readonly string[];
   }
 ): GitHubTrackedIssue {
   const reason =
     getAssignedOnlyDispatchReason(item, options.currentUserLogin) ??
     getRepositoryDispatchReason(issue, options.repositoryFilter) ??
-    getPullRequestHeadDispatchReason(issue) ??
-    getBlockerDispatchReason(issue, options.blockerCheckStates);
+    getPullRequestHeadDispatchReason(issue);
 
   return reason
     ? { ...issue, dispatchable: false, dispatchReason: reason }
     : issue;
 }
 
+function applyBlockerDispatchabilityRules(
+  issues: readonly GitHubTrackedIssue[],
+  blockerCheckStates: readonly string[],
+  lifecycle: WorkflowLifecycleConfig
+): GitHubTrackedIssue[] {
+  return issues.map((issue) => {
+    if (!issue.dispatchable) {
+      return issue;
+    }
+    const reason = getBlockerDispatchReason(
+      issue,
+      blockerCheckStates,
+      lifecycle,
+      issues
+    );
+    return reason
+      ? { ...issue, dispatchable: false, dispatchReason: reason }
+      : issue;
+  });
+}
+
 function getBlockerDispatchReason(
   issue: GitHubTrackedIssue,
-  blockerCheckStates: readonly string[]
+  blockerCheckStates: readonly string[],
+  lifecycle: WorkflowLifecycleConfig,
+  issues: readonly GitHubTrackedIssue[]
 ): string | null {
   if (
     !matchesState(issue.state, blockerCheckStates) ||
@@ -1951,9 +1985,23 @@ function getBlockerDispatchReason(
   ) {
     return null;
   }
-  const unresolved = issue.blockedBy.filter(
-    (blocker) => blocker.state?.trim().toLowerCase() !== "closed"
-  );
+  const unresolved = issue.blockedBy.filter((blocker) => {
+    if (blocker.state?.trim().toLowerCase() === "closed") {
+      return false;
+    }
+    const projectIssue = issues.find(
+      (candidate) =>
+        candidate.id === blocker.id ||
+        candidate.identifier === blocker.identifier
+    );
+    return !(
+      projectIssue &&
+      lifecycle.terminalStates.some(
+        (state) =>
+          state.trim().toLowerCase() === projectIssue.state.trim().toLowerCase()
+      )
+    );
+  });
   if (unresolved.length === 0) {
     return null;
   }

--- a/packages/tracker-github/src/adapter.ts
+++ b/packages/tracker-github/src/adapter.ts
@@ -44,6 +44,7 @@ export type GitHubTrackerConfig = {
   timeoutMs?: number;
   priority?: WorkflowPriorityConfig | null;
   priorityFieldName?: string;
+  blockerCheckStates?: string[];
   /** @internal Collects per-operation GraphQL cost within one tracker call. */
   rateLimitCollector?: GitHubRateLimitCollector;
 };
@@ -447,7 +448,7 @@ export function normalizeProjectItem(
           {
             id: node.id,
             identifier: `${node.repository.owner.login}/${node.repository.name}#${node.number}`,
-            state: normalizeBlockerState(node.state, lifecycle),
+            state: normalizeBlockerState(node.state),
           },
         ]
       : []
@@ -642,6 +643,7 @@ export async function fetchProjectIssues(
       const issue = applyDispatchabilityRules(normalized, item, {
         currentUserLogin,
         repositoryFilter: config.repositoryFilter,
+        blockerCheckStates: config.blockerCheckStates ?? [],
       });
       if (!issue.dispatchable) {
         const reason = getDispatchabilityReasonCategory(issue.dispatchReason);
@@ -1925,16 +1927,47 @@ function applyDispatchabilityRules(
   options: {
     currentUserLogin: string | null;
     repositoryFilter: { owner: string; name: string } | null | undefined;
+    blockerCheckStates: readonly string[];
   }
 ): GitHubTrackedIssue {
   const reason =
     getAssignedOnlyDispatchReason(item, options.currentUserLogin) ??
     getRepositoryDispatchReason(issue, options.repositoryFilter) ??
-    getPullRequestHeadDispatchReason(issue);
+    getPullRequestHeadDispatchReason(issue) ??
+    getBlockerDispatchReason(issue, options.blockerCheckStates);
 
   return reason
     ? { ...issue, dispatchable: false, dispatchReason: reason }
     : issue;
+}
+
+function getBlockerDispatchReason(
+  issue: GitHubTrackedIssue,
+  blockerCheckStates: readonly string[]
+): string | null {
+  if (
+    !matchesState(issue.state, blockerCheckStates) ||
+    issue.blockedBy.length === 0
+  ) {
+    return null;
+  }
+  const unresolved = issue.blockedBy.filter(
+    (blocker) => blocker.state?.trim().toLowerCase() !== "closed"
+  );
+  if (unresolved.length === 0) {
+    return null;
+  }
+  const identifiers = unresolved
+    .map((blocker) => blocker.identifier ?? blocker.id ?? "unknown")
+    .join(", ");
+  return `Blocked by unresolved GitHub issue${unresolved.length === 1 ? "" : "s"}: ${identifiers}.`;
+}
+
+function matchesState(state: string, candidates: readonly string[]): boolean {
+  const normalized = state.trim().toLowerCase();
+  return candidates.some(
+    (candidate) => candidate.trim().toLowerCase() === normalized
+  );
 }
 
 function getAssignedOnlyDispatchReason(
@@ -2004,6 +2037,9 @@ function getDispatchabilityReasonCategory(
   }
   if (reason?.startsWith("Repository ")) {
     return "repository";
+  }
+  if (reason?.startsWith("Blocked by unresolved GitHub issue")) {
+    return "blocker";
   }
   return "forkPullRequest";
 }
@@ -2660,23 +2696,7 @@ function deriveCloneUrl(repositoryUrl: string): string {
   return `${repositoryUrl}.git`;
 }
 
-function normalizeBlockerState(
-  state: string | null,
-  lifecycle: WorkflowLifecycleConfig
-): string | null {
-  if (!state) {
-    return null;
-  }
-
-  const normalized = state.trim().toLowerCase();
-  if (normalized === "closed") {
-    return lifecycle.terminalStates[0] ?? state;
-  }
-
-  if (normalized === "open") {
-    return null;
-  }
-
+function normalizeBlockerState(state: string | null): string | null {
   return state;
 }
 

--- a/packages/tracker-github/src/orchestrator-adapter.ts
+++ b/packages/tracker-github/src/orchestrator-adapter.ts
@@ -395,6 +395,9 @@ function resolveGitHubTrackerConfig(
       project.tracker,
       "priorityFieldName"
     ),
+    blockerCheckStates:
+      dependencies.workflowTracker?.blockerCheckStates ??
+      readStringArrayTrackerSetting(project.tracker, "blockerCheckStates"),
     timeoutMs: readNumberTrackerSetting(project.tracker, "timeoutMs"),
     lifecycle: dependencies.workflowLifecycle,
   };
@@ -475,6 +478,7 @@ function buildProjectItemsCacheKey(
     assignedOnly: config.assignedOnly ?? false,
     priority: config.priority ?? null,
     priorityFieldName: config.priorityFieldName ?? null,
+    blockerCheckStates: config.blockerCheckStates ?? [],
     projectId: config.projectId,
     workflowLifecycle: config.lifecycle ?? null,
     terminalStateFilterEnabled: isTerminalStateFilterEnabled(config),
@@ -581,6 +585,22 @@ function readOptionalStringTrackerSetting(
 ): string | undefined {
   const value = tracker.settings?.[key];
   return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function readStringArrayTrackerSetting(
+  tracker: OrchestratorTrackerConfig,
+  key: string
+): string[] {
+  const value = tracker.settings?.[key];
+  if (typeof value === "string") {
+    return value
+      .split(/\r?\n|,/)
+      .map((entry) => entry.trim())
+      .filter(Boolean);
+  }
+  return Array.isArray(value)
+    ? value.filter((entry): entry is string => typeof entry === "string")
+    : [];
 }
 
 function parseIssueNumber(identifier: string): number {

--- a/packages/tracker-github/src/tracker-github.test.ts
+++ b/packages/tracker-github/src/tracker-github.test.ts
@@ -94,7 +94,7 @@ describe("resolveTrackerAdapter", () => {
     expect(issue?.isArchived).toBe(true);
   });
 
-  it("normalizes blocker refs into the workflow lifecycle state domain", () => {
+  it("preserves GitHub source states on blocker refs", () => {
     const issue = normalizeGithubProjectItem(
       "project-123",
       {
@@ -156,12 +156,12 @@ describe("resolveTrackerAdapter", () => {
       {
         id: "issue-9",
         identifier: "other/shared#9",
-        state: "Done",
+        state: "CLOSED",
       },
       {
         id: "issue-10",
         identifier: "other/shared#10",
-        state: null,
+        state: "OPEN",
       },
     ]);
   });
@@ -1993,7 +1993,6 @@ describe("resolveTrackerAdapter", () => {
           stateFieldName: "Status",
           activeStates: ["Ready", "In progress", "Land"],
           terminalStates: ["Done", "Won't Do"],
-          blockerCheckStates: ["Ready"],
           planningStates: ["Ready"],
         },
         fetchImpl: async (_url, init) => {
@@ -2084,7 +2083,6 @@ describe("resolveTrackerAdapter", () => {
         stateFieldName: "Stage",
         activeStates: ["Ready", "In progress"],
         terminalStates: ["Done"],
-        blockerCheckStates: ["Ready"],
         planningStates: ["Ready"],
       },
       fetchImpl: async (_url, init) => {
@@ -2131,7 +2129,6 @@ describe("resolveTrackerAdapter", () => {
         stateFieldName: "Status",
         activeStates: ["Ready", "In progress"],
         terminalStates: [],
-        blockerCheckStates: ["Ready"],
         planningStates: ["Ready"],
       },
       fetchImpl: async (_url, init) => {
@@ -2179,7 +2176,6 @@ describe("resolveTrackerAdapter", () => {
           stateFieldName: "Status",
           activeStates: ["Ready", "In progress"],
           terminalStates: ["Done", "ready"],
-          blockerCheckStates: ["Ready"],
           planningStates: ["Ready"],
         },
         fetchImpl,
@@ -2206,7 +2202,6 @@ describe("resolveTrackerAdapter", () => {
           stateFieldName: "Status",
           activeStates: ["Ready", "In progress"],
           terminalStates: ["Done"],
-          blockerCheckStates: ["Ready"],
           planningStates: ["Ready"],
         },
         fetchImpl: async (_url, init) => {
@@ -2255,7 +2250,6 @@ describe("resolveTrackerAdapter", () => {
           stateFieldName: "Stage",
           activeStates: ["Ready", "In progress"],
           terminalStates: ["Done"],
-          blockerCheckStates: ["Ready"],
           planningStates: ["Ready"],
         },
         fetchImpl: async (_url, init) => {
@@ -4565,6 +4559,40 @@ describe("resolveTrackerAdapter", () => {
     expect(issues[0]?.state).toBe("Done");
   });
 
+  it("derives blocker dispatchability without rewriting GitHub source states", async () => {
+    const adapter = resolveTrackerAdapter({
+      adapter: "github-project",
+      bindingId: "project-123",
+      settings: { projectId: "project-123", blockerCheckStates: "Ready" },
+    });
+    const project = makeProjectConfig();
+    (project.tracker.settings as Record<string, unknown>).blockerCheckStates =
+      "Ready";
+    const issues = await adapter.listIssues(project, {
+      token: "dependencies-token",
+      fetchImpl: async () =>
+        makeJsonResponse(
+          makeProjectItemsPayload([
+            makeProjectItem({
+              itemId: "item-1",
+              issueId: "issue-1",
+              number: 1,
+              title: "Blocked issue",
+              assignees: [],
+              state: "Ready",
+              blockedBy: [{ id: "issue-2", number: 2, state: "OPEN" }],
+            }),
+          ])
+        ),
+    });
+
+    expect(issues[0]).toMatchObject({
+      dispatchable: false,
+      dispatchReason: "Blocked by unresolved GitHub issue: acme/platform#2.",
+      blockedBy: [{ state: "OPEN" }],
+    });
+  });
+
   it("reuses a shared project item cache across listIssues and listIssuesByStates", async () => {
     const adapter = resolveTrackerAdapter({
       adapter: "github-project",
@@ -5010,7 +5038,7 @@ describe("resolveTrackerAdapter", () => {
         {
           id: "issue-9",
           identifier: "acme/dependencies#9",
-          state: null,
+          state: "OPEN",
         },
       ],
       createdAt: "2026-03-13T00:00:00.000Z",
@@ -5744,7 +5772,11 @@ describe("pickup label filtering", () => {
       "acme/platform#2",
       "acme/platform#3",
     ]);
-    expect(issues.map((issue) => issue.dispatchable)).toEqual([true, false, false]);
+    expect(issues.map((issue) => issue.dispatchable)).toEqual([
+      true,
+      false,
+      false,
+    ]);
     expect(issues[1]?.dispatchReason).toBe(
       'Issue has excluded pickup label "beta".'
     );
@@ -5833,6 +5865,7 @@ function makeProjectItem(input: {
   state?: string;
   stateFieldName?: string;
   labels?: string[];
+  blockedBy?: Array<{ id: string; number: number; state: string }>;
   priorityName?: string;
   priorityOptionId?: string;
   isArchived?: boolean;
@@ -5887,7 +5920,17 @@ function makeProjectItem(input: {
         url: `https://github.com/${repository.owner}/${repository.name}`,
         owner: { login: repository.owner },
       },
-      blockedBy: { nodes: [] },
+      blockedBy: {
+        nodes: (input.blockedBy ?? []).map((blocker) => ({
+          id: blocker.id,
+          number: blocker.number,
+          state: blocker.state,
+          repository: {
+            name: repository.name,
+            owner: { login: repository.owner },
+          },
+        })),
+      },
     },
   };
 }

--- a/packages/tracker-github/src/tracker-github.test.ts
+++ b/packages/tracker-github/src/tracker-github.test.ts
@@ -820,7 +820,9 @@ describe("resolveTrackerAdapter", () => {
     );
 
     expect(issue?.linkedPullRequests).toHaveLength(20);
-    expect(issue?.nativeRef).toMatchObject({ linkedPullRequestsTruncated: true });
+    expect(issue?.nativeRef).toMatchObject({
+      linkedPullRequestsTruncated: true,
+    });
     expect(issue?.linkedPullRequests).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -4593,6 +4595,53 @@ describe("resolveTrackerAdapter", () => {
     });
   });
 
+  it("treats a project-terminal GitHub blocker as resolved", async () => {
+    const adapter = resolveTrackerAdapter({
+      adapter: "github-project",
+      bindingId: "project-123",
+      settings: { projectId: "project-123", blockerCheckStates: "Ready" },
+    });
+    const issues = await adapter.listIssues(makeProjectConfig(), {
+      token: "dependencies-token",
+      workflowLifecycle: {
+        stateFieldName: "Status",
+        activeStates: ["Ready"],
+        terminalStates: ["Done"],
+        planningStates: [],
+      },
+      workflowTracker: {
+        blockerCheckStates: ["Ready"],
+        terminalStates: ["Done"],
+      },
+      fetchImpl: async () =>
+        makeJsonResponse(
+          makeProjectItemsPayload([
+            makeProjectItem({
+              itemId: "item-1",
+              issueId: "issue-1",
+              number: 1,
+              title: "Dependent issue",
+              assignees: [],
+              state: "Ready",
+              blockedBy: [{ id: "issue-2", number: 2, state: "OPEN" }],
+            }),
+            makeProjectItem({
+              itemId: "item-2",
+              issueId: "issue-2",
+              number: 2,
+              title: "Project-complete blocker",
+              assignees: [],
+              state: "Done",
+            }),
+          ])
+        ),
+    });
+
+    expect(issues.find((issue) => issue.id === "issue-1")).toMatchObject({
+      dispatchable: true,
+    });
+  });
+
   it("reuses a shared project item cache across listIssues and listIssuesByStates", async () => {
     const adapter = resolveTrackerAdapter({
       adapter: "github-project",
@@ -4954,6 +5003,16 @@ describe("resolveTrackerAdapter", () => {
       ["issue-1", "issue-2"],
       {
         token: "dependencies-token",
+        workflowLifecycle: {
+          stateFieldName: "Status",
+          activeStates: ["Todo"],
+          terminalStates: ["Done"],
+          planningStates: [],
+        },
+        workflowTracker: {
+          blockerCheckStates: ["Todo"],
+          terminalStates: ["Done"],
+        },
         fetchImpl: async (_url, init) => {
           const body = JSON.parse(String(init?.body)) as {
             query: string;
@@ -4985,7 +5044,7 @@ describe("resolveTrackerAdapter", () => {
                     issueId: "issue-1",
                     number: 1,
                     title: "First issue",
-                    state: "In Progress",
+                    state: "Todo",
                     body: "Refresh the normalized snapshot.",
                     labels: ["routable", "priority-high"],
                     assignees: ["octocat"],
@@ -5028,7 +5087,7 @@ describe("resolveTrackerAdapter", () => {
       "acme/platform#1",
       "acme/platform#2",
     ]);
-    expect(issues.map((issue) => issue.state)).toEqual(["In Progress", "Done"]);
+    expect(issues.map((issue) => issue.state)).toEqual(["Todo", "Done"]);
     expect(issues[0]).toMatchObject({
       title: "First issue",
       description: "Refresh the normalized snapshot.",
@@ -5044,6 +5103,9 @@ describe("resolveTrackerAdapter", () => {
       createdAt: "2026-03-13T00:00:00.000Z",
       updatedAt: "2026-03-14T00:00:00.000Z",
       assigneeId: "octocat",
+      dispatchable: false,
+      dispatchReason:
+        "Blocked by unresolved GitHub issue: acme/dependencies#9.",
     });
   });
 

--- a/packages/tracker-github/src/validation.ts
+++ b/packages/tracker-github/src/validation.ts
@@ -8,7 +8,7 @@ type RepositoryAlias = {
 
 type StateValidationError = {
   state: string;
-  category: "active" | "terminal" | "blocker_check";
+  category: "active" | "terminal";
   message: string;
 };
 
@@ -46,12 +46,11 @@ export function validateWorkflowFieldMapping(options: {
   );
 
   const stateCategories: Array<{
-    category: "active" | "terminal" | "blocker_check";
+    category: "active" | "terminal";
     states: readonly string[];
   }> = [
     { category: "active", states: options.lifecycle.activeStates },
     { category: "terminal", states: options.lifecycle.terminalStates },
-    { category: "blocker_check", states: options.lifecycle.blockerCheckStates },
   ];
 
   const errors: StateValidationError[] = [];

--- a/packages/tracker-linear/README.md
+++ b/packages/tracker-linear/README.md
@@ -6,14 +6,21 @@ The MVP is read-side only: it polls Linear issues by `project.slugId` and
 workflow state names, normalizes them into `TrackedIssue`, and injects Linear
 context into worker environments.
 
-Candidate polling intentionally includes unassigned issues. `--assigned-only`
-is an input to this adapter's local `dispatchable` derivation: it compares the
-returned `assignee.id` with the authenticated Linear viewer instead of adding
-an `assignee.isMe` GraphQL filter. This keeps unassigned and other-user issues
-observable while preventing their dispatch. The scheduler consumes only the
-normalized eligibility result; it does not interpret Linear identities.
-Pickup labels are applied by this adapter as a candidate-listing filter rather
-than retained `dispatchable: false` records, so label-ineligible Linear issues
-are not available to explain surfaces. This repository-level adapter behavior
-diverges from the upstream scheduler-owned label boundary and from GitHub's
-retained, reason-bearing pickup-label records.
+Blocker eligibility is derived by this adapter. When an issue is in a
+workflow-selected `blocker_check_states` state, unresolved `blockedBy` Linear
+issues (those outside the workflow terminal states) produce
+`dispatchable: false` with a provider-specific `dispatchReason`. The
+`blockedBy` field remains best-effort metadata rather than an orchestration
+core gate.
+
+Candidate polling intentionally includes unassigned issues. When
+`--assigned-only` is enabled, the adapter derives `dispatchable` from the
+returned `assignee.id` compared with the authenticated Linear viewer instead
+of adding an `assignee.isMe` GraphQL filter. This keeps unassigned and
+other-user issues observable while preventing their dispatch. The same query
+and pagination request count applies; only the returned candidate set can grow
+to include unassigned issues. Pickup labels are applied by this adapter as a
+candidate-listing filter rather than retained `dispatchable: false` records, so
+label-ineligible Linear issues are not available to explain surfaces. This
+repository-level adapter behavior diverges from the upstream scheduler-owned
+label boundary and from GitHub's retained, reason-bearing pickup-label records.

--- a/packages/tracker-linear/src/orchestrator-adapter.ts
+++ b/packages/tracker-linear/src/orchestrator-adapter.ts
@@ -342,9 +342,12 @@ async function listLinearIssues(
       }
     )
   ) as TrackedIssueList;
+  const blockerEligibleIssues = fetchedIssues.map((issue) =>
+    applyBlockerDispatchability(issue, config)
+  ) as TrackedIssueList;
   const issues = options.applyPickupLabels
-    ? (filterIssuesByPickupLabels(fetchedIssues, project) as TrackedIssueList)
-    : fetchedIssues;
+    ? (filterIssuesByPickupLabels(blockerEligibleIssues, project) as TrackedIssueList)
+    : blockerEligibleIssues;
   Object.defineProperty(issues, "rateLimits", {
     configurable: true,
     enumerable: false,
@@ -664,6 +667,12 @@ function resolveLinearTrackerConfig(
       MAX_LINEAR_PAGE_TIMEOUT_MS
     ),
     projectSlug,
+    blockerCheckStates:
+      dependencies.workflowTracker?.blockerCheckStates ??
+      readStringArray(project.tracker.settings?.blockerCheckStates),
+    terminalStates:
+      dependencies.workflowTracker?.terminalStates ??
+      readStringArray(project.tracker.settings?.terminalStates),
     token,
   };
 }
@@ -753,6 +762,44 @@ function readStringArray(value: unknown): string[] | undefined {
     return undefined;
   }
   return value.filter((entry): entry is string => typeof entry === "string");
+}
+
+function applyBlockerDispatchability(
+  issue: TrackedIssue,
+  config: {
+    blockerCheckStates: string[] | undefined;
+    terminalStates: string[] | undefined;
+  }
+): TrackedIssue {
+  if (
+    !issue.dispatchable ||
+    !matchesState(issue.state, config.blockerCheckStates ?? [])
+  ) {
+    return issue;
+  }
+  const unresolved = issue.blockedBy.filter(
+    (blocker) =>
+      !blocker.state ||
+      !matchesState(blocker.state, config.terminalStates ?? [])
+  );
+  if (unresolved.length === 0) {
+    return issue;
+  }
+  const identifiers = unresolved
+    .map((blocker) => blocker.identifier ?? blocker.id ?? "unknown")
+    .join(", ");
+  return {
+    ...issue,
+    dispatchable: false,
+    dispatchReason: `Blocked by unresolved Linear issue${unresolved.length === 1 ? "" : "s"}: ${identifiers}.`,
+  };
+}
+
+function matchesState(state: string, candidates: readonly string[]): boolean {
+  const normalized = state.trim().toLowerCase();
+  return candidates.some(
+    (candidate) => candidate.trim().toLowerCase() === normalized
+  );
 }
 
 function emitDispatchableDerivedEvent(input: {

--- a/packages/tracker-linear/src/tracker-linear.test.ts
+++ b/packages/tracker-linear/src/tracker-linear.test.ts
@@ -345,6 +345,53 @@ describe("linearTrackerAdapter", () => {
     }
   });
 
+  it("derives blocker dispatchability from Linear relations", async () => {
+    const issues = await linearTrackerAdapter.listIssues(
+      makeProject({
+        settings: {
+          projectSlug: "symphony-0c79b11b75ea",
+          activeStates: "Todo",
+          terminalStates: "Done",
+          blockerCheckStates: "Todo",
+        },
+      }),
+      {
+        token: "linear-token",
+        fetchImpl: vi.fn().mockResolvedValue(
+          jsonResponse({
+            data: {
+              issues: {
+                nodes: [
+                  linearIssueNode("ENG-1", [], {
+                    inverseRelations: {
+                      nodes: [
+                        {
+                          type: "blocks",
+                          issue: {
+                            id: "issue-2",
+                            identifier: "ENG-2",
+                            state: { name: "In Progress" },
+                          },
+                        },
+                      ],
+                    },
+                  }),
+                ],
+                pageInfo: { hasNextPage: false, endCursor: null },
+              },
+            },
+          })
+        ),
+      }
+    );
+
+    expect(issues[0]).toMatchObject({
+      dispatchable: false,
+      dispatchReason: "Blocked by unresolved Linear issue: ENG-2.",
+      blockedBy: [{ state: "In Progress" }],
+    });
+  });
+
   it("uses runtime assignedOnly before legacy tracker settings", async () => {
     const fetchImpl = vi.fn().mockResolvedValue(
       jsonResponse({

--- a/packages/worker/src/conformance.test.ts
+++ b/packages/worker/src/conformance.test.ts
@@ -47,8 +47,10 @@ describe("Symphony core conformance", () => {
       hookPath: "hooks/after_create.sh",
       lifecycle: {
         ...DEFAULT_WORKFLOW_LIFECYCLE,
-        blockerCheckStates: ["Todo"],
         planningStates: [],
+      },
+      tracker: {
+        blockerCheckStates: ["Todo"],
       },
     });
   });

--- a/packages/worker/src/github-tracker.test.ts
+++ b/packages/worker/src/github-tracker.test.ts
@@ -99,7 +99,7 @@ describe("normalizeGithubProjectItem", () => {
         {
           id: "issue-9",
           identifier: "other/shared#9",
-          state: "Done"
+          state: "CLOSED"
         }
       ],
       createdAt: "2026-03-07T09:00:00.000Z",


### PR DESCRIPTION
## Issues — Closed #663

## TL;DR

Move blocker eligibility out of orchestration core and make tracker adapters the single source of `dispatchable` and `dispatchReason`.

## Change-point diagram

```text
Selected WORKFLOW.md tracker policy
          │
          ▼
GitHub / Linear adapters ──► dispatchable + dispatchReason ──► scheduler / retry / repo explain
                                           │
                                           └── blocked_by remains best-effort metadata
```

## Start here

- `packages/tracker-github/src/adapter.ts`
- `packages/tracker-github/src/orchestrator-adapter.ts`
- `packages/orchestrator/src/service.ts`
- `packages/orchestrator/src/explain.ts`

## Changes

- GitHub and Linear adapters derive blocker eligibility from tracker-owned policy; core lifecycle no longer owns `blockerCheckStates`.
- GitHub applies the same derivation to candidate and by-ID reads, so retry reconciliation cannot restart a blocked issue.
- GitHub resolves blockers that are source-closed or terminal in the Project workflow state.
- Scheduler, retry, and `repo explain` consume adapter-derived `dispatchable`; obsolete blocker context was removed.
- `tracker.provider` owns the configuration, with the flat key retained as a compatibility alias.
- Updated configuration, adapter profiles, unit coverage, and TC-18 ownership documentation.

## Risks & rollback

Eligibility now has one provider-owned source of truth. Reverting this PR restores the former core-owned blocker gate.

## Changed files

- Core workflow tracker policy and parser coverage
- GitHub and Linear adapters
- Orchestrator scheduler, retry, and explain plumbing
- CLI explain integration
- Configuration and Docker E2E scenario documentation

## Validation

- `pnpm lint` — pass
- `pnpm test` — pass in CI (1,777 tests)
- `pnpm typecheck` — pass
- `pnpm build` — pass
- `pnpm --filter @gh-symphony/tracker-github test -- --run src/tracker-github.test.ts` — pass (105 tests)
- `pnpm --filter @gh-symphony/orchestrator test -- --run src/dispatch.test.ts` — pass (37 tests)
- Docker E2E TC-18 — pass: the blocked file-tracker record had no `run-dispatched` event while its unblocked dependency dispatched. This correction preserves that fixture/scheduler contract.
- PR checks (`Test`, `Container Smoke`) — pass on `496f7ce4`.

## Post-merge / human validation

- [ ] Confirm blocked GitHub and Linear issues remain visible but non-dispatchable.
- [ ] Confirm `repo explain` reports the adapter-provided dispatch reason for the selected workflow.
