### PR TITLE
fix(orchestrator): enforce workspace hook lifecycle

### DIFF
--- a/.changeset/fatal-workspace-hooks.md
+++ b/.changeset/fatal-workspace-hooks.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Make workspace creation and run hooks fail their corresponding attempt, rerun attempt hooks on retries, and bound hook diagnostics. (#655)

--- a/.changeset/fatal-workspace-hooks.md
+++ b/.changeset/fatal-workspace-hooks.md
@@ -2,4 +2,4 @@
 "@gh-symphony/cli": patch
 ---
 
-Make workspace creation and run hooks fail their corresponding attempt, rerun attempt hooks on retries, and bound hook diagnostics. (#655)
+Make workspace creation and run hooks abort their corresponding attempt on failure, rerun attempt hooks on retries, and bound hook diagnostics. (#655)

--- a/packages/core/src/workspace/hooks.test.ts
+++ b/packages/core/src/workspace/hooks.test.ts
@@ -9,7 +9,11 @@ import {
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, describe, expect, it } from "vitest";
-import { buildHookExecutionEnv, executeWorkspaceHook } from "./hooks.js";
+import {
+  buildHookExecutionEnv,
+  executeWorkspaceHook,
+  MAX_HOOK_OUTPUT_BYTES,
+} from "./hooks.js";
 
 const tempDirs: string[] = [];
 
@@ -73,6 +77,61 @@ describe("executeWorkspaceHook", () => {
     });
 
     expect(result.outcome).toBe("timeout");
+  });
+
+  it("drains large stdout without waiting for the timeout", async () => {
+    const repositoryPath = await mkdtemp(join(tmpdir(), "hook-stdout-"));
+    tempDirs.push(repositoryPath);
+    await writeFile(
+      join(repositoryPath, "large-output.sh"),
+      "#!/usr/bin/env bash\nhead -c 131072 /dev/zero\n",
+      "utf8"
+    );
+    await chmod(join(repositoryPath, "large-output.sh"), 0o755);
+
+    const result = await executeWorkspaceHook({
+      kind: "before_run",
+      hooks: {
+        afterCreate: null,
+        beforeRun: "large-output.sh",
+        afterRun: null,
+        beforeRemove: null,
+      },
+      repositoryPath,
+      env: {},
+      trusted: true,
+      timeoutMs: 1_000,
+    });
+
+    expect(result.outcome).toBe("success");
+  });
+
+  it("bounds failed hook stderr diagnostics", async () => {
+    const repositoryPath = await mkdtemp(join(tmpdir(), "hook-stderr-"));
+    tempDirs.push(repositoryPath);
+    await writeFile(
+      join(repositoryPath, "large-error.sh"),
+      "#!/usr/bin/env bash\nhead -c 8192 /dev/zero | tr '\\0' x >&2\nexit 1\n",
+      "utf8"
+    );
+    await chmod(join(repositoryPath, "large-error.sh"), 0o755);
+
+    const result = await executeWorkspaceHook({
+      kind: "before_run",
+      hooks: {
+        afterCreate: null,
+        beforeRun: "large-error.sh",
+        afterRun: null,
+        beforeRemove: null,
+      },
+      repositoryPath,
+      env: {},
+      trusted: true,
+      timeoutMs: 1_000,
+    });
+
+    expect(result.outcome).toBe("failure");
+    expect(result.error?.length).toBeLessThanOrEqual(MAX_HOOK_OUTPUT_BYTES);
   });
 
   it("supports repository-relative hook paths via bash execution", async () => {

--- a/packages/core/src/workspace/hooks.test.ts
+++ b/packages/core/src/workspace/hooks.test.ts
@@ -111,7 +111,7 @@ describe("executeWorkspaceHook", () => {
     tempDirs.push(repositoryPath);
     await writeFile(
       join(repositoryPath, "large-error.sh"),
-      "#!/usr/bin/env bash\nhead -c 8192 /dev/zero | tr '\\0' x >&2\nexit 1\n",
+      "#!/usr/bin/env bash\nyes '가나다라' | head -c 8192 >&2\nexit 1\n",
       "utf8"
     );
     await chmod(join(repositoryPath, "large-error.sh"), 0o755);
@@ -131,7 +131,10 @@ describe("executeWorkspaceHook", () => {
     });
 
     expect(result.outcome).toBe("failure");
-    expect(result.error?.length).toBeLessThanOrEqual(MAX_HOOK_OUTPUT_BYTES);
+    expect(Buffer.byteLength(result.error ?? "", "utf8")).toBeLessThanOrEqual(
+      MAX_HOOK_OUTPUT_BYTES
+    );
+    expect(result.error).not.toContain("�");
   });
 
   it("supports repository-relative hook paths via bash execution", async () => {

--- a/packages/core/src/workspace/hooks.ts
+++ b/packages/core/src/workspace/hooks.ts
@@ -65,11 +65,14 @@ export async function executeHook(
 
     // Drain both pipes so a verbose hook cannot block on the OS pipe buffer.
     // Retain only the bounded diagnostic suffix used by the orchestrator.
-    let stderr = "";
-    const appendOutput = (current: string, chunk: Buffer): string => {
-      const combined = current + chunk.toString("utf8");
+    let stderr: Buffer<ArrayBufferLike> = Buffer.alloc(0);
+    const appendOutput = (
+      current: Buffer<ArrayBufferLike>,
+      chunk: Buffer<ArrayBufferLike>
+    ): Buffer<ArrayBufferLike> => {
+      const combined = Buffer.concat([current, chunk]);
       return combined.length > MAX_HOOK_OUTPUT_BYTES
-        ? combined.slice(-MAX_HOOK_OUTPUT_BYTES)
+        ? combined.subarray(-MAX_HOOK_OUTPUT_BYTES)
         : combined;
     };
     child.stdout?.on("data", () => {
@@ -99,7 +102,37 @@ export async function executeHook(
         clearTimeout(timer);
       }
       const durationMs = Date.now() - start;
-      const errorOutput = stderr.trim();
+      // A bounded suffix can begin midway through a UTF-8 sequence. Drop its
+      // continuation bytes before decoding so diagnostics stay valid text.
+      while (stderr.length > 0 && (stderr[0]! & 0b1100_0000) === 0b1000_0000) {
+        stderr = stderr.subarray(1);
+      }
+      // A hook may be terminated immediately after a partial code point.
+      // Remove that suffix instead of emitting a replacement character.
+      let trailingContinuationBytes = 0;
+      for (
+        let index = stderr.length - 1;
+        index >= 0 && (stderr[index]! & 0b1100_0000) === 0b1000_0000;
+        index -= 1
+      ) {
+        trailingContinuationBytes += 1;
+      }
+      if (trailingContinuationBytes > 0) {
+        const leadingIndex = stderr.length - trailingContinuationBytes - 1;
+        const leadingByte = stderr[leadingIndex];
+        const expectedContinuationBytes =
+          leadingByte !== undefined && (leadingByte & 0b1111_1000) === 0b1111_0000
+            ? 3
+            : leadingByte !== undefined && (leadingByte & 0b1111_0000) === 0b1110_0000
+              ? 2
+              : leadingByte !== undefined && (leadingByte & 0b1110_0000) === 0b1100_0000
+                ? 1
+                : 0;
+        if (trailingContinuationBytes < expectedContinuationBytes) {
+          stderr = stderr.subarray(0, leadingIndex);
+        }
+      }
+      const errorOutput = stderr.toString("utf8").trim();
 
       if (timedOut) {
         resolveResult({

--- a/packages/core/src/workspace/hooks.ts
+++ b/packages/core/src/workspace/hooks.ts
@@ -35,6 +35,7 @@ export type HookExecutionOptions = {
 };
 
 const DEFAULT_HOOK_TIMEOUT_MS = 60_000;
+export const MAX_HOOK_OUTPUT_BYTES = 4 * 1024;
 
 export async function executeHook(
   options: HookExecutionOptions
@@ -62,9 +63,20 @@ export async function executeHook(
       stdio: "pipe",
     });
 
-    const stderrChunks: Buffer[] = [];
+    // Drain both pipes so a verbose hook cannot block on the OS pipe buffer.
+    // Retain only the bounded diagnostic suffix used by the orchestrator.
+    let stderr = "";
+    const appendOutput = (current: string, chunk: Buffer): string => {
+      const combined = current + chunk.toString("utf8");
+      return combined.length > MAX_HOOK_OUTPUT_BYTES
+        ? combined.slice(-MAX_HOOK_OUTPUT_BYTES)
+        : combined;
+    };
+    child.stdout?.on("data", () => {
+      // Output is deliberately discarded after draining.
+    });
     child.stderr?.on("data", (chunk: Buffer) => {
-      stderrChunks.push(chunk);
+      stderr = appendOutput(stderr, chunk);
     });
 
     if (timeoutMs > 0) {
@@ -87,7 +99,7 @@ export async function executeHook(
         clearTimeout(timer);
       }
       const durationMs = Date.now() - start;
-      const stderr = Buffer.concat(stderrChunks).toString("utf8").trim();
+      const errorOutput = stderr.trim();
 
       if (timedOut) {
         resolveResult({
@@ -106,7 +118,7 @@ export async function executeHook(
           outcome: "failure",
           exitCode: code,
           durationMs,
-          error: stderr || `Hook "${kind}" exited with code ${code}`,
+          error: errorOutput || `Hook "${kind}" exited with code ${code}`,
         });
         return;
       }
@@ -253,9 +265,7 @@ export function buildHookExecutionEnv(
   return Object.fromEntries(
     Object.entries(env).filter(([key]) => {
       return (
-        allowed.has(key) ||
-        key.startsWith("SYMPHONY_") ||
-        key.startsWith("LC_")
+        allowed.has(key) || key.startsWith("SYMPHONY_") || key.startsWith("LC_")
       );
     })
   );
@@ -263,7 +273,9 @@ export function buildHookExecutionEnv(
 
 function resolveHookCommandSpawn(
   command: string
-): { ok: true; command: string; args: string[] } | { ok: false; error: string } {
+):
+  | { ok: true; command: string; args: string[] }
+  | { ok: false; error: string } {
   const trimmed = command.trim();
   if (!trimmed) {
     return { ok: false, error: "Hook command is empty." };

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -14505,7 +14505,7 @@ Prefer focused changes.
     await mkdir(join(repository.path, "scripts"), { recursive: true });
     await writeFile(
       join(repository.path, "scripts", "setup-env.sh"),
-      '#!/usr/bin/env bash\nset -eu\nprintf "%s\\n" "$STAGING_API_HOST" > "$SYMPHONY_REPOSITORY_PATH/.after_create_host"\nprintf "%s\\n" "$FILE_ONLY" > "$SYMPHONY_REPOSITORY_PATH/.after_create_file_only"\n',
+      '#!/usr/bin/env bash\nset -eu\nprintf "%s\\n" "$STAGING_API_HOST" > "$SYMPHONY_REPOSITORY_PATH/.after_create_host"\nprintf "%s\\n" "$FILE_ONLY" > "$SYMPHONY_REPOSITORY_PATH/.after_create_file_only"\nprintf "%s\\n" "${SYMPHONY_ISSUE_STATE-unset}" > "$SYMPHONY_REPOSITORY_PATH/.after_create_issue_state"\n',
       "utf8"
     );
     await chmod(join(repository.path, "scripts", "setup-env.sh"), 0o755);
@@ -14553,6 +14553,9 @@ Prefer focused changes.
     await expect(
       readFile(join(repositoryPath, ".after_create_file_only"), "utf8")
     ).resolves.toBe("from-project-env\n");
+    await expect(
+      readFile(join(repositoryPath, ".after_create_issue_state"), "utf8")
+    ).resolves.toBe("unset\n");
   });
 
   it("fails a before_run hook without spawning the worker and queues a retry", async () => {
@@ -14734,6 +14737,103 @@ Test hook failure.
         }),
       }),
     ]);
+  });
+
+  it("runs after_create only for a new workspace and before_run for retries", async () => {
+    process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
+    const tempRoot = await mkdtemp(
+      join(tmpdir(), "orchestrator-reused-workspace-hooks-")
+    );
+    const repository = await createRepositoryFixture(
+      tempRoot,
+      "acme",
+      "platform",
+      {
+        rawWorkflow: `---
+tracker:
+  kind: github-project
+  project_id: project-123
+  state_field: Status
+  active_states: [Todo]
+  terminal_states: [Done]
+  blocker_check_states: [Todo]
+hooks:
+  after_create: hooks/count-after-create.sh
+  before_run: hooks/fail-before-run.sh
+polling:
+  interval_ms: 30000
+workspace:
+  root: .runtime/symphony-workspaces
+agent:
+  max_concurrent_agents: 10
+  retry_base_delay_ms: 1000
+codex:
+  command: codex app-server
+---
+Test workspace hook retries.
+`,
+      }
+    );
+    await mkdir(join(repository.path, "hooks"), { recursive: true });
+    await writeFile(
+      join(repository.path, "hooks", "count-after-create.sh"),
+      "#!/usr/bin/env bash\nprintf 'after_create\\n' >> \"$SYMPHONY_WORKSPACE_PATH/.after_create_calls\"\n",
+      "utf8"
+    );
+    await writeFile(
+      join(repository.path, "hooks", "fail-before-run.sh"),
+      "#!/usr/bin/env bash\nprintf 'before_run\\n' >> \"$SYMPHONY_WORKSPACE_PATH/.before_run_calls\"\nprintf 'before run failed' >&2\nexit 1\n",
+      "utf8"
+    );
+    await chmod(join(repository.path, "hooks", "count-after-create.sh"), 0o755);
+    await chmod(join(repository.path, "hooks", "fail-before-run.sh"), 0o755);
+    execSync(`git -C ${shell(repository.path)} add hooks`, {
+      stdio: "ignore",
+    });
+    execSync(
+      `git -C ${shell(repository.path)} commit -m reused-workspace-hook-counts`,
+      { stdio: "ignore" }
+    );
+
+    const store = new OrchestratorFsStore(tempRoot);
+    const projectConfig = createProjectConfig(tempRoot, repository);
+    await store.saveProjectConfig(projectConfig);
+    await writeFile(
+      join(store.projectDir(projectConfig.projectId), ".env"),
+      "SYMPHONY_ALLOW_WORKFLOW_HOOKS=1\n",
+      "utf8"
+    );
+    const spawnImpl = vi.fn().mockReturnValue({ pid: 4313, unref: vi.fn() });
+    let currentTime = new Date("2026-03-08T00:00:00.000Z");
+    const service = new OrchestratorService(store, projectConfig, {
+      fetchImpl: vi.fn().mockResolvedValue(createTrackerResponse(repository)),
+      spawnImpl: spawnImpl as never,
+      now: () => currentTime,
+    });
+
+    await service.runOnce();
+    currentTime = new Date("2026-03-08T00:01:00.000Z");
+    await service.runOnce();
+    currentTime = new Date("2026-03-08T00:02:00.000Z");
+    await service.runOnce();
+
+    const workspaceKey = (
+      await store.loadProjectIssueOrchestrations(projectConfig.projectId)
+    )[0]?.workspaceKey;
+    const repositoryPath = join(
+      resolveIssueWorkspaceDirectory(
+        store.projectDir(projectConfig.projectId),
+        workspaceKey ?? ""
+      ),
+      "repository"
+    );
+    await expect(
+      readFile(join(repositoryPath, "..", ".after_create_calls"), "utf8")
+    ).resolves.toBe("after_create\n");
+    await expect(
+      readFile(join(repositoryPath, "..", ".before_run_calls"), "utf8")
+    ).resolves.toBe("before_run\nbefore_run\nbefore_run\n");
+    expect(spawnImpl).not.toHaveBeenCalled();
   });
 
   it("resolves standalone project .env $VAR values with host precedence", async () => {

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -1862,10 +1862,11 @@ describe("OrchestratorService", () => {
       pid: 4101,
       unref: vi.fn(),
     });
+    const currentTime = new Date("2026-03-08T00:00:00.000Z");
     const service = new OrchestratorService(store, projectConfig, {
       fetchImpl: vi.fn().mockResolvedValue(createTrackerResponse(repository)),
       spawnImpl: spawnImpl as never,
-      now: () => new Date("2026-03-08T00:00:00.000Z"),
+      now: () => currentTime,
     });
 
     const first = await service.runOnce();
@@ -14697,10 +14698,11 @@ Test hook failure.
       "utf8"
     );
     const spawnImpl = vi.fn().mockReturnValue({ pid: 4312, unref: vi.fn() });
+    let currentTime = new Date("2026-03-08T00:00:00.000Z");
     const service = new OrchestratorService(store, projectConfig, {
       fetchImpl: vi.fn().mockResolvedValue(createTrackerResponse(repository)),
       spawnImpl: spawnImpl as never,
-      now: () => new Date("2026-03-08T00:00:00.000Z"),
+      now: () => currentTime,
     });
 
     await service.runOnce();
@@ -14708,7 +14710,30 @@ Test hook failure.
     expect(spawnImpl).not.toHaveBeenCalled();
     await expect(
       store.loadProjectIssueOrchestrations(projectConfig.projectId)
-    ).resolves.toEqual([expect.objectContaining({ state: "retry_queued" })]);
+    ).resolves.toEqual([
+      expect.objectContaining({
+        state: "retry_queued",
+        retryEntry: expect.objectContaining({
+          error: expect.stringContaining("after_create hook failure"),
+        }),
+      }),
+    ]);
+    currentTime = new Date("2026-03-08T00:01:00.000Z");
+    await service.runOnce();
+
+    // The failed setup directory was removed, so retrying runs after_create
+    // again and never bypasses it to spawn a worker.
+    expect(spawnImpl).not.toHaveBeenCalled();
+    await expect(
+      store.loadProjectIssueOrchestrations(projectConfig.projectId)
+    ).resolves.toEqual([
+      expect.objectContaining({
+        state: "retry_queued",
+        retryEntry: expect.objectContaining({
+          error: expect.stringContaining("after_create hook failure"),
+        }),
+      }),
+    ]);
   });
 
   it("resolves standalone project .env $VAR values with host precedence", async () => {

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -14554,6 +14554,163 @@ Prefer focused changes.
     ).resolves.toBe("from-project-env\n");
   });
 
+  it("fails a before_run hook without spawning the worker and queues a retry", async () => {
+    process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
+    const tempRoot = await mkdtemp(
+      join(tmpdir(), "orchestrator-before-run-failure-")
+    );
+    const repository = await createRepositoryFixture(
+      tempRoot,
+      "acme",
+      "platform",
+      {
+        rawWorkflow: `---
+tracker:
+  kind: github-project
+  project_id: project-123
+  state_field: Status
+  active_states: [Todo]
+  terminal_states: [Done]
+  blocker_check_states: [Todo]
+hooks:
+  before_run: hooks/fail-before-run.sh
+polling:
+  interval_ms: 30000
+workspace:
+  root: .runtime/symphony-workspaces
+agent:
+  max_concurrent_agents: 10
+  retry_base_delay_ms: 1000
+codex:
+  command: codex app-server
+---
+Test hook failure.
+`,
+      }
+    );
+    await mkdir(join(repository.path, "hooks"), { recursive: true });
+    await writeFile(
+      join(repository.path, "hooks", "fail-before-run.sh"),
+      "#!/usr/bin/env bash\nprintf 'before run failed' >&2\nexit 1\n",
+      "utf8"
+    );
+    await chmod(join(repository.path, "hooks", "fail-before-run.sh"), 0o755);
+    execSync(`git -C ${shell(repository.path)} add hooks/fail-before-run.sh`, {
+      stdio: "ignore",
+    });
+    execSync(
+      `git -C ${shell(repository.path)} commit -m failing-before-run-hook`,
+      {
+        stdio: "ignore",
+      }
+    );
+
+    const store = new OrchestratorFsStore(tempRoot);
+    const projectConfig = createProjectConfig(tempRoot, repository);
+    await store.saveProjectConfig(projectConfig);
+    await writeFile(
+      join(store.projectDir(projectConfig.projectId), ".env"),
+      "SYMPHONY_ALLOW_WORKFLOW_HOOKS=1\n",
+      "utf8"
+    );
+    const spawnImpl = vi.fn().mockReturnValue({ pid: 4311, unref: vi.fn() });
+    const service = new OrchestratorService(store, projectConfig, {
+      fetchImpl: vi.fn().mockResolvedValue(createTrackerResponse(repository)),
+      spawnImpl: spawnImpl as never,
+      now: () => new Date("2026-03-08T00:00:00.000Z"),
+    });
+
+    await service.runOnce();
+
+    expect(spawnImpl).not.toHaveBeenCalled();
+    await expect(
+      store.loadProjectIssueOrchestrations(projectConfig.projectId)
+    ).resolves.toEqual([
+      expect.objectContaining({
+        state: "retry_queued",
+        retryEntry: expect.objectContaining({
+          error: expect.stringContaining("before_run hook failure"),
+        }),
+      }),
+    ]);
+  });
+
+  it("fails workspace creation when after_create fails", async () => {
+    process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
+    const tempRoot = await mkdtemp(
+      join(tmpdir(), "orchestrator-after-create-failure-")
+    );
+    const repository = await createRepositoryFixture(
+      tempRoot,
+      "acme",
+      "platform",
+      {
+        rawWorkflow: `---
+tracker:
+  kind: github-project
+  project_id: project-123
+  state_field: Status
+  active_states: [Todo]
+  terminal_states: [Done]
+  blocker_check_states: [Todo]
+hooks:
+  after_create: hooks/fail-after-create.sh
+polling:
+  interval_ms: 30000
+workspace:
+  root: .runtime/symphony-workspaces
+agent:
+  max_concurrent_agents: 10
+codex:
+  command: codex app-server
+---
+Test hook failure.
+`,
+      }
+    );
+    await mkdir(join(repository.path, "hooks"), { recursive: true });
+    await writeFile(
+      join(repository.path, "hooks", "fail-after-create.sh"),
+      "#!/usr/bin/env bash\nprintf 'after create failed' >&2\nexit 1\n",
+      "utf8"
+    );
+    await chmod(join(repository.path, "hooks", "fail-after-create.sh"), 0o755);
+    execSync(
+      `git -C ${shell(repository.path)} add hooks/fail-after-create.sh`,
+      {
+        stdio: "ignore",
+      }
+    );
+    execSync(
+      `git -C ${shell(repository.path)} commit -m failing-after-create-hook`,
+      {
+        stdio: "ignore",
+      }
+    );
+
+    const store = new OrchestratorFsStore(tempRoot);
+    const projectConfig = createProjectConfig(tempRoot, repository);
+    await store.saveProjectConfig(projectConfig);
+    await writeFile(
+      join(store.projectDir(projectConfig.projectId), ".env"),
+      "SYMPHONY_ALLOW_WORKFLOW_HOOKS=1\n",
+      "utf8"
+    );
+    const spawnImpl = vi.fn().mockReturnValue({ pid: 4312, unref: vi.fn() });
+    const service = new OrchestratorService(store, projectConfig, {
+      fetchImpl: vi.fn().mockResolvedValue(createTrackerResponse(repository)),
+      spawnImpl: spawnImpl as never,
+      now: () => new Date("2026-03-08T00:00:00.000Z"),
+    });
+
+    await service.runOnce();
+
+    expect(spawnImpl).not.toHaveBeenCalled();
+    await expect(
+      store.loadProjectIssueOrchestrations(projectConfig.projectId)
+    ).resolves.toEqual([expect.objectContaining({ state: "retry_queued" })]);
+  });
+
   it("resolves standalone project .env $VAR values with host precedence", async () => {
     process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
     const originalProjectId = process.env.PROJECT_ENV_WORKFLOW_ID;

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -130,6 +130,14 @@ function resolveTrackerSecretEnvironmentNames(
   return declaration.call(trackerAdapter);
 }
 
+function isSuccessfulHookResult(result: HookResult): boolean {
+  return result.outcome === "success" || result.outcome === "skipped";
+}
+
+function formatFatalHookError(result: HookResult): string {
+  return `${result.kind} hook ${result.outcome}: ${result.error ?? "unknown hook failure"}`;
+}
+
 export function clampPollInterval(intervalMs: number): number {
   return Math.min(
     MAX_POLL_INTERVAL_MS,
@@ -2794,11 +2802,17 @@ export class OrchestratorService {
       recursive: true,
       mode: 0o700,
     });
+    // `mkdir` is the source of truth: persisted workspace metadata can outlive
+    // a deleted directory, and a directory can predate its metadata.
+    const createdWorkspaceDirectory = await mkdir(issueWorkspacePath, {
+      recursive: true,
+      mode: 0o700,
+    });
+    const createdNow = createdWorkspaceDirectory !== undefined;
     const repositoryDirectory = await ensureIssueWorkspaceRepository({
       repository: issue.repository,
       issueWorkspacePath,
-      existingWorkspace:
-        existingWorkspaceAtConfiguredRoot && !workspaceQuarantined,
+      existingWorkspace: !createdNow && !workspaceQuarantined,
       pullRequestBranch,
       allowDirtyExistingWorkspace:
         recovery?.kind === "incomplete-turn-dirty-workspace",
@@ -2818,7 +2832,11 @@ export class OrchestratorService {
     );
     await excludeRuntimeSkillsFromGit(repositoryDirectory, agentCommand);
 
-    if (!existingWorkspaceAtConfiguredRoot || workspaceQuarantined) {
+    if (
+      !existingWorkspaceAtConfiguredRoot ||
+      workspaceQuarantined ||
+      createdNow
+    ) {
       const workspaceRecord: IssueWorkspaceRecord = {
         workspaceKey,
         projectId: tenant.projectId,
@@ -2833,8 +2851,10 @@ export class OrchestratorService {
         lastError: null,
       };
       await this.store.saveIssueWorkspace(workspaceRecord);
+    }
 
-      // Run after_create hook for new issue workspaces
+    // Run after_create only when this process actually created the directory.
+    if (createdNow) {
       const afterCreateResult = await this.runHook(
         "after_create",
         tenant,
@@ -2849,18 +2869,8 @@ export class OrchestratorService {
           repositoryPath: repositoryDirectory,
         }
       );
-      if (
-        afterCreateResult &&
-        afterCreateResult.outcome !== "success" &&
-        afterCreateResult.outcome !== "skipped"
-      ) {
-        await this.store.appendRunEvent(runId, {
-          at: now.toISOString(),
-          event: "hook-failed",
-          projectId: tenant.projectId,
-          hook: "after_create",
-          error: afterCreateResult.error ?? null,
-        } as OrchestratorEvent);
+      if (!isSuccessfulHookResult(afterCreateResult)) {
+        throw new Error(formatFatalHookError(afterCreateResult));
       }
     }
 
@@ -2893,7 +2903,7 @@ export class OrchestratorService {
       repositoryDirectory,
       agentCommand,
     });
-    await this.runHook(
+    const beforeRunResult = await this.runHook(
       "before_run",
       tenant,
       repositoryDirectory,
@@ -2909,6 +2919,9 @@ export class OrchestratorService {
         state: issue.state,
       }
     );
+    if (!isSuccessfulHookResult(beforeRunResult)) {
+      throw new Error(formatFatalHookError(beforeRunResult));
+    }
 
     const runtimeTimeouts = resolveWorkflowRuntimeTimeouts(workflow.workflow);
     const buildRunRecord = (
@@ -3421,29 +3434,7 @@ export class OrchestratorService {
       );
     }
 
-    if (run.issueWorkspaceKey) {
-      const issueWorkspacePath = resolveIssueWorkspaceDirectory(
-        this.resolveIssueWorkspaceRoot(tenant),
-        run.issueWorkspaceKey
-      );
-
-      await this.runHook(
-        "after_run",
-        tenant,
-        run.workingDirectory,
-        run.repository,
-        {
-          projectId: run.projectId,
-          workspaceKey: run.issueWorkspaceKey,
-          issueSubjectId: run.issueSubjectId,
-          issueIdentifier: run.issueIdentifier,
-          workspacePath: issueWorkspacePath,
-          repositoryPath: run.workingDirectory,
-          runId: run.runId,
-          state: run.issueState,
-        }
-      );
-    }
+    await this.runAfterRunHook(tenant, run);
 
     const currentTrackerProgress =
       runWithTokens.runPhase === "succeeded" &&
@@ -4466,7 +4457,7 @@ export class OrchestratorService {
 
   /**
    * Execute a workspace lifecycle hook using the workflow configuration
-   * loaded from the repository. Failures are logged and mirrored to the
+   * loaded from the repository. Starts and bounded failures are logged and mirrored to the
    * run event stream when a run id is available.
    */
   private async runHook(
@@ -4487,6 +4478,9 @@ export class OrchestratorService {
     resolution?: ProjectWorkflowResolution
   ): Promise<HookResult> {
     let result: HookResult;
+    this.writeStderr(
+      `[orchestrator] starting ${kind} hook for ${context.issueIdentifier}`
+    );
     try {
       const workflowResolution =
         resolution ?? (await this.loadProjectWorkflow(tenant, repository));
@@ -4550,6 +4544,33 @@ export class OrchestratorService {
     }
 
     return result;
+  }
+
+  private async runAfterRunHook(
+    tenant: OrchestratorProjectConfig,
+    run: OrchestratorRunRecord
+  ): Promise<void> {
+    if (!run.issueWorkspaceKey) return;
+    const workspacePath = resolveIssueWorkspaceDirectory(
+      this.resolveIssueWorkspaceRoot(tenant),
+      run.issueWorkspaceKey
+    );
+    await this.runHook(
+      "after_run",
+      tenant,
+      run.workingDirectory,
+      run.repository,
+      {
+        projectId: run.projectId,
+        workspaceKey: run.issueWorkspaceKey,
+        issueSubjectId: run.issueSubjectId,
+        issueIdentifier: run.issueIdentifier,
+        workspacePath,
+        repositoryPath: run.workingDirectory,
+        runId: run.runId,
+        state: run.issueState,
+      }
+    );
   }
 
   private readProjectEnv(

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -19,6 +19,7 @@ import {
   deriveIssueWorkspaceKey,
   deriveLegacyIssueWorkspaceKey,
   executeWorkspaceHook,
+  resolveHookCommand,
   isStateTerminal,
   isMatchingIssueRun,
   matchesWorkflowState,
@@ -2832,11 +2833,36 @@ export class OrchestratorService {
     );
     await excludeRuntimeSkillsFromGit(repositoryDirectory, agentCommand);
 
-    if (
-      !existingWorkspaceAtConfiguredRoot ||
-      workspaceQuarantined ||
-      createdNow
-    ) {
+    const shouldSaveWorkspaceRecord =
+      !existingWorkspaceAtConfiguredRoot || workspaceQuarantined || createdNow;
+
+    // Run after_create only when this process actually created the directory.
+    // If it fails, remove the partial workspace so a retry creates it again
+    // rather than starting in an uninitialized directory.
+    if (createdNow) {
+      const afterCreateResult = await this.runHook(
+        "after_create",
+        tenant,
+        repositoryDirectory,
+        issue.repository,
+        {
+          projectId: tenant.projectId,
+          workspaceKey,
+          issueSubjectId,
+          issueIdentifier: issue.identifier,
+          workspacePath: issueWorkspacePath,
+          repositoryPath: repositoryDirectory,
+          eventRunId: runId,
+          state: issue.state,
+        }
+      );
+      if (!isSuccessfulHookResult(afterCreateResult)) {
+        await rm(issueWorkspacePath, { recursive: true, force: true });
+        throw new Error(formatFatalHookError(afterCreateResult));
+      }
+    }
+
+    if (shouldSaveWorkspaceRecord) {
       const workspaceRecord: IssueWorkspaceRecord = {
         workspaceKey,
         projectId: tenant.projectId,
@@ -2851,27 +2877,6 @@ export class OrchestratorService {
         lastError: null,
       };
       await this.store.saveIssueWorkspace(workspaceRecord);
-    }
-
-    // Run after_create only when this process actually created the directory.
-    if (createdNow) {
-      const afterCreateResult = await this.runHook(
-        "after_create",
-        tenant,
-        repositoryDirectory,
-        issue.repository,
-        {
-          projectId: tenant.projectId,
-          workspaceKey,
-          issueSubjectId,
-          issueIdentifier: issue.identifier,
-          workspacePath: issueWorkspacePath,
-          repositoryPath: repositoryDirectory,
-        }
-      );
-      if (!isSuccessfulHookResult(afterCreateResult)) {
-        throw new Error(formatFatalHookError(afterCreateResult));
-      }
     }
 
     const workflow = workflowForPopulate;
@@ -4473,14 +4478,12 @@ export class OrchestratorService {
       workspacePath: string;
       repositoryPath: string;
       runId?: string;
+      eventRunId?: string;
       state?: string;
     },
     resolution?: ProjectWorkflowResolution
   ): Promise<HookResult> {
     let result: HookResult;
-    this.writeStderr(
-      `[orchestrator] starting ${kind} hook for ${context.issueIdentifier}`
-    );
     try {
       const workflowResolution =
         resolution ?? (await this.loadProjectWorkflow(tenant, repository));
@@ -4499,6 +4502,11 @@ export class OrchestratorService {
           tenant,
           buildHookEnv(context)
         );
+        if (resolveHookCommand(workflowResolution.workflow.hooks, kind)) {
+          this.writeStderr(
+            `[orchestrator] starting ${kind} hook for ${context.issueIdentifier}`
+          );
+        }
         result = await executeWorkspaceHook({
           kind,
           hooks: workflowResolution.workflow.hooks,
@@ -4526,9 +4534,10 @@ export class OrchestratorService {
       this.writeStderr(
         `[orchestrator] ${kind} hook failed for ${context.issueIdentifier}: ${errorMessage}`
       );
-      if (context.runId) {
+      const eventRunId = context.eventRunId ?? context.runId;
+      if (eventRunId) {
         try {
-          await this.store.appendRunEvent(context.runId, {
+          await this.store.appendRunEvent(eventRunId, {
             at: this.now().toISOString(),
             event: "hook-failed",
             projectId: tenant.projectId,

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -2853,7 +2853,6 @@ export class OrchestratorService {
           workspacePath: issueWorkspacePath,
           repositoryPath: repositoryDirectory,
           eventRunId: runId,
-          state: issue.state,
         }
       );
       if (!isSuccessfulHookResult(afterCreateResult)) {


### PR DESCRIPTION
## TL;DR

Fixes #655 by enforcing fatal workspace hook boundaries without allowing retries to bypass initialization, while keeping hook diagnostics bounded and observable.

## Change-point diagram

```text
mkdir(workspace) result → created_now → after_create (actual creation only)
after_create failure → remove partial workspace → retry creates and initializes again
each start/restart attempt → before_run → worker spawn
completed attempt → after_run exactly once → retry scheduling
hook stdout + stderr → drained → UTF-8-safe 4 KiB stderr diagnostic
```

## Start here

- `packages/orchestrator/src/service.ts` — filesystem-derived workspace creation, fatal lifecycle gates, partial-workspace cleanup, event persistence, and the `after_create` environment boundary.
- `packages/orchestrator/src/service.test.ts` — fatal hook retry/no-spawn acceptance coverage, retained-workspace hook ordering, and the absent `SYMPHONY_ISSUE_STATE` contract.
- `packages/core/src/workspace/hooks.ts` — stdout draining and byte-bounded UTF-8 diagnostics.
- `packages/core/src/workspace/hooks.test.ts` — large stdout and multibyte diagnostic truncation coverage.

## Risks & rollback

- Trusted failing `after_create` and `before_run` hooks abort the attempt; a failed creation is removed before retry.
- `after_run` remains exactly once per completed attempt; the retry path starts the next attempt through `startRun`.
- `after_create` retains its documented environment contract: it has neither `SYMPHONY_RUN_ID` nor `SYMPHONY_ISSUE_STATE`.
- Hook stdout is discarded after draining; failures retain at most 4 KiB of valid UTF-8 stderr.
- The existing `SYMPHONY_ALLOW_WORKFLOW_HOOKS` gate and path-only execution model are unchanged.
- Roll back by reverting `89b17617`, `a61e9230`, `343bd093`, and `3d2bd5aa`.

## Changed files

- `.changeset/fatal-workspace-hooks.md`
- `packages/core/src/workspace/hooks.ts`
- `packages/core/src/workspace/hooks.test.ts`
- `packages/orchestrator/src/service.ts`
- `packages/orchestrator/src/service.test.ts`

## Evidence

- `pnpm lint` — pass.
- `pnpm test` — pass.
- `pnpm typecheck` — pass.
- `pnpm build` — pass.
- `bash e2e/run-e2e.sh happy 60` — pass; Docker worker dispatched, retried, and converged to idle.

## Issues — Closed #655

Fixes #655

## Post-merge / human validation

- [ ] Observe hook start, failure, and truncation diagnostics in a production repository with workflow hooks enabled.
- [ ] Confirm existing hook enablement and path-only workflow policy remain unchanged.
