### PR TITLE
fix(cli): align repo init with config directory

### DIFF
--- a/.changeset/fresh-config-dir-init.md
+++ b/.changeset/fresh-config-dir-init.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Make `repo init` register explicit configuration directories so `repo start` selects the initialized repository (#715).

--- a/README.md
+++ b/README.md
@@ -569,7 +569,7 @@ gh-symphony repo recover --dry-run       # Preview what would be recovered
 
 ### Repository Runtime
 
-`gh-symphony repo init` binds the orchestrator to the cwd repository. It reads `WORKFLOW.md` (or `--workflow-file <path>`), infers `owner/name` from the Git remote, and writes per-repo runtime state under `.runtime/orchestrator/`. The selected absolute workflow path is persisted and validated before `repo start` or `project start` launches the daemon.
+`gh-symphony repo init` binds the orchestrator to the cwd repository. It reads `WORKFLOW.md` (or `--workflow-file <path>`), infers `owner/name` from the Git remote, and writes per-repo runtime state under `.runtime/orchestrator/`. The selected absolute workflow path is persisted and validated before `repo start` or `project start` launches the daemon. When `GH_SYMPHONY_CONFIG_DIR` or `--config <dir>` is explicitly set, it also registers a path-scoped record in that shared config directory and makes it active, so `repo start` in the repository or one of its subdirectories selects this repository. Other repository records in the directory are preserved.
 
 For Linear tracker repositories, `WORKFLOW.md` remains the source of truth:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -70,9 +70,11 @@ blocked by the current issue and are not blockers of it.
 `GH_SYMPHONY_CONFIG_DIR` (or `--config <dir>`) selects the shared CLI registry
 used by repository lifecycle commands. `gh-symphony repo init` always writes the
 repo-embedded runtime under `<repo>/.runtime/orchestrator`; when a config
-directory is explicitly selected, it also writes the repository project record
-and active-project registry under that directory. This keeps a subsequent
+directory is explicitly selected, it also writes a repository-path-scoped project
+record and makes that record active under the directory. This keeps a subsequent
 `gh-symphony repo start` in the same environment consistent with initialization.
+Records for other repositories in the same shared directory are preserved; each
+subsequent `repo init` makes its own repository the active project.
 Without an explicit config directory, repository lifecycle commands use the
 repo-embedded runtime directly. The environment variable does not relocate the
 repository's orchestrator state.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -65,6 +65,18 @@ planning/human-review execution phase. Linear `blocked_by` metadata is derived
 from inverse relations of type `blocks`; source-side relations describe issues
 blocked by the current issue and are not blockers of it.
 
+## `GH_SYMPHONY_CONFIG_DIR` and Repository Runtimes
+
+`GH_SYMPHONY_CONFIG_DIR` (or `--config <dir>`) selects the shared CLI registry
+used by repository lifecycle commands. `gh-symphony repo init` always writes the
+repo-embedded runtime under `<repo>/.runtime/orchestrator`; when a config
+directory is explicitly selected, it also writes the repository project record
+and active-project registry under that directory. This keeps a subsequent
+`gh-symphony repo start` in the same environment consistent with initialization.
+Without an explicit config directory, repository lifecycle commands use the
+repo-embedded runtime directly. The environment variable does not relocate the
+repository's orchestrator state.
+
 ## Standalone Projects
 
 `gh-symphony project start` runs the project folder in the working directory as
@@ -256,19 +268,19 @@ uses them during setup and doctor checks where applicable.
 These variables affect the local `gh-symphony` process or repository runtime
 layout.
 
-| Variable                               | Default                                                                                       | Read by                       | Audience           | Notes                                                                                                                    |
-| -------------------------------------- | --------------------------------------------------------------------------------------------- | ----------------------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------ |
+| Variable                               | Default                                                                                       | Read by                       | Audience           | Notes                                                                                                                                                                                            |
+| -------------------------------------- | --------------------------------------------------------------------------------------------- | ----------------------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `GH_SYMPHONY_CONFIG_DIR`               | CLI default config directory; official container sets `/var/lib/gh-symphony`                  | CLI                           | User-facing/ops    | Overrides the global runtime config directory. `--config <dir>` takes precedence. It also selects the explicit global `instances/` registry namespace; `--config` alone never splits that index. |
-| `GH_SYMPHONY_INSTANCES_DIR`            | `${GH_SYMPHONY_CONFIG_DIR:-~/.gh-symphony}/instances`                                         | CLI daemon + `instances`      | User-facing/ops    | Host-global instance registry namespace. Captured before a `--config` runtime override and inherited by daemon children. |
-| `GH_SYMPHONY_FILE_TRACKER_ISSUES_PATH` | unset                                                                                         | CLI `repo init`               | Internal/E2E       | Required only when binding the file tracker to a mounted issues fixture. Not needed for GitHub or Linear trackers.       |
-| `GH_SYMPHONY_HTTP_TOKEN`               | random per `repo start` process                                                               | CLI HTTP servers              | User-facing/ops    | Shared bearer secret for all `/api/v1/*` routes. Set this for scripts, daemon clients, or a stable dashboard URL.        |
-| `SYMPHONY_EVENTS_DIR`                  | runtime-managed event storage                                                                 | Orchestrator package CLI      | User-facing/ops    | Optional override for where orchestrator events are written.                                                             |
-| `SYMPHONY_LOG_LEVEL`                   | `normal`                                                                                      | CLI, orchestrator package CLI | User-facing/ops    | Supports `normal` and `verbose`. CLI flags override the env value.                                                       |
-| `SYMPHONY_WORKER_COMMAND`              | auto-resolved `@gh-symphony/worker`, bundled worker entry, then `gh-symphony-worker` fallback | Orchestrator                  | User-facing/ops    | Shell command used to start worker processes. Useful for local E2E, debugging, or custom worker wrappers.                |
-| `SYMPHONY_E2E_PROJECT`                 | `symphony-e2e-<worktree-path-hash>`                                                          | Docker E2E runner scripts     | Internal/E2E       | Optional Compose project-name override. The runner derives a stable name from the current worktree and uses it for isolated containers, networks, volumes, and image tags. |
-| `NO_COLOR`                             | unset                                                                                         | CLI                           | User-facing        | Set indirectly by `--no-color`; honored by terminal output rendering.                                                    |
-| `EDITOR` / `VISUAL`                    | `vi` fallback                                                                                 | CLI `config edit`             | User-facing        | Selects the editor for interactive config editing.                                                                       |
-| `PATH` / `PATHEXT`                     | inherited from shell                                                                          | CLI doctor, child processes   | User-facing/system | Used for prerequisite and command discovery.                                                                             |
+| `GH_SYMPHONY_INSTANCES_DIR`            | `${GH_SYMPHONY_CONFIG_DIR:-~/.gh-symphony}/instances`                                         | CLI daemon + `instances`      | User-facing/ops    | Host-global instance registry namespace. Captured before a `--config` runtime override and inherited by daemon children.                                                                         |
+| `GH_SYMPHONY_FILE_TRACKER_ISSUES_PATH` | unset                                                                                         | CLI `repo init`               | Internal/E2E       | Required only when binding the file tracker to a mounted issues fixture. Not needed for GitHub or Linear trackers.                                                                               |
+| `GH_SYMPHONY_HTTP_TOKEN`               | random per `repo start` process                                                               | CLI HTTP servers              | User-facing/ops    | Shared bearer secret for all `/api/v1/*` routes. Set this for scripts, daemon clients, or a stable dashboard URL.                                                                                |
+| `SYMPHONY_EVENTS_DIR`                  | runtime-managed event storage                                                                 | Orchestrator package CLI      | User-facing/ops    | Optional override for where orchestrator events are written.                                                                                                                                     |
+| `SYMPHONY_LOG_LEVEL`                   | `normal`                                                                                      | CLI, orchestrator package CLI | User-facing/ops    | Supports `normal` and `verbose`. CLI flags override the env value.                                                                                                                               |
+| `SYMPHONY_WORKER_COMMAND`              | auto-resolved `@gh-symphony/worker`, bundled worker entry, then `gh-symphony-worker` fallback | Orchestrator                  | User-facing/ops    | Shell command used to start worker processes. Useful for local E2E, debugging, or custom worker wrappers.                                                                                        |
+| `SYMPHONY_E2E_PROJECT`                 | `symphony-e2e-<worktree-path-hash>`                                                           | Docker E2E runner scripts     | Internal/E2E       | Optional Compose project-name override. The runner derives a stable name from the current worktree and uses it for isolated containers, networks, volumes, and image tags.                       |
+| `NO_COLOR`                             | unset                                                                                         | CLI                           | User-facing        | Set indirectly by `--no-color`; honored by terminal output rendering.                                                                                                                            |
+| `EDITOR` / `VISUAL`                    | `vi` fallback                                                                                 | CLI `config edit`             | User-facing        | Selects the editor for interactive config editing.                                                                                                                                               |
+| `PATH` / `PATHEXT`                     | inherited from shell                                                                          | CLI doctor, child processes   | User-facing/system | Used for prerequisite and command discovery.                                                                                                                                                     |
 
 ## Tuning Knobs
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -280,7 +280,7 @@ gh-symphony repo start               # Start this repository
 gh-symphony repo stop                # Stop this repository
 ```
 
-`gh-symphony repo init` reads `WORKFLOW.md` (or `--workflow-file <path>`), infers `owner/name` from the Git remote, and writes per-repo runtime state under `.runtime/orchestrator/`. The selected workflow path is persisted and startup validates it before launching the daemon.
+`gh-symphony repo init` reads `WORKFLOW.md` (or `--workflow-file <path>`), infers `owner/name` from the Git remote, and writes per-repo runtime state under `.runtime/orchestrator/`. The selected workflow path is persisted and startup validates it before launching the daemon. With an explicit `GH_SYMPHONY_CONFIG_DIR` or `--config <dir>`, it also registers a path-scoped record in that shared config directory and makes it active so `repo start` in the repository or one of its subdirectories selects this repository. Existing records for other repositories are preserved.
 
 ### Why Is My Issue Not Running?
 

--- a/packages/cli/src/commands/repo.test.ts
+++ b/packages/cli/src/commands/repo.test.ts
@@ -16,7 +16,10 @@ import {
   loadProjectConfig,
   saveGlobalConfig,
 } from "../config.js";
-import { inspectManagedProjectSelection } from "../project-selection.js";
+import {
+  inspectManagedProjectSelection,
+  resolveManagedProjectConfig,
+} from "../project-selection.js";
 import { standaloneProjectId } from "../standalone-project.js";
 
 async function loadRepoCommand() {
@@ -158,6 +161,12 @@ describe("repo init runtime migration", () => {
       projectConfig: {
         repository: { owner: "acme", name: "platform" },
       },
+    });
+    await expect(
+      resolveManagedProjectConfig({ configDir, cwd: repoDir })
+    ).resolves.toMatchObject({
+      projectId,
+      repository: { owner: "acme", name: "platform" },
     });
   });
 

--- a/packages/cli/src/commands/repo.test.ts
+++ b/packages/cli/src/commands/repo.test.ts
@@ -16,6 +16,8 @@ import {
   loadProjectConfig,
   saveGlobalConfig,
 } from "../config.js";
+import { inspectManagedProjectSelection } from "../project-selection.js";
+import { standaloneProjectId } from "../standalone-project.js";
 
 async function loadRepoCommand() {
   vi.resetModules();
@@ -137,14 +139,70 @@ describe("repo init runtime migration", () => {
       configDirOverride: true,
     });
 
+    const projectId = `repo-${standaloneProjectId(repoDir)}`;
     await expect(loadGlobalConfig(configDir)).resolves.toEqual({
-      activeProject: "repository",
-      projects: ["standalone", "repository"],
+      activeProject: projectId,
+      projects: ["standalone", projectId],
     });
     await expect(
-      loadProjectConfig(configDir, "repository")
+      loadProjectConfig(configDir, projectId)
     ).resolves.toMatchObject({
+      projectId,
       repository: { owner: "acme", name: "platform" },
+    });
+    await expect(
+      inspectManagedProjectSelection({ configDir, cwd: repoDir })
+    ).resolves.toMatchObject({
+      kind: "resolved",
+      projectId,
+      projectConfig: {
+        repository: { owner: "acme", name: "platform" },
+      },
+    });
+  });
+
+  it("keeps repository records distinct in a shared explicit config directory", async () => {
+    const repoA = await createGitRepo("platform-a");
+    const repoB = await createGitRepo("platform-b");
+    const configDir = await mkdtemp(join(tmpdir(), "repo-init-shared-config-"));
+    const { initRepoRuntime } = await loadRepoRuntimeModule();
+    await Promise.all(
+      [repoA, repoB].map((repoDir) =>
+        writeFile(join(repoDir, "WORKFLOW.md"), VALID_WORKFLOW, "utf8")
+      )
+    );
+
+    await initRepoRuntime({ repoDir: repoA, configDir });
+    await initRepoRuntime({ repoDir: repoB, configDir });
+
+    await expect(
+      inspectManagedProjectSelection({ configDir, cwd: repoA })
+    ).resolves.toMatchObject({
+      kind: "resolved",
+      projectId: `repo-${standaloneProjectId(repoA)}`,
+      projectConfig: {
+        repository: { owner: "acme", name: "platform-a" },
+      },
+    });
+    await expect(
+      loadProjectConfig(configDir, `repo-${standaloneProjectId(repoA)}`)
+    ).resolves.toMatchObject({
+      repository: { owner: "acme", name: "platform-a" },
+    });
+    await expect(
+      inspectManagedProjectSelection({ configDir, cwd: repoB })
+    ).resolves.toMatchObject({
+      kind: "resolved",
+      projectId: `repo-${standaloneProjectId(repoB)}`,
+      projectConfig: {
+        repository: { owner: "acme", name: "platform-b" },
+      },
+    });
+    await expect(loadGlobalConfig(configDir)).resolves.toMatchObject({
+      projects: [
+        `repo-${standaloneProjectId(repoA)}`,
+        `repo-${standaloneProjectId(repoB)}`,
+      ],
     });
   });
 

--- a/packages/cli/src/commands/repo.test.ts
+++ b/packages/cli/src/commands/repo.test.ts
@@ -11,6 +11,11 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { CliProjectConfig } from "../config.js";
+import {
+  loadGlobalConfig,
+  loadProjectConfig,
+  saveGlobalConfig,
+} from "../config.js";
 
 async function loadRepoCommand() {
   vi.resetModules();
@@ -117,6 +122,32 @@ afterEach(() => {
 });
 
 describe("repo init runtime migration", () => {
+  it("writes repository selection to an explicit config directory", async () => {
+    const repoDir = await createGitRepo();
+    const configDir = await mkdtemp(join(tmpdir(), "repo-init-config-dir-"));
+    const repoCommand = await loadRepoCommand();
+    await writeFile(join(repoDir, "WORKFLOW.md"), VALID_WORKFLOW, "utf8");
+    await saveGlobalConfig(configDir, {
+      activeProject: "standalone",
+      projects: ["standalone"],
+    });
+
+    await repoCommand(["init", "--repo-dir", repoDir], {
+      ...baseOptions(configDir),
+      configDirOverride: true,
+    });
+
+    await expect(loadGlobalConfig(configDir)).resolves.toEqual({
+      activeProject: "repository",
+      projects: ["standalone", "repository"],
+    });
+    await expect(
+      loadProjectConfig(configDir, "repository")
+    ).resolves.toMatchObject({
+      repository: { owner: "acme", name: "platform" },
+    });
+  });
+
   it("preserves an explicit global config override for repo subcommands", async () => {
     const { repoOptions } = await loadRepoModule();
     const configDir = join(tmpdir(), "captured-runtime");

--- a/packages/cli/src/commands/repo.ts
+++ b/packages/cli/src/commands/repo.ts
@@ -117,7 +117,10 @@ async function repoInit(args: string[], options: GlobalOptions): Promise<void> {
   }
 
   try {
-    const result = await initRepoRuntime(flags);
+    const result = await initRepoRuntime({
+      ...flags,
+      ...(options.configDirOverride ? { configDir: options.configDir } : {}),
+    });
     if (options.json) {
       process.stdout.write(JSON.stringify(result, null, 2) + "\n");
       return;

--- a/packages/cli/src/commands/repo.ts
+++ b/packages/cli/src/commands/repo.ts
@@ -129,6 +129,11 @@ async function repoInit(args: string[], options: GlobalOptions): Promise<void> {
       [
         `Repository initialized: ${formatRepoSpec(result.repository)}`,
         `Runtime: ${result.configDir}`,
+        ...(result.registryProjectId
+          ? [
+              `Config registry: ${options.configDir} (active project: ${result.registryProjectId})`,
+            ]
+          : []),
         `Workflow: ${result.workflowPath}`,
       ].join("\n") + "\n"
     );

--- a/packages/cli/src/project-selection.test.ts
+++ b/packages/cli/src/project-selection.test.ts
@@ -117,6 +117,51 @@ describe("resolveManagedProjectConfig", () => {
     expect(selectMock).not.toHaveBeenCalled();
   });
 
+  it("prefers the repository record matching cwd over another active repository", async () => {
+    const repositoryA = await mkdtemp(join(tmpdir(), "repository-a-"));
+    const repositoryB = await mkdtemp(join(tmpdir(), "repository-b-"));
+    const projectA = {
+      ...createProject("repository-a"),
+      repositoryDir: repositoryA,
+    };
+    const projectB = {
+      ...createProject("repository-b"),
+      repositoryDir: repositoryB,
+    };
+    const configDir = await createConfigFixture(
+      [projectA, projectB],
+      projectB.projectId
+    );
+
+    await expect(
+      resolveManagedProjectConfig({ configDir, cwd: repositoryA })
+    ).resolves.toMatchObject({ projectId: projectA.projectId });
+  });
+
+  it("prefers the deepest repository record containing cwd", async () => {
+    const repositoryDir = await mkdtemp(join(tmpdir(), "repository-root-"));
+    const nestedRepositoryDir = join(repositoryDir, "packages", "cli");
+    const projectA = {
+      ...createProject("repository-root"),
+      repositoryDir,
+    };
+    const projectB = {
+      ...createProject("repository-nested"),
+      repositoryDir: nestedRepositoryDir,
+    };
+    const configDir = await createConfigFixture(
+      [projectA, projectB],
+      projectA.projectId
+    );
+
+    await expect(
+      resolveManagedProjectConfig({
+        configDir,
+        cwd: join(nestedRepositoryDir, "src"),
+      })
+    ).resolves.toMatchObject({ projectId: projectB.projectId });
+  });
+
   it("requires interactive selection when multiple projects have no active project", async () => {
     const configDir = await createConfigFixture([
       createProject("tenant-a"),
@@ -219,20 +264,6 @@ describe("inspectManagedProjectSelection", () => {
     expect(result).toMatchObject({
       kind: "resolved",
       projectId: projectAId,
-    });
-  });
-
-  it("resolves the repository config written to a fresh config directory", async () => {
-    const configDir = await createConfigFixture(
-      [createProject("repository")],
-      "repository"
-    );
-
-    const result = await inspectManagedProjectSelection({ configDir });
-
-    expect(result).toMatchObject({
-      kind: "resolved",
-      projectId: "repository",
     });
   });
 

--- a/packages/cli/src/project-selection.test.ts
+++ b/packages/cli/src/project-selection.test.ts
@@ -222,6 +222,20 @@ describe("inspectManagedProjectSelection", () => {
     });
   });
 
+  it("resolves the repository config written to a fresh config directory", async () => {
+    const configDir = await createConfigFixture(
+      [createProject("repository")],
+      "repository"
+    );
+
+    const result = await inspectManagedProjectSelection({ configDir });
+
+    expect(result).toMatchObject({
+      kind: "resolved",
+      projectId: "repository",
+    });
+  });
+
   it("keeps an explicit selector ahead of the cached standalone cwd", async () => {
     const projectADir = await mkdtemp(join(tmpdir(), "standalone-a-"));
     const projectAId = standaloneProjectId(projectADir);

--- a/packages/cli/src/project-selection.ts
+++ b/packages/cli/src/project-selection.ts
@@ -79,12 +79,10 @@ async function loadRepositoryProjectFromCwd(
     null;
   for (const projectId of projectIds) {
     const projectConfig = await loadProjectConfig(configDir, projectId);
-    const repositoryDir = projectConfig?.repositoryDir
-      ? resolve(projectConfig.repositoryDir)
-      : undefined;
-    if (!repositoryDir) {
+    if (!projectConfig?.repositoryDir) {
       continue;
     }
+    const repositoryDir = resolve(projectConfig.repositoryDir);
     const pathToCwd = relative(repositoryDir, resolvedCwd);
     const containsCwd =
       pathToCwd === "" ||

--- a/packages/cli/src/project-selection.ts
+++ b/packages/cli/src/project-selection.ts
@@ -1,5 +1,5 @@
 import * as p from "@clack/prompts";
-import { resolve } from "node:path";
+import { isAbsolute, relative, resolve } from "node:path";
 import {
   loadGlobalConfig,
   loadProjectConfig,
@@ -69,6 +69,37 @@ async function loadStandaloneProjectFromCwd(
   return null;
 }
 
+async function loadRepositoryProjectFromCwd(
+  configDir: string,
+  cwd: string,
+  projectIds: readonly string[]
+): Promise<{ projectId: string; projectConfig: CliProjectConfig } | null> {
+  const resolvedCwd = resolve(cwd);
+  let bestMatch: { projectId: string; projectConfig: CliProjectConfig } | null =
+    null;
+  for (const projectId of projectIds) {
+    const projectConfig = await loadProjectConfig(configDir, projectId);
+    const repositoryDir = projectConfig?.repositoryDir
+      ? resolve(projectConfig.repositoryDir)
+      : undefined;
+    if (!repositoryDir) {
+      continue;
+    }
+    const pathToCwd = relative(repositoryDir, resolvedCwd);
+    const containsCwd =
+      pathToCwd === "" ||
+      (!pathToCwd.startsWith("..") && !isAbsolute(pathToCwd));
+    if (
+      containsCwd &&
+      (!bestMatch ||
+        repositoryDir.length > resolve(bestMatch.projectConfig.repositoryDir!).length)
+    ) {
+      bestMatch = { projectId, projectConfig };
+    }
+  }
+  return bestMatch;
+}
+
 export async function inspectManagedProjectSelection(
   input: ResolveProjectSelectionInput
 ): Promise<ManagedProjectResolution> {
@@ -116,6 +147,15 @@ export async function inspectManagedProjectSelection(
       message:
         "No repository runtime config is configured. Run 'gh-symphony repo init' first.",
     };
+  }
+
+  const cwdRepository = await loadRepositoryProjectFromCwd(
+    input.configDir,
+    input.cwd ?? process.cwd(),
+    projectIds
+  );
+  if (cwdRepository) {
+    return { kind: "resolved", ...cwdRepository };
   }
 
   if (global.activeProject) {
@@ -174,6 +214,15 @@ export async function resolveManagedProjectConfig(
 
   if (projectIds.length === 0) {
     return null;
+  }
+
+  const cwdRepository = await loadRepositoryProjectFromCwd(
+    input.configDir,
+    input.cwd ?? process.cwd(),
+    projectIds
+  );
+  if (cwdRepository) {
+    return cwdRepository.projectConfig;
   }
 
   if (projectIds.length === 1) {

--- a/packages/cli/src/repo-runtime.ts
+++ b/packages/cli/src/repo-runtime.ts
@@ -26,6 +26,7 @@ import {
 import {
   saveGlobalConfig,
   saveProjectConfig,
+  updateGlobalConfig,
   type CliProjectConfig,
 } from "./config.js";
 import { resolveRepoRuntimeRoot } from "./orchestrator-runtime.js";
@@ -33,6 +34,7 @@ import { resolveRepoRuntimeRoot } from "./orchestrator-runtime.js";
 export type RepoInitFlags = {
   repoDir: string;
   workflowFile?: string;
+  configDir?: string;
 };
 
 const INTERNAL_PROJECT_ID = "repository";
@@ -180,6 +182,15 @@ export async function initRepoRuntime(flags: RepoInitFlags): Promise<{
     activeProject: INTERNAL_PROJECT_ID,
     projects: [INTERNAL_PROJECT_ID],
   });
+
+  const configDir = flags.configDir ? resolve(flags.configDir) : runtimeRoot;
+  if (configDir !== runtimeRoot) {
+    await saveProjectConfig(configDir, INTERNAL_PROJECT_ID, projectConfig);
+    await updateGlobalConfig(configDir, (config) => ({
+      activeProject: INTERNAL_PROJECT_ID,
+      projects: Array.from(new Set([...config.projects, INTERNAL_PROJECT_ID])),
+    }));
+  }
 
   const orchestratorConfig: OrchestratorProjectConfig = {
     projectId: INTERNAL_PROJECT_ID,

--- a/packages/cli/src/repo-runtime.ts
+++ b/packages/cli/src/repo-runtime.ts
@@ -30,6 +30,7 @@ import {
   type CliProjectConfig,
 } from "./config.js";
 import { resolveRepoRuntimeRoot } from "./orchestrator-runtime.js";
+import { standaloneProjectId } from "./standalone-project.js";
 
 export type RepoInitFlags = {
   repoDir: string;
@@ -83,6 +84,7 @@ export function parseRepoRuntimeFlags(args: readonly string[]): RepoInitFlags {
 export async function initRepoRuntime(flags: RepoInitFlags): Promise<{
   configDir: string;
   projectId: string;
+  registryProjectId?: string;
   workflowPath: string;
   repository: RepositoryRef;
 }> {
@@ -184,11 +186,15 @@ export async function initRepoRuntime(flags: RepoInitFlags): Promise<{
   });
 
   const configDir = flags.configDir ? resolve(flags.configDir) : runtimeRoot;
+  const registryProjectId = `repo-${standaloneProjectId(repoDir)}`;
   if (configDir !== runtimeRoot) {
-    await saveProjectConfig(configDir, INTERNAL_PROJECT_ID, projectConfig);
+    await saveProjectConfig(configDir, registryProjectId, {
+      ...projectConfig,
+      projectId: registryProjectId,
+    });
     await updateGlobalConfig(configDir, (config) => ({
-      activeProject: INTERNAL_PROJECT_ID,
-      projects: Array.from(new Set([...config.projects, INTERNAL_PROJECT_ID])),
+      activeProject: registryProjectId,
+      projects: Array.from(new Set([...config.projects, registryProjectId])),
     }));
   }
 
@@ -206,6 +212,7 @@ export async function initRepoRuntime(flags: RepoInitFlags): Promise<{
   return {
     configDir: runtimeRoot,
     projectId: INTERNAL_PROJECT_ID,
+    ...(configDir !== runtimeRoot ? { registryProjectId } : {}),
     workflowPath,
     repository,
   };


### PR DESCRIPTION
## Issues — Closed #715

## TL;DR

`repo init` now records explicit `GH_SYMPHONY_CONFIG_DIR` registrations, allowing a subsequent `repo start` to resolve the initialized repository. Shared registries retain isolated records and resolve the deepest repository containing the current directory.

## Change-point diagram

```text
repo init --config <shared>
  -> <repo>/.runtime/orchestrator (embedded runtime)
  -> <shared>/projects/repo-<path-id>/project.json
  -> <shared>/config.json (active repo-<path-id>)
repo start from <repo>/subdir
  -> chooses the deepest repositoryDir containing cwd
```

## Start here

- `packages/cli/src/repo-runtime.ts` mirrors an explicit-config registration under a `repo-` namespaced path ID.
- `packages/cli/src/project-selection.ts` resolves the deepest containing repository record before the active-project fallback.
- `packages/cli/src/commands/repo.test.ts` covers `repo init` through the same selection used by `repo start`, including a shared registry.

## Changes

- Rebased onto current `main`, preserving repository workflow-source metadata.
- Stored explicit registry records with `repo-` namespaced, path-scoped IDs.
- Selected repository registrations from a repository root or descendant, with deepest-match precedence.
- Removed unrelated standalone cwd precedence from managed command selection.
- Added lifecycle, shared-registry, and nested-directory regression coverage.
- Documented config-directory and embedded-runtime behavior and added an `@gh-symphony/cli` patch changeset.

## Evidence

- `pnpm --filter @gh-symphony/cli exec vitest run src/commands/repo.test.ts src/project-selection.test.ts` — 44 tests passed.
- `pnpm lint` — passed.
- `pnpm test` — passed (all workspace suites; CLI: 42 files, 583 tests).
- `pnpm typecheck` — passed.
- `pnpm build` — passed.

## Risks & rollback

- Explicit config directories retain one `repo-` path-scoped record per initialized checkout; this prevents cross-repository overwrite.
- Roll back by reverting commits `2ac93ded`, `cdd7d261`, `480872f5`, and `06f31882`.

## Changed files

- `packages/cli/src/repo-runtime.ts`
- `packages/cli/src/project-selection.ts`
- `packages/cli/src/commands/repo.ts`
- `packages/cli/src/commands/repo.test.ts`
- `packages/cli/src/project-selection.test.ts`
- `README.md`, `packages/cli/README.md`, `docs/configuration.md`
- `.changeset/fresh-config-dir-init.md`

## Post-merge / human validation

- [ ] With a fresh `GH_SYMPHONY_CONFIG_DIR`, run `repo init` and then `repo start` from the same repository.
- [ ] Initialize two repositories against one explicit config directory and confirm `repo start` from each root and nested directory resolves the correct checkout.
