### PR TITLE
feat(core): add required label routing

### DIFF
--- a/.changeset/tidy-required-label-routing.md
+++ b/.changeset/tidy-required-label-routing.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": minor
+---
+
+Add normalized workflow required-label routing for #720.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -75,7 +75,8 @@ strict parser as workflow loading. Failures include a stable error code; the
 | `hooks.timeout_ms`  | A positive integer when provided                                                                                           | `workflow_validation_error` at `hooks.timeout_ms`                             |
 | `agent.max_turns`   | A positive integer when provided                                                                                           | `workflow_validation_error` at `agent.max_turns`                              |
 | `codex.command`     | A non-empty string when provided                                                                                           | `workflow_validation_error` at `codex.command`                                |
-| `tracker.kind`      | One of `github-project`, `linear`, or `file`                                                                               | `workflow_validation_error` at `tracker.kind`                                 |
+| `tracker.kind`            | One of `github-project`, `linear`, or `file`                                                                         | `workflow_validation_error` at `tracker.kind`                           |
+| `tracker.required_labels` | An array of strings; comma-separated strings are rejected                                                            | `workflow_validation_error` at `tracker.required_labels`                |
 
 Omitted optional values retain their documented defaults. Per-state concurrency
 maps remain supported through `agent.max_concurrent_agents_by_state` and their
@@ -89,8 +90,10 @@ Core normalizes workflow pickup labels and tracker-provided labels before label
 matching: it trims surrounding whitespace, lowercases values, drops blanks, and
 deduplicates while keeping the first occurrence. Thus `" Agent "`, `"agent"`,
 and `"AGENT"` are the same label. The same `normalizeLabels` helper is the
-shared implementation for current pickup-label handling and future
-`tracker.required_labels` configuration support.
+shared implementation for pickup-label handling. `tracker.required_labels`
+uses a deliberately separate blank-preserving normalization path: it trims and
+lowercases values, but a configured blank remains and therefore matches no
+issue, as required by Symphony specification §5.3.1.
 
 `parseTrackerTimestamp` accepts RFC 3339 timestamps, including lowercase `t` /
 `z` designators and leap seconds, and returns a canonical ISO 8601 UTC string;

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -68,15 +68,15 @@ diverge from the upstream shell-command hook model.
 strict parser as workflow loading. Failures include a stable error code; the
 `workflow validate --json` error also exposes its field path separately.
 
-| Rule                | Required value                                                                                                             | Error code/path                                                               |
-| ------------------- | -------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
-| Front matter syntax | A valid YAML mapping                                                                                                       | `workflow_parse_error` or `workflow_front_matter_not_a_map` at `front_matter` |
-| Numeric fields      | YAML integers; quoted numeric strings and fractions are rejected, including priority maps and per-state concurrency values | `workflow_validation_error` at the field path                                 |
-| `hooks.timeout_ms`  | A positive integer when provided                                                                                           | `workflow_validation_error` at `hooks.timeout_ms`                             |
-| `agent.max_turns`   | A positive integer when provided                                                                                           | `workflow_validation_error` at `agent.max_turns`                              |
-| `codex.command`     | A non-empty string when provided                                                                                           | `workflow_validation_error` at `codex.command`                                |
-| `tracker.kind`            | One of `github-project`, `linear`, or `file`                                                                         | `workflow_validation_error` at `tracker.kind`                           |
-| `tracker.required_labels` | An array of strings; comma-separated strings are rejected                                                            | `workflow_validation_error` at `tracker.required_labels`                |
+| Rule                      | Required value                                                                                                             | Error code/path                                                               |
+| ------------------------- | -------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| Front matter syntax       | A valid YAML mapping                                                                                                       | `workflow_parse_error` or `workflow_front_matter_not_a_map` at `front_matter` |
+| Numeric fields            | YAML integers; quoted numeric strings and fractions are rejected, including priority maps and per-state concurrency values | `workflow_validation_error` at the field path                                 |
+| `hooks.timeout_ms`        | A positive integer when provided                                                                                           | `workflow_validation_error` at `hooks.timeout_ms`                             |
+| `agent.max_turns`         | A positive integer when provided                                                                                           | `workflow_validation_error` at `agent.max_turns`                              |
+| `codex.command`           | A non-empty string when provided                                                                                           | `workflow_validation_error` at `codex.command`                                |
+| `tracker.kind`            | One of `github-project`, `linear`, or `file`                                                                               | `workflow_validation_error` at `tracker.kind`                                 |
+| `tracker.required_labels` | An array of strings; comma-separated strings are rejected                                                                  | `workflow_validation_error` at `tracker.required_labels`                      |
 
 Omitted optional values retain their documented defaults. Per-state concurrency
 maps remain supported through `agent.max_concurrent_agents_by_state` and their
@@ -84,16 +84,18 @@ values must be positive YAML integers. This repository intentionally rejects an
 invalid override rather than ignoring it, so invalid configuration cannot silently
 disable dispatch for a state.
 
+`tracker.required_labels` defaults to `[]`. Labels are compared after trimming
+and lowercasing; every configured label must be present before an issue can be
+routed. A blank configured label is preserved and therefore matches no issue.
+
 ## Label and Timestamp Normalization
 
 Core normalizes workflow pickup labels and tracker-provided labels before label
 matching: it trims surrounding whitespace, lowercases values, drops blanks, and
 deduplicates while keeping the first occurrence. Thus `" Agent "`, `"agent"`,
-and `"AGENT"` are the same label. The same `normalizeLabels` helper is the
-shared implementation for pickup-label handling. `tracker.required_labels`
-uses a deliberately separate blank-preserving normalization path: it trims and
-lowercases values, but a configured blank remains and therefore matches no
-issue, as required by Symphony specification §5.3.1.
+and `"AGENT"` are the same label. `tracker.required_labels` deliberately uses
+a separate normalization path: it retains blank configured labels so they match
+no issue, as required by Symphony specification §5.3.1.
 
 `parseTrackerTimestamp` accepts RFC 3339 timestamps, including lowercase `t` /
 `z` designators and leap seconds, and returns a canonical ISO 8601 UTC string;

--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -260,6 +260,44 @@ Prompt {{ issue.identifier }}
     );
   });
 
+  it("includes normalized required labels in JSON validation output", async () => {
+    const root = await mkdtemp(
+      join(tmpdir(), "workflow-validate-required-labels-")
+    );
+    const workflowPath = join(root, "WORKFLOW.md");
+    const stdout = captureWrites(process.stdout);
+
+    await writeFile(
+      workflowPath,
+      `---
+tracker:
+  kind: github-project
+  required_labels: [" Ready ", Agent]
+codex:
+  command: codex app-server
+---
+Prompt {{ issue.identifier }}
+`,
+      "utf8"
+    );
+
+    try {
+      await workflowCommand(["validate", "--file", workflowPath], {
+        configDir: root,
+        verbose: false,
+        json: true,
+        noColor: false,
+      });
+    } finally {
+      stdout.restore();
+    }
+
+    const report = JSON.parse(stdout.output()) as {
+      summary: { requiredLabels: string[] };
+    };
+    expect(report.summary.requiredLabels).toEqual(["ready", "agent"]);
+  });
+
   it("previews a workflow with the built-in sample issue", async () => {
     const root = await mkdtemp(join(tmpdir(), "workflow-preview-"));
     const workflowPath = join(root, "WORKFLOW.md");

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -92,6 +92,7 @@ type WorkflowValidationReport = {
     terminalStates: string[];
     blockerCheckStates: string[];
     planningStates: string[];
+    requiredLabels: string[];
     pollingIntervalMs: number;
     workspaceRoot: string | null;
     agentCommand: string;
@@ -863,6 +864,7 @@ function validateWorkflow(
       terminalStates: workflow.lifecycle.terminalStates,
       blockerCheckStates: workflow.tracker.blockerCheckStates,
       planningStates: workflow.lifecycle.planningStates,
+      requiredLabels: workflow.lifecycle.requiredLabels ?? [],
       pollingIntervalMs: workflow.polling.intervalMs,
       workspaceRoot: workflow.workspace.root,
       agentCommand: workflow.agentCommand,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,6 +14,7 @@ export * from "./workflow/render.js";
 export * from "./workflow/exit-classification.js";
 export * from "./workflow/issue-identity.js";
 export * from "./workflow/normalization.js";
+export * from "./workflow/issue-routable.js";
 export * from "./workflow/pickup-labels.js";
 export * from "./orchestration/index.js";
 export * from "./runtime/index.js";

--- a/packages/core/src/workflow-loader.test.ts
+++ b/packages/core/src/workflow-loader.test.ts
@@ -1013,6 +1013,57 @@ Prompt body.
     });
   });
 
+  it("normalizes required labels while preserving blank labels", () => {
+    const workflow = parseWorkflowMarkdown(`---
+tracker:
+  kind: github-project
+  required_labels:
+    - " Ready "
+    - ""
+  pickup_labels:
+    include:
+      - " Agent "
+codex:
+  command: codex app-server
+---
+Prompt body.
+`);
+
+    expect(workflow.tracker.requiredLabels).toEqual(["ready", ""]);
+    expect(workflow.lifecycle.requiredLabels).toEqual(["ready", ""]);
+    expect(workflow.tracker.pickupLabels).toEqual({
+      include: ["agent"],
+      exclude: [],
+    });
+  });
+
+  it("rejects comma-separated required labels with the field path", () => {
+    try {
+      parseWorkflowMarkdown(`---
+tracker:
+  kind: github-project
+  required_labels: ready, agent
+codex:
+  command: codex app-server
+---
+Prompt body.
+`);
+      throw new Error("Expected parsing to fail.");
+    } catch (error) {
+      expect(error).toMatchObject({
+        code: "workflow_validation_error",
+        path: "tracker.required_labels",
+      });
+    }
+  });
+
+  it("defaults omitted required labels to an empty list", () => {
+    const workflow = parseWorkflowMarkdown(SAMPLE_WORKFLOW);
+
+    expect(workflow.tracker.requiredLabels).toEqual([]);
+    expect(workflow.lifecycle.requiredLabels).toEqual([]);
+  });
+
   it("surfaces typed provider validation errors from the selected adapter", () => {
     const adapterError = new WorkflowValidationError(
       "workflow_validation_error",

--- a/packages/core/src/workflow-loader.test.ts
+++ b/packages/core/src/workflow-loader.test.ts
@@ -1047,7 +1047,7 @@ codex:
   command: codex app-server
 ---
 Prompt body.
-`);
+`)
     ).toThrow(
       expect.objectContaining({
         code: "workflow_validation_error",

--- a/packages/core/src/workflow-loader.test.ts
+++ b/packages/core/src/workflow-loader.test.ts
@@ -1038,7 +1038,7 @@ Prompt body.
   });
 
   it("rejects comma-separated required labels with the field path", () => {
-    try {
+    expect(() =>
       parseWorkflowMarkdown(`---
 tracker:
   kind: github-project
@@ -1048,13 +1048,12 @@ codex:
 ---
 Prompt body.
 `);
-      throw new Error("Expected parsing to fail.");
-    } catch (error) {
-      expect(error).toMatchObject({
+    ).toThrow(
+      expect.objectContaining({
         code: "workflow_validation_error",
         path: "tracker.required_labels",
-      });
-    }
+      })
+    );
   });
 
   it("defaults omitted required labels to an empty list", () => {

--- a/packages/core/src/workflow/config.ts
+++ b/packages/core/src/workflow/config.ts
@@ -18,6 +18,8 @@ export type WorkflowTrackerConfig = {
   apiKey: string | null;
   projectSlug: string | null;
   pickupLabels: WorkflowPickupLabelsConfig;
+  /** Core lifecycle routing constraint from tracker.required_labels. */
+  requiredLabels: string[];
   activeStates: string[];
   terminalStates: string[];
   projectId: string | null;
@@ -179,6 +181,7 @@ export const DEFAULT_WORKFLOW_TRACKER: WorkflowTrackerConfig = {
     include: [],
     exclude: [],
   },
+  requiredLabels: [],
   activeStates: [],
   terminalStates: [],
   projectId: null,
@@ -230,6 +233,7 @@ export const DEFAULT_WORKFLOW_DEFINITION: ParsedWorkflow = {
     activeStates: [],
     terminalStates: [],
     planningStates: [],
+    requiredLabels: [],
   },
   format: "default",
   githubProjectId: null,

--- a/packages/core/src/workflow/issue-routable.test.ts
+++ b/packages/core/src/workflow/issue-routable.test.ts
@@ -36,7 +36,7 @@ describe("issueRoutable", () => {
     ).toEqual({ routable: true });
   });
 
-  it("preserves empty required labels as unsatisfied", () => {
+  it("keeps empty required labels unsatisfied even with blank issue labels", () => {
     expect(
       issueRoutable(issue({ labels: ["ready", "  "] }), {
         ...DEFAULT_WORKFLOW_LIFECYCLE,

--- a/packages/core/src/workflow/issue-routable.test.ts
+++ b/packages/core/src/workflow/issue-routable.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import type { TrackedIssue } from "../contracts/tracker-adapter.js";
+import { issueRoutable } from "./issue-routable.js";
+import { DEFAULT_WORKFLOW_LIFECYCLE } from "./lifecycle.js";
+
+function issue(input: Partial<TrackedIssue>): TrackedIssue {
+  return {
+    id: "1",
+    identifier: "acme/repo#1",
+    title: "Test issue",
+    description: null,
+    priority: null,
+    state: "Ready",
+    branchName: null,
+    url: null,
+    labels: [],
+    dispatchable: true,
+    assigneeId: null,
+    blockedBy: [],
+    createdAt: null,
+    updatedAt: null,
+    repository: { owner: "acme", name: "repo", cloneUrl: "" },
+    tracker: { adapter: "file", bindingId: "test" },
+    metadata: {},
+    ...input,
+  };
+}
+
+describe("issueRoutable", () => {
+  it("matches required labels case-insensitively after trimming", () => {
+    expect(
+      issueRoutable(issue({ labels: [" Ready ", "AGENT"] }), {
+        ...DEFAULT_WORKFLOW_LIFECYCLE,
+        requiredLabels: ["ready", " agent "],
+      })
+    ).toEqual({ routable: true });
+  });
+
+  it("preserves empty required labels as unsatisfied", () => {
+    expect(
+      issueRoutable(issue({ labels: ["ready", "  "] }), {
+        ...DEFAULT_WORKFLOW_LIFECYCLE,
+        requiredLabels: ["ready", ""],
+      })
+    ).toEqual({
+      routable: false,
+      reason: 'Issue is missing required labels ("").',
+    });
+  });
+
+  it("prioritizes a non-dispatchable issue over required-label checks", () => {
+    expect(
+      issueRoutable(
+        issue({ dispatchable: false, dispatchReason: "Archived issue." }),
+        { ...DEFAULT_WORKFLOW_LIFECYCLE, requiredLabels: ["ready"] }
+      )
+    ).toEqual({ routable: false, reason: "Archived issue." });
+  });
+});

--- a/packages/core/src/workflow/issue-routable.ts
+++ b/packages/core/src/workflow/issue-routable.ts
@@ -1,0 +1,34 @@
+import type { TrackedIssue } from "../contracts/tracker-adapter.js";
+import type { WorkflowLifecycleConfig } from "./lifecycle.js";
+import { normalizeLabels } from "./normalization.js";
+
+/** Resolves whether an issue is eligible for workflow routing. */
+export function issueRoutable(
+  issue: Pick<TrackedIssue, "dispatchable" | "dispatchReason" | "labels">,
+  lifecycle: Pick<WorkflowLifecycleConfig, "requiredLabels">
+): { routable: boolean; reason?: string } {
+  if (!issue.dispatchable) {
+    return {
+      routable: false,
+      reason: issue.dispatchReason ?? "Issue is not dispatchable.",
+    };
+  }
+
+  const labels = new Set(normalizeLabels(issue.labels));
+  const missingLabels = (lifecycle.requiredLabels ?? []).filter((label) => {
+    const normalized = label.trim().toLowerCase();
+    // Preserve the config-side blank invariant from §5.3.1 even though issue
+    // labels are normalized with the shared helper, which drops blanks.
+    return normalized === "" || !labels.has(normalized);
+  });
+  if (missingLabels.length > 0) {
+    return {
+      routable: false,
+      reason: `Issue is missing required labels (${missingLabels
+        .map((label) => JSON.stringify(label))
+        .join(", ")}).`,
+    };
+  }
+
+  return { routable: true };
+}

--- a/packages/core/src/workflow/lifecycle.ts
+++ b/packages/core/src/workflow/lifecycle.ts
@@ -3,6 +3,8 @@ export type WorkflowLifecycleConfig = {
   activeStates: string[];
   terminalStates: string[];
   planningStates: string[];
+  /** Normalized required tracker labels; omitted legacy configs are unrestricted. */
+  requiredLabels?: string[];
 };
 
 export const DEFAULT_WORKFLOW_LIFECYCLE: WorkflowLifecycleConfig = {
@@ -10,6 +12,7 @@ export const DEFAULT_WORKFLOW_LIFECYCLE: WorkflowLifecycleConfig = {
   activeStates: ["Todo", "In Progress"],
   terminalStates: ["Done"],
   planningStates: [],
+  requiredLabels: [],
 };
 
 export function isStateActive(

--- a/packages/core/src/workflow/parser.ts
+++ b/packages/core/src/workflow/parser.ts
@@ -186,8 +186,7 @@ function parseWorkflowMarkdownInternal(
       provider,
       explicitProviderKeys,
       "blocker_check_states"
-    ) ??
-    (activeStates[0] ? [activeStates[0]] : []);
+    ) ?? (activeStates[0] ? [activeStates[0]] : []);
   const planningStates =
     readNormalizedStringList(
       tracker,
@@ -607,7 +606,10 @@ function readRequiredLabelList(
   if (value === undefined || value === null) {
     return undefined;
   }
-  if (!Array.isArray(value) || value.some((entry) => typeof entry !== "string")) {
+  if (
+    !Array.isArray(value) ||
+    value.some((entry) => typeof entry !== "string")
+  ) {
     throw new WorkflowValidationError(
       "workflow_validation_error",
       "tracker.required_labels",
@@ -617,7 +619,7 @@ function readRequiredLabelList(
 
   // §5.3.1 requires blank configured labels to remain unsatisfied. The shared
   // normalizeLabels helper drops blanks, so it is intentionally not used here.
-  return value.map((label) => label.trim().toLowerCase());
+  return (value as string[]).map((label) => label.trim().toLowerCase());
 }
 
 function readPriorityConfig(

--- a/packages/core/src/workflow/parser.ts
+++ b/packages/core/src/workflow/parser.ts
@@ -197,6 +197,8 @@ function parseWorkflowMarkdownInternal(
     ) ??
     defaultLifecycle?.planningStates ??
     DEFAULT_WORKFLOW_TRACKER.planningStates;
+  const requiredLabels =
+    readRequiredLabelList(tracker) ?? DEFAULT_WORKFLOW_TRACKER.requiredLabels;
   const stateFieldName =
     readNormalizedOptionalString(
       tracker,
@@ -289,6 +291,7 @@ function parseWorkflowMarkdownInternal(
         provider,
         explicitProviderKeys
       ),
+      requiredLabels,
       activeStates,
       terminalStates,
       projectId: readNormalizedOptionalString(
@@ -373,6 +376,7 @@ function parseWorkflowMarkdownInternal(
       activeStates,
       terminalStates,
       planningStates,
+      requiredLabels,
     },
     format: "front-matter",
     githubProjectId: readNormalizedOptionalString(
@@ -594,6 +598,26 @@ function readPickupLabelsConfig(
     include: normalizeLabels(readStringList(input, "include") ?? []),
     exclude: normalizeLabels(readStringList(input, "exclude") ?? []),
   };
+}
+
+function readRequiredLabelList(
+  tracker: Record<string, WorkflowFrontMatterNode>
+): string[] | undefined {
+  const value = tracker.required_labels;
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  if (!Array.isArray(value) || value.some((entry) => typeof entry !== "string")) {
+    throw new WorkflowValidationError(
+      "workflow_validation_error",
+      "tracker.required_labels",
+      'Workflow front matter field "tracker.required_labels" must be an array of strings.'
+    );
+  }
+
+  // §5.3.1 requires blank configured labels to remain unsatisfied. The shared
+  // normalizeLabels helper drops blanks, so it is intentionally not used here.
+  return value.map((label) => label.trim().toLowerCase());
 }
 
 function readPriorityConfig(

--- a/packages/core/src/workflow/pickup-labels.test.ts
+++ b/packages/core/src/workflow/pickup-labels.test.ts
@@ -79,6 +79,6 @@ describe("resolvePickupLabelDispatchReason", () => {
         issue(["agent", "blocked"]),
         mixedCaseProject
       )
-    ).toBe('Issue has excluded pickup label "BLOCKED".');
+    ).toBe('Issue has excluded pickup label "blocked".');
   });
 });

--- a/packages/core/src/workflow/pickup-labels.test.ts
+++ b/packages/core/src/workflow/pickup-labels.test.ts
@@ -79,6 +79,6 @@ describe("resolvePickupLabelDispatchReason", () => {
         issue(["agent", "blocked"]),
         mixedCaseProject
       )
-    ).toBe('Issue has excluded pickup label "blocked".');
+    ).toBe('Issue has excluded pickup label "BLOCKED".');
   });
 });


### PR DESCRIPTION
## TL;DR

Adds core support for `tracker.required_labels`, normalizes configured pickup labels, and exposes `issueRoutable()` for dispatchability-first routing.

## Change-point diagram

```text
WORKFLOW.md tracker.required_labels
  -> parser / lifecycle snapshot
  -> normalized requiredLabels
  -> issueRoutable(issue, lifecycle)
       dispatchable === true
       && every required label is present
```

## Start here

- `packages/core/src/workflow/parser.ts` parses and validates the new configuration.
- `packages/core/src/workflow/issue-routable.ts` applies the policy.
- `packages/core/src/workflow-loader.test.ts` and `issue-routable.test.ts` cover normalization, blank labels, comma rejection, and dispatchability precedence.

## Changes

- Preserve blank required labels so they intentionally match no issue.
- Trim and lowercase configured pickup labels before matching.
- Expose `requiredLabels` through lifecycle configuration and snapshots.
- Restore the current `docs/configuration.md` from main and add only the required-label documentation.

## Evidence

- `pnpm install --frozen-lockfile`
- `pnpm lint`
- `pnpm test`
- `pnpm typecheck`
- `pnpm build`

## Risks & rollback

- Blank `required_labels` entries remain deliberately unsatisfiable per Symphony §5.3.1.
- Roll back the PR to remove the new optional routing gate; workflows without `required_labels` continue to use `[]`.

## Changed files

- Core workflow parser, lifecycle config, routing helper, exports, and tests.
- CLI workflow snapshot coverage and configuration reference.
- CLI minor changeset.

## Issues — Closed #720

Closes #720

## Post-merge / human validation

- [ ] Confirm a workflow with mixed-case required labels routes only matching issues.
- [ ] Confirm a blank configured required label routes no issue.
