### PR TITLE
feat(tracker-github,cli): validate provider config

### DIFF
--- a/.changeset/bright-trains-accept.md
+++ b/.changeset/bright-trains-accept.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": minor
+---
+
+Add GitHub Project provider validation, documented lifecycle defaults, and copyable deprecated flat-key migration diagnostics for #708.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -214,6 +214,44 @@ gate: configure a Liquid conditional in the prompt when planning runs must not
 implement. Existing prompts that do not reference the variable keep their
 current behavior.
 
+### GitHub Project provider profile
+
+For `tracker.kind: github-project`, configure GitHub-specific settings in
+`tracker.provider`. The adapter owns `project_id`, `endpoint`, `state_field`,
+`priority`, `pickup_labels`, `blocker_check_states`, and `planning_states`.
+Unknown provider keys are preserved so provider extensions remain forward
+compatible. `project_id`, `endpoint`, and `state_field` are non-empty strings
+when supplied; `endpoint` must be an HTTP(S) URL; state lists contain only
+non-empty strings.
+
+```yaml
+tracker:
+  kind: github-project
+  provider:
+    project_id: PVT_kwDOxxxxxx
+    endpoint: https://api.github.com/graphql
+    state_field: Status
+    active_states: [Todo, In Progress]
+    terminal_states: [Done]
+    blocker_check_states: [Todo]
+    planning_states: []
+    pickup_labels:
+      include: [agent-ready]
+      exclude: [blocked]
+    priority:
+      source: disabled
+```
+
+The documented GitHub Project lifecycle profile is `Status`, active states
+`Todo` and `In Progress`, terminal state `Done`, blocker-check state `Todo`,
+and no planning states. These defaults apply only when the corresponding list
+or field is omitted. Flat `tracker.project_id`, `tracker.endpoint`,
+`tracker.state_field`, `tracker.priority`, `tracker.pickup_labels`,
+`tracker.blocker_check_states`, and `tracker.planning_states` aliases remain
+supported for compatibility, but `gh-symphony workflow validate` and
+`gh-symphony repo doctor` warn and print a copyable `tracker.provider` block.
+They are scheduled for removal in the next major release.
+
 ## Skill Layering
 
 Before each worker attempt the orchestrator injects agent skills into the

--- a/packages/cli/src/commands/doctor.test.ts
+++ b/packages/cli/src/commands/doctor.test.ts
@@ -549,6 +549,84 @@ describe("runDoctorDiagnostics", () => {
     });
   });
 
+  it("snapshots provider deprecation guidance for flat GitHub keys", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "doctor-config-"));
+    const workspaceDir = join(configDir, "workspaces");
+    await prepareDoctorPaths(configDir, workspaceDir);
+    const { repoDir, pathEnv } = await createWorkflowFixture();
+    await writeFile(
+      join(repoDir, "WORKFLOW.md"),
+      `---
+tracker:
+  kind: github-project
+  project_id: PVT_test
+  pickup_labels:
+    include:
+      - agent-ready
+    exclude:
+      - blocked
+codex:
+  command: fake-agent
+---
+Prompt body
+`,
+      "utf8"
+    );
+
+    const report = await withCwd(repoDir, () =>
+      runDoctorDiagnostics(baseOptions(configDir), [], {
+        ...authDependencies(),
+        inspectManagedProjectSelection: async () => ({
+          kind: "resolved",
+          projectId: "tenant-a",
+          projectConfig: createProjectConfig(workspaceDir),
+        }),
+        getProjectDetail: (async () => createProjectDetail()) as never,
+        execFileSync: (() => "git version 2.43.0") as never,
+        pathEnv,
+      })
+    );
+
+    expect(report.checks.find((check) => check.id === "provider_deprecation"))
+      .toMatchInlineSnapshot(`
+      {
+        "details": {
+          "deprecatedKeys": [
+            "project_id",
+            "pickup_labels",
+          ],
+          "providerBlock": "\`\`\`yaml
+      tracker:
+        provider:
+          project_id: "PVT_test"
+          pickup_labels:
+            include:
+              - "agent-ready"
+            exclude:
+              - "blocked"
+      \`\`\`",
+        },
+        "id": "provider_deprecation",
+        "remediation": "Move them under tracker.provider (flat aliases will be removed in the next major release):
+
+      \`\`\`yaml
+      tracker:
+        provider:
+          project_id: "PVT_test"
+          pickup_labels:
+            include:
+              - "agent-ready"
+            exclude:
+              - "blocked"
+      \`\`\`",
+        "required": true,
+        "status": "warn",
+        "summary": "Flat tracker key(s) project_id, pickup_labels are deprecated and remain supported for compatibility.",
+        "title": "Deprecated GitHub tracker keys",
+      }
+    `);
+  });
+
   it("validates GitHub auth against the configured GraphQL endpoint", async () => {
     const configDir = await mkdtemp(join(tmpdir(), "doctor-config-"));
     const workspaceDir = join(configDir, "workspaces");

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -18,7 +18,10 @@ import {
   resolveRuntimeCommandBinary,
   type ClaudePreflightCheck,
 } from "@gh-symphony/runtime-claude";
-import { getSupportedTrackerKinds } from "@gh-symphony/orchestrator";
+import {
+  getSupportedTrackerKinds,
+  resolveWorkflowConfigTrackerAdapter,
+} from "@gh-symphony/orchestrator";
 import {
   fetchGithubProjectIssueByRepositoryAndNumber,
   fetchGithubProjectIssues,
@@ -50,6 +53,7 @@ import type { GlobalOptions } from "../index.js";
 import { resolveRuntimeRoot } from "../orchestrator-runtime.js";
 import { resolveManagedProjectEnvironment } from "../managed-project-environment.js";
 import {
+  buildProviderDeprecationDiagnostics,
   buildPriorityConfigDiagnostics,
   buildPriorityDriftDiagnostics,
 } from "../priority-diagnostics.js";
@@ -83,6 +87,7 @@ type DoctorCheckId =
   | "runtime_root"
   | "workspace_root"
   | "workflow_file"
+  | "provider_deprecation"
   | "runtime_command"
   | "project_repository_link"
   | "smoke_issue"
@@ -702,6 +707,7 @@ async function checkWorkflow(
   try {
     const parsed = deps.parseWorkflowMarkdown(markdown, environment, {
       supportedTrackerKinds: getSupportedTrackerKinds(),
+      resolveTrackerAdapter: resolveWorkflowConfigTrackerAdapter,
     });
     return {
       status: "pass",
@@ -2149,6 +2155,18 @@ export async function runDoctorDiagnostics(
   }
 
   checks.push(
+    ...(workflow.status === "pass"
+      ? buildProviderDeprecationDiagnostics(workflow.workflow).map(
+          (diagnostic) =>
+            warnCheck(
+              "provider_deprecation",
+              diagnostic.title,
+              diagnostic.summary,
+              diagnostic.remediation,
+              diagnostic.details
+            )
+        )
+      : []),
     ...(await buildPriorityMappingChecks({
       auth,
       selection: resolvedProjectConfig,

--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -152,6 +152,9 @@ Prompt {{ issue.identifier }}
     }
 
     expect(stdout.output()).toContain("Warnings");
+    expect(stdout.output()).toContain("Deprecated GitHub tracker keys");
+    expect(stdout.output()).toContain("tracker:\n  provider:");
+    expect(stdout.output()).toContain('priority_field: "Priority"');
     expect(stdout.output()).toContain("Legacy priority mapping");
   });
 

--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -201,6 +201,7 @@ Prompt {{ issue.identifier }}
     const providerBlock = stdout
       .output()
       .match(/```yaml\n([\s\S]*?)\n```/)?.[1];
+    expect(stdout.output()).toContain("tracker.project_id=project-123");
     expect(providerBlock).toContain("pickup_labels:\n      include:");
     expect(providerBlock).toContain("priority:\n      source:");
     const migrated = parseWorkflowMarkdown(

--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -2,6 +2,7 @@ import { mkdtemp, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { parseWorkflowMarkdown } from "@gh-symphony/core";
 import workflowCommand, {
   resetWorkflowCommandDependenciesForTest,
   setWorkflowCommandDependenciesForTest,
@@ -156,6 +157,60 @@ Prompt {{ issue.identifier }}
     expect(stdout.output()).toContain("tracker:\n  provider:");
     expect(stdout.output()).toContain('priority_field: "Priority"');
     expect(stdout.output()).toContain("Legacy priority mapping");
+  });
+
+  it("renders a copyable provider migration block that round-trips", async () => {
+    const root = await mkdtemp(join(tmpdir(), "workflow-provider-migration-"));
+    const workflowPath = join(root, "WORKFLOW.md");
+    const stdout = captureWrites(process.stdout);
+
+    await writeFile(
+      workflowPath,
+      `---
+tracker:
+  kind: github-project
+  project_id: project-123
+  pickup_labels:
+    include:
+      - agent-ready
+    exclude:
+      - blocked
+  priority:
+    source: labels
+    labels:
+      urgent: 1
+codex:
+  command: codex app-server
+---
+Prompt {{ issue.identifier }}
+`,
+      "utf8"
+    );
+
+    try {
+      await workflowCommand(["validate", "--file", workflowPath], {
+        configDir: root,
+        verbose: false,
+        json: false,
+        noColor: false,
+      });
+    } finally {
+      stdout.restore();
+    }
+
+    const providerBlock = stdout
+      .output()
+      .match(/```yaml\n([\s\S]*?)\n```/)?.[1];
+    expect(providerBlock).toContain("pickup_labels:\n      include:");
+    expect(providerBlock).toContain("priority:\n      source:");
+    const migrated = parseWorkflowMarkdown(
+      `---\n${providerBlock?.replace("tracker:\n", "tracker:\n  kind: github-project\n")}\ncodex:\n  command: codex app-server\n---\nPrompt`
+    );
+    expect(migrated.tracker.provider).toMatchObject({
+      project_id: "project-123",
+      pickup_labels: { include: ["agent-ready"], exclude: ["blocked"] },
+      priority: { source: "labels", labels: { urgent: 1 } },
+    });
   });
 
   it("includes priority precedence warnings in JSON validation output", async () => {

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -71,7 +71,6 @@ type WorkflowCommandDependencies = {
   getGitHubTokenWithSource: typeof getGhTokenWithSource;
   resolveManagedProjectSelection: typeof inspectManagedProjectSelection;
   resolveTrackerAdapter: typeof resolveTrackerAdapter;
-  resolveWorkflowConfigTrackerAdapter: typeof resolveWorkflowConfigTrackerAdapter;
   validateGitHubToken: typeof validateGitHubToken;
 };
 
@@ -169,7 +168,6 @@ const workflowCommandDependencies: WorkflowCommandDependencies = {
   getGitHubTokenWithSource: getGhTokenWithSource,
   resolveManagedProjectSelection: inspectManagedProjectSelection,
   resolveTrackerAdapter,
-  resolveWorkflowConfigTrackerAdapter,
   validateGitHubToken,
 };
 
@@ -188,8 +186,6 @@ export function resetWorkflowCommandDependenciesForTest(): void {
   workflowCommandDependencies.resolveManagedProjectSelection =
     inspectManagedProjectSelection;
   workflowCommandDependencies.resolveTrackerAdapter = resolveTrackerAdapter;
-  workflowCommandDependencies.resolveWorkflowConfigTrackerAdapter =
-    resolveWorkflowConfigTrackerAdapter;
   workflowCommandDependencies.validateGitHubToken = validateGitHubToken;
 }
 
@@ -820,8 +816,7 @@ function validateWorkflow(
 ): WorkflowValidationReport {
   const workflow = parseWorkflowMarkdown(markdown, process.env, {
     supportedTrackerKinds: getSupportedTrackerKinds(),
-    resolveTrackerAdapter: workflowCommandDependencies
-      .resolveWorkflowConfigTrackerAdapter,
+    resolveTrackerAdapter: resolveWorkflowConfigTrackerAdapter,
   });
   const samplePhase = resolveWorkflowExecutionPhase({
     issueState: SAMPLE_ISSUE.state,
@@ -973,8 +968,7 @@ async function runPreview(
   const { workflowPath, markdown } = await loadWorkflowMarkdown(flags.file);
   const workflow = parseWorkflowMarkdown(markdown, process.env, {
     supportedTrackerKinds: getSupportedTrackerKinds(),
-    resolveTrackerAdapter: workflowCommandDependencies
-      .resolveWorkflowConfigTrackerAdapter,
+    resolveTrackerAdapter: resolveWorkflowConfigTrackerAdapter,
   });
   if (
     flags.issue &&

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -12,6 +12,7 @@ import {
 import {
   getSupportedTrackerKinds,
   resolveTrackerAdapter,
+  resolveWorkflowConfigTrackerAdapter,
 } from "@gh-symphony/orchestrator";
 import { fetchGithubProjectIssueByRepositoryAndNumber } from "@gh-symphony/tracker-github";
 import { type CliProjectConfig } from "../config.js";
@@ -29,6 +30,7 @@ import {
 import type { GlobalOptions } from "../index.js";
 import { writeCliError } from "../cli-error.js";
 import {
+  buildProviderDeprecationDiagnostics,
   buildPriorityConfigDiagnostics,
   type PriorityDiagnostic,
 } from "../priority-diagnostics.js";
@@ -69,6 +71,7 @@ type WorkflowCommandDependencies = {
   getGitHubTokenWithSource: typeof getGhTokenWithSource;
   resolveManagedProjectSelection: typeof inspectManagedProjectSelection;
   resolveTrackerAdapter: typeof resolveTrackerAdapter;
+  resolveWorkflowConfigTrackerAdapter: typeof resolveWorkflowConfigTrackerAdapter;
   validateGitHubToken: typeof validateGitHubToken;
 };
 
@@ -166,6 +169,7 @@ const workflowCommandDependencies: WorkflowCommandDependencies = {
   getGitHubTokenWithSource: getGhTokenWithSource,
   resolveManagedProjectSelection: inspectManagedProjectSelection,
   resolveTrackerAdapter,
+  resolveWorkflowConfigTrackerAdapter,
   validateGitHubToken,
 };
 
@@ -184,6 +188,8 @@ export function resetWorkflowCommandDependenciesForTest(): void {
   workflowCommandDependencies.resolveManagedProjectSelection =
     inspectManagedProjectSelection;
   workflowCommandDependencies.resolveTrackerAdapter = resolveTrackerAdapter;
+  workflowCommandDependencies.resolveWorkflowConfigTrackerAdapter =
+    resolveWorkflowConfigTrackerAdapter;
   workflowCommandDependencies.validateGitHubToken = validateGitHubToken;
 }
 
@@ -814,6 +820,8 @@ function validateWorkflow(
 ): WorkflowValidationReport {
   const workflow = parseWorkflowMarkdown(markdown, process.env, {
     supportedTrackerKinds: getSupportedTrackerKinds(),
+    resolveTrackerAdapter: workflowCommandDependencies
+      .resolveWorkflowConfigTrackerAdapter,
   });
   const samplePhase = resolveWorkflowExecutionPhase({
     issueState: SAMPLE_ISSUE.state,
@@ -848,7 +856,10 @@ function validateWorkflow(
       promptRetry: "pass",
       continuationGuidance: continuationGuidanceStatus,
     },
-    warnings: buildPriorityConfigDiagnostics(workflow),
+    warnings: [
+      ...buildProviderDeprecationDiagnostics(workflow),
+      ...buildPriorityConfigDiagnostics(workflow),
+    ],
     summary: {
       trackerKind: workflow.tracker.kind,
       githubProjectId: workflow.githubProjectId,
@@ -962,6 +973,8 @@ async function runPreview(
   const { workflowPath, markdown } = await loadWorkflowMarkdown(flags.file);
   const workflow = parseWorkflowMarkdown(markdown, process.env, {
     supportedTrackerKinds: getSupportedTrackerKinds(),
+    resolveTrackerAdapter: workflowCommandDependencies
+      .resolveWorkflowConfigTrackerAdapter,
   });
   if (
     flags.issue &&

--- a/packages/cli/src/priority-diagnostics.ts
+++ b/packages/cli/src/priority-diagnostics.ts
@@ -65,6 +65,8 @@ export function buildProviderDeprecationDiagnostics(
 
   const githubKeys = [
     "project_id",
+    "project_slug",
+    "api_key",
     "endpoint",
     "state_field",
     "priority",
@@ -81,22 +83,58 @@ export function buildProviderDeprecationDiagnostics(
   const provider = Object.fromEntries(
     migrated.map((key) => [key, workflow.tracker.provider[key]])
   );
+  const providerBlock = renderProviderBlock(provider);
   return [
     {
       title: "Deprecated GitHub tracker keys",
       summary: `Flat tracker key(s) ${migrated.join(", ")} are deprecated and remain supported for compatibility.`,
-      remediation: `Move them under tracker.provider (flat aliases will be removed in the next major release):\n\n${renderProviderBlock(provider)}`,
-      details: { deprecatedKeys: migrated, providerBlock: renderProviderBlock(provider) },
+      remediation: `Move them under tracker.provider (flat aliases will be removed in the next major release):\n\n${providerBlock}`,
+      details: { deprecatedKeys: migrated, providerBlock },
     },
   ];
 }
 
 function renderProviderBlock(provider: Record<string, unknown>): string {
   const lines = ["tracker:", "  provider:"];
-  for (const [key, value] of Object.entries(provider)) {
-    lines.push(`    ${key}: ${JSON.stringify(value)}`);
-  }
+  renderYamlObject(lines, provider, 4);
   return ["```yaml", ...lines, "```"].join("\n");
+}
+
+function renderYamlObject(
+  lines: string[],
+  value: Record<string, unknown>,
+  indent: number
+): void {
+  for (const [key, entry] of Object.entries(value)) {
+    const padding = " ".repeat(indent);
+    if (Array.isArray(entry)) {
+      if (entry.length === 0) {
+        lines.push(`${padding}${key}: []`);
+      } else {
+        lines.push(`${padding}${key}:`);
+        for (const item of entry) {
+          lines.push(`${padding}  - ${renderYamlScalar(item)}`);
+        }
+      }
+    } else if (entry && typeof entry === "object") {
+      lines.push(`${padding}${key}:`);
+      renderYamlObject(lines, entry as Record<string, unknown>, indent + 2);
+    } else {
+      lines.push(`${padding}${key}: ${renderYamlScalar(entry)}`);
+    }
+  }
+}
+
+function renderYamlScalar(value: unknown): string {
+  if (typeof value === "string") return JSON.stringify(value);
+  if (
+    typeof value === "number" ||
+    typeof value === "boolean" ||
+    value === null
+  ) {
+    return String(value);
+  }
+  return JSON.stringify(value);
 }
 
 export function buildPriorityDriftDiagnostics(input: {
@@ -255,7 +293,9 @@ function buildLabelDriftDiagnostics(input: {
       );
       return configuredLabel ? [configuredLabel] : [];
     });
-    return matches.length > 1 ? [{ issue: issue.identifier, labels: matches }] : [];
+    return matches.length > 1
+      ? [{ issue: issue.identifier, labels: matches }]
+      : [];
   });
   if (activeConflicts.length > 0) {
     diagnostics.push({

--- a/packages/cli/src/priority-diagnostics.ts
+++ b/packages/cli/src/priority-diagnostics.ts
@@ -52,6 +52,53 @@ export function buildPriorityConfigDiagnostics(
   return diagnostics;
 }
 
+/** Migration guidance for flat tracker keys promoted by the core parser. */
+export function buildProviderDeprecationDiagnostics(
+  workflow: ParsedWorkflow
+): PriorityDiagnostic[] {
+  if (
+    workflow.tracker.kind !== "github-project" ||
+    workflow.tracker.deprecatedKeys.length === 0
+  ) {
+    return [];
+  }
+
+  const githubKeys = [
+    "project_id",
+    "endpoint",
+    "state_field",
+    "priority",
+    "priority_field",
+    "pickup_labels",
+    "blocker_check_states",
+    "planning_states",
+  ];
+  const migrated = githubKeys.filter((key) =>
+    workflow.tracker.deprecatedKeys.includes(key)
+  );
+  if (migrated.length === 0) return [];
+
+  const provider = Object.fromEntries(
+    migrated.map((key) => [key, workflow.tracker.provider[key]])
+  );
+  return [
+    {
+      title: "Deprecated GitHub tracker keys",
+      summary: `Flat tracker key(s) ${migrated.join(", ")} are deprecated and remain supported for compatibility.`,
+      remediation: `Move them under tracker.provider (flat aliases will be removed in the next major release):\n\n${renderProviderBlock(provider)}`,
+      details: { deprecatedKeys: migrated, providerBlock: renderProviderBlock(provider) },
+    },
+  ];
+}
+
+function renderProviderBlock(provider: Record<string, unknown>): string {
+  const lines = ["tracker:", "  provider:"];
+  for (const [key, value] of Object.entries(provider)) {
+    lines.push(`    ${key}: ${JSON.stringify(value)}`);
+  }
+  return ["```yaml", ...lines, "```"].join("\n");
+}
+
 export function buildPriorityDriftDiagnostics(input: {
   workflow: ParsedWorkflow;
   projectDetail: ProjectDetail;

--- a/packages/core/src/workflow-loader.test.ts
+++ b/packages/core/src/workflow-loader.test.ts
@@ -217,6 +217,30 @@ Prompt`,
     );
   });
 
+  it("resolves provider environment values before adapter validation", () => {
+    const validateProviderConfig = vi.fn(() => []);
+    parseWorkflowMarkdownStrict(
+      `---
+tracker:
+  kind: custom-tracker
+  provider:
+    endpoint: $GHES_URL
+codex:
+  command: codex
+---
+Prompt`,
+      { GHES_URL: "https://github.example/api/graphql" },
+      {
+        supportedTrackerKinds: ["custom-tracker"],
+        trackerAdapter: { validateProviderConfig },
+      }
+    );
+
+    expect(validateProviderConfig).toHaveBeenCalledWith({
+      endpoint: "https://github.example/api/graphql",
+    });
+  });
+
   it("resolves provider validation and lifecycle defaults from tracker.kind", () => {
     const selectedAdapter = {
       validateProviderConfig: vi.fn(() => []),

--- a/packages/core/src/workflow/parser.ts
+++ b/packages/core/src/workflow/parser.ts
@@ -149,6 +149,12 @@ function parseWorkflowMarkdownInternal(
   const provider = readProviderConfig(tracker);
   const explicitProviderKeys = new Set(Object.keys(provider));
   const deprecatedKeys = promoteDeprecatedTrackerKeys(tracker, provider);
+  const resolvedProvider = resolveProviderEnvironmentValues(
+    provider,
+    env,
+    "tracker.provider",
+    explicitProviderKeys
+  );
   const defaultLifecycle = trackerAdapter?.defaultLifecycle?.();
   // Keep existing workflows usable while tracker adapters adopt defaultLifecycle.
   // This disables the required-lifecycle path until every supported adapter
@@ -202,7 +208,7 @@ function parseWorkflowMarkdownInternal(
     defaultLifecycle?.stateFieldName ??
     legacyLifecycle.stateFieldName;
   throwProviderValidationErrors(
-    trackerAdapter?.validateProviderConfig?.(provider) ?? []
+    trackerAdapter?.validateProviderConfig?.(resolvedProvider) ?? []
   );
 
   const maxConcurrentAgentsByState = readNumberMap(
@@ -369,7 +375,13 @@ function parseWorkflowMarkdownInternal(
       planningStates,
     },
     format: "front-matter",
-    githubProjectId: readOptionalString(tracker, "project_id", env),
+    githubProjectId: readNormalizedOptionalString(
+      tracker,
+      provider,
+      explicitProviderKeys,
+      "project_id",
+      env
+    ),
     agentCommand,
     hookPath: readOptionalString(hooks, "after_create", env),
     maxConcurrentByState: maxConcurrentAgentsByState,
@@ -420,6 +432,46 @@ function promoteDeprecatedTrackerKeys(
     }
   }
   return deprecatedKeys;
+}
+
+/** Resolve provider values before adapter validation, as required by the spec. */
+function resolveProviderEnvironmentValues(
+  provider: Record<string, unknown>,
+  env: NodeJS.ProcessEnv,
+  path = "tracker.provider",
+  explicitProviderKeys?: ReadonlySet<string>
+): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(provider).map(([key, value]) => {
+      const valuePath = explicitProviderKeys?.has(key)
+        ? `${path}.${key}`
+        : path === "tracker.provider"
+          ? `tracker.${key}`
+          : `${path}.${key}`;
+      if (typeof value === "string") {
+        return [key, resolveEnvironmentValue(value, env, valuePath)];
+      } else if (Array.isArray(value)) {
+        return [
+          key,
+          value.map((entry, index) =>
+            typeof entry === "string"
+              ? resolveEnvironmentValue(entry, env, `${valuePath}[${index}]`)
+              : entry
+          ),
+        ];
+      } else if (value && typeof value === "object") {
+        return [
+          key,
+          resolveProviderEnvironmentValues(
+            value as Record<string, unknown>,
+            env,
+            valuePath
+          ),
+        ];
+      }
+      return [key, value];
+    })
+  );
 }
 
 function readProviderOptionalString(

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -32,6 +32,7 @@ export {
   findGithubProjectIssue,
   getSupportedTrackerKinds,
   resolveTrackerAdapter,
+  resolveWorkflowConfigTrackerAdapter,
 } from "./tracker-adapters.js";
 export {
   acquireProjectLock,

--- a/packages/orchestrator/src/tracker-adapters.ts
+++ b/packages/orchestrator/src/tracker-adapters.ts
@@ -24,3 +24,18 @@ export function resolveTrackerAdapter(
   if (local) return local;
   return resolveGitHubAdapter(tracker);
 }
+
+/** Resolves adapter-owned workflow parser hooks without requiring a binding. */
+export function resolveWorkflowConfigTrackerAdapter(
+  kind: string
+): OrchestratorTrackerAdapter | undefined {
+  const local = localAdapters.get(kind);
+  if (local) return local;
+  if (kind === "github-project") {
+    return resolveGitHubAdapter({
+      adapter: kind,
+      bindingId: "workflow-validation",
+    });
+  }
+  return undefined;
+}

--- a/packages/orchestrator/src/tracker-adapters.ts
+++ b/packages/orchestrator/src/tracker-adapters.ts
@@ -1,4 +1,4 @@
-import { resolveTrackerAdapter as resolveGitHubAdapter } from "@gh-symphony/tracker-github";
+import { githubProjectTrackerAdapter } from "@gh-symphony/tracker-github";
 export { findGithubProjectIssue } from "@gh-symphony/tracker-github";
 import { fileTrackerAdapter } from "@gh-symphony/tracker-file";
 import { linearTrackerAdapter } from "@gh-symphony/tracker-linear";
@@ -7,35 +7,30 @@ import type {
   OrchestratorTrackerConfig,
 } from "@gh-symphony/core";
 
-const localAdapters = new Map<string, OrchestratorTrackerAdapter>([
+const trackerAdapters = new Map<string, OrchestratorTrackerAdapter>([
+  ["github-project", githubProjectTrackerAdapter],
   ["file", fileTrackerAdapter],
   ["linear", linearTrackerAdapter],
 ]);
 
 /** Adapter-owned tracker kinds supplied to workflow validation at the boundary. */
 export function getSupportedTrackerKinds(): readonly string[] {
-  return ["github-project", ...localAdapters.keys()];
+  return [...trackerAdapters.keys()];
 }
 
 export function resolveTrackerAdapter(
   tracker: OrchestratorTrackerConfig
 ): OrchestratorTrackerAdapter {
-  const local = localAdapters.get(tracker.adapter);
-  if (local) return local;
-  return resolveGitHubAdapter(tracker);
+  const adapter = trackerAdapters.get(tracker.adapter);
+  if (!adapter) {
+    throw new Error(`Unsupported tracker adapter: ${tracker.adapter}`);
+  }
+  return adapter;
 }
 
 /** Resolves adapter-owned workflow parser hooks without requiring a binding. */
 export function resolveWorkflowConfigTrackerAdapter(
   kind: string
 ): OrchestratorTrackerAdapter | undefined {
-  const local = localAdapters.get(kind);
-  if (local) return local;
-  if (kind === "github-project") {
-    return resolveGitHubAdapter({
-      adapter: kind,
-      bindingId: "workflow-validation",
-    });
-  }
-  return undefined;
+  return trackerAdapters.get(kind);
 }

--- a/packages/tracker-github/src/orchestrator-adapter.ts
+++ b/packages/tracker-github/src/orchestrator-adapter.ts
@@ -27,6 +27,7 @@ export const githubProjectTrackerAdapter: OrchestratorTrackerAdapter = {
   },
 
   defaultLifecycle() {
+    // GitHub owns this Project vocabulary; the core fallback is transitional.
     return {
       stateFieldName: "Status",
       activeStates: ["Todo", "In Progress"],
@@ -306,6 +307,8 @@ const GITHUB_PROVIDER_STRING_KEYS = [
   "priority_field",
 ] as const;
 
+const GITHUB_PROVIDER_OBJECT_KEYS = ["priority", "pickup_labels"] as const;
+
 const GITHUB_PROVIDER_LIST_KEYS = [
   "active_states",
   "terminal_states",
@@ -359,6 +362,21 @@ export function validateGitHubProviderConfig(
           "workflow_validation_error",
           `tracker.provider.${key}`,
           `GitHub provider key "${key}" must be a list of non-empty strings when provided.`
+        )
+      );
+    }
+  }
+  for (const key of GITHUB_PROVIDER_OBJECT_KEYS) {
+    const value = provider[key];
+    if (
+      value !== undefined &&
+      (value === null || Array.isArray(value) || typeof value !== "object")
+    ) {
+      errors.push(
+        new WorkflowValidationError(
+          "workflow_validation_error",
+          `tracker.provider.${key}`,
+          `GitHub provider key "${key}" must be an object when provided.`
         )
       );
     }

--- a/packages/tracker-github/src/orchestrator-adapter.ts
+++ b/packages/tracker-github/src/orchestrator-adapter.ts
@@ -10,6 +10,7 @@ import type {
 import {
   NonRetryableTrackerAdapterError,
   resolvePickupLabelDispatchReason,
+  WorkflowValidationError,
 } from "@gh-symphony/core";
 import {
   fetchGithubIssueStatesByIds,
@@ -21,6 +22,20 @@ import {
 } from "./adapter.js";
 
 export const githubProjectTrackerAdapter: OrchestratorTrackerAdapter = {
+  validateProviderConfig(provider) {
+    return validateGitHubProviderConfig(provider);
+  },
+
+  defaultLifecycle() {
+    return {
+      stateFieldName: "Status",
+      activeStates: ["Todo", "In Progress"],
+      terminalStates: ["Done"],
+      blockerCheckStates: ["Todo"],
+      planningStates: [],
+    };
+  },
+
   secretEnvironmentNames() {
     return [
       "GH_TOKEN",
@@ -283,6 +298,73 @@ export const githubProjectTrackerAdapter: OrchestratorTrackerAdapter = {
     );
   },
 };
+
+const GITHUB_PROVIDER_STRING_KEYS = [
+  "project_id",
+  "endpoint",
+  "state_field",
+  "priority_field",
+] as const;
+
+const GITHUB_PROVIDER_LIST_KEYS = [
+  "active_states",
+  "terminal_states",
+  "blocker_check_states",
+  "planning_states",
+] as const;
+
+/** Validates documented GitHub Project provider keys while preserving unknown keys. */
+export function validateGitHubProviderConfig(
+  provider: Record<string, unknown>
+): WorkflowValidationError[] {
+  const errors: WorkflowValidationError[] = [];
+  for (const key of GITHUB_PROVIDER_STRING_KEYS) {
+    const value = provider[key];
+    if (value !== undefined && (typeof value !== "string" || !value.trim())) {
+      errors.push(
+        new WorkflowValidationError(
+          "workflow_validation_error",
+          `tracker.provider.${key}`,
+          `GitHub provider key "${key}" must be a non-empty string when provided.`
+        )
+      );
+    }
+  }
+  const endpoint = provider.endpoint;
+  if (typeof endpoint === "string" && endpoint.trim()) {
+    try {
+      const url = new URL(endpoint);
+      if (url.protocol !== "https:" && url.protocol !== "http:") {
+        throw new Error("unsupported protocol");
+      }
+    } catch {
+      errors.push(
+        new WorkflowValidationError(
+          "workflow_validation_error",
+          "tracker.provider.endpoint",
+          'GitHub provider key "endpoint" must be an HTTP(S) URL.'
+        )
+      );
+    }
+  }
+  for (const key of GITHUB_PROVIDER_LIST_KEYS) {
+    const value = provider[key];
+    if (
+      value !== undefined &&
+      (!Array.isArray(value) ||
+        value.some((item) => typeof item !== "string" || !item.trim()))
+    ) {
+      errors.push(
+        new WorkflowValidationError(
+          "workflow_validation_error",
+          `tracker.provider.${key}`,
+          `GitHub provider key "${key}" must be a list of non-empty strings when provided.`
+        )
+      );
+    }
+  }
+  return errors;
+}
 
 type GitHubNativeRef = {
   itemId?: string;

--- a/packages/tracker-github/src/tracker-github.test.ts
+++ b/packages/tracker-github/src/tracker-github.test.ts
@@ -86,11 +86,15 @@ describe("resolveTrackerAdapter", () => {
       validateGitHubProviderConfig({
         endpoint: "not-a-url",
         planning_states: "Ready",
+        priority: [],
+        pickup_labels: "agent-ready",
         custom_key: { preserved: true },
       }).map((error) => error.path)
     ).toEqual([
       "tracker.provider.endpoint",
       "tracker.provider.planning_states",
+      "tracker.provider.priority",
+      "tracker.provider.pickup_labels",
     ]);
   });
 

--- a/packages/tracker-github/src/tracker-github.test.ts
+++ b/packages/tracker-github/src/tracker-github.test.ts
@@ -16,6 +16,7 @@ import {
   findGithubProjectIssue,
   githubProjectTrackerAdapter,
   resolveTrackerAdapter,
+  validateGitHubProviderConfig,
 } from "./orchestrator-adapter.js";
 import {
   validateWorkflowFieldMapping,
@@ -73,6 +74,26 @@ describe("GitHub canonical subject adapter hook", () => {
 });
 
 describe("resolveTrackerAdapter", () => {
+  it("validates documented GitHub provider keys and supplies its lifecycle profile", () => {
+    expect(githubProjectTrackerAdapter.defaultLifecycle?.()).toEqual({
+      stateFieldName: "Status",
+      activeStates: ["Todo", "In Progress"],
+      terminalStates: ["Done"],
+      blockerCheckStates: ["Todo"],
+      planningStates: [],
+    });
+    expect(
+      validateGitHubProviderConfig({
+        endpoint: "not-a-url",
+        planning_states: "Ready",
+        custom_key: { preserved: true },
+      }).map((error) => error.path)
+    ).toEqual([
+      "tracker.provider.endpoint",
+      "tracker.provider.planning_states",
+    ]);
+  });
+
   it("normalizes archived project items to an explicit non-terminal state", () => {
     const projectItem = makeProjectItem({
       itemId: "item-archived",


### PR DESCRIPTION
## TL;DR

GitHub Project workflows now validate adapter-owned provider configuration, supply the documented GitHub lifecycle profile, and emit a parseable, copyable `tracker.provider` migration block for deprecated flat keys.

## Change-point diagram

```text
WORKFLOW.md tracker configuration
        │
        ├─ provider values resolve before GitHub adapter validation
        ├─ GitHub adapter owns lifecycle/profile validation hooks
        └─ workflow validate + repo doctor warn with round-trippable YAML
```

## Start here

- `packages/tracker-github/src/orchestrator-adapter.ts` — provider validation and GitHub lifecycle defaults.
- `packages/core/src/workflow/parser.ts` — provider alias normalization and validation boundary.
- `packages/cli/src/priority-diagnostics.ts` — recursive YAML migration renderer.
- `packages/cli/src/commands/{workflow,doctor}.ts` — validate and doctor diagnostics.

## Risks & rollback

- Flat keys remain supported as deprecated aliases. Reverting this PR removes the new warnings and adapter-owned validation hooks without changing existing workflow syntax.

## Changed files

- `.changeset/bright-trains-accept.md`
- `docs/configuration.md`
- GitHub tracker adapter and workflow parser
- CLI workflow/doctor diagnostics and regression snapshots

## Issues — Closed #708

## Evidence

- `pnpm lint`
- `pnpm test`
- `pnpm typecheck`
- `pnpm build`
- `./e2e/run-e2e.sh happy 60` — passed in 12s.

## Post-merge / human validation

- [ ] Confirm an existing GitHub `WORKFLOW.md` with flat keys still loads and shows the migration block.
- [ ] Confirm the GitHub Project lifecycle profile matches the target board before relying on omitted lifecycle settings.
