### PR TITLE
fix(core): normalize workflow path expansion

### DIFF
--- a/.changeset/calm-workflow-paths.md
+++ b/.changeset/calm-workflow-paths.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Normalize `workspace.root` paths, keep command and hook strings opaque, and allow prompt-only WORKFLOW.md files (#668).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -68,15 +68,25 @@ diverge from the upstream shell-command hook model.
 strict parser as workflow loading. Failures include a stable error code; the
 `workflow validate --json` error also exposes its field path separately.
 
-| Rule                      | Required value                                                                                                       | Error code/path                                                               |
-| ------------------------- | -------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
-| Front matter syntax       | A valid YAML mapping                                                                                                 | `workflow_parse_error` or `workflow_front_matter_not_a_map` at `front_matter` |
-| Numeric fields            | YAML integers; quoted numeric strings and fractions are rejected. Invalid per-state concurrency entries are ignored. | `workflow_validation_error` at other invalid numeric field paths              |
-| `hooks.timeout_ms`        | A positive integer when provided                                                                                     | `workflow_validation_error` at `hooks.timeout_ms`                             |
-| `agent.max_turns`         | A positive integer when provided                                                                                     | `workflow_validation_error` at `agent.max_turns`                              |
-| `codex.command`           | A non-empty string when provided                                                                                     | `workflow_validation_error` at `codex.command`                                |
-| `tracker.kind`            | One of `github-project`, `linear`, or `file`                                                                         | `workflow_validation_error` at `tracker.kind`                                 |
-| `tracker.required_labels` | An array of strings; comma-separated strings are rejected                                                            | `workflow_validation_error` at `tracker.required_labels`                      |
+| Rule                      | Required value                                                                                                             | Error code/path                                                               |
+| ------------------------- | -------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| Front matter syntax       | Optional; when present it must be a valid YAML mapping                                                                     | `workflow_parse_error` or `workflow_front_matter_not_a_map` at `front_matter` |
+| Numeric fields            | YAML integers; quoted numeric strings and fractions are rejected, including priority maps and per-state concurrency values | `workflow_validation_error` at the field path                                 |
+| `hooks.timeout_ms`        | A positive integer when provided                                                                                           | `workflow_validation_error` at `hooks.timeout_ms`                             |
+| `agent.max_turns`         | A positive integer when provided                                                                                           | `workflow_validation_error` at `agent.max_turns`                              |
+| `codex.command`           | A non-empty string when provided                                                                                           | `workflow_validation_error` at `codex.command`                                |
+| `tracker.kind`            | One of `github-project`, `linear`, or `file`                                                                               | `workflow_validation_error` at `tracker.kind`                                 |
+| `tracker.required_labels` | An array of strings; comma-separated strings are rejected                                                                  | `workflow_validation_error` at `tracker.required_labels`                      |
+
+Without front matter, the complete trimmed file is used as the workflow prompt
+and all configuration uses defaults; tracker selection is then checked by the
+dispatch preflight. `workspace.root` expands `~`, `$VAR`, `${VAR}`, and
+`env:VAR`, resolves relative paths from the selected `WORKFLOW.md` directory,
+and stores the normalized absolute path. Environment expansion is deliberately
+limited to workspace paths and documented secret values such as
+`tracker.api_key`; hook scripts, Codex commands, and other arbitrary strings
+remain unchanged. A missing or empty referenced secret returns a typed error at
+that specific field rather than rewriting unrelated configuration.
 
 Omitted optional values retain their documented defaults. Per-state concurrency
 maps remain supported through `agent.max_concurrent_agents_by_state`. State keys

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -82,11 +82,11 @@ Without front matter, the complete trimmed file is used as the workflow prompt
 and all configuration uses defaults; tracker selection is then checked by the
 dispatch preflight. `workspace.root` expands `~`, `$VAR`, `${VAR}`, and
 `env:VAR`, resolves relative paths from the selected `WORKFLOW.md` directory,
-and stores the normalized absolute path. Environment expansion is deliberately
-limited to workspace paths and documented secret values such as
-`tracker.api_key`; hook scripts, Codex commands, and other arbitrary strings
-remain unchanged. A missing or empty referenced secret returns a typed error at
-that specific field rather than rewriting unrelated configuration.
+and stores the normalized absolute path. Tracker configuration values (including
+provider values) resolve documented environment references before adapter
+validation; hook scripts and Codex/runtime command strings remain unchanged. A
+missing or empty referenced secret returns a typed error at that specific field
+rather than rewriting unrelated configuration.
 
 Omitted optional values retain their documented defaults. Per-state concurrency
 maps remain supported through `agent.max_concurrent_agents_by_state`. State keys

--- a/packages/cli/src/commands/doctor.test.ts
+++ b/packages/cli/src/commands/doctor.test.ts
@@ -1314,10 +1314,10 @@ Prompt body
     });
   });
 
-  it("reports invalid workflow files and blocks runtime command validation", async () => {
+  it("reports unterminated front matter and blocks runtime command validation", async () => {
     const configDir = await mkdtemp(join(tmpdir(), "doctor-config-"));
     const repoDir = await mkdtemp(join(tmpdir(), "doctor-repo-"));
-    await writeFile(join(repoDir, "WORKFLOW.md"), "invalid workflow", "utf8");
+    await writeFile(join(repoDir, "WORKFLOW.md"), "---\ntracker:\n", "utf8");
 
     const report = await withCwd(repoDir, () =>
       runDoctorDiagnostics(baseOptions(configDir), [], {

--- a/packages/cli/src/commands/doctor.test.ts
+++ b/packages/cli/src/commands/doctor.test.ts
@@ -1347,6 +1347,31 @@ Prompt body
     });
   });
 
+  it("reports a prompt-only workflow as non-dispatchable", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "doctor-config-"));
+    const repoDir = await mkdtemp(join(tmpdir(), "doctor-repo-"));
+    await writeFile(join(repoDir, "WORKFLOW.md"), "Prompt only", "utf8");
+
+    const report = await withCwd(repoDir, () =>
+      runDoctorDiagnostics(baseOptions(configDir), [], {
+        checkGhInstalled: () => false,
+        inspectManagedProjectSelection: async () => ({
+          kind: "no_projects",
+          message:
+            "No repository runtime config is configured. Run 'gh-symphony repo init' first.",
+        }),
+      })
+    );
+
+    expect(
+      report.checks.find((check) => check.id === "workflow_file")
+    ).toMatchObject({
+      status: "fail",
+      summary: expect.stringContaining("no tracker.kind"),
+      remediation: expect.stringContaining("tracker.kind"),
+    });
+  });
+
   it("uses env auth when GITHUB_GRAPHQL_TOKEN is present and gh is unavailable", async () => {
     const configDir = await mkdtemp(join(tmpdir(), "doctor-config-"));
     const workspaceDir = join(configDir, "workspaces");

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -708,6 +708,7 @@ async function checkWorkflow(
     const parsed = deps.parseWorkflowMarkdown(markdown, environment, {
       supportedTrackerKinds: getSupportedTrackerKinds(),
       resolveTrackerAdapter: resolveWorkflowConfigTrackerAdapter,
+      workflowPath,
     });
     return {
       status: "pass",

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -710,6 +710,16 @@ async function checkWorkflow(
       resolveTrackerAdapter: resolveWorkflowConfigTrackerAdapter,
       workflowPath,
     });
+    if (!parsed.tracker.kind) {
+      return {
+        status: "fail",
+        reason: "invalid",
+        workflowPath,
+        summary: "WORKFLOW.md has no tracker.kind, so it cannot dispatch work.",
+        remediation:
+          'Add front matter with a supported "tracker.kind" before starting dispatch.',
+      };
+    }
     return {
       status: "pass",
       command: parsed.agentCommand,

--- a/packages/cli/src/commands/project.test.ts
+++ b/packages/cli/src/commands/project.test.ts
@@ -160,7 +160,9 @@ describe("deriveStandaloneProject", () => {
 
     await expect(
       deriveStandaloneProject(projectDir, { configDir })
-    ).rejects.toThrow('Workflow dispatch requires front matter field "tracker.kind".');
+    ).rejects.toThrow(
+      'Workflow dispatch requires front matter field "tracker.kind".'
+    );
   });
 
   it("points a repo-embedded workflow at repo start", async () => {

--- a/packages/cli/src/commands/project.test.ts
+++ b/packages/cli/src/commands/project.test.ts
@@ -153,6 +153,16 @@ describe("deriveStandaloneProject", () => {
     ).rejects.toThrow("No WORKFLOW.md in");
   });
 
+  it("requires tracker.kind before deriving a standalone project", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "cli-standalone-config-"));
+    const projectDir = await mkdtemp(join(tmpdir(), "cli-standalone-project-"));
+    await writeFile(join(projectDir, "WORKFLOW.md"), "Prompt only", "utf8");
+
+    await expect(
+      deriveStandaloneProject(projectDir, { configDir })
+    ).rejects.toThrow('Workflow dispatch requires front matter field "tracker.kind".');
+  });
+
   it("points a repo-embedded workflow at repo start", async () => {
     const configDir = await mkdtemp(join(tmpdir(), "cli-standalone-config-"));
     const projectDir = await mkdtemp(join(tmpdir(), "cli-standalone-project-"));

--- a/packages/cli/src/commands/project.ts
+++ b/packages/cli/src/commands/project.ts
@@ -59,6 +59,7 @@ export async function deriveStandaloneProject(
   const workflow = parseWorkflowMarkdown(markdown, process.env, {
     supportedTrackerKinds: getSupportedTrackerKinds(),
     resolveTrackerAdapter: resolveWorkflowConfigTrackerAdapter,
+    workflowPath,
   });
   const repository = parseRepository(workflow.repository);
   const adapter = workflow.tracker.kind ?? "github-project";

--- a/packages/cli/src/commands/project.ts
+++ b/packages/cli/src/commands/project.ts
@@ -61,8 +61,13 @@ export async function deriveStandaloneProject(
     resolveTrackerAdapter: resolveWorkflowConfigTrackerAdapter,
     workflowPath,
   });
+  if (!workflow.tracker.kind) {
+    throw new Error(
+      'Workflow dispatch requires front matter field "tracker.kind".'
+    );
+  }
   const repository = parseRepository(workflow.repository);
-  const adapter = workflow.tracker.kind ?? "github-project";
+  const adapter = workflow.tracker.kind;
   const bindingId =
     workflow.tracker.projectId ?? workflow.tracker.projectSlug ?? "";
   if (!bindingId) {

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -248,6 +248,7 @@ async function preflightWorkflowStart(
     parseWorkflowMarkdown(await readFile(configuredPath, "utf8"), environment, {
       supportedTrackerKinds: getSupportedTrackerKinds(),
       resolveTrackerAdapter: resolveWorkflowConfigTrackerAdapter,
+      workflowPath: configuredPath,
     });
     return true;
   } catch (error) {

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -818,6 +818,7 @@ function validateWorkflow(
   const workflow = parseWorkflowMarkdown(markdown, process.env, {
     supportedTrackerKinds: getSupportedTrackerKinds(),
     resolveTrackerAdapter: resolveWorkflowConfigTrackerAdapter,
+    workflowPath,
   });
   const samplePhase = resolveWorkflowExecutionPhase({
     issueState: SAMPLE_ISSUE.state,
@@ -971,6 +972,7 @@ async function runPreview(
   const workflow = parseWorkflowMarkdown(markdown, process.env, {
     supportedTrackerKinds: getSupportedTrackerKinds(),
     resolveTrackerAdapter: resolveWorkflowConfigTrackerAdapter,
+    workflowPath,
   });
   if (
     flags.issue &&

--- a/packages/cli/src/priority-diagnostics.test.ts
+++ b/packages/cli/src/priority-diagnostics.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { parseWorkflowMarkdown } from "@gh-symphony/core";
+import { buildProviderDeprecationDiagnostics } from "./priority-diagnostics.js";
+
+describe("buildProviderDeprecationDiagnostics", () => {
+  it("keeps environment references out of migration guidance", () => {
+    const workflow = parseWorkflowMarkdown(
+      `---
+tracker:
+  kind: github-project
+  api_key: env:PLAIN_TOKEN
+codex:
+  command: codex
+---
+Prompt`,
+      { PLAIN_TOKEN: "ghp_plain_SECRET" }
+    );
+
+    const [diagnostic] = buildProviderDeprecationDiagnostics(workflow);
+
+    expect(diagnostic?.remediation).toContain('api_key: "env:PLAIN_TOKEN"');
+    expect(diagnostic?.remediation).not.toContain("ghp_plain_SECRET");
+    expect(diagnostic?.details?.providerBlock).toContain(
+      'api_key: "env:PLAIN_TOKEN"'
+    );
+  });
+});

--- a/packages/cli/src/repo-runtime.ts
+++ b/packages/cli/src/repo-runtime.ts
@@ -107,6 +107,7 @@ export async function initRepoRuntime(flags: RepoInitFlags): Promise<{
     {
       supportedTrackerKinds: getSupportedTrackerKinds(),
       resolveTrackerAdapter: resolveWorkflowConfigTrackerAdapter,
+      workflowPath,
     }
   );
   validateRepoInitWorkflow(workflow);

--- a/packages/core/src/workflow-loader.test.ts
+++ b/packages/core/src/workflow-loader.test.ts
@@ -299,7 +299,7 @@ Prompt`,
     );
   });
 
-  it("keeps non-secret provider values literal for adapter validation", () => {
+  it("resolves provider values before adapter validation", () => {
     const validateProviderConfig = vi.fn(() => []);
     parseWorkflowMarkdownStrict(
       `---
@@ -322,6 +322,15 @@ Prompt`,
       { endpoint: "https://github.example/api/graphql" },
       { rawProvider: { endpoint: "$GHES_URL" } }
     );
+  });
+
+  it("accepts empty front matter as an empty configuration", () => {
+    const workflow = parseWorkflowMarkdown("---\r\n---\r\nPrompt only");
+
+    expect(workflow).toMatchObject({
+      promptTemplate: "Prompt only",
+      tracker: { kind: null },
+    });
   });
 
   it("resolves provider validation and lifecycle defaults from tracker.kind", () => {
@@ -396,7 +405,7 @@ Prompt`,
     );
 
     expect(workflow.tracker.provider).toMatchObject({
-      api_key: "$TRACKER_TOKEN",
+      api_key: "token",
       endpoint: "https://provider.example.test/graphql",
       project_slug: "platform",
       custom_setting: "retained",

--- a/packages/core/src/workflow-loader.test.ts
+++ b/packages/core/src/workflow-loader.test.ts
@@ -405,7 +405,7 @@ Prompt`,
     );
 
     expect(workflow.tracker.provider).toMatchObject({
-      api_key: "token",
+      api_key: "$TRACKER_TOKEN",
       endpoint: "https://provider.example.test/graphql",
       project_slug: "platform",
       custom_setting: "retained",
@@ -445,6 +445,38 @@ Prompt`,
       projectId: "project-123",
       apiKey: "token",
       endpoint: "https://provider.example.test/graphql",
+    });
+  });
+
+  it("keeps resolved provider secrets private and resolves them once", () => {
+    const validateProviderConfig = vi.fn(() => []);
+    const workflow = parseWorkflowMarkdownStrict(
+      `---
+tracker:
+  kind: custom-tracker
+  provider:
+    api_key: env:TRACKER_TOKEN
+  state_field: Cost $USD
+codex:
+  command: codex
+---
+Prompt`,
+      { TRACKER_TOKEN: "abc$def" },
+      {
+        supportedTrackerKinds: ["custom-tracker"],
+        trackerAdapter: { validateProviderConfig },
+      }
+    );
+
+    expect(workflow.tracker.provider).toMatchObject({
+      api_key: "env:TRACKER_TOKEN",
+      state_field: "Cost $USD",
+    });
+    expect(workflow.tracker.apiKey).toBe("abc$def");
+    expect(workflow.tracker.stateFieldName).toBe("Cost $USD");
+    expect(validateProviderConfig).toHaveBeenCalledWith({
+      api_key: "abc$def",
+      state_field: "Cost $USD",
     });
   });
 

--- a/packages/core/src/workflow-loader.test.ts
+++ b/packages/core/src/workflow-loader.test.ts
@@ -474,10 +474,18 @@ Prompt`,
     });
     expect(workflow.tracker.apiKey).toBe("abc$def");
     expect(workflow.tracker.stateFieldName).toBe("Cost $USD");
-    expect(validateProviderConfig).toHaveBeenCalledWith({
-      api_key: "abc$def",
-      state_field: "Cost $USD",
-    });
+    expect(validateProviderConfig).toHaveBeenCalledWith(
+      {
+        api_key: "abc$def",
+        state_field: "Cost $USD",
+      },
+      {
+        rawProvider: {
+          api_key: "env:TRACKER_TOKEN",
+          state_field: "Cost $USD",
+        },
+      }
+    );
   });
 
   it("uses provider values consistently when deprecated flat keys coexist", () => {

--- a/packages/core/src/workflow-loader.test.ts
+++ b/packages/core/src/workflow-loader.test.ts
@@ -83,6 +83,87 @@ Prefer focused changes.
 `;
 
 describe("parseWorkflowMarkdown", () => {
+  it("treats a front-matter-free workflow as its prompt with default config", () => {
+    const workflow = parseWorkflowMarkdown(
+      "\r\n# Agent instructions\r\n\r\nWork carefully.\r\n"
+    );
+
+    expect(workflow).toMatchObject({
+      promptTemplate: "# Agent instructions\r\n\r\nWork carefully.",
+      tracker: { kind: null },
+      codex: { command: "codex app-server" },
+      format: "front-matter",
+    });
+  });
+
+  it("accepts CRLF front matter and normalizes workspace.root from WORKFLOW.md", () => {
+    const workflow = parseWorkflowMarkdown(
+      "---\r\nworkspace:\r\n  root: ~/workspaces\r\n---\r\nPrompt\r\n",
+      {},
+      {
+        workflowPath: "/projects/example/.config/WORKFLOW.md",
+        homeDir: "/home/agent",
+      }
+    );
+
+    expect(workflow.workspace.root).toBe("/home/agent/workspaces");
+  });
+
+  it("resolves relative workspace.root values from the workflow directory", () => {
+    const workflow = parseWorkflowMarkdown(
+      "---\nworkspace:\n  root: ../shared-workspaces\n---\nPrompt",
+      {},
+      { workflowPath: "/projects/example/.config/WORKFLOW.md" }
+    );
+
+    expect(workflow.workspace.root).toBe("/projects/example/shared-workspaces");
+  });
+
+  it("expands lowercase environment variables only in workspace paths", () => {
+    const workflow = parseWorkflowMarkdown(
+      `---
+workspace:
+  root: $workspace_dir/checkouts
+hooks:
+  before_run: echo $workspace_dir ${"${workspace_dir}"}
+codex:
+  command: runner $workspace_dir ${"${workspace_dir}"}
+---
+Prompt`,
+      { workspace_dir: "/var/lib/symphony" },
+      { workflowPath: "/projects/example/WORKFLOW.md" }
+    );
+
+    expect(workflow.workspace.root).toBe("/var/lib/symphony/checkouts");
+    expect(workflow.hooks.beforeRun).toBe(
+      "echo $workspace_dir ${workspace_dir}"
+    );
+    expect(workflow.codex.command).toBe(
+      "runner $workspace_dir ${workspace_dir}"
+    );
+  });
+
+  it("reports a missing secret at the individual secret field", () => {
+    let thrown: unknown;
+    try {
+      parseWorkflowMarkdown(
+        `---
+tracker:
+  kind: github-project
+  api_key: env:missing_token
+---
+Prompt`,
+        {}
+      );
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toMatchObject({
+      code: "workflow_validation_error",
+      path: "tracker.api_key",
+    });
+  });
+
   it.each([
     [
       "invalid YAML",
@@ -218,7 +299,7 @@ Prompt`,
     );
   });
 
-  it("resolves provider environment values before adapter validation", () => {
+  it("keeps non-secret provider values literal for adapter validation", () => {
     const validateProviderConfig = vi.fn(() => []);
     parseWorkflowMarkdownStrict(
       `---
@@ -578,15 +659,15 @@ Prompt`);
     });
   });
 
-  it("preserves paths for unresolved environment-backed fields", () => {
+  it("preserves the path for an unresolved environment-backed workspace root", () => {
     let thrown: unknown;
     try {
       parseWorkflowMarkdown(
         `---
 tracker:
   kind: github-project
-codex:
-  command: ${"${UNSET_CODEX_COMMAND}"}
+workspace:
+  root: ${"${UNSET_WORKSPACE_ROOT}"}
 ---
 Prompt`,
         {}
@@ -596,7 +677,7 @@ Prompt`,
     }
     expect(thrown).toMatchObject({
       code: "workflow_validation_error",
-      path: "codex.command",
+      path: "workspace.root",
     });
   });
 
@@ -1068,7 +1149,7 @@ Prompt body.
     ).toThrow(adapterError);
   });
 
-  it("resolves environment indirection from yaml front matter", () => {
+  it("keeps command strings opaque when they contain environment syntax", () => {
     const workflow = parseWorkflowMarkdown(
       `---
 tracker:
@@ -1083,7 +1164,7 @@ Render with env indirection.
       } as NodeJS.ProcessEnv
     );
 
-    expect(workflow.agentCommand).toBe("custom-app-server");
+    expect(workflow.agentCommand).toBe("${TEST_AGENT_COMMAND}");
   });
 
   it.each(["on-request", "untrusted"])(
@@ -1354,7 +1435,7 @@ runtime:
 ---
 Old schema.
 `)
-    ).toThrow(/tracker/);
+    ).toThrow(/kind/);
   });
 
   it("preserves multiline hook bodies", () => {
@@ -1553,18 +1634,18 @@ Broken prompt.
 
     await writeFile(
       workflowPath,
-      SAMPLE_WORKFLOW.replace("codex app-server", "$AGENT_COMMAND"),
+      SAMPLE_WORKFLOW.replace(".runtime/workspaces", "$WORKSPACE_ROOT"),
       "utf8"
     );
 
     const first = await store.load(workflowPath, {
-      AGENT_COMMAND: "codex app-server",
+      WORKSPACE_ROOT: "/tmp/first-workspaces",
     });
     const second = await store.load(workflowPath, {
-      AGENT_COMMAND: "claude --print",
+      WORKSPACE_ROOT: "/tmp/second-workspaces",
     });
 
     expect(second.revision).not.toBe(first.revision);
-    expect(second.agentCommand).toBe("claude --print");
+    expect(second.workflow.workspace.root).toBe("/tmp/second-workspaces");
   });
 });

--- a/packages/core/src/workflow/loader.ts
+++ b/packages/core/src/workflow/loader.ts
@@ -60,7 +60,10 @@ export class WorkflowConfigStore {
     }
 
     try {
-      const workflow = parseWorkflowMarkdown(markdown, env, this.parseOptions);
+      const workflow = parseWorkflowMarkdown(markdown, env, {
+        ...this.parseOptions,
+        workflowPath,
+      });
       const revision = createWorkflowRevision(workflow);
       const loadedAt = new Date().toISOString();
       this.cache.set(workflowPath, {

--- a/packages/core/src/workflow/parser.ts
+++ b/packages/core/src/workflow/parser.ts
@@ -20,6 +20,8 @@ import {
   type WorkflowRuntimeKind,
   resolveWorkflowRuntimeCommand,
 } from "./config.js";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
 import {
   DEFAULT_WORKFLOW_LIFECYCLE,
   normalizeWorkflowState,
@@ -47,6 +49,10 @@ export type ParseWorkflowOptions = {
   resolveTrackerAdapter?: (
     kind: string
   ) => WorkflowConfigTrackerAdapter | undefined;
+  /** Absolute or relative path of the selected WORKFLOW.md, when known. */
+  workflowPath?: string;
+  /** Test seam for deterministic home-directory expansion. */
+  homeDir?: string;
 };
 
 export type WorkflowConfigTrackerAdapter = {
@@ -108,46 +114,65 @@ function parseWorkflowMarkdownInternal(
   options: ParseWorkflowOptions
 ): ParsedWorkflow {
   const compatibilityMode = options.compatibilityMode ?? "strict";
-  const frontMatterMatch = markdown.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
+  const frontMatterMatch = markdown.match(
+    /^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/
+  );
 
   if (!frontMatterMatch) {
-    if (compatibilityMode === "legacy") {
+    if (/^---(?:\r?\n|$)/.test(markdown)) {
+      throw new WorkflowValidationError(
+        "workflow_parse_error",
+        "front_matter",
+        "WORKFLOW.md has unterminated YAML front matter."
+      );
+    }
+    if (
+      compatibilityMode === "legacy" &&
+      markdown.startsWith("## Prompt Guidelines")
+    ) {
       return parseLegacyWorkflowMarkdown(markdown);
     }
-    throw new WorkflowValidationError(
-      "workflow_parse_error",
-      "front_matter",
-      "WORKFLOW.md must use YAML front matter."
-    );
+    return parseWorkflowConfig({}, markdown.trim(), env, options);
   }
 
   const [, rawFrontMatter, rawPromptTemplate = ""] = frontMatterMatch;
   const frontMatter = parseFrontMatter(rawFrontMatter);
-  const promptTemplate = rawPromptTemplate.trim();
+  return parseWorkflowConfig(
+    frontMatter,
+    rawPromptTemplate.trim(),
+    env,
+    options
+  );
+}
 
-  const tracker = readRequiredObject(frontMatter, "tracker");
+function parseWorkflowConfig(
+  frontMatter: Record<string, WorkflowFrontMatterNode>,
+  promptTemplate: string,
+  env: NodeJS.ProcessEnv,
+  options: ParseWorkflowOptions
+): ParsedWorkflow {
+  const tracker = readObject(frontMatter, "tracker");
   const polling = readObject(frontMatter, "polling");
   const workspace = readObject(frontMatter, "workspace");
   const hooks = readObject(frontMatter, "hooks");
   const agent = readObject(frontMatter, "agent");
   const runtimeNode = readOptionalRuntimeObject(frontMatter);
   const hasRuntime = runtimeNode !== null;
-  const codex = hasRuntime
-    ? readObject(frontMatter, "codex")
-    : readRequiredObject(frontMatter, "codex");
+  const codex = readObject(frontMatter, "codex");
 
-  const trackerKind = readRequiredString(tracker, "kind", env, "tracker.kind");
+  const trackerKind = readOptionalString(tracker, "kind", "tracker.kind");
   const supportedTrackerKinds =
     options.supportedTrackerKinds ?? DEFAULT_SUPPORTED_TRACKER_KINDS;
-  if (!supportedTrackerKinds.includes(trackerKind)) {
+  if (trackerKind && !supportedTrackerKinds.includes(trackerKind)) {
     throw new WorkflowValidationError(
       "workflow_validation_error",
       "tracker.kind",
       `Unsupported workflow tracker.kind "${trackerKind}". Supported values: ${supportedTrackerKinds.join(", ")}.`
     );
   }
-  const trackerAdapter =
-    options.resolveTrackerAdapter?.(trackerKind) ?? options.trackerAdapter;
+  const trackerAdapter = trackerKind
+    ? (options.resolveTrackerAdapter?.(trackerKind) ?? options.trackerAdapter)
+    : options.trackerAdapter;
   const provider = readProviderConfig(tracker);
   const explicitProviderKeys = new Set(Object.keys(provider));
   const deprecatedKeys = promoteDeprecatedTrackerKeys(tracker, provider);
@@ -287,7 +312,7 @@ function parseWorkflowMarkdownInternal(
           "endpoint",
           env
         ) ?? (trackerKind === "linear" ? DEFAULT_LINEAR_GRAPHQL_URL : null),
-      apiKey: readNormalizedOptionalString(
+      apiKey: readNormalizedOptionalSecret(
         tracker,
         provider,
         explicitProviderKeys,
@@ -343,13 +368,13 @@ function parseWorkflowMarkdownInternal(
     },
     repository: readOptionalExtensionObject(frontMatter, "repository"),
     workspace: {
-      root: readOptionalString(workspace, "root", env),
+      root: readOptionalPath(workspace, "root", env, "workspace.root", options),
     },
     hooks: {
-      afterCreate: readOptionalString(hooks, "after_create", env),
-      beforeRun: readOptionalString(hooks, "before_run", env),
-      afterRun: readOptionalString(hooks, "after_run", env),
-      beforeRemove: readOptionalString(hooks, "before_remove", env),
+      afterCreate: readOptionalString(hooks, "after_create"),
+      beforeRun: readOptionalString(hooks, "before_run"),
+      afterRun: readOptionalString(hooks, "after_run"),
+      beforeRemove: readOptionalString(hooks, "before_remove"),
       timeoutMs:
         readOptionalPositiveInteger(hooks, "timeout_ms", "hooks.timeout_ms") ??
         DEFAULT_HOOK_TIMEOUT_MS,
@@ -402,7 +427,7 @@ function parseWorkflowMarkdownInternal(
       env
     ),
     agentCommand,
-    hookPath: readOptionalString(hooks, "after_create", env),
+    hookPath: readOptionalString(hooks, "after_create"),
     maxConcurrentByState: maxConcurrentAgentsByState,
   };
 
@@ -497,8 +522,7 @@ function promoteDeprecatedTrackerKeys(
 
 function readProviderOptionalString(
   provider: Record<string, unknown>,
-  key: string,
-  env: NodeJS.ProcessEnv
+  key: string
 ): string | null {
   const value = provider[key];
   if (value === undefined || value === null) {
@@ -511,7 +535,7 @@ function readProviderOptionalString(
       `Workflow front matter field "tracker.provider.${key}" must be a string.`
     );
   }
-  return resolveEnvironmentValue(value, env, `tracker.provider.${key}`);
+  return value;
 }
 
 function readNormalizedOptionalString(
@@ -519,11 +543,27 @@ function readNormalizedOptionalString(
   provider: Record<string, unknown>,
   explicitProviderKeys: ReadonlySet<string>,
   key: string,
-  env: NodeJS.ProcessEnv
+  _env: NodeJS.ProcessEnv
 ): string | null {
   return explicitProviderKeys.has(key)
-    ? readProviderOptionalString(provider, key, env)
-    : readOptionalString(tracker, key, env, `tracker.${key}`);
+    ? readProviderOptionalString(provider, key)
+    : readOptionalString(tracker, key, `tracker.${key}`);
+}
+
+function readNormalizedOptionalSecret(
+  tracker: Record<string, WorkflowFrontMatterNode>,
+  provider: Record<string, unknown>,
+  explicitProviderKeys: ReadonlySet<string>,
+  key: string,
+  env: NodeJS.ProcessEnv
+): string | null {
+  const path = explicitProviderKeys.has(key)
+    ? `tracker.provider.${key}`
+    : `tracker.${key}`;
+  const value = explicitProviderKeys.has(key)
+    ? readProviderOptionalString(provider, key)
+    : readOptionalString(tracker, key, path);
+  return value === null ? null : resolveEnvironmentValue(value, env, path);
 }
 
 function readProviderStringList(
@@ -644,7 +684,7 @@ function readPriorityConfig(
   tracker: Record<string, WorkflowFrontMatterNode>,
   provider: Record<string, unknown>,
   explicitProviderKeys: ReadonlySet<string>,
-  env: NodeJS.ProcessEnv
+  _env: NodeJS.ProcessEnv
 ): WorkflowPriorityConfig | null {
   const priorityValue =
     (explicitProviderKeys.has("priority") ? provider.priority : undefined) ??
@@ -659,12 +699,12 @@ function readPriorityConfig(
     );
   }
   const priority = priorityValue as Record<string, WorkflowFrontMatterNode>;
-  const source = readRequiredString(priority, "source", env);
+  const source = readRequiredString(priority, "source");
   const keys = new Set(Object.keys(priority));
 
   if (source === "project-field") {
     rejectPriorityKeys(keys, ["source", "field", "values"], source);
-    const field = readRequiredString(priority, "field", env);
+    const field = readRequiredString(priority, "field");
     const values = readNumberMap(priority, "values", "tracker.priority.values");
     if (Object.keys(values).length === 0) {
       throw new Error(
@@ -1053,13 +1093,13 @@ function pushInlineArrayEntry(
 
 function parseRuntimeConfig(
   runtime: Record<string, WorkflowFrontMatterNode>,
-  env: NodeJS.ProcessEnv
+  _env: NodeJS.ProcessEnv
 ): WorkflowRuntimeConfig {
-  const kind = readRuntimeKind(runtime, env);
+  const kind = readRuntimeKind(runtime);
   const isolation = readObject(runtime, "isolation", "runtime.isolation");
   const auth = readObject(runtime, "auth", "runtime.auth");
   const timeouts = readObject(runtime, "timeouts", "runtime.timeouts");
-  const configuredCommand = readOptionalString(runtime, "command", env);
+  const configuredCommand = readOptionalString(runtime, "command");
   const command = configuredCommand ?? defaultRuntimeCommand(kind);
 
   if (!command) {
@@ -1090,7 +1130,7 @@ function parseRuntimeConfig(
         ) ?? false,
     },
     auth: {
-      env: readOptionalString(auth, "env", env),
+      env: readOptionalString(auth, "env"),
     },
     timeouts: {
       turnTimeoutMs:
@@ -1107,10 +1147,9 @@ function parseRuntimeConfig(
 }
 
 function readRuntimeKind(
-  runtime: Record<string, WorkflowFrontMatterNode>,
-  env: NodeJS.ProcessEnv
+  runtime: Record<string, WorkflowFrontMatterNode>
 ): WorkflowRuntimeKind {
-  const kind = readRequiredString(runtime, "kind", env);
+  const kind = readRequiredString(runtime, "kind");
   if (
     kind === "codex-app-server" ||
     kind === "claude-print" ||
@@ -1168,20 +1207,9 @@ function readOptionalExtensionObject(
   return readObject(input, key) as Record<string, unknown>;
 }
 
-function readRequiredObject(
-  input: Record<string, WorkflowFrontMatterNode>,
-  key: string
-): Record<string, WorkflowFrontMatterNode> {
-  if (!(key in input)) {
-    throw new Error(`Workflow front matter field "${key}" is required.`);
-  }
-  return readObject(input, key);
-}
-
 function readOptionalString(
   input: Record<string, WorkflowFrontMatterNode>,
   key: string,
-  env: NodeJS.ProcessEnv,
   path = key
 ): string | null {
   const value = input[key];
@@ -1191,28 +1219,56 @@ function readOptionalString(
   if (typeof value !== "string") {
     throw new Error(`Workflow front matter field "${path}" must be a string.`);
   }
-  return resolveEnvironmentValue(value, env, path);
+  return value;
+}
+
+function readOptionalPath(
+  input: Record<string, WorkflowFrontMatterNode>,
+  key: string,
+  env: NodeJS.ProcessEnv,
+  path: string,
+  options: ParseWorkflowOptions
+): string | null {
+  const value = readOptionalString(input, key, path);
+  if (value === null) {
+    return null;
+  }
+  const expanded = resolveEnvironmentValue(value, env, path);
+  const normalized = expandHomeDirectory(expanded, options.homeDir);
+  return resolve(
+    options.workflowPath ? dirname(options.workflowPath) : process.cwd(),
+    normalized
+  );
+}
+
+function expandHomeDirectory(value: string, homeDir = homedir()): string {
+  if (value === "~") {
+    return homeDir;
+  }
+  if (value.startsWith("~/") || value.startsWith("~\\")) {
+    return join(homeDir, value.slice(2));
+  }
+  return value;
 }
 
 function readOptionalWorkflowString(
   input: Record<string, WorkflowFrontMatterNode>,
   primaryKey: string,
   fallbackKey: string,
-  env: NodeJS.ProcessEnv
+  _env: NodeJS.ProcessEnv
 ): string | null {
   return (
-    readOptionalString(input, primaryKey, env) ??
-    readOptionalString(input, fallbackKey, env)
+    readOptionalString(input, primaryKey) ??
+    readOptionalString(input, fallbackKey)
   );
 }
 
 function readRequiredString(
   input: Record<string, WorkflowFrontMatterNode>,
   key: string,
-  env: NodeJS.ProcessEnv,
   path = key
 ): string {
-  const value = readOptionalString(input, key, env, path);
+  const value = readOptionalString(input, key, path);
   if (!value) {
     throw new Error(`Workflow front matter field "${path}" is required.`);
   }
@@ -1316,10 +1372,10 @@ function readOptionalPositiveInteger(
 function readOptionalNonEmptyString(
   input: Record<string, WorkflowFrontMatterNode>,
   key: string,
-  env: NodeJS.ProcessEnv,
+  _env: NodeJS.ProcessEnv,
   path: string
 ): string | null {
-  const value = readOptionalString(input, key, env, path);
+  const value = readOptionalString(input, key, path);
   if (value !== null && value.trim().length === 0) {
     throw new WorkflowValidationError(
       "workflow_validation_error",
@@ -1402,7 +1458,7 @@ export function resolveEnvironmentValue(
   env: NodeJS.ProcessEnv,
   path: string
 ): string {
-  const envTokenMatch = value.match(/^(?:env:)?([A-Z0-9_]+)$/);
+  const envTokenMatch = value.match(/^(?:env:)?([A-Za-z_][A-Za-z0-9_]*)$/);
   if (value.startsWith("env:") && envTokenMatch) {
     const resolved = env[envTokenMatch[1]];
     if (!resolved) {
@@ -1415,30 +1471,21 @@ export function resolveEnvironmentValue(
     return resolved;
   }
 
-  const dollarEnvTokenMatch = value.match(/^\$([A-Z0-9_]+)$/);
-  if (dollarEnvTokenMatch) {
-    const resolved = env[dollarEnvTokenMatch[1]];
-    if (!resolved) {
-      throw new WorkflowValidationError(
-        "workflow_validation_error",
-        path,
-        `Workflow front matter field "${path}" requires environment variable ${dollarEnvTokenMatch[1]}.`
-      );
+  return value.replace(
+    /\$(?:\{([A-Za-z_][A-Za-z0-9_]*)\}|([A-Za-z_][A-Za-z0-9_]*))/g,
+    (_, bracedName: string | undefined, plainName: string | undefined) => {
+      const name = bracedName ?? plainName!;
+      const resolved = env[name];
+      if (!resolved) {
+        throw new WorkflowValidationError(
+          "workflow_validation_error",
+          path,
+          `Workflow front matter field "${path}" requires environment variable ${name}.`
+        );
+      }
+      return resolved;
     }
-    return resolved;
-  }
-
-  return value.replace(/\$\{([A-Z0-9_]+)\}/g, (_, name: string) => {
-    const resolved = env[name];
-    if (!resolved) {
-      throw new WorkflowValidationError(
-        "workflow_validation_error",
-        path,
-        `Workflow front matter field "${path}" requires environment variable ${name}.`
-      );
-    }
-    return resolved;
-  });
+  );
 }
 
 function matchOptionalSection(

--- a/packages/core/src/workflow/parser.ts
+++ b/packages/core/src/workflow/parser.ts
@@ -115,7 +115,7 @@ function parseWorkflowMarkdownInternal(
 ): ParsedWorkflow {
   const compatibilityMode = options.compatibilityMode ?? "strict";
   const frontMatterMatch = markdown.match(
-    /^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/
+    /^---\r?\n(?:([\s\S]*?)\r?\n)?---(?:\r?\n|$)([\s\S]*)$/
   );
 
   if (!frontMatterMatch) {
@@ -135,7 +135,7 @@ function parseWorkflowMarkdownInternal(
     return parseWorkflowConfig({}, markdown.trim(), env, options);
   }
 
-  const [, rawFrontMatter, rawPromptTemplate = ""] = frontMatterMatch;
+  const [, rawFrontMatter = "", rawPromptTemplate = ""] = frontMatterMatch;
   const frontMatter = parseFrontMatter(rawFrontMatter);
   return parseWorkflowConfig(
     frontMatter,
@@ -520,6 +520,48 @@ function promoteDeprecatedTrackerKeys(
   return deprecatedKeys;
 }
 
+/** Resolve tracker configuration before selected-adapter validation. */
+function resolveProviderEnvironmentValues(
+  provider: Record<string, unknown>,
+  env: NodeJS.ProcessEnv,
+  path = "tracker.provider",
+  explicitProviderKeys?: ReadonlySet<string>
+): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(provider).map(([key, value]) => {
+      const valuePath = explicitProviderKeys?.has(key)
+        ? `${path}.${key}`
+        : path === "tracker.provider"
+          ? `tracker.${key}`
+          : `${path}.${key}`;
+      if (typeof value === "string") {
+        return [key, resolveEnvironmentValue(value, env, valuePath)];
+      }
+      if (Array.isArray(value)) {
+        return [
+          key,
+          value.map((entry, index) =>
+            typeof entry === "string"
+              ? resolveEnvironmentValue(entry, env, `${valuePath}[${index}]`)
+              : entry
+          ),
+        ];
+      }
+      if (value && typeof value === "object") {
+        return [
+          key,
+          resolveProviderEnvironmentValues(
+            value as Record<string, unknown>,
+            env,
+            valuePath
+          ),
+        ];
+      }
+      return [key, value];
+    })
+  );
+}
+
 function readProviderOptionalString(
   provider: Record<string, unknown>,
   key: string
@@ -543,11 +585,12 @@ function readNormalizedOptionalString(
   provider: Record<string, unknown>,
   explicitProviderKeys: ReadonlySet<string>,
   key: string,
-  _env: NodeJS.ProcessEnv
+  env: NodeJS.ProcessEnv
 ): string | null {
-  return explicitProviderKeys.has(key)
+  const value = explicitProviderKeys.has(key)
     ? readProviderOptionalString(provider, key)
     : readOptionalString(tracker, key, `tracker.${key}`);
+  return value === null ? null : resolveEnvironmentValue(value, env, `tracker.${key}`);
 }
 
 function readNormalizedOptionalSecret(
@@ -1458,14 +1501,21 @@ export function resolveEnvironmentValue(
   env: NodeJS.ProcessEnv,
   path: string
 ): string {
-  const envTokenMatch = value.match(/^(?:env:)?([A-Za-z_][A-Za-z0-9_]*)$/);
-  if (value.startsWith("env:") && envTokenMatch) {
-    const resolved = env[envTokenMatch[1]];
+  if (value.startsWith("env:")) {
+    const name = value.slice("env:".length);
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) {
+      throw new WorkflowValidationError(
+        "workflow_validation_error",
+        path,
+        `Workflow front matter field "${path}" has invalid environment variable name ${name}.`
+      );
+    }
+    const resolved = env[name];
     if (!resolved) {
       throw new WorkflowValidationError(
         "workflow_validation_error",
         path,
-        `Workflow front matter field "${path}" requires environment variable ${envTokenMatch[1]}.`
+        `Workflow front matter field "${path}" requires environment variable ${name}.`
       );
     }
     return resolved;

--- a/packages/core/src/workflow/parser.ts
+++ b/packages/core/src/workflow/parser.ts
@@ -251,7 +251,6 @@ function parseWorkflowConfig(
   const approvalPolicy = readOptionalString(
     codex,
     "approval_policy",
-    env,
     "codex.approval_policy"
   );
   if (approvalPolicy !== null && approvalPolicy !== "never") {
@@ -266,8 +265,8 @@ function parseWorkflowConfig(
       readOptionalNonEmptyString(codex, "command", env, "codex.command") ??
       DEFAULT_AGENT_COMMAND,
     approvalPolicy,
-    threadSandbox: readOptionalString(codex, "thread_sandbox", env),
-    turnSandboxPolicy: readOptionalString(codex, "turn_sandbox_policy", env),
+    threadSandbox: readOptionalString(codex, "thread_sandbox"),
+    turnSandboxPolicy: readOptionalString(codex, "turn_sandbox_policy"),
     turnTimeoutMs:
       readOptionalIntegerLike(
         codex,
@@ -518,48 +517,6 @@ function promoteDeprecatedTrackerKeys(
     }
   }
   return deprecatedKeys;
-}
-
-/** Resolve tracker configuration before selected-adapter validation. */
-function resolveProviderEnvironmentValues(
-  provider: Record<string, unknown>,
-  env: NodeJS.ProcessEnv,
-  path = "tracker.provider",
-  explicitProviderKeys?: ReadonlySet<string>
-): Record<string, unknown> {
-  return Object.fromEntries(
-    Object.entries(provider).map(([key, value]) => {
-      const valuePath = explicitProviderKeys?.has(key)
-        ? `${path}.${key}`
-        : path === "tracker.provider"
-          ? `tracker.${key}`
-          : `${path}.${key}`;
-      if (typeof value === "string") {
-        return [key, resolveEnvironmentValue(value, env, valuePath)];
-      }
-      if (Array.isArray(value)) {
-        return [
-          key,
-          value.map((entry, index) =>
-            typeof entry === "string"
-              ? resolveEnvironmentValue(entry, env, `${valuePath}[${index}]`)
-              : entry
-          ),
-        ];
-      }
-      if (value && typeof value === "object") {
-        return [
-          key,
-          resolveProviderEnvironmentValues(
-            value as Record<string, unknown>,
-            env,
-            valuePath
-          ),
-        ];
-      }
-      return [key, value];
-    })
-  );
 }
 
 function readProviderOptionalString(

--- a/packages/core/src/workflow/parser.ts
+++ b/packages/core/src/workflow/parser.ts
@@ -590,7 +590,9 @@ function readNormalizedOptionalString(
   const value = explicitProviderKeys.has(key)
     ? readProviderOptionalString(provider, key)
     : readOptionalString(tracker, key, `tracker.${key}`);
-  return value === null ? null : resolveEnvironmentValue(value, env, `tracker.${key}`);
+  return value === null
+    ? null
+    : resolveEnvironmentValue(value, env, `tracker.${key}`);
 }
 
 function readNormalizedOptionalSecret(
@@ -1276,7 +1278,7 @@ function readOptionalPath(
   if (value === null) {
     return null;
   }
-  const expanded = resolveEnvironmentValue(value, env, path);
+  const expanded = resolvePathEnvironmentValue(value, env, path);
   const normalized = expandHomeDirectory(expanded, options.homeDir);
   return resolve(
     options.workflowPath ? dirname(options.workflowPath) : process.cwd(),
@@ -1519,6 +1521,34 @@ export function resolveEnvironmentValue(
       );
     }
     return resolved;
+  }
+
+  const match = value.match(
+    /^\$(?:\{([A-Za-z_][A-Za-z0-9_]*)\}|([A-Za-z_][A-Za-z0-9_]*))$/
+  );
+  if (!match) {
+    return value;
+  }
+
+  const name = match[1] ?? match[2]!;
+  const resolved = env[name];
+  if (!resolved) {
+    throw new WorkflowValidationError(
+      "workflow_validation_error",
+      path,
+      `Workflow front matter field "${path}" requires environment variable ${name}.`
+    );
+  }
+  return resolved;
+}
+
+function resolvePathEnvironmentValue(
+  value: string,
+  env: NodeJS.ProcessEnv,
+  path: string
+): string {
+  if (value.startsWith("env:")) {
+    return resolveEnvironmentValue(value, env, path);
   }
 
   return value.replace(

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -14528,6 +14528,33 @@ Workspace prompt.
     expect(result.warnings).toEqual([]);
   });
 
+  it("does not dispatch a prompt-only workflow without tracker.kind", async () => {
+    process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
+    const tempRoot = await mkdtemp(
+      join(tmpdir(), "orchestrator-prompt-only-workflow-")
+    );
+    const repository = await createRepositoryFixture(
+      tempRoot,
+      "acme",
+      "platform",
+      { rawWorkflow: "Handle the assigned issue." }
+    );
+    const store = new OrchestratorFsStore(tempRoot);
+    const projectConfig = createProjectConfig(tempRoot, repository);
+    await store.saveProjectConfig(projectConfig);
+    const spawnImpl = vi.fn();
+    const service = new OrchestratorService(store, projectConfig, {
+      fetchImpl: vi.fn().mockResolvedValue(createTrackerResponse(repository)),
+      spawnImpl: spawnImpl as never,
+      now: () => new Date("2026-03-08T00:00:00.000Z"),
+    });
+
+    const result = await service.runOnce();
+
+    expect(result.summary.dispatched).toBe(0);
+    expect(spawnImpl).not.toHaveBeenCalled();
+  });
+
   it("loads project .env for repository script hooks during workspace creation", async () => {
     process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
     const tempRoot = await mkdtemp(
@@ -14903,7 +14930,7 @@ Test workspace hook retries.
     expect(spawnImpl).not.toHaveBeenCalled();
   });
 
-  it("resolves standalone project .env $VAR values with host precedence", async () => {
+  it("keeps standalone project identifiers literal when they contain $VAR", async () => {
     process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
     const originalProjectId = process.env.PROJECT_ENV_WORKFLOW_ID;
     process.env.PROJECT_ENV_WORKFLOW_ID = "host-project-id";
@@ -14971,7 +14998,9 @@ Prefer focused changes.
         }
       ).loadProjectWorkflowUncached(projectConfig, repository);
 
-      expect(resolution.workflow.tracker.projectId).toBe("host-project-id");
+      expect(resolution.workflow.tracker.projectId).toBe(
+        "$PROJECT_ENV_WORKFLOW_ID"
+      );
 
       delete process.env.PROJECT_ENV_WORKFLOW_ID;
       const projectResolution = await (
@@ -14983,7 +15012,7 @@ Prefer focused changes.
         }
       ).loadProjectWorkflowUncached(projectConfig, repository);
       expect(projectResolution.workflow.tracker.projectId).toBe(
-        "project-env-id"
+        "$PROJECT_ENV_WORKFLOW_ID"
       );
     } finally {
       if (originalProjectId === undefined) {

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -14930,7 +14930,7 @@ Test workspace hook retries.
     expect(spawnImpl).not.toHaveBeenCalled();
   });
 
-  it("keeps standalone project identifiers literal when they contain $VAR", async () => {
+  it("resolves standalone project identifiers when they contain $VAR", async () => {
     process.env.GITHUB_GRAPHQL_TOKEN = "test-token";
     const originalProjectId = process.env.PROJECT_ENV_WORKFLOW_ID;
     process.env.PROJECT_ENV_WORKFLOW_ID = "host-project-id";
@@ -14998,9 +14998,7 @@ Prefer focused changes.
         }
       ).loadProjectWorkflowUncached(projectConfig, repository);
 
-      expect(resolution.workflow.tracker.projectId).toBe(
-        "$PROJECT_ENV_WORKFLOW_ID"
-      );
+      expect(resolution.workflow.tracker.projectId).toBe("host-project-id");
 
       delete process.env.PROJECT_ENV_WORKFLOW_ID;
       const projectResolution = await (
@@ -15011,9 +15009,7 @@ Prefer focused changes.
           ): Promise<WorkflowResolution>;
         }
       ).loadProjectWorkflowUncached(projectConfig, repository);
-      expect(projectResolution.workflow.tracker.projectId).toBe(
-        "$PROJECT_ENV_WORKFLOW_ID"
-      );
+      expect(projectResolution.workflow.tracker.projectId).toBe("project-env-id");
     } finally {
       if (originalProjectId === undefined) {
         delete process.env.PROJECT_ENV_WORKFLOW_ID;

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -15009,7 +15009,9 @@ Prefer focused changes.
           ): Promise<WorkflowResolution>;
         }
       ).loadProjectWorkflowUncached(projectConfig, repository);
-      expect(projectResolution.workflow.tracker.projectId).toBe("project-env-id");
+      expect(projectResolution.workflow.tracker.projectId).toBe(
+        "project-env-id"
+      );
     } finally {
       if (originalProjectId === undefined) {
         delete process.env.PROJECT_ENV_WORKFLOW_ID;

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -5192,10 +5192,19 @@ export class OrchestratorService {
     resolution: WorkflowResolution
   ): Promise<WorkflowResolution> {
     const cacheKey = this.workflowCacheKey(repository);
+    const dispatchResolution =
+      resolution.isValid && !resolution.workflow.tracker.kind
+        ? {
+            ...resolution,
+            isValid: false,
+            validationError:
+              'Workflow dispatch requires front matter field "tracker.kind".',
+          }
+        : resolution;
 
-    if (resolution.isValid) {
+    if (dispatchResolution.isValid) {
       const effectiveResolution: WorkflowResolution = {
-        ...resolution,
+        ...dispatchResolution,
         isValid: true,
         usedLastKnownGood: false,
         validationError: null,
@@ -5219,13 +5228,13 @@ export class OrchestratorService {
 
     const cached = this.lastKnownGoodWorkflows.get(cacheKey);
     const message =
-      resolution.validationError ?? "Invalid repository WORKFLOW.md";
+      dispatchResolution.validationError ?? "Invalid repository WORKFLOW.md";
     this.writeStderr(
       `[orchestrator] failed to reload WORKFLOW.md for ${repository.owner}/${repository.name}: ${message}`
     );
 
     if (!cached) {
-      return resolution;
+      return dispatchResolution;
     }
 
     return {

--- a/packages/worker/src/conformance.test.ts
+++ b/packages/worker/src/conformance.test.ts
@@ -55,10 +55,13 @@ describe("Symphony core conformance", () => {
     });
   });
 
-  it("rejects workflows without canonical front matter in strict mode", () => {
-    expect(() =>
-      parseWorkflowMarkdown("## Prompt Guidelines\n\nMissing everything else")
-    ).toThrow(/YAML front matter/);
+  it("accepts workflows without front matter as prompt-only defaults", () => {
+    expect(
+      parseWorkflowMarkdown("## Prompt Guidelines\n\nPrompt-only workflow")
+    ).toMatchObject({
+      promptTemplate: "## Prompt Guidelines\n\nPrompt-only workflow",
+      tracker: { kind: null },
+    });
   });
 
   it("keeps workspace paths isolated under the configured root", () => {

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -536,7 +536,8 @@ async function startAssignedRun() {
     runtimeState.runPhase = "building_prompt";
     const workflow = parseWorkflowMarkdown(
       await readFile(workflowPath, "utf8"),
-      launcherEnv
+      launcherEnv,
+      { workflowPath }
     );
     const route = resolveWorkerRuntimeRoute(workflow);
     const runtimeCommand = resolveWorkflowRuntimeCommand(workflow);


### PR DESCRIPTION
## Issues — Closed #668

Closes #668

## TL;DR

- `workspace.root` expands `~`, `$VAR`, `${VAR}`, and `env:VAR`, then becomes an absolute path relative to the selected `WORKFLOW.md`.
- Workflow command and hook strings remain opaque; tracker and provider references resolve once for adapter validation without replacing public source references.
- Prompt-only and empty-front-matter workflows parse correctly, while dispatch reports a missing `tracker.kind` consistently.

## Change-point diagram

```text
WORKFLOW.md
  ├─ prompt-only / empty front matter ──→ prompt + defaults
  └─ configuration values
       ├─ workspace.root ───────────────→ env/home expansion → absolute path
       ├─ tracker + provider values ────→ resolved validation copy
       └─ hooks / runtime / codex commands → preserved literally
```

## Start here

- `packages/core/src/workflow/parser.ts` — parsing, scoped normalization, provider resolution, and typed errors.
- `packages/core/src/workflow-loader.test.ts` — parser and secret-redaction regressions.
- `packages/orchestrator/src/service.ts` and CLI diagnostics — dispatch preflight for `tracker.kind`.

## Risks & rollback

- Existing tracker/provider values that intentionally use a `$VAR`-shaped whole value resolve at load time; command and hook values are unaffected.
- Revert the #668 commits on this PR to restore the previous workflow parser behavior.

## Changed files

- Workflow parser, loader, orchestrator, worker, and CLI regression coverage.
- Configuration reference and patch changeset.

## Evidence

- Rebased onto `main` at `45bb54e9`; resolved the `docs/configuration.md` integration conflict while preserving the optional front-matter rule.
- `pnpm --filter @gh-symphony/core test -- workflow-loader.test.ts` — pass (85 tests).
- `pnpm lint` — pass.
- `pnpm test` — pass.
- `pnpm typecheck` — pass.
- `pnpm build` — pass.
- `./e2e/run-e2e.sh happy 60` — pass; worker dispatch/retry, configured workspace root, redaction, and final idle health verified.

## Post-merge / human validation

- [ ] Start a prompt-only `WORKFLOW.md` and confirm doctor/start clearly require `tracker.kind` for dispatch.
- [ ] Confirm a provider endpoint using `$VAR` or `env:VAR` is resolved before adapter validation without exposing its resolved value.
- [ ] Confirm command and hook strings containing shell environment syntax remain unchanged.
