### PR TITLE
feat(trackers): normalize adapter metadata and pagination failures

### DIFF
--- a/.changeset/quiet-trackers-normalize.md
+++ b/.changeset/quiet-trackers-normalize.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Normalize GitHub and Linear tracker labels and timestamps, map Linear no-priority values to `null`, and fail explicitly when tracker pagination loses integrity (#726).

--- a/packages/tracker-github/README.md
+++ b/packages/tracker-github/README.md
@@ -2,6 +2,8 @@
 
 GitHub Project polling, issue normalization, and tracker-facing configuration validation that stay behind the core tracker adapter contract.
 
+Adapter profile note: labels are trimmed, lowercased, deduplicated, and sorted; timestamps are parsed to canonical ISO 8601 or `null`. A pagination response with `hasNextPage: true` and no cursor fails with the `tracker_pagination` category and a structured integrity event.
+
 ## Adapter profile
 
 - Candidate polling returns every active, in-scope Project item, including items

--- a/packages/tracker-github/src/adapter.ts
+++ b/packages/tracker-github/src/adapter.ts
@@ -545,8 +545,8 @@ function normalizePullRequestProjectItem(
     dispatchable: true,
     assigneeId: null,
     blockedBy: [],
-    createdAt: content.createdAt,
-    updatedAt: trackedUpdatedAt,
+    createdAt: parseTrackerTimestamp(content.createdAt),
+    updatedAt: parseTrackerTimestamp(trackedUpdatedAt),
     repository: pullRequest.repository,
     tracker: {
       adapter: "github-project",

--- a/packages/tracker-github/src/adapter.ts
+++ b/packages/tracker-github/src/adapter.ts
@@ -11,6 +11,8 @@ import {
   type TrackerIssueCommentUpsertResult,
   type WorkflowPriorityConfig,
   type WorkflowLifecycleConfig,
+  normalizeLabels,
+  parseTrackerTimestamp,
 } from "@gh-symphony/core";
 import {
   extractGitHubRateLimits,
@@ -482,8 +484,8 @@ export function normalizeProjectItem(
       item.content.assignees?.nodes?.find((assignee) => assignee?.login)
         ?.login ?? null,
     blockedBy,
-    createdAt: item.content.createdAt,
-    updatedAt: trackedUpdatedAt,
+    createdAt: parseTrackerTimestamp(item.content.createdAt),
+    updatedAt: parseTrackerTimestamp(trackedUpdatedAt),
     repository: {
       owner: repository.owner.login,
       name: repository.name,
@@ -648,6 +650,14 @@ export async function fetchProjectIssues(
     });
 
     issues.push(...pageIssues);
+    if (page.pageInfo.hasNextPage && !page.pageInfo.endCursor) {
+      throw trackerPaginationError({
+        adapter: "github-project",
+        projectId: config.projectId,
+        pageCount,
+        reason: "hasNextPage=true but endCursor is null",
+      });
+    }
     cursor = page.pageInfo.hasNextPage ? page.pageInfo.endCursor : null;
   } while (cursor);
 
@@ -2422,9 +2432,15 @@ function normalizeRepositoryRef(repository: {
 function normalizeLabelNames(
   nodes: Array<{ name: string | null } | null>
 ): string[] {
-  return nodes
-    .flatMap((label) => (label?.name ? [label.name.toLowerCase()] : []))
-    .sort();
+  return normalizeLabels(nodes.map((label) => label?.name)).sort();
+}
+
+function trackerPaginationError(input: Record<string, unknown>): Error {
+  const event = { event: "tracker-pagination-integrity-failure", ...input };
+  console.error(JSON.stringify(event));
+  const error = new Error(`tracker_pagination: ${input.reason}`);
+  Object.assign(error, { category: "tracker_pagination", event });
+  return error;
 }
 
 async function resolveIssueProjectItemForStateLookup(

--- a/packages/tracker-github/src/tracker-github.test.ts
+++ b/packages/tracker-github/src/tracker-github.test.ts
@@ -732,6 +732,30 @@ describe("resolveTrackerAdapter", () => {
     expect(issue?.pullRequest).not.toHaveProperty("assignees");
   });
 
+  it("normalizes PullRequest Project item timestamps", () => {
+    const item = makePullRequestProjectItem({
+      itemId: "item-pr-normalized",
+      pullRequestId: "pr-normalized",
+      number: 8,
+      title: "Normalize pull request timestamps",
+      state: "Ready",
+      createdAt: "not-a-timestamp",
+      updatedAt: "2026-03-14t01:02:03+09:00",
+      itemUpdatedAt: "2026-03-13T00:00:00.000Z",
+    });
+
+    expect(
+      normalizeGithubProjectItem(
+        "project-123",
+        item,
+        DEFAULT_WORKFLOW_LIFECYCLE
+      )
+    ).toMatchObject({
+      createdAt: null,
+      updatedAt: "2026-03-13T16:02:03.000Z",
+    });
+  });
+
   it("preserves fork head repository metadata when normalizing PullRequest Project items", () => {
     // Checkout safety for fork PR subjects is enforced at the orchestrator layer.
     const issue = normalizeGithubProjectItem(
@@ -6126,6 +6150,9 @@ function makePullRequestProjectItem(input: {
   number: number;
   title: string;
   state?: string;
+  createdAt?: string | null;
+  updatedAt?: string | null;
+  itemUpdatedAt?: string | null;
   headRepository?: {
     name: string;
     url: string;
@@ -6134,7 +6161,7 @@ function makePullRequestProjectItem(input: {
 }) {
   return {
     id: input.itemId,
-    updatedAt: "2026-03-14T00:05:00.000Z",
+    updatedAt: input.itemUpdatedAt ?? "2026-03-14T00:05:00.000Z",
     fieldValues: {
       nodes: [
         {
@@ -6169,8 +6196,8 @@ function makePullRequestProjectItem(input: {
         url: "https://github.com/acme/platform",
         owner: { login: "acme" },
       },
-      createdAt: "2026-03-13T00:00:00.000Z",
-      updatedAt: "2026-03-14T00:00:00.000Z",
+      createdAt: input.createdAt ?? "2026-03-13T00:00:00.000Z",
+      updatedAt: input.updatedAt ?? "2026-03-14T00:00:00.000Z",
     },
   };
 }

--- a/packages/tracker-github/src/tracker-github.test.ts
+++ b/packages/tracker-github/src/tracker-github.test.ts
@@ -456,6 +456,83 @@ describe("resolveTrackerAdapter", () => {
     expect(issue?.metadata).toEqual({});
   });
 
+  it("normalizes GitHub labels and malformed timestamps", () => {
+    const item = makeProjectItem({
+      itemId: "item-normalized",
+      issueId: "issue-normalized",
+      number: 17,
+      title: "Normalized issue",
+      assignees: [],
+      labels: [" Ready ", "READY", "", "Bug"],
+    });
+    item.updatedAt = "2026-03-01T00:00:00.000Z";
+    item.content.createdAt = "not-a-timestamp";
+    item.content.updatedAt = "2026-03-14t01:02:03+09:00";
+
+    expect(
+      normalizeGithubProjectItem(
+        "project-123",
+        item,
+        DEFAULT_WORKFLOW_LIFECYCLE
+      )
+    ).toMatchObject({
+      labels: ["bug", "ready"],
+      createdAt: null,
+      updatedAt: "2026-03-13T16:02:03.000Z",
+    });
+  });
+
+  it("fails and emits a structured event when GitHub pagination loses its cursor", async () => {
+    const error = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    const adapter = resolveTrackerAdapter({
+      adapter: "github-project",
+      bindingId: "project-123",
+      settings: { projectId: "project-123" },
+    });
+
+    await expect(
+      adapter.listIssues(
+        {
+          projectId: "workspace-1",
+          slug: "workspace-1",
+          workspaceDir: "/tmp/workspace-1",
+          repository: {
+            owner: "acme",
+            name: "platform",
+            cloneUrl: "https://github.com/acme/platform.git",
+          },
+          tracker: {
+            adapter: "github-project",
+            bindingId: "project-123",
+            settings: { projectId: "project-123" },
+          },
+        },
+        {
+          token: "token",
+          fetchImpl: async () =>
+            makeJsonResponse({
+              data: {
+                node: {
+                  __typename: "ProjectV2",
+                  items: {
+                    nodes: [],
+                    pageInfo: { endCursor: null, hasNextPage: true },
+                  },
+                },
+              },
+            }),
+        }
+      )
+    ).rejects.toMatchObject({ category: "tracker_pagination" });
+
+    expect(JSON.parse(String(error.mock.calls[0]?.[0]))).toMatchObject({
+      event: "tracker-pagination-integrity-failure",
+      adapter: "github-project",
+    });
+  });
+
   it("skips and emits an event when a Project item omits the configured state field", () => {
     const item = makeProjectItem({
       itemId: "item-missing-state",

--- a/packages/tracker-linear/README.md
+++ b/packages/tracker-linear/README.md
@@ -2,6 +2,8 @@
 
 Linear tracker adapter for GitHub Symphony.
 
+Adapter profile note: labels are trimmed, lowercased, and deduplicated; timestamps are parsed to canonical ISO 8601 or `null`; Linear priority `0` (No priority) maps to `null`. Cursor integrity loss and max-page truncation fail with the `tracker_pagination` category and a structured integrity event.
+
 The MVP is read-side only: it polls Linear issues by `project.slugId` and
 workflow state names, normalizes them into `TrackedIssue`, and injects Linear
 context into worker environments.

--- a/packages/tracker-linear/src/orchestrator-adapter.ts
+++ b/packages/tracker-linear/src/orchestrator-adapter.ts
@@ -415,7 +415,7 @@ async function fetchPaginatedLinearIssues(
       });
     }
     after = connection?.pageInfo?.hasNextPage
-      ? connection.pageInfo.endCursor
+      ? (connection.pageInfo.endCursor ?? null)
       : null;
     if (!after) {
       break;

--- a/packages/tracker-linear/src/orchestrator-adapter.ts
+++ b/packages/tracker-linear/src/orchestrator-adapter.ts
@@ -8,6 +8,8 @@ import {
   type TrackedIssue,
   type TrackedIssueList,
   filterIssuesByPickupLabels,
+  normalizeLabels,
+  parseTrackerTimestamp,
 } from "@gh-symphony/core";
 
 export const DEFAULT_LINEAR_GRAPHQL_URL = CORE_DEFAULT_LINEAR_GRAPHQL_URL;
@@ -331,22 +333,20 @@ async function listLinearIssues(
   }
 
   const fetchedIssues = result.nodes.map((node) =>
-    normalizeLinearIssue(
-      project,
-      config.projectSlug,
-      node,
-      {
-        assignedOnly: config.assignedOnly,
-        rateLimits: result.rateLimits,
-        viewerId: result.viewerId,
-      }
-    )
+    normalizeLinearIssue(project, config.projectSlug, node, {
+      assignedOnly: config.assignedOnly,
+      rateLimits: result.rateLimits,
+      viewerId: result.viewerId,
+    })
   ) as TrackedIssueList;
   const blockerEligibleIssues = fetchedIssues.map((issue) =>
     applyBlockerDispatchability(issue, config)
   ) as TrackedIssueList;
   const issues = options.applyPickupLabels
-    ? (filterIssuesByPickupLabels(blockerEligibleIssues, project) as TrackedIssueList)
+    ? (filterIssuesByPickupLabels(
+        blockerEligibleIssues,
+        project
+      ) as TrackedIssueList)
     : blockerEligibleIssues;
   Object.defineProperty(issues, "rateLimits", {
     configurable: true,
@@ -358,11 +358,9 @@ async function listLinearIssues(
   if (config.assignedOnly) {
     emitDispatchableDerivedEvent({
       projectSlug: config.projectSlug,
-      dispatchableCount: issues.filter((issue) => issue.dispatchable)
+      dispatchableCount: issues.filter((issue) => issue.dispatchable).length,
+      nonDispatchableCount: issues.filter((issue) => !issue.dispatchable)
         .length,
-      nonDispatchableCount: issues.filter(
-        (issue) => !issue.dispatchable
-      ).length,
     });
   }
 
@@ -408,12 +406,29 @@ async function fetchPaginatedLinearIssues(
     const connection: LinearConnection<LinearIssueNode> | null | undefined =
       response.data.issues;
     issues.push(...(connection?.nodes ?? []));
+    if (connection?.pageInfo?.hasNextPage && !connection.pageInfo.endCursor) {
+      throw trackerPaginationError({
+        adapter: "linear",
+        projectSlug: input.projectSlug,
+        pageCount: page + 1,
+        reason: "hasNextPage=true but endCursor is null",
+      });
+    }
     after = connection?.pageInfo?.hasNextPage
-      ? (connection.pageInfo.endCursor ?? null)
+      ? connection.pageInfo.endCursor
       : null;
     if (!after) {
       break;
     }
+  }
+
+  if (after) {
+    throw trackerPaginationError({
+      adapter: "linear",
+      projectSlug: input.projectSlug,
+      pageCount: input.maxPages,
+      reason: `maximum page limit (${input.maxPages}) reached before pagination completed`,
+    });
   }
 
   return {
@@ -472,13 +487,16 @@ export function normalizeLinearIssue(
         : parseLinearIssueNumber(identifier),
     title: issue.title ?? identifier,
     description: issue.description ?? null,
-    priority: typeof issue.priority === "number" ? issue.priority : null,
+    priority:
+      typeof issue.priority === "number" && issue.priority !== 0
+        ? issue.priority
+        : null,
     state,
     branchName: null,
     url: issue.url ?? null,
-    labels: (issue.labels?.nodes ?? [])
-      .map((label) => label.name)
-      .filter((label): label is string => typeof label === "string"),
+    labels: normalizeLabels(
+      (issue.labels?.nodes ?? []).map((label) => label.name)
+    ),
     dispatchable:
       !options.assignedOnly ||
       (assigneeId !== null && assigneeId === options.viewerId),
@@ -493,8 +511,8 @@ export function normalizeLinearIssue(
             : null,
         state: relation.issue?.state?.name ?? null,
       })),
-    createdAt: issue.createdAt ?? null,
-    updatedAt: issue.updatedAt ?? null,
+    createdAt: parseTrackerTimestamp(issue.createdAt),
+    updatedAt: parseTrackerTimestamp(issue.updatedAt),
     repository: project.repository,
     tracker: {
       adapter: "linear",
@@ -505,6 +523,14 @@ export function normalizeLinearIssue(
     metadata: {},
     rateLimits: options.rateLimits ?? null,
   };
+}
+
+function trackerPaginationError(input: Record<string, unknown>): Error {
+  const event = { event: "tracker-pagination-integrity-failure", ...input };
+  console.error(JSON.stringify(event));
+  const error = new Error(`tracker_pagination: ${input.reason}`);
+  Object.assign(error, { category: "tracker_pagination", event });
+  return error;
 }
 
 function createLinearGraphqlClient(

--- a/packages/tracker-linear/src/tracker-linear.test.ts
+++ b/packages/tracker-linear/src/tracker-linear.test.ts
@@ -68,6 +68,25 @@ function linearIssueNode(
 }
 
 describe("linearTrackerAdapter", () => {
+  it("normalizes labels and timestamps and maps priority zero to null", () => {
+    const issue = normalizeLinearIssue(
+      makeProject(),
+      "project-slug",
+      linearIssueNode("ENG-1", [" Ready ", "READY", "", "Bug"], {
+        priority: 0,
+        createdAt: "not-a-timestamp",
+        updatedAt: "2026-05-01t01:02:03+09:00",
+      })
+    );
+
+    expect(issue).toMatchObject({
+      priority: null,
+      labels: ["ready", "bug"],
+      createdAt: null,
+      updatedAt: "2026-04-30T16:02:03.000Z",
+    });
+  });
+
   it("queries Linear by project slug and state names with cursor pagination", async () => {
     const fetchImpl = vi
       .fn()
@@ -185,7 +204,7 @@ describe("linearTrackerAdapter", () => {
     ]);
   });
 
-  it("limits pagination and supplies a per-page abort signal", async () => {
+  it("fails rather than truncating when pagination reaches maxPages", async () => {
     const fetchImpl = vi.fn().mockResolvedValue(
       jsonResponse({
         data: {
@@ -197,21 +216,53 @@ describe("linearTrackerAdapter", () => {
       })
     );
 
-    const issues = await linearTrackerAdapter.listIssues(
-      makeProject({
-        settings: {
-          projectSlug: "symphony-0c79b11b75ea",
-          activeStates: "Todo",
-          maxPages: 1,
-          pageTimeoutMs: 1_000,
-        },
-      }),
-      { fetchImpl, token: "linear-token" }
-    );
+    await expect(
+      linearTrackerAdapter.listIssues(
+        makeProject({
+          settings: {
+            projectSlug: "symphony-0c79b11b75ea",
+            activeStates: "Todo",
+            maxPages: 1,
+            pageTimeoutMs: 1_000,
+          },
+        }),
+        { fetchImpl, token: "linear-token" }
+      )
+    ).rejects.toMatchObject({
+      message:
+        "tracker_pagination: maximum page limit (1) reached before pagination completed",
+      category: "tracker_pagination",
+    });
 
-    expect(issues).toHaveLength(1);
     expect(fetchImpl).toHaveBeenCalledOnce();
     expect(fetchImpl.mock.calls[0]?.[1]?.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("fails and emits a structured event when Linear pagination loses its cursor", async () => {
+    const error = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonResponse({
+        data: {
+          issues: {
+            nodes: [],
+            pageInfo: { hasNextPage: true, endCursor: null },
+          },
+        },
+      })
+    );
+
+    await expect(
+      linearTrackerAdapter.listIssues(makeProject(), {
+        fetchImpl,
+        token: "linear-token",
+      })
+    ).rejects.toMatchObject({ category: "tracker_pagination" });
+    expect(JSON.parse(String(error.mock.calls[0]?.[0]))).toMatchObject({
+      event: "tracker-pagination-integrity-failure",
+      adapter: "linear",
+    });
   });
 
   it("keeps the per-page timeout active while reading the response body", async () => {
@@ -1107,7 +1158,10 @@ describe("linearTrackerAdapter", () => {
   });
 
   it("derives assignedOnly eligibility through the normalizer options object", () => {
-    const issue = normalizeLinearIssue(makeProject(), "project-slug", {
+    const issue = normalizeLinearIssue(
+      makeProject(),
+      "project-slug",
+      {
         id: "issue-1",
         identifier: "eng-123",
         state: { name: "Todo" },


### PR DESCRIPTION
## Issues — Closed #726

## TL;DR

GitHub and Linear tracker adapters now emit consistent label/timestamp metadata and reject incomplete pagination instead of silently returning partial issue lists.

## Change-point diagram

`GitHub / Linear API response` → `shared metadata normalization` → `tracked issue`

`malformed pagination` → `tracker_pagination` error + `tracker-pagination-integrity-failure` event

## Start here

- `packages/tracker-github/src/adapter.ts`
- `packages/tracker-linear/src/orchestrator-adapter.ts`
- Tracker adapter regression suites

## Changes

- Reuse core label and RFC 3339 timestamp normalization in both adapters.
- Map Linear priority `0` (No priority) to `null`.
- Fail on missing cursors; Linear also fails when its configured page cap would truncate results.
- Document the normalization and pagination policy in each adapter package profile note.

## Evidence

- `pnpm build`
- `pnpm lint`
- `pnpm test`
- `pnpm typecheck`
- `./e2e/run-e2e.sh happy 60`
- `pnpm --filter @gh-symphony/tracker-github test -- tracker-github.test.ts`
- Rework commit: `94cb49f`.

## Risks & rollback

- Provider pagination corruption now interrupts polling rather than returning a partial list; this is intentional integrity protection.
- Revert this PR to restore prior behavior.

## Changed files

- `packages/tracker-github/src/adapter.ts` and tests
- `packages/tracker-linear/src/orchestrator-adapter.ts` and tests
- Adapter package profile notes and CLI patch changeset

## Post-merge / human validation

- [ ] Confirm a provider cursor-integrity error is visible in deployment logs with its structured event.
- [ ] Confirm normal GitHub and Linear polling continues with provider credentials.
