### PR TITLE
fix(orchestrator): sort candidates by parsed timestamps

### DIFF
--- a/.changeset/sorted-orcas-prove.md
+++ b/.changeset/sorted-orcas-prove.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Correct dispatch ordering for equal-priority candidates whose creation timestamps use different timezone offsets. (#727)

--- a/packages/orchestrator/src/dispatch.test.ts
+++ b/packages/orchestrator/src/dispatch.test.ts
@@ -179,7 +179,8 @@ describe("sortCandidatesForDispatch", () => {
     ]);
   });
 
-  it("orders explicit tracker priority values before null priorities", () => {
+  // #725 documents this repository-local numeric priority mapping.
+  it("orders explicit tracker priority values per ADR 2026-08-28 before null priorities", () => {
     const sorted = sortCandidatesForDispatch([
       makeIssue({ identifier: "acme/repo#null", priority: null }),
       makeIssue({ identifier: "acme/repo#high", priority: 1 }),
@@ -195,23 +196,31 @@ describe("sortCandidatesForDispatch", () => {
     ]);
   });
 
-  it("breaks ties by createdAt oldest first", () => {
+  it("breaks ties by parsed createdAt instant, with null timestamps last", () => {
     const sorted = sortCandidatesForDispatch([
       makeIssue({
-        identifier: "acme/repo#2",
+        identifier: "acme/repo#null",
         priority: 1,
-        createdAt: "2026-03-09T00:00:00.000Z",
+        createdAt: null,
       }),
       makeIssue({
-        identifier: "acme/repo#1",
+        identifier: "acme/repo#later",
         priority: 1,
         createdAt: "2026-03-08T00:00:00.000Z",
+      }),
+      makeIssue({
+        identifier: "acme/repo#older",
+        priority: 1,
+        // This is 2026-03-07T23:30:00.000Z, despite sorting after the
+        // `Z` timestamp lexicographically.
+        createdAt: "2026-03-08T00:30:00.000+01:00",
       }),
     ]);
 
     expect(sorted.map((issue) => issue.identifier)).toEqual([
-      "acme/repo#1",
-      "acme/repo#2",
+      "acme/repo#older",
+      "acme/repo#later",
+      "acme/repo#null",
     ]);
   });
 

--- a/packages/orchestrator/src/dispatch.test.ts
+++ b/packages/orchestrator/src/dispatch.test.ts
@@ -196,12 +196,24 @@ describe("sortCandidatesForDispatch", () => {
     ]);
   });
 
-  it("breaks ties by parsed createdAt instant, with null timestamps last", () => {
+  it("breaks ties by parsed RFC 3339 createdAt instant, with invalid timestamps last", () => {
     const sorted = sortCandidatesForDispatch([
       makeIssue({
         identifier: "acme/repo#null",
         priority: 1,
         createdAt: null,
+      }),
+      makeIssue({
+        identifier: "acme/repo#invalid",
+        priority: 1,
+        createdAt: "not-a-date",
+      }),
+      makeIssue({
+        identifier: "acme/repo#local",
+        priority: 1,
+        // Offset-free timestamps are not RFC 3339 instants and must not be
+        // interpreted using the host timezone. They join the null bucket.
+        createdAt: "2026-03-08T00:00:00",
       }),
       makeIssue({
         identifier: "acme/repo#later",
@@ -220,6 +232,8 @@ describe("sortCandidatesForDispatch", () => {
     expect(sorted.map((issue) => issue.identifier)).toEqual([
       "acme/repo#older",
       "acme/repo#later",
+      "acme/repo#invalid",
+      "acme/repo#local",
       "acme/repo#null",
     ]);
   });

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -26,6 +26,7 @@ import {
   matchesWorkflowState,
   isOrchestratorChannelEvent,
   mapIssueOrchestrationStateToStatus,
+  parseTrackerTimestamp,
   readEnvFile,
   renderPrompt,
   resolveWorkflowExecutionPhase,
@@ -6161,30 +6162,36 @@ export function createStore(
 export function sortCandidatesForDispatch(
   candidates: TrackedIssue[]
 ): TrackedIssue[] {
-  return [...candidates].sort((a, b) => {
-    // 1. Priority ascending (null last). See
-    // docs/adr/2026-08-28_priority-mapping-documented-different-mapping.md
-    // (#725).
-    if (a.priority !== b.priority) {
-      if (a.priority === null) return 1;
-      if (b.priority === null) return -1;
-      return a.priority - b.priority;
-    }
-    // 2. createdAt oldest first (null or invalid timestamps last). Compare
-    // parsed instants rather than ISO strings so timezone offsets are ordered
-    // chronologically.
-    const aCreatedAt = a.createdAt === null ? null : Date.parse(a.createdAt);
-    const bCreatedAt = b.createdAt === null ? null : Date.parse(b.createdAt);
-    const aCreatedAtMillis = Number.isNaN(aCreatedAt) ? null : aCreatedAt;
-    const bCreatedAtMillis = Number.isNaN(bCreatedAt) ? null : bCreatedAt;
-    if (aCreatedAtMillis !== bCreatedAtMillis) {
-      if (aCreatedAtMillis === null) return 1;
-      if (bCreatedAtMillis === null) return -1;
-      return aCreatedAtMillis - bCreatedAtMillis;
-    }
-    // 3. identifier lexicographic
-    return a.identifier.localeCompare(b.identifier);
-  });
+  return candidates
+    .map((issue) => ({
+      issue,
+      createdAt: parseTrackerTimestamp(issue.createdAt),
+    }))
+    .sort((a, b) => {
+      const { issue: aIssue, createdAt: aCreatedAt } = a;
+      const { issue: bIssue, createdAt: bCreatedAt } = b;
+
+      // 1. Priority ascending (null last). See
+      // docs/adr/2026-08-28_priority-mapping-documented-different-mapping.md
+      // (#725).
+      if (aIssue.priority !== bIssue.priority) {
+        if (aIssue.priority === null) return 1;
+        if (bIssue.priority === null) return -1;
+        return aIssue.priority - bIssue.priority;
+      }
+      // 2. createdAt oldest first (null or invalid timestamps last). The core
+      // parser accepts RFC 3339 instants only and produces fixed-width UTC ISO
+      // keys, so comparing these precomputed keys is chronological and host
+      // timezone-independent.
+      if (aCreatedAt !== bCreatedAt) {
+        if (aCreatedAt === null) return 1;
+        if (bCreatedAt === null) return -1;
+        return aCreatedAt.localeCompare(bCreatedAt);
+      }
+      // 3. identifier lexicographic
+      return aIssue.identifier.localeCompare(bIssue.identifier);
+    })
+    .map(({ issue }) => issue);
 }
 
 function createProjectItemsCache(): ProjectItemsCache {

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -6162,17 +6162,25 @@ export function sortCandidatesForDispatch(
   candidates: TrackedIssue[]
 ): TrackedIssue[] {
   return [...candidates].sort((a, b) => {
-    // 1. Priority ascending (null last)
+    // 1. Priority ascending (null last). See
+    // docs/adr/2026-08-28_priority-mapping-documented-different-mapping.md
+    // (#725).
     if (a.priority !== b.priority) {
       if (a.priority === null) return 1;
       if (b.priority === null) return -1;
       return a.priority - b.priority;
     }
-    // 2. createdAt oldest first (null last)
-    if (a.createdAt !== b.createdAt) {
-      if (a.createdAt === null) return 1;
-      if (b.createdAt === null) return -1;
-      return a.createdAt < b.createdAt ? -1 : 1;
+    // 2. createdAt oldest first (null or invalid timestamps last). Compare
+    // parsed instants rather than ISO strings so timezone offsets are ordered
+    // chronologically.
+    const aCreatedAt = a.createdAt === null ? null : Date.parse(a.createdAt);
+    const bCreatedAt = b.createdAt === null ? null : Date.parse(b.createdAt);
+    const aCreatedAtMillis = Number.isNaN(aCreatedAt) ? null : aCreatedAt;
+    const bCreatedAtMillis = Number.isNaN(bCreatedAt) ? null : bCreatedAt;
+    if (aCreatedAtMillis !== bCreatedAtMillis) {
+      if (aCreatedAtMillis === null) return 1;
+      if (bCreatedAtMillis === null) return -1;
+      return aCreatedAtMillis - bCreatedAtMillis;
     }
     // 3. identifier lexicographic
     return a.identifier.localeCompare(b.identifier);


### PR DESCRIPTION
## Issues — Closed #727

## TL;DR

Dispatch candidates with equal priority now use one normalized RFC 3339 creation-time key per candidate, preserving chronological ordering across timezone offsets and deterministic null handling.

## Change-point diagram

`priority (numeric ascending; null last)` → `createdAt (normalized RFC 3339 instant, oldest; invalid/null last)` → `identifier (lexicographic)`

## Start here

- `packages/orchestrator/src/service.ts` precomputes `parseTrackerTimestamp` keys and retains the documented #725 priority ordering.
- `packages/orchestrator/src/dispatch.test.ts` covers timezone offsets, invalid input, offset-free input, nulls, and identifier tie-breaking.

## Changes

- Replaced host-timezone-dependent `Date.parse` ordering with core `parseTrackerTimestamp` normalization.
- Added regression fixtures for `not-a-date` and offset-free timestamps; both join the null/invalid bucket and resolve by identifier.
- Preserved numeric priority ascending (null last), as documented by ADR 2026-08-28 / #725.
- Retained the existing `@gh-symphony/cli` patch changeset.

## Evidence

- `pnpm --filter @gh-symphony/orchestrator test -- --run src/dispatch.test.ts` — 37 passed
- `pnpm lint` — passed
- `pnpm test` — passed
- `pnpm typecheck` — passed
- `pnpm build` — passed
- `./e2e/run-e2e.sh happy 60` — passed

## Risks & rollback

- Low risk: only equal-priority tie-breaking changes, correcting timezone-dependent ordering for malformed tracker values.
- Rollback: revert `945598af` and `5493ebca`.

## Changed files

- `packages/orchestrator/src/service.ts`
- `packages/orchestrator/src/dispatch.test.ts`
- `.changeset/sorted-orcas-prove.md`

## Post-merge / human validation

- [ ] Observe a normal orchestration dispatch and confirm equal-priority candidates use oldest RFC 3339 creation instants.

## Human validation

- [ ] Confirm reviewer-visible behavior matches the issue requirements.
