### PR TITLE
fix(worker): restore host tool rate-limit updates

### DIFF
--- a/.changeset/bright-tools-guard.md
+++ b/.changeset/bright-tools-guard.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Restore host-side dynamic-tool GitHub rate-limit protection and publish tool rate-limit updates to worker observability (#744).

--- a/packages/worker/src/host-dynamic-tool-call.test.ts
+++ b/packages/worker/src/host-dynamic-tool-call.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from "vitest";
+import { executeRateLimitedCodexDynamicToolCall } from "./host-dynamic-tool-call.js";
+
+describe("executeRateLimitedCodexDynamicToolCall", () => {
+  it("returns a structured tool error when the GitHub guard rejects", async () => {
+    const execute = vi.fn();
+
+    await expect(
+      executeRateLimitedCodexDynamicToolCall({
+        toolName: "github_graphql",
+        rateLimits: {
+          source: "github",
+          resource: "graphql",
+          remaining: 0,
+          resetAt: "2099-01-01T00:00:00.000Z",
+        },
+        execute,
+      })
+    ).resolves.toEqual({
+      success: false,
+      contentItems: [
+        {
+          type: "inputText",
+          text: expect.stringContaining('"code":"rate_limit_guard"'),
+        },
+      ],
+    });
+    expect(execute).not.toHaveBeenCalled();
+  });
+});

--- a/packages/worker/src/host-dynamic-tool-call.ts
+++ b/packages/worker/src/host-dynamic-tool-call.ts
@@ -1,0 +1,33 @@
+import type { CodexDynamicToolCallResponse } from "./codex-dynamic-tools.js";
+import { guardDynamicToolRateLimit } from "./tool-rate-limit.js";
+
+export async function executeRateLimitedCodexDynamicToolCall(options: {
+  toolName: string;
+  rateLimits: Record<string, unknown> | null;
+  execute: () => Promise<CodexDynamicToolCallResponse>;
+}): Promise<CodexDynamicToolCallResponse> {
+  try {
+    await guardDynamicToolRateLimit(options.toolName, options.rateLimits);
+    return await options.execute();
+  } catch (error) {
+    return failure(
+      "rate_limit_guard",
+      error instanceof Error ? error.message : String(error)
+    );
+  }
+}
+
+function failure(
+  code: string,
+  message: string
+): CodexDynamicToolCallResponse {
+  return {
+    success: false,
+    contentItems: [
+      {
+        type: "inputText",
+        text: JSON.stringify({ error: { code, message } }),
+      },
+    ],
+  };
+}

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -79,6 +79,10 @@ import {
   executeCodexDynamicToolCall,
 } from "./codex-dynamic-tools.js";
 import {
+  extractToolRateLimitPayload,
+  guardDynamicToolRateLimit,
+} from "./tool-rate-limit.js";
+import {
   buildCodexDynamicToolsParams,
   buildCodexInitializeParams,
 } from "./codex-initialize.js";
@@ -1516,15 +1520,33 @@ async function runCodexClientProtocol(
       process.stderr.write(
         `[worker] executing host dynamic tool "${toolName}" (callId=${callId})\n`
       );
-      void executeCodexDynamicToolCall(
+      void guardDynamicToolRateLimit(
         toolName,
-        params?.arguments,
-        createTrackerToolContext(env),
-        env,
-        {},
-        plan.dynamicTools.map((tool) => tool.name)
+        runtimeState.agentGitHubRateLimits ?? runtimeState.rateLimits
       )
+        .then(() =>
+          executeCodexDynamicToolCall(
+            toolName,
+            params?.arguments,
+            createTrackerToolContext(env),
+            env,
+            {},
+            plan.dynamicTools.map((tool) => tool.name)
+          )
+        )
         .then((result) => {
+          const toolRateLimits = extractToolRateLimitPayload(
+            result.contentItems.find((item) => item.type === "inputText")
+              ?.text ?? ""
+          );
+          if (toolRateLimits) {
+            applyRateLimitUpdate(
+              `tool.${toolName}`,
+              toolRateLimits,
+              "agent-tool"
+            );
+            emitOrchestratorChannelEvent("agent.rateLimit");
+          }
           sendMessage({ jsonrpc: "2.0", id: msg.id, result });
           runtimeState.lastEventAt = new Date().toISOString();
         })

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -80,8 +80,8 @@ import {
 } from "./codex-dynamic-tools.js";
 import {
   extractToolRateLimitPayload,
-  guardDynamicToolRateLimit,
 } from "./tool-rate-limit.js";
+import { executeRateLimitedCodexDynamicToolCall } from "./host-dynamic-tool-call.js";
 import {
   buildCodexDynamicToolsParams,
   buildCodexInitializeParams,
@@ -1520,11 +1520,10 @@ async function runCodexClientProtocol(
       process.stderr.write(
         `[worker] executing host dynamic tool "${toolName}" (callId=${callId})\n`
       );
-      void guardDynamicToolRateLimit(
+      void executeRateLimitedCodexDynamicToolCall({
         toolName,
-        runtimeState.agentGitHubRateLimits ?? runtimeState.rateLimits
-      )
-        .then(() =>
+        rateLimits: runtimeState.agentGitHubRateLimits ?? runtimeState.rateLimits,
+        execute: () =>
           executeCodexDynamicToolCall(
             toolName,
             params?.arguments,
@@ -1532,12 +1531,11 @@ async function runCodexClientProtocol(
             env,
             {},
             plan.dynamicTools.map((tool) => tool.name)
-          )
-        )
+          ),
+      })
         .then((result) => {
           const toolRateLimits = extractToolRateLimitPayload(
-            result.contentItems.find((item) => item.type === "inputText")
-              ?.text ?? ""
+            result.contentItems[0]?.text ?? ""
           );
           if (toolRateLimits) {
             applyRateLimitUpdate(

--- a/packages/worker/src/worker-protocol.test.ts
+++ b/packages/worker/src/worker-protocol.test.ts
@@ -29,6 +29,10 @@ import {
   createTrackerToolContext,
   executeCodexDynamicToolCall,
 } from "./codex-dynamic-tools.js";
+import {
+  extractToolRateLimitPayload,
+  guardDynamicToolRateLimit,
+} from "./tool-rate-limit.js";
 
 const TEST_DYNAMIC_TOOLS = [
   {
@@ -180,6 +184,7 @@ function createProtocolContext(options: {
     tokenUsage: { ...tokenUsageBaseline },
     lastEventAt: null as string | null,
     rateLimits: null as Record<string, unknown> | null,
+    agentGitHubRateLimits: null as Record<string, unknown> | null,
     sessionInfo: {
       threadId: "thread-1" as string | null,
       turnId: "turn-1" as string | null,
@@ -207,12 +212,19 @@ function createProtocolContext(options: {
 
   function applyRateLimitUpdate(
     source: string,
-    rateLimits: Record<string, unknown>
+    rateLimits: Record<string, unknown>,
+    runtimeSource = "codex"
   ): void {
     runtimeState.rateLimits = {
       ...rateLimits,
-      source: "codex",
+      source:
+        typeof rateLimits.source === "string"
+          ? rateLimits.source
+          : runtimeSource,
     };
+    if (runtimeState.rateLimits.source === "github") {
+      runtimeState.agentGitHubRateLimits = runtimeState.rateLimits;
+    }
     logs.push(
       `[worker] rate_limits source=${source} payload=${JSON.stringify(runtimeState.rateLimits)}`
     );
@@ -923,15 +935,33 @@ function createProtocolContext(options: {
       runtimeState.lastEventAt = new Date().toISOString();
       const params = msg.params as Record<string, unknown> | undefined;
       const toolName = typeof params?.tool === "string" ? params.tool : "";
-      void executeCodexDynamicToolCall(
+      void guardDynamicToolRateLimit(
         toolName,
-        params?.arguments,
-        createTrackerToolContext(TEST_TOOL_ENV),
-        TEST_TOOL_ENV,
-        {},
-        TEST_DYNAMIC_TOOLS.map((tool) => tool.name)
+        runtimeState.agentGitHubRateLimits ?? runtimeState.rateLimits
       )
+        .then(() =>
+          executeCodexDynamicToolCall(
+            toolName,
+            params?.arguments,
+            createTrackerToolContext(TEST_TOOL_ENV),
+            TEST_TOOL_ENV,
+            {},
+            TEST_DYNAMIC_TOOLS.map((tool) => tool.name)
+          )
+        )
         .then((result) => {
+          const toolRateLimits = extractToolRateLimitPayload(
+            result.contentItems.find((item) => item.type === "inputText")
+              ?.text ?? ""
+          );
+          if (toolRateLimits) {
+            applyRateLimitUpdate(
+              `tool.${toolName}`,
+              toolRateLimits,
+              "agent-tool"
+            );
+            emitOrchestratorChannelEvent("agent.rateLimit");
+          }
           sendMessage({ jsonrpc: "2.0", id: msg.id, result });
           runtimeState.lastEventAt = new Date().toISOString();
         })
@@ -1679,7 +1709,7 @@ describe("rate-limit telemetry", () => {
     });
 
     expect(ctx.runtimeState.rateLimits).toEqual({
-      source: "codex",
+      source: "upstream",
       remaining: 42,
       resetAt: "2026-03-08T00:30:00.000Z",
     });
@@ -2703,9 +2733,28 @@ describe("token usage tracking", () => {
 describe("lastEventAt timestamp tracking", () => {
   it("responds to a host dynamic tool call and records tool activity", async () => {
     const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify({ data: { viewer: { login: "octo" } } }), {
-        status: 200,
-      })
+      new Response(
+        JSON.stringify({
+          data: {
+            viewer: { login: "octo" },
+            __ghSymphonyRateLimit: {
+              cost: 3,
+              remaining: 4_997,
+              resetAt: "2026-08-29T10:00:00.000Z",
+            },
+          },
+        }),
+        {
+          status: 200,
+          headers: {
+            "x-ratelimit-limit": "5000",
+            "x-ratelimit-remaining": "4997",
+            "x-ratelimit-used": "3",
+            "x-ratelimit-reset": "1787997600",
+            "x-ratelimit-resource": "graphql",
+          },
+        }
+      )
     );
     const ctx = createProtocolContext({});
 
@@ -2736,6 +2785,21 @@ describe("lastEventAt timestamp tracking", () => {
       });
     });
     expect(ctx.runtimeState.lastEventAt).not.toBeNull();
+    expect(ctx.runtimeState.rateLimits).toMatchObject({
+      source: "github",
+      resource: "graphql",
+      remaining: 4_997,
+      cost: 3,
+    });
+    expect(ctx.orchestratorEvents).toContainEqual(
+      expect.objectContaining({
+        event: "agent.rateLimit",
+        rateLimits: expect.objectContaining({
+          source: "github",
+          remaining: 4_997,
+        }),
+      })
+    );
     expect(fetchSpy).toHaveBeenCalledWith(
       "https://api.github.com/graphql",
       expect.objectContaining({


### PR DESCRIPTION
## Issues — Closed #744

## TL;DR

Restores host-side GitHub dynamic-tool rate-limit protection and publishes tool `rateLimits` to worker/orchestrator observability. A rejected rate-limit guard now returns an immediate structured JSON-RPC tool error instead of leaving the Codex turn waiting for its timeout.

## Change-point diagram

`item/tool/call` → guard saved GitHub budget → execute host-side tool → apply `rateLimits` → `agent.rateLimit` event
                    └→ rejected guard → structured `rate_limit_guard` response

## Start here

- `packages/worker/src/index.ts` invokes the rate-limited production call boundary and publishes response-derived telemetry.
- `packages/worker/src/host-dynamic-tool-call.ts` converts guard rejection into the tool-error envelope sent by the JSON-RPC handler.
- `packages/worker/src/host-dynamic-tool-call.test.ts` proves exhausted GitHub budget blocks execution and returns that envelope.

## Risks & rollback

- Risk: malformed tool payloads may omit rate-limit data; telemetry remains conditional without affecting a successful tool response.
- Rollback: revert this PR to restore the current host-side behavior.

## Changed files

- `packages/worker/src/index.ts`
- `packages/worker/src/host-dynamic-tool-call.ts`
- `packages/worker/src/host-dynamic-tool-call.test.ts`
- `packages/worker/src/worker-protocol.test.ts`
- `.changeset/bright-tools-guard.md`

## Evidence

- `pnpm --filter @gh-symphony/worker test -- host-dynamic-tool-call.test.ts tool-rate-limit.test.ts worker-protocol.test.ts` (67 passed)
- `pnpm lint && pnpm test && pnpm typecheck && pnpm build`
- Docker: `docker compose --project-name symphony-e2e-744 -f docker-compose.e2e.yml exec -T symphony-e2e node /app/e2e/host-dynamic-tool-e2e.mjs` (`host_dynamic_tool_e2e=pass`)

## Scope boundary

Claude host MCP has a separate execution path and is not part of the Codex `item/tool/call` regression fixed by #744. Its rate-limit parity is intentionally not expanded into this patch.

## Post-merge / human validation

- [ ] Exercise a host-side GitHub tool call and verify its rate-limit event appears in worker/orchestrator telemetry.

## Human Validation

- [ ] Confirm a rejected GitHub rate-limit guard returns a tool error promptly rather than stalling the turn.
- [ ] Confirm host-side tool behavior is unchanged apart from rate-limit protection and telemetry.
- [ ] Confirm rate-limit data reaches worker status/event consumers.
