### PR TITLE
feat(cli): support workflow server port

### DIFF
--- a/.changeset/server-port-frontmatter.md
+++ b/.changeset/server-port-frontmatter.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Support `server.port` workflow configuration and the `--port` HTTP CLI alias for #751.

--- a/README.md
+++ b/README.md
@@ -932,6 +932,7 @@ The orchestrator runs independently as long as the repository has been initializ
 gh-symphony repo start                    # continuous polling
 gh-symphony repo start --once             # run startup cleanup + one poll/reconcile/dispatch tick
 gh-symphony repo start --http             # continuous polling + JSON status API on 127.0.0.1:4680
+gh-symphony repo start --port 4800        # preferred alias for --http with an explicit port
 gh-symphony repo start --once --http      # keep the JSON status API available after the one-shot tick until Ctrl+C
 gh-symphony repo start --web              # continuous polling + browser dashboard on 127.0.0.1:4680
 gh-symphony repo run beta/api#42          # dispatch a single issue
@@ -958,7 +959,7 @@ Runtime state lives under `.runtime/orchestrator/`:
 
 Read orchestration state via the status API (`/api/v1/state`) rather than reading status files directly.
 
-Run `gh-symphony doctor --smoke` before the first `start --once` when you want a safe pre-dispatch readiness check. `gh-symphony repo start --once` is the first production-like run: it validates the real GitHub Project binding, repository `WORKFLOW.md`, and dispatch eligibility, then performs one poll/reconcile/dispatch tick instead of starting a long-lived poller. Add `--http` when you want the JSON status API available; with `--once --http`, the one-shot tick still completes, but the HTTP server stays up afterward and the process keeps the project lock until you stop it with `Ctrl+C`. Add `--web` instead when you want the browser dashboard at `/` plus the JSON API.
+Run `gh-symphony doctor --smoke` before the first `start --once` when you want a safe pre-dispatch readiness check. `gh-symphony repo start --once` is the first production-like run: it validates the real GitHub Project binding, repository `WORKFLOW.md`, and dispatch eligibility, then performs one poll/reconcile/dispatch tick instead of starting a long-lived poller. Add `--port [port]` when you want the JSON status API available; `--http [port]` remains a supported alias. With `--once --port`, the one-shot tick still completes, but the HTTP server stays up afterward and the process keeps the project lock until you stop it with `Ctrl+C`. `server.port` in `WORKFLOW.md` enables the same API when no CLI port is supplied. Add `--web` instead when you want the browser dashboard at `/` plus the JSON API.
 
 ## Verification
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -34,6 +34,9 @@ touches a layer, check that its slice (and the linked documents) still holds.
 ### 2. Configuration — typed parsing and validation
 
 - `WORKFLOW.md` front matter parsing and validation: `packages/core/src/workflow/`
+- Workflow `server.port` configuration and the `repo start --port` / `--http`
+  status-API options: `packages/core/src/workflow/`,
+  `packages/cli/src/commands/start.ts`
 - Shared lifecycle state normalization and execution-phase classification: `packages/core/src/workflow/lifecycle.ts`
 - Layered MCP composition (`.mcp.json` sidecar): `packages/core/src/runtime/mcp-compose.ts` + each runtime adapter. Claude's worker starts the selected provider tool as a loopback HTTP/SSE MCP service; its generated `mcp.json` contains the service URL and an ephemeral session capability, never adapter credentials.
 - CLI global/project config, discoverable repo/standalone runtime command options,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -115,9 +115,10 @@ same map remain effective.
 Set `server.port` in `WORKFLOW.md` to enable the HTTP status API on that port.
 `0` requests an ephemeral port. `gh-symphony repo start --port [port]` is the
 preferred CLI form and overrides `server.port`; `--http [port]` remains a
-supported alias. A configured or CLI-requested port fails startup when it is
-already occupied, while the internal listener uses an automatic port only when
-neither setting is present.
+supported alias. A configured or explicit CLI port fails startup when it is
+already occupied. A bare `--port` or `--http` keeps the legacy default-port
+auto-increment behavior, while omitting both options and `server.port` uses an
+ephemeral internal listener.
 
 `tracker.required_labels` defaults to `[]`. Labels are compared after trimming
 and lowercasing; every configured label must be present before an issue can be

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -91,6 +91,7 @@ strict parser as workflow loading. Failures include a stable error code; the
 | `codex.command`           | A non-empty string when provided                                                                                           | `workflow_validation_error` at `codex.command`                                |
 | `tracker.kind`            | One of `github-project`, `linear`, or `file`                                                                               | `workflow_validation_error` at `tracker.kind`                                 |
 | `tracker.required_labels` | An array of strings; comma-separated strings are rejected                                                                  | `workflow_validation_error` at `tracker.required_labels`                      |
+| `server.port`             | An integer from `0` to `65535`; `0` requests an ephemeral local port                                                       | `workflow_validation_error` at `server.port`                                  |
 
 Without front matter, the complete trimmed file is used as the workflow prompt
 and all configuration uses defaults; tracker selection is then checked by the
@@ -108,6 +109,15 @@ are trimmed and lowercased before storage and dispatch lookup, so for example
 `" In Progress "` and `in progress` configure the same limit. Entries whose
 values are non-positive or not YAML integers are ignored; valid entries in the
 same map remain effective.
+
+## Optional HTTP Server
+
+Set `server.port` in `WORKFLOW.md` to enable the HTTP status API on that port.
+`0` requests an ephemeral port. `gh-symphony repo start --port [port]` is the
+preferred CLI form and overrides `server.port`; `--http [port]` remains a
+supported alias. A configured or CLI-requested port fails startup when it is
+already occupied, while the internal listener uses an automatic port only when
+neither setting is present.
 
 `tracker.required_labels` defaults to `[]`. Labels are compared after trimming
 and lowercasing; every configured label must be present before an issue can be

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -356,7 +356,7 @@ gh-symphony repo start --daemon          # Start in background
 gh-symphony repo stop                    # Stop the daemon
 ```
 
-Run `doctor --smoke` before the first `start --once` when you want a safe pre-dispatch readiness check. Use `start --once` for the first real managed-project run or a CI smoke check. It reuses the configured GitHub Project binding and `WORKFLOW.md` and performs exactly one poll/reconcile/dispatch cycle instead of entering the long-running orchestration loop. `--daemon --once` is rejected because the modes conflict. If you add `--http`, the dashboard/API remains available after that one-shot tick completes, and the process stays up until you interrupt it with `Ctrl+C`.
+Run `doctor --smoke` before the first `start --once` when you want a safe pre-dispatch readiness check. Use `start --once` for the first real managed-project run or a CI smoke check. It reuses the configured GitHub Project binding and `WORKFLOW.md` and performs exactly one poll/reconcile/dispatch cycle instead of entering the long-running orchestration loop. `--daemon --once` is rejected because the modes conflict. Add `--port [port]` to enable the JSON status API; `--http [port]` remains an alias, and `server.port` in `WORKFLOW.md` applies when neither CLI option is present.
 
 ### Monitor
 

--- a/packages/cli/src/commands/start.test.ts
+++ b/packages/cli/src/commands/start.test.ts
@@ -3,6 +3,7 @@ import { EventEmitter } from "node:events";
 import { mkdtemp, mkdir, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { CliProjectConfig } from "../config.js";
 import * as configModule from "../config.js";
@@ -1947,6 +1948,66 @@ Handle {{issue.identifier}}.\n`,
     expect(exitSpy).toHaveBeenCalledWith(0);
   });
 
+  it.each(["--http", "--port"])(
+    "uses server.port in preference to a bare %s option",
+    async (option) => {
+      const configDir = await createConfigFixture({
+        activeProject: "tenant-a",
+        projects: [createProject("tenant-a", "acme", "platform")],
+      });
+      const probe = createServer();
+      await new Promise<void>((resolve) =>
+        probe.listen(0, "127.0.0.1", () => resolve())
+      );
+      const address = probe.address();
+      if (!address || typeof address === "string") {
+        probe.close();
+        throw new Error("Expected TCP address");
+      }
+      await new Promise<void>((resolve, reject) =>
+        probe.close((error) => (error ? reject(error) : resolve()))
+      );
+      await configureWorkflow(configDir, address.port);
+      acquireProjectLock.mockResolvedValue({
+        lockPath: join(configDir, ".lock"),
+        ownerToken: "owner",
+        pid: 1234,
+        startedAt: "2026-03-17T00:00:00.000Z",
+      });
+      let resolveRun: (() => void) | undefined;
+      run.mockImplementation(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveRun = resolve;
+          })
+      );
+      shutdown.mockImplementation(async () => {
+        resolveRun?.();
+      });
+      const exitSpy = vi
+        .spyOn(process, "exit")
+        .mockImplementation(
+          ((_code?: number) => undefined) as (code?: number) => never
+        );
+      const stdout = captureWrites(process.stdout);
+
+      try {
+        const startPromise = startModule.default(
+          [option],
+          baseOptions(configDir)
+        );
+        const url = await waitForHttpUrl(stdout.output);
+        expect(new URL(url).port).toBe(String(address.port));
+        process.emit("SIGINT");
+        await startPromise;
+      } finally {
+        stdout.restore();
+      }
+
+      expect(exitSpy).toHaveBeenCalledWith(0);
+    }
+  );
+
   it("reads server.port from a legacy repository workflow fallback", async () => {
     const configDir = await createConfigFixture({
       activeProject: "tenant-a",
@@ -1999,6 +2060,30 @@ Handle {{issue.identifier}}.\n`,
       stdout.restore();
     }
 
+    expect(exitSpy).toHaveBeenCalledWith(0);
+  });
+
+  it("continues when an implicit legacy workflow is invalid", async () => {
+    const configDir = await createConfigFixture({
+      activeProject: "tenant-a",
+      projects: [createProject("tenant-a", "acme", "platform")],
+    });
+    await configureInvalidLegacyWorkflow(configDir);
+    acquireProjectLock.mockResolvedValue({
+      lockPath: join(configDir, ".lock"),
+      ownerToken: "owner",
+      pid: 1234,
+      startedAt: "2026-03-17T00:00:00.000Z",
+    });
+    const exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation(
+        ((_code?: number) => undefined) as (code?: number) => never
+      );
+
+    await startModule.default(["--once"], baseOptions(configDir));
+
+    expect(run).toHaveBeenCalledOnce();
     expect(exitSpy).toHaveBeenCalledWith(0);
   });
 
@@ -2287,7 +2372,7 @@ async function configureLegacyWorkflow(
     await readFile(projectPath, "utf8")
   ) as CliProjectConfig;
   const repositoryDir = join(configDir, "legacy-repository");
-  project.repositoryDir = repositoryDir;
+  project.repository.cloneUrl = pathToFileURL(repositoryDir).href;
   project.workflowSource = { type: "repo" };
   await mkdir(repositoryDir, { recursive: true });
   await writeFile(projectPath, JSON.stringify(project), "utf8");
@@ -2302,6 +2387,25 @@ codex:
   command: codex app-server
 ---
 Prompt\n`,
+    "utf8"
+  );
+}
+
+async function configureInvalidLegacyWorkflow(
+  configDir: string
+): Promise<void> {
+  const projectPath = join(configDir, "projects", "tenant-a", "project.json");
+  const project = JSON.parse(
+    await readFile(projectPath, "utf8")
+  ) as CliProjectConfig;
+  const repositoryDir = join(configDir, "invalid-legacy-repository");
+  project.repository.cloneUrl = pathToFileURL(repositoryDir).href;
+  project.workflowSource = { type: "repo" };
+  await mkdir(repositoryDir, { recursive: true });
+  await writeFile(projectPath, JSON.stringify(project), "utf8");
+  await writeFile(
+    join(repositoryDir, "WORKFLOW.md"),
+    "---\nserver:\n  port: invalid\n---\nPrompt\n",
     "utf8"
   );
 }

--- a/packages/cli/src/commands/start.test.ts
+++ b/packages/cli/src/commands/start.test.ts
@@ -1837,15 +1837,18 @@ Handle {{issue.identifier}}.\n`,
       activeProject: "tenant-a",
       projects: [createProject("tenant-a", "acme", "platform")],
     });
-    const blocker = createServer();
+    const probe = createServer();
     await new Promise<void>((resolve) =>
-      blocker.listen(0, "127.0.0.1", () => resolve())
+      probe.listen(0, "127.0.0.1", () => resolve())
     );
-    const address = blocker.address();
+    const address = probe.address();
     if (!address || typeof address === "string") {
-      blocker.close();
+      probe.close();
       throw new Error("Expected TCP address");
     }
+    await new Promise<void>((resolve, reject) =>
+      probe.close((error) => (error ? reject(error) : resolve()))
+    );
     await configureWorkflow(configDir, address.port);
     const lock = {
       lockPath: join(configDir, ".lock"),
@@ -1874,20 +1877,17 @@ Handle {{issue.identifier}}.\n`,
 
     try {
       const startPromise = startModule.default(
-        ["--port", "0"],
+        ["--port", String(address.port)],
         baseOptions(configDir)
       );
 
       const url = await waitForHttpUrl(stdout.output);
-      expect(new URL(url).port).not.toBe(String(address.port));
+      expect(new URL(url).port).toBe(String(address.port));
 
       process.emit("SIGINT");
       await startPromise;
     } finally {
       stdout.restore();
-      await new Promise<void>((resolve, reject) =>
-        blocker.close((error) => (error ? reject(error) : resolve()))
-      );
     }
 
     expect(exitSpy).toHaveBeenCalledWith(0);
@@ -2007,6 +2007,63 @@ Handle {{issue.identifier}}.\n`,
       expect(exitSpy).toHaveBeenCalledWith(0);
     }
   );
+
+  it("auto-increments an occupied configured port for a bare HTTP alias", async () => {
+    const configDir = await createConfigFixture({
+      activeProject: "tenant-a",
+      projects: [createProject("tenant-a", "acme", "platform")],
+    });
+    const blocker = createServer();
+    await new Promise<void>((resolve) =>
+      blocker.listen(0, "127.0.0.1", () => resolve())
+    );
+    const address = blocker.address();
+    if (!address || typeof address === "string") {
+      blocker.close();
+      throw new Error("Expected TCP address");
+    }
+    await configureWorkflow(configDir, address.port);
+    acquireProjectLock.mockResolvedValue({
+      lockPath: join(configDir, ".lock"),
+      ownerToken: "owner",
+      pid: 1234,
+      startedAt: "2026-03-17T00:00:00.000Z",
+    });
+    let resolveRun: (() => void) | undefined;
+    run.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveRun = resolve;
+        })
+    );
+    shutdown.mockImplementation(async () => {
+      resolveRun?.();
+    });
+    const exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation(
+        ((_code?: number) => undefined) as (code?: number) => never
+      );
+    const stdout = captureWrites(process.stdout);
+
+    try {
+      const startPromise = startModule.default(
+        ["--http"],
+        baseOptions(configDir)
+      );
+      const url = await waitForHttpUrl(stdout.output);
+      expect(Number(new URL(url).port)).toBeGreaterThan(address.port);
+      process.emit("SIGINT");
+      await startPromise;
+    } finally {
+      stdout.restore();
+      await new Promise<void>((resolve, reject) =>
+        blocker.close((error) => (error ? reject(error) : resolve()))
+      );
+    }
+
+    expect(exitSpy).toHaveBeenCalledWith(0);
+  });
 
   it("reads server.port from a legacy repository workflow fallback", async () => {
     const configDir = await createConfigFixture({

--- a/packages/cli/src/commands/start.test.ts
+++ b/packages/cli/src/commands/start.test.ts
@@ -1892,6 +1892,116 @@ Handle {{issue.identifier}}.\n`,
     expect(exitSpy).toHaveBeenCalledWith(0);
   });
 
+  it("uses server.port when no CLI HTTP option is supplied", async () => {
+    const configDir = await createConfigFixture({
+      activeProject: "tenant-a",
+      projects: [createProject("tenant-a", "acme", "platform")],
+    });
+    const probe = createServer();
+    await new Promise<void>((resolve) =>
+      probe.listen(0, "127.0.0.1", () => resolve())
+    );
+    const address = probe.address();
+    if (!address || typeof address === "string") {
+      probe.close();
+      throw new Error("Expected TCP address");
+    }
+    await new Promise<void>((resolve, reject) =>
+      probe.close((error) => (error ? reject(error) : resolve()))
+    );
+    await configureWorkflow(configDir, address.port);
+    acquireProjectLock.mockResolvedValue({
+      lockPath: join(configDir, ".lock"),
+      ownerToken: "owner",
+      pid: 1234,
+      startedAt: "2026-03-17T00:00:00.000Z",
+    });
+    let resolveRun: (() => void) | undefined;
+    run.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveRun = resolve;
+        })
+    );
+    shutdown.mockImplementation(async () => {
+      resolveRun?.();
+    });
+    const exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation(
+        ((_code?: number) => undefined) as (code?: number) => never
+      );
+    const stdout = captureWrites(process.stdout);
+
+    try {
+      const startPromise = startModule.default([], baseOptions(configDir));
+      const url = await waitForHttpUrl(stdout.output);
+      expect(new URL(url).port).toBe(String(address.port));
+
+      process.emit("SIGINT");
+      await startPromise;
+    } finally {
+      stdout.restore();
+    }
+
+    expect(exitSpy).toHaveBeenCalledWith(0);
+  });
+
+  it("reads server.port from a legacy repository workflow fallback", async () => {
+    const configDir = await createConfigFixture({
+      activeProject: "tenant-a",
+      projects: [createProject("tenant-a", "acme", "platform")],
+    });
+    const probe = createServer();
+    await new Promise<void>((resolve) =>
+      probe.listen(0, "127.0.0.1", () => resolve())
+    );
+    const address = probe.address();
+    if (!address || typeof address === "string") {
+      probe.close();
+      throw new Error("Expected TCP address");
+    }
+    await new Promise<void>((resolve, reject) =>
+      probe.close((error) => (error ? reject(error) : resolve()))
+    );
+    await configureLegacyWorkflow(configDir, address.port);
+    acquireProjectLock.mockResolvedValue({
+      lockPath: join(configDir, ".lock"),
+      ownerToken: "owner",
+      pid: 1234,
+      startedAt: "2026-03-17T00:00:00.000Z",
+    });
+    let resolveRun: (() => void) | undefined;
+    run.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveRun = resolve;
+        })
+    );
+    shutdown.mockImplementation(async () => {
+      resolveRun?.();
+    });
+    const exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation(
+        ((_code?: number) => undefined) as (code?: number) => never
+      );
+    const stdout = captureWrites(process.stdout);
+
+    try {
+      const startPromise = startModule.default([], baseOptions(configDir));
+      const url = await waitForHttpUrl(stdout.output);
+      expect(new URL(url).port).toBe(String(address.port));
+
+      process.emit("SIGINT");
+      await startPromise;
+    } finally {
+      stdout.restore();
+    }
+
+    expect(exitSpy).toHaveBeenCalledWith(0);
+  });
+
   it("fails when a requested port is already in use", async () => {
     const configDir = await createConfigFixture({
       activeProject: "tenant-a",
@@ -2155,6 +2265,34 @@ async function configureWorkflow(
   await writeFile(projectPath, JSON.stringify(project), "utf8");
   await writeFile(
     workflowPath,
+    `---
+tracker:
+  kind: github-project
+server:
+  port: ${port}
+codex:
+  command: codex app-server
+---
+Prompt\n`,
+    "utf8"
+  );
+}
+
+async function configureLegacyWorkflow(
+  configDir: string,
+  port: number
+): Promise<void> {
+  const projectPath = join(configDir, "projects", "tenant-a", "project.json");
+  const project = JSON.parse(
+    await readFile(projectPath, "utf8")
+  ) as CliProjectConfig;
+  const repositoryDir = join(configDir, "legacy-repository");
+  project.repositoryDir = repositoryDir;
+  project.workflowSource = { type: "repo" };
+  await mkdir(repositoryDir, { recursive: true });
+  await writeFile(projectPath, JSON.stringify(project), "utf8");
+  await writeFile(
+    join(repositoryDir, "WORKFLOW.md"),
     `---
 tracker:
   kind: github-project

--- a/packages/cli/src/commands/start.test.ts
+++ b/packages/cli/src/commands/start.test.ts
@@ -1831,11 +1831,21 @@ Handle {{issue.identifier}}.\n`,
     expect(exitSpy).toHaveBeenCalledWith(0);
   });
 
-  it("increments the port when the requested HTTP port is already in use", async () => {
+  it("uses --port in preference to server.port", async () => {
     const configDir = await createConfigFixture({
       activeProject: "tenant-a",
       projects: [createProject("tenant-a", "acme", "platform")],
     });
+    const blocker = createServer();
+    await new Promise<void>((resolve) =>
+      blocker.listen(0, "127.0.0.1", () => resolve())
+    );
+    const address = blocker.address();
+    if (!address || typeof address === "string") {
+      blocker.close();
+      throw new Error("Expected TCP address");
+    }
+    await configureWorkflow(configDir, address.port);
     const lock = {
       lockPath: join(configDir, ".lock"),
       ownerToken: "owner",
@@ -1854,16 +1864,6 @@ Handle {{issue.identifier}}.\n`,
       resolveRun?.();
     });
 
-    const blocker = createServer();
-    await new Promise<void>((resolve) =>
-      blocker.listen(0, "127.0.0.1", () => resolve())
-    );
-    const address = blocker.address();
-    if (!address || typeof address === "string") {
-      blocker.close();
-      throw new Error("Expected TCP address");
-    }
-
     const exitSpy = vi
       .spyOn(process, "exit")
       .mockImplementation(
@@ -1873,12 +1873,12 @@ Handle {{issue.identifier}}.\n`,
 
     try {
       const startPromise = startModule.default(
-        ["--http", String(address.port)],
+        ["--port", "0"],
         baseOptions(configDir)
       );
 
       const url = await waitForHttpUrl(stdout.output);
-      expect(new URL(url).port).toBe(String(address.port + 1));
+      expect(new URL(url).port).not.toBe(String(address.port));
 
       process.emit("SIGINT");
       await startPromise;
@@ -1890,6 +1890,41 @@ Handle {{issue.identifier}}.\n`,
     }
 
     expect(exitSpy).toHaveBeenCalledWith(0);
+  });
+
+  it("fails when a requested port is already in use", async () => {
+    const configDir = await createConfigFixture({
+      activeProject: "tenant-a",
+      projects: [createProject("tenant-a", "acme", "platform")],
+    });
+    const blocker = createServer();
+    await new Promise<void>((resolve) =>
+      blocker.listen(0, "127.0.0.1", () => resolve())
+    );
+    const address = blocker.address();
+    if (!address || typeof address === "string") {
+      blocker.close();
+      throw new Error("Expected TCP address");
+    }
+    acquireProjectLock.mockResolvedValue({
+      lockPath: join(configDir, ".lock"),
+      ownerToken: "owner",
+      pid: 1234,
+      startedAt: "2026-03-17T00:00:00.000Z",
+    });
+
+    try {
+      await expect(
+        startModule.default(
+          ["--port", String(address.port)],
+          baseOptions(configDir)
+        )
+      ).rejects.toThrow(`HTTP server port ${address.port} is already in use`);
+    } finally {
+      await new Promise<void>((resolve, reject) =>
+        blocker.close((error) => (error ? reject(error) : resolve()))
+      );
+    }
   });
 
   it("propagates lock acquisition failures", async () => {
@@ -2105,4 +2140,30 @@ async function createConfigFixture(input: {
   }
 
   return configDir;
+}
+
+async function configureWorkflow(
+  configDir: string,
+  port: number
+): Promise<void> {
+  const projectPath = join(configDir, "projects", "tenant-a", "project.json");
+  const project = JSON.parse(
+    await readFile(projectPath, "utf8")
+  ) as CliProjectConfig;
+  const workflowPath = join(configDir, "projects", "tenant-a", "WORKFLOW.md");
+  project.workflowSource = { type: "repo", path: workflowPath };
+  await writeFile(projectPath, JSON.stringify(project), "utf8");
+  await writeFile(
+    workflowPath,
+    `---
+tracker:
+  kind: github-project
+server:
+  port: ${port}
+codex:
+  command: codex app-server
+---
+Prompt\n`,
+    "utf8"
+  );
 }

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -253,7 +253,7 @@ async function preflightWorkflowStart(
       {
         supportedTrackerKinds: getSupportedTrackerKinds(),
         resolveTrackerAdapter: resolveWorkflowConfigTrackerAdapter,
-        workflowPath: configuredPath,
+        workflowPath,
       }
     );
     return { ok: true, workflow };

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -33,7 +33,7 @@ import type {
   TrackerStateRequest,
   TrackerStateResult,
 } from "@gh-symphony/core";
-import { parseWorkflowMarkdown } from "@gh-symphony/core";
+import { parseWorkflowMarkdown, type ParsedWorkflow } from "@gh-symphony/core";
 import {
   DashboardFsReader,
   isAuthorizedApiRequest,
@@ -232,12 +232,12 @@ async function resolveConfiguredLinearToken(
 async function preflightWorkflowStart(
   projectConfig: OrchestratorProjectConfig,
   runtimeRoot: string
-): Promise<boolean> {
+): Promise<{ ok: true; workflow: ParsedWorkflow | null } | { ok: false }> {
   const configuredPath = projectConfig.workflowSource?.path;
   if (!configuredPath) {
     // Legacy managed-project configs rely on the daemon's repository lookup,
     // including its default workflow fallback. Avoid a divergent preflight.
-    return true;
+    return { ok: true, workflow: null };
   }
 
   try {
@@ -245,25 +245,29 @@ async function preflightWorkflowStart(
       projectConfig,
       runtimeRoot
     );
-    parseWorkflowMarkdown(await readFile(configuredPath, "utf8"), environment, {
-      supportedTrackerKinds: getSupportedTrackerKinds(),
-      resolveTrackerAdapter: resolveWorkflowConfigTrackerAdapter,
-      workflowPath: configuredPath,
-    });
-    return true;
+    const workflow = parseWorkflowMarkdown(
+      await readFile(configuredPath, "utf8"),
+      environment,
+      {
+        supportedTrackerKinds: getSupportedTrackerKinds(),
+        resolveTrackerAdapter: resolveWorkflowConfigTrackerAdapter,
+        workflowPath: configuredPath,
+      }
+    );
+    return { ok: true, workflow };
   } catch (error) {
     if ((error as NodeJS.ErrnoException | undefined)?.code === "ENOENT") {
       process.stderr.write(
         `Configured workflow not found at ${configuredPath}. Restore the file or run 'gh-symphony repo init --workflow-file <path>'.\n`
       );
       process.exitCode = 1;
-      return false;
+      return { ok: false };
     }
     process.stderr.write(
       `Workflow preflight failed for ${configuredPath}: ${error instanceof Error ? error.message : "Invalid workflow definition."}\n`
     );
     process.exitCode = 1;
-    return false;
+    return { ok: false };
   }
 }
 
@@ -402,7 +406,7 @@ function parseStartArgs(args: string[]): {
       parsed.bindAll = true;
       continue;
     }
-    if (arg === "--http") {
+    if (arg === "--http" || arg === "--port") {
       const value = args[i + 1];
       if (!value || value.startsWith("-")) {
         parsed.httpPort = DEFAULT_HTTP_PORT;
@@ -650,6 +654,7 @@ async function startHttpServer(input: {
   runtimeRoot: string;
   projectId: string;
   initialPort: number;
+  explicitPort: boolean;
   host: string;
   apiToken: string;
   service: {
@@ -841,6 +846,9 @@ async function startHttpServer(input: {
     } catch (error) {
       await closeHttpServer(server).catch(() => {});
       if ((error as NodeJS.ErrnoException)?.code === "EADDRINUSE") {
+        if (input.explicitPort) {
+          throw new Error(`HTTP server port ${port} is already in use`);
+        }
         continue;
       }
       throw error;
@@ -951,7 +959,7 @@ const handler = async (
   if (parsed.error) {
     process.stderr.write(`${parsed.error}\n`);
     process.stderr.write(
-      `Usage: gh-symphony ${options.invocation === "project" ? "project" : "repo"} start [--daemon] [--once] [--assigned-only] [--http [port]] [--web [port]] [--bind-all]${options.invocation === "project" ? " [--project-dir <path>]" : ""}\n`
+      `Usage: gh-symphony ${options.invocation === "project" ? "project" : "repo"} start [--daemon] [--once] [--assigned-only] [--port [port]] [--http [port]] [--web [port]] [--bind-all]${options.invocation === "project" ? " [--project-dir <path>]" : ""}\n`
     );
     process.exitCode = 2;
     return;
@@ -1023,9 +1031,16 @@ const handler = async (
   if (!authPreflight.ok) {
     return;
   }
-  if (!(await preflightWorkflowStart(projectConfig, runtimeRoot))) {
+  const workflowPreflight = await preflightWorkflowStart(
+    projectConfig,
+    runtimeRoot
+  );
+  if (!workflowPreflight.ok) {
     return;
   }
+  const configuredServerPort = workflowPreflight.workflow?.server.port;
+  const requestedHttpPort =
+    parsed.httpPort ?? configuredServerPort ?? undefined;
   const httpApiToken = resolveHttpApiToken();
   const httpHost = parsed.bindAll ? BIND_ALL_HTTP_HOST : DEFAULT_HTTP_HOST;
 
@@ -1034,7 +1049,7 @@ const handler = async (
       options,
       projectId,
       parsed.logLevel ?? (options.verbose ? "verbose" : undefined),
-      parsed.httpPort,
+      requestedHttpPort,
       parsed.webPort,
       parsed.assignedOnly === true,
       parsed.bindAll,
@@ -1167,8 +1182,9 @@ const handler = async (
       workerHttpServer = await startHttpServer({
         runtimeRoot,
         projectId,
-        initialPort: parsed.httpPort ?? 0,
-        host: parsed.httpPort !== undefined ? httpHost : DEFAULT_HTTP_HOST,
+        initialPort: requestedHttpPort ?? 0,
+        explicitPort: requestedHttpPort !== undefined,
+        host: requestedHttpPort !== undefined ? httpHost : DEFAULT_HTTP_HOST,
         apiToken: httpApiToken,
         service,
         trackerStateToken,
@@ -1189,7 +1205,7 @@ const handler = async (
               apiToken: httpApiToken,
               onRefreshRequest: () => service.requestReconcile(),
             })
-          : parsed.httpPort !== undefined
+          : requestedHttpPort !== undefined
             ? workerHttpServer
             : null;
       if (httpServer) {
@@ -1433,7 +1449,7 @@ async function startDaemon(
       ...(allowDuplicate ? ["--allow-duplicate"] : []),
       ...(assignedOnly ? ["--assigned-only"] : []),
       ...(bindAll ? ["--bind-all"] : []),
-      ...(httpPort !== undefined ? ["--http", String(httpPort)] : []),
+      ...(httpPort !== undefined ? ["--port", String(httpPort)] : []),
       ...(webPort !== undefined ? ["--web", String(webPort)] : []),
       ...(logLevel ? ["--log-level", logLevel] : []),
     ],

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -234,11 +234,17 @@ async function preflightWorkflowStart(
   runtimeRoot: string
 ): Promise<{ ok: true; workflow: ParsedWorkflow | null } | { ok: false }> {
   const configuredPath = projectConfig.workflowSource?.path;
-  if (!configuredPath) {
-    // Legacy managed-project configs rely on the daemon's repository lookup,
-    // including its default workflow fallback. Avoid a divergent preflight.
-    return { ok: true, workflow: null };
-  }
+  const workflowPath =
+    configuredPath ??
+    (projectConfig.workflowSource?.type === "repo"
+      ? join(
+          projectConfig.repositoryDir ??
+            projectConfig.repository.path ??
+            process.cwd(),
+          "WORKFLOW.md"
+        )
+      : undefined);
+  if (!workflowPath) return { ok: true, workflow: null };
 
   try {
     const environment = resolveManagedProjectEnvironment(
@@ -246,7 +252,7 @@ async function preflightWorkflowStart(
       runtimeRoot
     );
     const workflow = parseWorkflowMarkdown(
-      await readFile(configuredPath, "utf8"),
+      await readFile(workflowPath, "utf8"),
       environment,
       {
         supportedTrackerKinds: getSupportedTrackerKinds(),
@@ -257,14 +263,15 @@ async function preflightWorkflowStart(
     return { ok: true, workflow };
   } catch (error) {
     if ((error as NodeJS.ErrnoException | undefined)?.code === "ENOENT") {
+      if (!configuredPath) return { ok: true, workflow: null };
       process.stderr.write(
-        `Configured workflow not found at ${configuredPath}. Restore the file or run 'gh-symphony repo init --workflow-file <path>'.\n`
+        `Configured workflow not found at ${workflowPath}. Restore the file or run 'gh-symphony repo init --workflow-file <path>'.\n`
       );
       process.exitCode = 1;
       return { ok: false };
     }
     process.stderr.write(
-      `Workflow preflight failed for ${configuredPath}: ${error instanceof Error ? error.message : "Invalid workflow definition."}\n`
+      `Workflow preflight failed for ${workflowPath}: ${error instanceof Error ? error.message : "Invalid workflow definition."}\n`
     );
     process.exitCode = 1;
     return { ok: false };
@@ -364,6 +371,8 @@ function parseStartArgs(args: string[]): {
   allowDuplicate?: boolean;
   bindAll: boolean;
   httpPort?: number;
+  httpPortExplicit: boolean;
+  httpOption?: "--http" | "--port";
   webPort?: number;
   logLevel?: string;
   error?: string;
@@ -375,6 +384,8 @@ function parseStartArgs(args: string[]): {
     allowDuplicate?: boolean;
     bindAll: boolean;
     httpPort?: number;
+    httpPortExplicit: boolean;
+    httpOption?: "--http" | "--port";
     webPort?: number;
     logLevel?: string;
     error?: string;
@@ -382,6 +393,7 @@ function parseStartArgs(args: string[]): {
     daemon: false,
     bindAll: false,
     once: false,
+    httpPortExplicit: false,
   };
 
   for (let i = 0; i < args.length; i += 1) {
@@ -407,12 +419,14 @@ function parseStartArgs(args: string[]): {
       continue;
     }
     if (arg === "--http" || arg === "--port") {
+      parsed.httpOption = arg;
       const value = args[i + 1];
       if (!value || value.startsWith("-")) {
         parsed.httpPort = DEFAULT_HTTP_PORT;
         continue;
       }
       parsed.httpPort = parsePort(value, arg);
+      parsed.httpPortExplicit = true;
       i += 1;
       continue;
     }
@@ -443,7 +457,7 @@ function parseStartArgs(args: string[]): {
   }
 
   if (parsed.httpPort !== undefined && parsed.webPort !== undefined) {
-    parsed.error = "Options '--http' and '--web' cannot be used together";
+    parsed.error = `Options '${parsed.httpOption ?? "--http"}' and '--web' cannot be used together`;
   }
 
   return parsed;
@@ -1038,9 +1052,16 @@ const handler = async (
   if (!workflowPreflight.ok) {
     return;
   }
-  const configuredServerPort = workflowPreflight.workflow?.server.port;
+  const configuredServerPort =
+    parsed.webPort === undefined
+      ? workflowPreflight.workflow?.server.port
+      : undefined;
   const requestedHttpPort =
     parsed.httpPort ?? configuredServerPort ?? undefined;
+  const explicitHttpPort =
+    parsed.httpPort !== undefined
+      ? parsed.httpPortExplicit
+      : configuredServerPort !== undefined;
   const httpApiToken = resolveHttpApiToken();
   const httpHost = parsed.bindAll ? BIND_ALL_HTTP_HOST : DEFAULT_HTTP_HOST;
 
@@ -1050,6 +1071,7 @@ const handler = async (
       projectId,
       parsed.logLevel ?? (options.verbose ? "verbose" : undefined),
       requestedHttpPort,
+      explicitHttpPort,
       parsed.webPort,
       parsed.assignedOnly === true,
       parsed.bindAll,
@@ -1078,10 +1100,6 @@ const handler = async (
         processIdentity: projectLock.processIdentity,
       };
       await registerInstance(instance);
-      const readyPath = process.env[DAEMON_READY_PATH_ENV];
-      if (readyPath) {
-        await writeFile(readyPath, `${projectLock.pid}\n`, { mode: 0o600 });
-      }
     }
 
     const store = createStore(runtimeRoot);
@@ -1183,7 +1201,7 @@ const handler = async (
         runtimeRoot,
         projectId,
         initialPort: requestedHttpPort ?? 0,
-        explicitPort: requestedHttpPort !== undefined,
+        explicitPort: explicitHttpPort,
         host: requestedHttpPort !== undefined ? httpHost : DEFAULT_HTTP_HOST,
         apiToken: httpApiToken,
         service,
@@ -1191,6 +1209,10 @@ const handler = async (
       });
       service.setWorkerOrchestratorUrl(workerHttpServer.url);
       service.setWorkerOrchestratorToken(trackerStateToken);
+      const readyPath = process.env[DAEMON_READY_PATH_ENV];
+      if (readyPath) {
+        await writeFile(readyPath, `${projectLock.pid}\n`, { mode: 0o600 });
+      }
 
       httpServer =
         parsed.webPort !== undefined
@@ -1420,6 +1442,7 @@ async function startDaemon(
   projectId: string,
   logLevel?: string,
   httpPort?: number,
+  httpPortExplicit = false,
   webPort?: number,
   assignedOnly = false,
   bindAll = false,
@@ -1449,7 +1472,11 @@ async function startDaemon(
       ...(allowDuplicate ? ["--allow-duplicate"] : []),
       ...(assignedOnly ? ["--assigned-only"] : []),
       ...(bindAll ? ["--bind-all"] : []),
-      ...(httpPort !== undefined ? ["--port", String(httpPort)] : []),
+      ...(httpPort !== undefined
+        ? httpPortExplicit
+          ? ["--port", String(httpPort)]
+          : ["--http"]
+        : []),
       ...(webPort !== undefined ? ["--web", String(webPort)] : []),
       ...(logLevel ? ["--log-level", logLevel] : []),
     ],

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -1,6 +1,7 @@
 import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { randomBytes, timingSafeEqual } from "node:crypto";
-import { dirname, join, resolve } from "node:path";
+import { dirname, isAbsolute, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { spawn, type ChildProcess } from "node:child_process";
 import {
   createServer,
@@ -237,12 +238,7 @@ async function preflightWorkflowStart(
   const workflowPath =
     configuredPath ??
     (projectConfig.workflowSource?.type === "repo"
-      ? join(
-          projectConfig.repositoryDir ??
-            projectConfig.repository.path ??
-            process.cwd(),
-          "WORKFLOW.md"
-        )
+      ? join(resolveWorkflowRepositoryDirectory(projectConfig), "WORKFLOW.md")
       : undefined);
   if (!workflowPath) return { ok: true, workflow: null };
 
@@ -262,8 +258,10 @@ async function preflightWorkflowStart(
     );
     return { ok: true, workflow };
   } catch (error) {
+    if (!configuredPath) {
+      return { ok: true, workflow: null };
+    }
     if ((error as NodeJS.ErrnoException | undefined)?.code === "ENOENT") {
-      if (!configuredPath) return { ok: true, workflow: null };
       process.stderr.write(
         `Configured workflow not found at ${workflowPath}. Restore the file or run 'gh-symphony repo init --workflow-file <path>'.\n`
       );
@@ -276,6 +274,27 @@ async function preflightWorkflowStart(
     process.exitCode = 1;
     return { ok: false };
   }
+}
+
+function resolveWorkflowRepositoryDirectory(
+  projectConfig: OrchestratorProjectConfig
+): string {
+  const { repository } = projectConfig;
+  if (repository.path) return repository.path;
+
+  try {
+    const url = new URL(repository.cloneUrl);
+    if (url.protocol === "file:") return fileURLToPath(url);
+  } catch {
+    if (
+      isAbsolute(repository.cloneUrl) ||
+      repository.cloneUrl.startsWith(".")
+    ) {
+      return repository.cloneUrl;
+    }
+  }
+
+  return process.cwd();
 }
 
 type GitHubAuthRuntimeError =
@@ -1056,12 +1075,12 @@ const handler = async (
     parsed.webPort === undefined
       ? workflowPreflight.workflow?.server.port
       : undefined;
-  const requestedHttpPort =
-    parsed.httpPort ?? configuredServerPort ?? undefined;
+  const requestedHttpPort = parsed.httpPortExplicit
+    ? parsed.httpPort
+    : (configuredServerPort ?? parsed.httpPort);
   const explicitHttpPort =
-    parsed.httpPort !== undefined
-      ? parsed.httpPortExplicit
-      : configuredServerPort !== undefined;
+    parsed.httpPortExplicit ||
+    (parsed.httpPort === undefined && configuredServerPort !== undefined);
   const httpApiToken = resolveHttpApiToken();
   const httpHost = parsed.bindAll ? BIND_ALL_HTTP_HOST : DEFAULT_HTTP_HOST;
 

--- a/packages/cli/src/completion.ts
+++ b/packages/cli/src/completion.ts
@@ -58,7 +58,7 @@ const COMMAND_OPTIONS: Record<string, readonly string[]> = {
   upgrade: [...GLOBAL_OPTIONS],
   repo: ["init", "start", "status", "stop", "run", "recover", "logs", "explain"],
   "repo:init": ["--repo-dir", "--workflow-file", ...GLOBAL_OPTIONS],
-  "repo:start": ["--daemon", "-d", "--once", "--assigned-only", "--http", "--web", "--bind-all", "--log-level", ...GLOBAL_OPTIONS],
+  "repo:start": ["--daemon", "-d", "--once", "--assigned-only", "--port", "--http", "--web", "--bind-all", "--log-level", ...GLOBAL_OPTIONS],
   "repo:status": ["--watch", "-w", ...GLOBAL_OPTIONS],
   "repo:stop": ["--force", ...GLOBAL_OPTIONS],
   "repo:run": ["--watch", ...GLOBAL_OPTIONS],

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -303,6 +303,7 @@ describe("Commander CLI entrypoint", () => {
     expect(output).toContain("--assigned-only");
     expect(output).toContain("--allow-duplicate");
     expect(output).toContain("--bind-all");
+    expect(output).toContain("--port [port]");
     expect(output).toContain("--http [port]");
     expect(output).toContain("--web [port]");
     expect(output).toContain("--log-level <level>");

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -57,6 +57,7 @@ type CliOptionValues = Partial<
     follow?: boolean;
     force?: boolean;
     http?: string | boolean;
+    port?: string | boolean;
     issue?: string;
     level?: string;
     logLevel?: string;
@@ -585,6 +586,10 @@ function createProgram(): { program: Command; wasInvoked: () => boolean } {
         "Bind HTTP servers to all interfaces instead of localhost"
       )
       .option(
+        "--port [port]",
+        "Expose the JSON status API and refresh endpoints over HTTP"
+      )
+      .option(
         "--http [port]",
         "Expose the JSON status API and refresh endpoints over HTTP"
       )
@@ -604,6 +609,7 @@ function createProgram(): { program: Command; wasInvoked: () => boolean } {
     pushOption(args, "--assigned-only", values.assignedOnly);
     pushOption(args, "--allow-duplicate", values.allowDuplicate);
     pushOption(args, "--bind-all", values.bindAll);
+    pushOption(args, "--port", values.port);
     pushOption(args, "--http", values.http);
     pushOption(args, "--web", values.web);
     pushOption(args, "--log-level", values.logLevel);
@@ -719,6 +725,10 @@ function createProgram(): { program: Command; wasInvoked: () => boolean } {
         "Bind HTTP servers to all interfaces instead of localhost"
       )
       .option(
+        "--port [port]",
+        "Expose the JSON status API and refresh endpoints over HTTP"
+      )
+      .option(
         "--http [port]",
         "Expose the JSON status API and refresh endpoints over HTTP"
       )
@@ -738,6 +748,7 @@ function createProgram(): { program: Command; wasInvoked: () => boolean } {
     pushOption(args, "--assigned-only", values.assignedOnly);
     pushOption(args, "--allow-duplicate", values.allowDuplicate);
     pushOption(args, "--bind-all", values.bindAll);
+    pushOption(args, "--port", values.port);
     pushOption(args, "--http", values.http);
     pushOption(args, "--web", values.web);
     pushOption(args, "--log-level", values.logLevel);

--- a/packages/core/src/workflow-loader.test.ts
+++ b/packages/core/src/workflow-loader.test.ts
@@ -246,6 +246,37 @@ Prompt`);
     expect(workflow.agent.maxConcurrentAgentsByState).toEqual({ ready: 2 });
   });
 
+  it("parses the optional HTTP server port", () => {
+    const workflow = parseWorkflowMarkdown(`---
+tracker:
+  kind: github-project
+server:
+  port: 0
+codex:
+  command: codex
+---
+Prompt`);
+
+    expect(workflow.server.port).toBe(0);
+  });
+
+  it.each([-1, 65536, "'4680'"])(
+    "rejects invalid server.port values",
+    (port) => {
+      expect(() =>
+        parseWorkflowMarkdown(`---
+tracker:
+  kind: github-project
+server:
+  port: ${port}
+codex:
+  command: codex
+---
+Prompt`)
+      ).toThrow(/server.port/);
+    }
+  );
+
   it("accepts tracker kinds injected by the adapter boundary", () => {
     const workflow = parseWorkflowMarkdown(
       `---

--- a/packages/core/src/workflow/config.ts
+++ b/packages/core/src/workflow/config.ts
@@ -57,6 +57,11 @@ export type WorkflowWorkspaceConfig = {
   root: string | null;
 };
 
+export type WorkflowServerConfig = {
+  /** Enables the optional HTTP server extension when present. */
+  port: number | null;
+};
+
 /**
  * Repository-specific front matter is an optional extension. Its schema is
  * owned by the extension consumer, so core preserves the decoded object.
@@ -130,6 +135,7 @@ export type WorkflowDefinition = {
     intervalMs: number;
   };
   repository: WorkflowRepositoryExtension;
+  server: WorkflowServerConfig;
   workspace: WorkflowWorkspaceConfig;
   hooks: WorkflowHooksConfig;
   agent: WorkflowAgentConfig;
@@ -196,6 +202,10 @@ export const DEFAULT_WORKFLOW_WORKSPACE: WorkflowWorkspaceConfig = {
   root: null,
 };
 
+export const DEFAULT_WORKFLOW_SERVER: WorkflowServerConfig = {
+  port: null,
+};
+
 export const DEFAULT_WORKFLOW_AGENT: WorkflowAgentConfig = {
   maxConcurrentAgents: DEFAULT_MAX_CONCURRENT_AGENTS,
   maxRetryBackoffMs: DEFAULT_MAX_RETRY_BACKOFF_MS,
@@ -223,6 +233,7 @@ export const DEFAULT_WORKFLOW_DEFINITION: ParsedWorkflow = {
     intervalMs: DEFAULT_POLL_INTERVAL_MS,
   },
   repository: null,
+  server: DEFAULT_WORKFLOW_SERVER,
   workspace: DEFAULT_WORKFLOW_WORKSPACE,
   hooks: DEFAULT_WORKFLOW_HOOKS,
   agent: DEFAULT_WORKFLOW_AGENT,

--- a/packages/core/src/workflow/parser.ts
+++ b/packages/core/src/workflow/parser.ts
@@ -154,6 +154,7 @@ function parseWorkflowConfig(
   const tracker = readObject(frontMatter, "tracker");
   const polling = readObject(frontMatter, "polling");
   const workspace = readObject(frontMatter, "workspace");
+  const server = readObject(frontMatter, "server");
   const hooks = readObject(frontMatter, "hooks");
   const agent = readObject(frontMatter, "agent");
   const runtimeNode = readOptionalRuntimeObject(frontMatter);
@@ -366,6 +367,9 @@ function parseWorkflowConfig(
         ) ?? DEFAULT_POLL_INTERVAL_MS,
     },
     repository: readOptionalExtensionObject(frontMatter, "repository"),
+    server: {
+      port: readOptionalPort(server, "port", "server.port"),
+    },
     workspace: {
       root: readOptionalPath(workspace, "root", env, "workspace.root", options),
     },
@@ -1366,6 +1370,22 @@ function readOptionalPositiveInteger(
       "workflow_validation_error",
       path,
       `Workflow front matter field "${path}" must be a positive integer.`
+    );
+  }
+  return value;
+}
+
+function readOptionalPort(
+  input: Record<string, WorkflowFrontMatterNode>,
+  key: string,
+  path: string
+): number | null {
+  const value = readOptionalIntegerLike(input, key, path);
+  if (value !== null && (value < 0 || value > 65_535)) {
+    throw new WorkflowValidationError(
+      "workflow_validation_error",
+      path,
+      `Workflow front matter field "${path}" must be a port number between 0 and 65535.`
     );
   }
   return value;


### PR DESCRIPTION
## TL;DR

`server.port` enables the status API from workflow front matter, and explicit CLI `--port <port>` takes precedence. Bare `--http` and `--port` preserve an explicit configured port; without one they retain auto-increment behavior.

## Change-point diagram

```text
--port <n> ───────────────────────┐
server.port ──────────────────────┼─> requested status port ─> bind or fail
bare --http / --port ─────────────┘    (configured port if present; otherwise auto-increment)
```

## Start here

- `packages/core/src/workflow/parser.ts` parses and validates `server.port`.
- `packages/cli/src/commands/start.ts` resolves CLI/configuration precedence, explicit bind failures, and legacy workflow preflight paths.
- `packages/cli/src/commands/start.test.ts` covers direct CLI precedence, bare aliases, occupied explicit ports, and auto-increment.

## Risks & rollback

- Explicit CLI and configured ports fail fast when occupied; only bare aliases without a configured port may auto-increment.
- Rollback is limited to reverting this PR.

## Changed files

- Core workflow parser and configuration model
- CLI start command and tests
- Configuration and CLI documentation
- Patch changeset for `@gh-symphony/cli`

## Evidence

- `pnpm --filter @gh-symphony/cli test -- start.test.ts`
- `pnpm --filter @gh-symphony/core test -- workflow-loader.test.ts`
- `pnpm lint`
- `pnpm test`
- `pnpm typecheck`
- `pnpm build`
- `git diff --check`

## Issues — Closed #751

## Post-merge / human validation

- [ ] Start a managed repository with `server.port` and confirm the status URL binds there.
- [ ] Confirm `--port <available-port>` overrides `server.port`.
- [ ] Confirm an occupied explicitly requested port reports an error.
