### PR TITLE
fix(observability): accumulate session runtime

### DIFF
--- a/.changeset/750-accumulated-session-runtime.md
+++ b/.changeset/750-accumulated-session-runtime.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Report `seconds_running` as accumulated worker-session runtime, excluding retry gaps while retaining completed-session runtime across restarts (#750).

--- a/.changeset/750-accumulated-session-runtime.md
+++ b/.changeset/750-accumulated-session-runtime.md
@@ -2,4 +2,4 @@
 "@gh-symphony/cli": patch
 ---
 
-Report `seconds_running` as accumulated worker-session runtime, excluding retry gaps while retaining completed-session runtime across restarts (#750).
+Report `seconds_running` as accumulated worker-session runtime, excluding retry gaps while retaining completed-session runtime across restarts (#750). Retry records now freeze their completed-session boundary so retry scheduling does not extend that measurement.

--- a/packages/core/src/contracts/status-surface.ts
+++ b/packages/core/src/contracts/status-surface.ts
@@ -266,6 +266,8 @@ export type OrchestratorRunRecord = {
   cumulativeTurnCount?: number;
   /** Runtime from completed worker sessions in the current run lifecycle. */
   cumulativeRuntimeMs?: number;
+  /** Stable identity shared by all worker sessions for one logical run. */
+  runtimeLifecycleId?: string;
   /** Brief summary of the most recent completed/terminal turn. */
   lastTurnSummary?: string | null;
   createdAt: string;

--- a/packages/core/src/contracts/status-surface.ts
+++ b/packages/core/src/contracts/status-surface.ts
@@ -264,6 +264,8 @@ export type OrchestratorRunRecord = {
   threadId?: string | null;
   /** Total turns accumulated across worker sessions for the run. */
   cumulativeTurnCount?: number;
+  /** Runtime from completed worker sessions in the current run lifecycle. */
+  cumulativeRuntimeMs?: number;
   /** Brief summary of the most recent completed/terminal turn. */
   lastTurnSummary?: string | null;
   createdAt: string;

--- a/packages/core/src/observability/snapshot-builder.test.ts
+++ b/packages/core/src/observability/snapshot-builder.test.ts
@@ -251,6 +251,7 @@ describe("buildProjectSnapshot", () => {
     });
     const run2 = mockRun({
       runId: "run-002",
+      createdAt: "2024-01-01T00:06:00Z",
       tokenUsage: {
         inputTokens: 2000,
         outputTokens: 1000,
@@ -274,7 +275,7 @@ describe("buildProjectSnapshot", () => {
     expect(snapshot.codexTotals!.inputTokens).toBe(3000);
     expect(snapshot.codexTotals!.outputTokens).toBe(1500);
     expect(snapshot.codexTotals!.totalTokens).toBe(4500);
-    expect(snapshot.codexTotals!.secondsRunning).toBeGreaterThan(0);
+    expect(snapshot.codexTotals!.secondsRunning).toBe(540);
   });
 
   it("handles runs with missing tokenUsage gracefully", () => {
@@ -826,6 +827,48 @@ describe("buildProjectSnapshot", () => {
 
     // 5 minutes = 300 seconds
     expect(snapshot.codexTotals!.secondsRunning).toBe(300);
+  });
+
+  it("accumulates completed retry sessions without counting retry gaps", () => {
+    const initialStartedAt = "2024-01-01T00:00:00Z";
+    const completedSession = mockRun({
+      runId: "run-001",
+      status: "failed",
+      createdAt: initialStartedAt,
+      updatedAt: "2024-01-01T00:02:00Z",
+      startedAt: initialStartedAt,
+      completedAt: "2024-01-01T00:02:00Z",
+    });
+    const retrySession = mockRun({
+      runId: "run-002",
+      status: "failed",
+      createdAt: initialStartedAt,
+      updatedAt: "2024-01-01T00:09:00Z",
+      startedAt: "2024-01-01T00:07:00Z",
+      completedAt: "2024-01-01T00:09:00Z",
+      cumulativeRuntimeMs: 120_000,
+    });
+    const activeSession = mockRun({
+      runId: "run-003",
+      status: "running",
+      createdAt: initialStartedAt,
+      updatedAt: "2024-01-01T00:12:00Z",
+      startedAt: "2024-01-01T00:11:00Z",
+      completedAt: null,
+      cumulativeRuntimeMs: 240_000,
+    });
+
+    const snapshot = buildProjectSnapshot({
+      project: mockProject(),
+      activeRuns: [activeSession],
+      allRuns: [completedSession, retrySession, activeSession],
+      summary: { dispatched: 3, suppressed: 0, recovered: 0 },
+      lastTickAt: "2024-01-01T00:14:00Z",
+      lastError: null,
+    });
+
+    // 2 min + 2 min + 3 min active; retry gaps (5 min and 2 min) are excluded.
+    expect(snapshot.codexTotals!.secondsRunning).toBe(420);
   });
 
   it("handles retrying run with null retryKind by defaulting to 'failure'", () => {

--- a/packages/core/src/observability/snapshot-builder.test.ts
+++ b/packages/core/src/observability/snapshot-builder.test.ts
@@ -956,6 +956,38 @@ describe("buildProjectSnapshot", () => {
     expect(snapshot.codexTotals!.secondsRunning).toBe(240);
   });
 
+  it("does not double count a lifecycle that crosses the runtime upgrade", () => {
+    const legacySession = mockRun({
+      runId: "run-001",
+      status: "failed",
+      createdAt: "2024-01-01T00:00:00Z",
+      startedAt: "2024-01-01T00:00:00Z",
+      completedAt: "2024-01-01T00:02:00Z",
+      updatedAt: "2024-01-01T00:02:00Z",
+    });
+    const activeRetry = mockRun({
+      runId: "run-002",
+      status: "running",
+      createdAt: "2024-01-01T00:07:00Z",
+      startedAt: "2024-01-01T00:07:00Z",
+      completedAt: null,
+      updatedAt: "2024-01-01T00:09:00Z",
+      cumulativeRuntimeMs: 120_000,
+      runtimeLifecycleId: "2024-01-01T00:00:00Z",
+    });
+
+    const snapshot = buildProjectSnapshot({
+      project: mockProject(),
+      activeRuns: [activeRetry],
+      allRuns: [legacySession, activeRetry],
+      summary: { dispatched: 2, suppressed: 0, recovered: 0 },
+      lastTickAt: "2024-01-01T00:09:00Z",
+      lastError: null,
+    });
+
+    expect(snapshot.codexTotals!.secondsRunning).toBe(240);
+  });
+
   it("handles retrying run with null retryKind by defaulting to 'failure'", () => {
     const run = mockRun({
       status: "retrying",

--- a/packages/core/src/observability/snapshot-builder.test.ts
+++ b/packages/core/src/observability/snapshot-builder.test.ts
@@ -871,6 +871,91 @@ describe("buildProjectSnapshot", () => {
     expect(snapshot.codexTotals!.secondsRunning).toBe(420);
   });
 
+  it("accumulates a tick-dispatched retry with a fresh createdAt exactly once", () => {
+    const completedSession = mockRun({
+      runId: "run-001",
+      status: "failed",
+      createdAt: "2024-01-01T00:00:00Z",
+      updatedAt: "2024-01-01T00:02:00Z",
+      startedAt: "2024-01-01T00:00:00Z",
+      completedAt: "2024-01-01T00:02:00Z",
+      runtimeLifecycleId: "run-001",
+    });
+    const activeRetry = mockRun({
+      runId: "run-002",
+      status: "running",
+      createdAt: "2024-01-01T00:07:00Z",
+      updatedAt: "2024-01-01T00:09:00Z",
+      startedAt: "2024-01-01T00:07:00Z",
+      completedAt: null,
+      cumulativeRuntimeMs: 120_000,
+      runtimeLifecycleId: "run-001",
+    });
+
+    const snapshot = buildProjectSnapshot({
+      project: mockProject(),
+      activeRuns: [activeRetry],
+      allRuns: [completedSession, activeRetry],
+      summary: { dispatched: 2, suppressed: 0, recovered: 0 },
+      lastTickAt: "2024-01-01T00:09:00Z",
+      lastError: null,
+    });
+
+    expect(snapshot.codexTotals!.secondsRunning).toBe(240);
+  });
+
+  it("uses frozen retry runtime instead of capacity wait bookkeeping time", () => {
+    const retryingRun = mockRun({
+      status: "retrying",
+      startedAt: null,
+      completedAt: "2024-01-01T00:02:00Z",
+      updatedAt: "2024-01-01T00:07:00Z",
+      cumulativeRuntimeMs: 120_000,
+      runtimeLifecycleId: "run-001",
+    });
+
+    const snapshot = buildProjectSnapshot({
+      project: mockProject(),
+      activeRuns: [],
+      allRuns: [retryingRun],
+      summary: { dispatched: 1, suppressed: 0, recovered: 0 },
+      lastTickAt: "2024-01-01T00:07:00Z",
+      lastError: null,
+    });
+
+    expect(snapshot.codexTotals!.secondsRunning).toBe(120);
+  });
+
+  it("sums legacy lifecycle sessions without cumulative runtime", () => {
+    const firstSession = mockRun({
+      runId: "run-001",
+      status: "failed",
+      createdAt: "2024-01-01T00:00:00Z",
+      startedAt: "2024-01-01T00:00:00Z",
+      completedAt: "2024-01-01T00:02:00Z",
+      updatedAt: "2024-01-01T00:02:00Z",
+    });
+    const secondSession = mockRun({
+      runId: "run-002",
+      status: "failed",
+      createdAt: "2024-01-01T00:00:00Z",
+      startedAt: "2024-01-01T00:07:00Z",
+      completedAt: "2024-01-01T00:09:00Z",
+      updatedAt: "2024-01-01T00:09:00Z",
+    });
+
+    const snapshot = buildProjectSnapshot({
+      project: mockProject(),
+      activeRuns: [],
+      allRuns: [firstSession, secondSession],
+      summary: { dispatched: 2, suppressed: 0, recovered: 0 },
+      lastTickAt: "2024-01-01T00:09:00Z",
+      lastError: null,
+    });
+
+    expect(snapshot.codexTotals!.secondsRunning).toBe(240);
+  });
+
   it("handles retrying run with null retryKind by defaulting to 'failure'", () => {
     const run = mockRun({
       status: "retrying",

--- a/packages/core/src/observability/snapshot-builder.ts
+++ b/packages/core/src/observability/snapshot-builder.ts
@@ -304,33 +304,57 @@ function aggregateTokenUsage(
   let inputTokens = 0;
   let outputTokens = 0;
   let totalTokens = 0;
-  let earliestStart: number | null = null;
-  let latestEnd: number | null = null;
-
   for (const run of runs) {
     if (run.tokenUsage) {
       inputTokens += run.tokenUsage.inputTokens;
       outputTokens += run.tokenUsage.outputTokens;
       totalTokens += run.tokenUsage.totalTokens;
     }
-    if (run.startedAt) {
-      const start = new Date(run.startedAt).getTime();
-      if (earliestStart === null || start < earliestStart) {
-        earliestStart = start;
-      }
-    }
-    const end = run.completedAt
-      ? new Date(run.completedAt).getTime()
-      : new Date(lastTickAt).getTime();
-    if (latestEnd === null || end > latestEnd) {
-      latestEnd = end;
+  }
+
+  const runtimeMs = Array.from(latestSessionsByRunLifecycle(runs).values())
+    .map((run) => runtimeMsForSnapshot(run, lastTickAt))
+    .reduce((total, sessionRuntimeMs) => total + sessionRuntimeMs, 0);
+  const secondsRunning = Math.max(0, Math.round(runtimeMs / 1000));
+
+  return { inputTokens, outputTokens, totalTokens, secondsRunning };
+}
+
+function latestSessionsByRunLifecycle(
+  runs: OrchestratorRunRecord[]
+): Map<string, OrchestratorRunRecord> {
+  const latestRuns = new Map<string, OrchestratorRunRecord>();
+
+  for (const run of runs) {
+    const key = `${run.projectId}:${run.issueId}:${run.createdAt}`;
+    const current = latestRuns.get(key);
+    if (
+      !current ||
+      new Date(run.updatedAt).getTime() >= new Date(current.updatedAt).getTime()
+    ) {
+      latestRuns.set(key, run);
     }
   }
 
-  const secondsRunning =
-    earliestStart !== null && latestEnd !== null
-      ? Math.max(0, Math.round((latestEnd - earliestStart) / 1000))
-      : 0;
+  return latestRuns;
+}
 
-  return { inputTokens, outputTokens, totalTokens, secondsRunning };
+function runtimeMsForSnapshot(
+  run: OrchestratorRunRecord,
+  lastTickAt: string
+): number {
+  const accumulatedRuntimeMs = run.cumulativeRuntimeMs ?? 0;
+  if (!run.startedAt) {
+    return accumulatedRuntimeMs;
+  }
+
+  const startedAtMs = new Date(run.startedAt).getTime();
+  const endedAt =
+    run.completedAt ?? (run.status === "running" ? lastTickAt : run.updatedAt);
+  const endedAtMs = new Date(endedAt).getTime();
+  if (!Number.isFinite(startedAtMs) || !Number.isFinite(endedAtMs)) {
+    return accumulatedRuntimeMs;
+  }
+
+  return accumulatedRuntimeMs + Math.max(0, endedAtMs - startedAtMs);
 }

--- a/packages/core/src/observability/snapshot-builder.ts
+++ b/packages/core/src/observability/snapshot-builder.ts
@@ -312,31 +312,64 @@ function aggregateTokenUsage(
     }
   }
 
-  const runtimeMs = Array.from(latestSessionsByRunLifecycle(runs).values())
-    .map((run) => runtimeMsForSnapshot(run, lastTickAt))
-    .reduce((total, sessionRuntimeMs) => total + sessionRuntimeMs, 0);
+  const runtimeMs = Array.from(runsByLifecycle(runs).values()).reduce(
+    (total, lifecycleRuns) =>
+      total + runtimeMsForLifecycle(lifecycleRuns, lastTickAt),
+    0
+  );
   const secondsRunning = Math.max(0, Math.round(runtimeMs / 1000));
 
   return { inputTokens, outputTokens, totalTokens, secondsRunning };
 }
 
-function latestSessionsByRunLifecycle(
+function runsByLifecycle(
   runs: OrchestratorRunRecord[]
-): Map<string, OrchestratorRunRecord> {
-  const latestRuns = new Map<string, OrchestratorRunRecord>();
+): Map<string, OrchestratorRunRecord[]> {
+  const groupedRuns = new Map<string, OrchestratorRunRecord[]>();
 
   for (const run of runs) {
-    const key = `${run.projectId}:${run.issueId}:${run.createdAt}`;
-    const current = latestRuns.get(key);
-    if (
-      !current ||
-      new Date(run.updatedAt).getTime() >= new Date(current.updatedAt).getTime()
-    ) {
-      latestRuns.set(key, run);
-    }
+    const lifecycleId = run.runtimeLifecycleId ?? run.createdAt;
+    const key = `${run.projectId}:${run.issueId}:${lifecycleId}`;
+    groupedRuns.set(key, [...(groupedRuns.get(key) ?? []), run]);
   }
 
-  return latestRuns;
+  return groupedRuns;
+}
+
+function runtimeMsForLifecycle(
+  runs: OrchestratorRunRecord[],
+  lastTickAt: string
+): number {
+  // Records written before cumulativeRuntimeMs existed share the legacy
+  // createdAt lifecycle identity. Sum their individual sessions so upgrading
+  // does not discard already-finished runtime.
+  if (!runs.some((run) => run.cumulativeRuntimeMs !== undefined)) {
+    return runs.reduce(
+      (total, run) => total + runtimeMsForSnapshot(run, lastTickAt),
+      0
+    );
+  }
+
+  return runtimeMsForSnapshot(latestSession(runs), lastTickAt);
+}
+
+function latestSession(runs: OrchestratorRunRecord[]): OrchestratorRunRecord {
+  return runs.reduce((latest, candidate) => {
+    const latestUpdatedAt = new Date(latest.updatedAt).getTime();
+    const candidateUpdatedAt = new Date(candidate.updatedAt).getTime();
+    if (candidateUpdatedAt !== latestUpdatedAt) {
+      return candidateUpdatedAt > latestUpdatedAt ? candidate : latest;
+    }
+    if ((candidate.status === "running") !== (latest.status === "running")) {
+      return candidate.status === "running" ? candidate : latest;
+    }
+    const latestStartedAt = latest.startedAt ?? "";
+    const candidateStartedAt = candidate.startedAt ?? "";
+    if (candidateStartedAt !== latestStartedAt) {
+      return candidateStartedAt > latestStartedAt ? candidate : latest;
+    }
+    return candidate.runId > latest.runId ? candidate : latest;
+  });
 }
 
 function runtimeMsForSnapshot(
@@ -350,7 +383,11 @@ function runtimeMsForSnapshot(
 
   const startedAtMs = new Date(run.startedAt).getTime();
   const endedAt =
-    run.completedAt ?? (run.status === "running" ? lastTickAt : run.updatedAt);
+    run.completedAt ??
+    (run.runtimeSession?.status !== "active"
+      ? run.runtimeSession?.updatedAt
+      : null) ??
+    (run.status === "running" ? lastTickAt : run.updatedAt);
   const endedAtMs = new Date(endedAt).getTime();
   if (!Number.isFinite(startedAtMs) || !Number.isFinite(endedAtMs)) {
     return accumulatedRuntimeMs;

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -2460,6 +2460,7 @@ describe("OrchestratorService", () => {
     expect(recoveryRun).toMatchObject({
       status: "running",
       retryKind: "recovery",
+      cumulativeRuntimeMs: 300_000,
       recovery: expect.objectContaining({
         kind: "incomplete-turn-dirty-workspace",
         dirtyFiles: expectedDirtyFiles,

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -2464,7 +2464,7 @@ describe("OrchestratorService", () => {
       status: "running",
       retryKind: "recovery",
       cumulativeRuntimeMs: 300_000,
-      runtimeLifecycleId: "run-incomplete",
+      runtimeLifecycleId: "2026-03-08T00:00:00.000Z",
       recovery: expect.objectContaining({
         kind: "incomplete-turn-dirty-workspace",
         dirtyFiles: expectedDirtyFiles,
@@ -3463,7 +3463,7 @@ describe("OrchestratorService", () => {
       expect(updatedRun?.status).toBe("retrying");
       expect(updatedRun?.retryKind).toBe("failure");
       expect(updatedRun?.nextRetryAt).toBe("2026-03-08T00:01:02.000Z");
-      expect(updatedRun?.completedAt).toBeNull();
+      expect(updatedRun?.completedAt).toBe("2026-03-08T00:01:00.000Z");
       expect(updatedRun?.lastError).toBe(
         "convergence_detected: workspace unchanged"
       );

--- a/packages/orchestrator/src/service.test.ts
+++ b/packages/orchestrator/src/service.test.ts
@@ -747,7 +747,7 @@ describe("OrchestratorService", () => {
       retryKind: "recovery",
       createdAt: now.toISOString(),
       updatedAt: now.toISOString(),
-      startedAt: now.toISOString(),
+      startedAt: "2026-03-07T23:58:00.000Z",
       completedAt: null,
       lastError: "worker failed",
       nextRetryAt: now.toISOString(),
@@ -795,6 +795,9 @@ describe("OrchestratorService", () => {
     expect(await store.loadRun(run.runId)).toMatchObject({
       status: "retrying",
       retryKind: "recovery",
+      startedAt: null,
+      completedAt: now.toISOString(),
+      cumulativeRuntimeMs: 120_000,
     });
   });
 
@@ -2461,6 +2464,7 @@ describe("OrchestratorService", () => {
       status: "running",
       retryKind: "recovery",
       cumulativeRuntimeMs: 300_000,
+      runtimeLifecycleId: "run-incomplete",
       recovery: expect.objectContaining({
         kind: "incomplete-turn-dirty-workspace",
         dirtyFiles: expectedDirtyFiles,

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -1611,7 +1611,7 @@ export class OrchestratorService {
                 : undefined,
             runtimeLifecycleId:
               recoveryContext || existingIssueRecord?.retryEntry
-                ? (previousRun?.runtimeLifecycleId ?? previousRun?.runId)
+                ? (previousRun?.runtimeLifecycleId ?? previousRun?.createdAt)
                 : undefined,
             recovery: recoveryContext,
             onPrepared: async (candidate) => {
@@ -4758,7 +4758,7 @@ export class OrchestratorService {
       restarted = await this.startRun(tenant, issue, {
         attempt: run.attempt,
         cumulativeRuntimeMs: resolveCumulativeRuntimeMs(run),
-        runtimeLifecycleId: run.runtimeLifecycleId ?? run.runId,
+        runtimeLifecycleId: run.runtimeLifecycleId ?? run.createdAt,
         recovery,
         onPrepared: async (candidate) => {
           preparedRun = candidate;

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -1556,6 +1556,7 @@ export class OrchestratorService {
           issue,
           latestRunsByIssueId.get(issue.id) ?? null
         );
+        const previousRun = latestRunsByIssueId.get(issue.id) ?? null;
         const expiredConvergenceRun = expiredConvergenceLocks.get(issue.id);
         if (expiredConvergenceRun) {
           const recentEvents = await this.store.loadRecentRunEvents(
@@ -1604,6 +1605,10 @@ export class OrchestratorService {
         try {
           run = await this.startRun(tenant, issue, {
             attempt: existingIssueRecord?.retryEntry?.attempt ?? null,
+            cumulativeRuntimeMs:
+              recoveryContext || existingIssueRecord?.retryEntry
+                ? resolveCumulativeRuntimeMs(previousRun)
+                : undefined,
             recovery: recoveryContext,
             onPrepared: async (candidate) => {
               preparedRun = candidate;
@@ -2676,6 +2681,7 @@ export class OrchestratorService {
        * retry attempt exposed to workflow prompt rendering.
        */
       attempt?: number | null;
+      cumulativeRuntimeMs?: number;
       recovery?: IncompleteTurnRecoveryContext | null;
       onPrepared?: (run: OrchestratorRunRecord) => Promise<void>;
     } = {}
@@ -2958,6 +2964,7 @@ export class OrchestratorService {
       retryKind: recovery ? "recovery" : null,
       threadId: null,
       cumulativeTurnCount: 0,
+      cumulativeRuntimeMs: options.cumulativeRuntimeMs ?? 0,
       lastTurnSummary: null,
       createdAt: now.toISOString(),
       updatedAt: now.toISOString(),
@@ -4737,6 +4744,7 @@ export class OrchestratorService {
       const recovery = await this.resolveRetryRunRecoveryContext(tenant, run);
       restarted = await this.startRun(tenant, issue, {
         attempt: run.attempt,
+        cumulativeRuntimeMs: resolveCumulativeRuntimeMs(run),
         recovery,
         onPrepared: async (candidate) => {
           preparedRun = candidate;
@@ -6079,6 +6087,25 @@ function resolvePersistedCumulativeTurnCount(
   run: OrchestratorRunRecord
 ): number {
   return run.cumulativeTurnCount ?? run.turnCount ?? 0;
+}
+
+function resolveCumulativeRuntimeMs(run: OrchestratorRunRecord | null): number {
+  if (!run) {
+    return 0;
+  }
+
+  const accumulatedRuntimeMs = run.cumulativeRuntimeMs ?? 0;
+  if (!run.startedAt) {
+    return accumulatedRuntimeMs;
+  }
+
+  const startedAtMs = parseTimestampMs(run.startedAt);
+  const endedAtMs = parseTimestampMs(run.completedAt ?? run.updatedAt);
+  if (startedAtMs === null || endedAtMs === null) {
+    return accumulatedRuntimeMs;
+  }
+
+  return accumulatedRuntimeMs + Math.max(0, endedAtMs - startedAtMs);
 }
 
 function shellQuote(value: string): string {

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -1551,12 +1551,12 @@ export class OrchestratorService {
           existingWorkspace?.workspaceKey ??
           existingIssueRecord?.workspaceKey ??
           preferredWorkspaceKey;
+        const previousRun = latestRunsByIssueId.get(issue.id) ?? null;
         const recoveryContext = await this.resolveIncompleteTurnRecoveryContext(
           tenant,
           issue,
-          latestRunsByIssueId.get(issue.id) ?? null
+          previousRun
         );
-        const previousRun = latestRunsByIssueId.get(issue.id) ?? null;
         const expiredConvergenceRun = expiredConvergenceLocks.get(issue.id);
         if (expiredConvergenceRun) {
           const recentEvents = await this.store.loadRecentRunEvents(
@@ -1608,6 +1608,10 @@ export class OrchestratorService {
             cumulativeRuntimeMs:
               recoveryContext || existingIssueRecord?.retryEntry
                 ? resolveCumulativeRuntimeMs(previousRun)
+                : undefined,
+            runtimeLifecycleId:
+              recoveryContext || existingIssueRecord?.retryEntry
+                ? (previousRun?.runtimeLifecycleId ?? previousRun?.runId)
                 : undefined,
             recovery: recoveryContext,
             onPrepared: async (candidate) => {
@@ -2682,6 +2686,7 @@ export class OrchestratorService {
        */
       attempt?: number | null;
       cumulativeRuntimeMs?: number;
+      runtimeLifecycleId?: string;
       recovery?: IncompleteTurnRecoveryContext | null;
       onPrepared?: (run: OrchestratorRunRecord) => Promise<void>;
     } = {}
@@ -2965,6 +2970,7 @@ export class OrchestratorService {
       threadId: null,
       cumulativeTurnCount: 0,
       cumulativeRuntimeMs: options.cumulativeRuntimeMs ?? 0,
+      runtimeLifecycleId: options.runtimeLifecycleId ?? runId,
       lastTurnSummary: null,
       createdAt: now.toISOString(),
       updatedAt: now.toISOString(),
@@ -3661,6 +3667,7 @@ export class OrchestratorService {
       ).toISOString();
     }
 
+    const retryCompletedAt = now.toISOString();
     const retryRecord: OrchestratorRunRecord = {
       ...runWithTokens,
       finalizationDeferralCount: 0,
@@ -3670,7 +3677,13 @@ export class OrchestratorService {
       attempt:
         persistedRetryKind === "continuation" ? 1 : runWithTokens.attempt + 1,
       processId: null,
-      updatedAt: now.toISOString(),
+      updatedAt: retryCompletedAt,
+      startedAt: null,
+      completedAt: retryCompletedAt,
+      cumulativeRuntimeMs: resolveCumulativeRuntimeMs({
+        ...runWithTokens,
+        completedAt: retryCompletedAt,
+      }),
       nextRetryAt,
       retryKind: persistedRetryKind,
       threadId:
@@ -4745,6 +4758,7 @@ export class OrchestratorService {
       restarted = await this.startRun(tenant, issue, {
         attempt: run.attempt,
         cumulativeRuntimeMs: resolveCumulativeRuntimeMs(run),
+        runtimeLifecycleId: run.runtimeLifecycleId ?? run.runId,
         recovery,
         onPrepared: async (candidate) => {
           preparedRun = candidate;
@@ -4785,7 +4799,6 @@ export class OrchestratorService {
       ...restarted,
       attempt: run.attempt,
       retryKind: run.retryKind ?? "recovery",
-      createdAt: run.createdAt,
       issueWorkspaceKey: run.issueWorkspaceKey,
       threadId: null,
       cumulativeTurnCount: resolvePersistedCumulativeTurnCount(run),
@@ -5058,13 +5071,19 @@ export class OrchestratorService {
           error,
         ].join(" ")
       : error;
+    const sessionEndedAt = run.completedAt ?? now.toISOString();
     await this.store.saveRun({
       ...run,
       status: suppressed ? "suppressed" : "retrying",
       attempt,
       processId: null,
       updatedAt: now.toISOString(),
-      completedAt: suppressed ? now.toISOString() : null,
+      startedAt: null,
+      completedAt: sessionEndedAt,
+      cumulativeRuntimeMs: resolveCumulativeRuntimeMs({
+        ...run,
+        completedAt: sessionEndedAt,
+      }),
       nextRetryAt: dueAt,
       // Requeueing only postpones a due retry; it must not discard the
       // recovery context that snapshot consumers use to expose dirty-workspace


### PR DESCRIPTION
## TL;DR

`seconds_running` now reports accumulated worker-session runtime, including completed sessions and the current active session while excluding retry backoff and queue time.

## Change-point diagram

```text
completed session ──> freeze cumulativeRuntimeMs + completedAt
retry/restart ──────> retain runtimeLifecycleId (legacy: createdAt)
active session ─────> accumulated runtime + snapshot elapsed
```

## Start here

- `packages/core/src/observability/snapshot-builder.ts` groups records by lifecycle and computes only completed-session runtime plus the active-session elapsed span.
- `packages/orchestrator/src/service.ts` preserves the lifecycle identity through retry/restart, including a retry that crosses the runtime-record upgrade.
- `packages/core/src/observability/snapshot-builder.test.ts` contains exact multi-session, retry-gap, and mixed-version assertions.

## Changes

- Added persisted `cumulativeRuntimeMs` and `runtimeLifecycleId` support so retries and worker restarts retain accumulated runtime without double counting.
- Freeze retry records at the completed session boundary; later retry scheduling does not extend the metric.
- Added exact regression coverage for a legacy record followed by an upgraded active retry: 120 seconds completed + 120 seconds active = 240 seconds.

## Evidence

- `pnpm lint` — pass
- `pnpm test` — pass
- `pnpm typecheck` — pass
- `pnpm build` — pass
- `pnpm --filter @gh-symphony/core test -- snapshot-builder.test.ts` — pass (33 tests)
- `pnpm --filter @gh-symphony/orchestrator test -- service.test.ts -t 'queues a clean convergence failure when the tracker is already in the retryable state|classifies incomplete dirty turns and redispatches with recovery context'` — pass
- `./e2e/run-e2e.sh happy 60` — pass (Docker lifecycle reached retry then idle)

## Risks & rollback

The new run-record fields are optional for backward compatibility. Legacy retry/restart flows use the prior record’s `createdAt` as their lifecycle identity. Reverting the PR restores the prior wall-clock metric behavior.

## Changed files

- `.changeset/750-accumulated-session-runtime.md`
- `packages/core/src/contracts/status-surface.ts`
- `packages/core/src/observability/snapshot-builder.ts`
- `packages/core/src/observability/snapshot-builder.test.ts`
- `packages/orchestrator/src/service.ts`
- `packages/orchestrator/src/service.test.ts`

## Issues — Closed #750

Fixes #750

## Post-merge / human validation

- [ ] Observe a retried worker in the status surface and confirm retry idle time does not increase `seconds_running`.
