### PR TITLE
feat(doctor): warn on ignored state concurrency limits

### DIFF
--- a/.changeset/bright-state-concurrency-warnings.md
+++ b/.changeset/bright-state-concurrency-warnings.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Warn in `workflow validate` and `doctor` when ignored per-state concurrency entries cannot take effect (#767).

--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ Lower numbers dispatch first. If an issue has multiple configured priority label
 
 Legacy `tracker.priority_field: Priority` remains supported for existing workflows, but it is deprecated because it uses live Project option order. Project field definitions are cached for the process lifetime, so field creation, removal, and option changes take effect after the daemon restarts. To migrate, replace it with `tracker.provider.priority.source: project-field`, copy the exact field name, and write explicit option-name-to-number mappings. If both legacy and explicit config are present, explicit `tracker.provider.priority` wins and diagnostics warn about the conflict.
 
-`gh-symphony workflow validate` reports local config errors and legacy priority warnings. Strict front-matter failures use stable workflow error codes; with `--json`, `workflow validate` includes both `error.code` and `error.path`. `gh-symphony doctor` additionally checks live Project/repository drift: missing fields, missing labels, unmapped live options, stale configured mappings, and active issues that currently resolve to `priority = null` because their priority-like value is unmapped.
+`gh-symphony workflow validate` reports local config errors plus warnings for legacy priority configuration and ignored per-state concurrency entries. Each concurrency warning names the ignored `agent.max_concurrent_agents_by_state` path and reason, while valid entries in the same map remain active. Strict front-matter failures use stable workflow error codes; with `--json`, `workflow validate` includes both `error.code` and `error.path`. `gh-symphony doctor` additionally checks live Project/repository drift and reports the same local configuration warnings.
 
 ### Token-Only Setup
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -78,20 +78,20 @@ diverge from the upstream shell-command hook model.
 
 ## WORKFLOW.md Front-matter Validation
 
-`gh-symphony workflow validate` and `gh-symphony repo doctor` use the same
+`gh-symphony workflow validate` and `gh-symphony doctor` use the same
 strict parser as workflow loading. Failures include a stable error code; the
 `workflow validate --json` error also exposes its field path separately.
 
-| Rule                      | Required value                                                                                                             | Error code/path                                                               |
-| ------------------------- | -------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
-| Front matter syntax       | Optional; when present it must be a valid YAML mapping                                                                     | `workflow_parse_error` or `workflow_front_matter_not_a_map` at `front_matter` |
-| Numeric fields            | YAML integers; quoted numeric strings and fractions are rejected, including priority maps and per-state concurrency values | `workflow_validation_error` at the field path                                 |
-| `hooks.timeout_ms`        | A positive integer when provided                                                                                           | `workflow_validation_error` at `hooks.timeout_ms`                             |
-| `agent.max_turns`         | A positive integer when provided                                                                                           | `workflow_validation_error` at `agent.max_turns`                              |
-| `codex.command`           | A non-empty string when provided                                                                                           | `workflow_validation_error` at `codex.command`                                |
-| `tracker.kind`            | One of `github-project`, `linear`, or `file`                                                                               | `workflow_validation_error` at `tracker.kind`                                 |
-| `tracker.required_labels` | An array of strings; comma-separated strings are rejected                                                                  | `workflow_validation_error` at `tracker.required_labels`                      |
-| `server.port`             | An integer from `0` to `65535`; `0` requests an ephemeral local port                                                       | `workflow_validation_error` at `server.port`                                  |
+| Rule                      | Required value                                                                                                                     | Error code/path                                                                                     |
+| ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| Front matter syntax       | Optional; when present it must be a valid YAML mapping                                                                             | `workflow_parse_error` or `workflow_front_matter_not_a_map` at `front_matter`                       |
+| Numeric fields            | YAML integers; quoted numeric strings and fractions are rejected. Invalid per-state concurrency entries are ignored with warnings. | `workflow_validation_error` at other invalid numeric field paths; warnings name ignored entry paths |
+| `hooks.timeout_ms`        | A positive integer when provided                                                                                                   | `workflow_validation_error` at `hooks.timeout_ms`                                                   |
+| `agent.max_turns`         | A positive integer when provided                                                                                                   | `workflow_validation_error` at `agent.max_turns`                                                    |
+| `codex.command`           | A non-empty string when provided                                                                                                   | `workflow_validation_error` at `codex.command`                                                      |
+| `tracker.kind`            | One of `github-project`, `linear`, or `file`                                                                                       | `workflow_validation_error` at `tracker.kind`                                                       |
+| `tracker.required_labels` | An array of strings; comma-separated strings are rejected                                                                          | `workflow_validation_error` at `tracker.required_labels`                                            |
+| `server.port`             | An integer from `0` to `65535`; `0` requests an ephemeral local port                                                               | `workflow_validation_error` at `server.port`                                                        |
 
 Without front matter, the complete trimmed file is used as the workflow prompt
 and all configuration uses defaults; tracker selection is then checked by the
@@ -108,7 +108,9 @@ maps remain supported through `agent.max_concurrent_agents_by_state`. State keys
 are trimmed and lowercased before storage and dispatch lookup, so for example
 `" In Progress "` and `in progress` configure the same limit. Entries whose
 values are non-positive or not YAML integers are ignored; valid entries in the
-same map remain effective.
+same map remain effective. `gh-symphony workflow validate` and `gh-symphony
+doctor` warn with the ignored entry path and reason so the configuration
+can be corrected without changing dispatch behavior.
 
 ## Optional HTTP Server
 
@@ -359,7 +361,7 @@ or field is omitted. Flat `tracker.project_id`, `tracker.endpoint`,
 `tracker.state_field`, `tracker.priority`, `tracker.pickup_labels`,
 `tracker.blocker_check_states`, and `tracker.planning_states` aliases remain
 supported for compatibility, but `gh-symphony workflow validate` and
-`gh-symphony repo doctor` warn and print a copyable `tracker.provider` block.
+`gh-symphony doctor` warn and print a copyable `tracker.provider` block.
 They are scheduled for removal in the next major release; see
 [ADR 2026-08-29](adr/2026-08-29_tracker-provider-alias-deprecation.md).
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -204,7 +204,7 @@ Use `tracker.provider` for new workflows; `gh-symphony doctor` prints the
 normalized provider block for migration. The aliases are removed in the next
 major release (#679).
 
-Run `gh-symphony workflow validate` for local schema errors and `gh-symphony doctor` for live drift warnings such as missing Project fields, missing labels, unmapped live options, stale mappings, and active issues whose priority-like value resolves to `priority = null`. Strict front-matter failures use stable workflow error codes; `workflow validate --json` also emits the failing `error.path`.
+Run `gh-symphony workflow validate` for local schema errors and warnings. Ignored `agent.max_concurrent_agents_by_state` entries warn with their paths and reasons, while valid entries in the same map remain active; `gh-symphony doctor` reports the same warning alongside live drift checks such as missing Project fields, missing labels, unmapped live options, stale mappings, and active issues whose priority-like value resolves to `priority = null`. Strict front-matter failures use stable workflow error codes; `workflow validate --json` also emits the failing `error.path`.
 
 ### Linear Tracker Repositories
 

--- a/packages/cli/src/commands/doctor.test.ts
+++ b/packages/cli/src/commands/doctor.test.ts
@@ -2961,6 +2961,50 @@ describe("doctor command handler", () => {
     });
   });
 
+  it("warns about ignored per-state concurrency entries", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "doctor-config-"));
+    const workspaceDir = join(configDir, "workspaces");
+    await prepareDoctorPaths(configDir, workspaceDir);
+    const { repoDir, pathEnv } = await createWorkflowFixture();
+    await writeFile(
+      join(repoDir, "WORKFLOW.md"),
+      "---\ntracker:\n  kind: github-project\nagent:\n  max_concurrent_agents_by_state:\n    Ready: 0\n    Review: '2'\n    In-progress: 2\ncodex:\n  command: fake-agent\n---\nPrompt body\n",
+      "utf8"
+    );
+
+    const report = await withCwd(repoDir, () =>
+      runDoctorDiagnostics(baseOptions(configDir), [], {
+        ...authDependencies(),
+        inspectManagedProjectSelection: async () => ({
+          kind: "resolved",
+          projectId: "tenant-a",
+          projectConfig: createProjectConfig(workspaceDir),
+        }),
+        getProjectDetail: (async () => createProjectDetail() as never) as never,
+        pathEnv,
+      })
+    );
+
+    expect(report.ok).toBe(true);
+    expect(
+      report.checks.filter((check) => check.id === "state_concurrency")
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          status: "warn",
+          title: "Ignored per-state concurrency entry",
+          summary: expect.stringContaining(
+            "agent.max_concurrent_agents_by_state.Ready"
+          ),
+          details: expect.objectContaining({
+            path: "agent.max_concurrent_agents_by_state.Ready",
+            reason: "must be greater than zero",
+          }),
+        }),
+      ])
+    );
+  });
+
   it("warns for project-field priority drift without failing doctor", async () => {
     const configDir = await mkdtemp(join(tmpdir(), "doctor-config-"));
     const workspaceDir = join(configDir, "workspaces");

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -56,6 +56,7 @@ import {
   buildProviderDeprecationDiagnostics,
   buildPriorityConfigDiagnostics,
   buildPriorityDriftDiagnostics,
+  buildStateConcurrencyDiagnostics,
 } from "../priority-diagnostics.js";
 import { inspectManagedProjectSelection } from "../project-selection.js";
 import { standaloneProjectId } from "./project.js";
@@ -94,6 +95,7 @@ type DoctorCheckId =
   | "workflow_prompt_render"
   | "workflow_hooks"
   | "priority_mapping"
+  | "state_concurrency"
   | "claude_binary"
   | "anthropic_api_key"
   | "claude_mcp_config";
@@ -2176,6 +2178,17 @@ export async function runDoctorDiagnostics(
               diagnostic.remediation,
               diagnostic.details
             )
+        )
+      : []),
+    ...(workflow.status === "pass"
+      ? buildStateConcurrencyDiagnostics(workflow.workflow).map((diagnostic) =>
+          warnCheck(
+            "state_concurrency",
+            diagnostic.title,
+            diagnostic.summary,
+            diagnostic.remediation,
+            diagnostic.details
+          )
         )
       : []),
     ...(await buildPriorityMappingChecks({

--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -260,6 +260,71 @@ Prompt {{ issue.identifier }}
     );
   });
 
+  it("reports ignored per-state concurrency entries in validation output", async () => {
+    const root = await mkdtemp(
+      join(tmpdir(), "workflow-validate-concurrency-")
+    );
+    const workflowPath = join(root, "WORKFLOW.md");
+    const stdout = captureWrites(process.stdout);
+
+    await writeFile(
+      workflowPath,
+      `---
+tracker:
+  kind: github-project
+agent:
+  max_concurrent_agents_by_state:
+    Ready: 0
+    Review: '2'
+    " In Progress ": 2
+codex:
+  command: codex app-server
+---
+Prompt {{ issue.identifier }}
+`,
+      "utf8"
+    );
+
+    try {
+      await workflowCommand(["validate", "--file", workflowPath], {
+        configDir: root,
+        verbose: false,
+        json: true,
+        noColor: false,
+      });
+    } finally {
+      stdout.restore();
+    }
+
+    const report = JSON.parse(stdout.output()) as {
+      warnings: Array<{
+        title: string;
+        summary: string;
+        details: { path: string };
+      }>;
+    };
+    expect(report.warnings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          title: "Ignored per-state concurrency entry",
+          summary: expect.stringContaining(
+            "agent.max_concurrent_agents_by_state.Ready"
+          ),
+          details: {
+            path: "agent.max_concurrent_agents_by_state.Ready",
+            reason: "must be greater than zero",
+          },
+        }),
+        expect.objectContaining({
+          title: "Ignored per-state concurrency entry",
+          summary: expect.stringContaining(
+            "agent.max_concurrent_agents_by_state.Review"
+          ),
+        }),
+      ])
+    );
+  });
+
   it("includes normalized required labels in JSON validation output", async () => {
     const root = await mkdtemp(
       join(tmpdir(), "workflow-validate-required-labels-")

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -32,6 +32,7 @@ import { writeCliError } from "../cli-error.js";
 import {
   buildProviderDeprecationDiagnostics,
   buildPriorityConfigDiagnostics,
+  buildStateConcurrencyDiagnostics,
   type PriorityDiagnostic,
 } from "../priority-diagnostics.js";
 import { inspectManagedProjectSelection } from "../project-selection.js";
@@ -856,6 +857,7 @@ function validateWorkflow(
     warnings: [
       ...buildProviderDeprecationDiagnostics(workflow),
       ...buildPriorityConfigDiagnostics(workflow),
+      ...buildStateConcurrencyDiagnostics(workflow),
     ],
     summary: {
       trackerKind: workflow.tracker.kind,

--- a/packages/cli/src/priority-diagnostics.test.ts
+++ b/packages/cli/src/priority-diagnostics.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import { parseWorkflowMarkdown } from "@gh-symphony/core";
-import { buildProviderDeprecationDiagnostics } from "./priority-diagnostics.js";
+import {
+  buildProviderDeprecationDiagnostics,
+  buildStateConcurrencyDiagnostics,
+} from "./priority-diagnostics.js";
 
 describe("buildProviderDeprecationDiagnostics", () => {
   it("keeps environment references out of migration guidance", () => {
@@ -23,5 +26,27 @@ Prompt`,
     expect(diagnostic?.details?.providerBlock).toContain(
       'api_key: "env:PLAIN_TOKEN"'
     );
+  });
+});
+
+describe("buildStateConcurrencyDiagnostics", () => {
+  it("renders complete grammar for blank state names", () => {
+    const workflow = parseWorkflowMarkdown(`---
+tracker:
+  kind: github-project
+agent:
+  max_concurrent_agents_by_state:
+    "  ": 3
+codex:
+  command: codex
+---
+Prompt`);
+
+    expect(buildStateConcurrencyDiagnostics(workflow)).toEqual([
+      expect.objectContaining({
+        summary:
+          'agent.max_concurrent_agents_by_state["  "] is ignored: state name is blank after normalization.',
+      }),
+    ]);
   });
 });

--- a/packages/cli/src/priority-diagnostics.test.ts
+++ b/packages/cli/src/priority-diagnostics.test.ts
@@ -49,4 +49,25 @@ Prompt`);
       }),
     ]);
   });
+
+  it("renders collision warnings with grammar and padded paths", () => {
+    const workflow = parseWorkflowMarkdown(`---
+tracker:
+  kind: github-project
+agent:
+  max_concurrent_agents_by_state:
+    Ready: 1
+    " READY ": 2
+codex:
+  command: codex
+---
+Prompt`);
+
+    expect(buildStateConcurrencyDiagnostics(workflow)).toEqual([
+      expect.objectContaining({
+        summary:
+          'agent.max_concurrent_agents_by_state.Ready is ignored: duplicates agent.max_concurrent_agents_by_state[" READY "] after state-name normalization.',
+      }),
+    ]);
+  });
 });

--- a/packages/cli/src/priority-diagnostics.ts
+++ b/packages/cli/src/priority-diagnostics.ts
@@ -1,6 +1,7 @@
 import type {
   ParsedWorkflow,
   TrackedIssue,
+  WorkflowDiagnostic,
   WorkflowPriorityConfig,
 } from "@gh-symphony/core";
 import type { ProjectDetail } from "./github/client.js";
@@ -11,6 +12,17 @@ export type PriorityDiagnostic = {
   remediation?: string;
   details?: Record<string, unknown>;
 };
+
+export function buildStateConcurrencyDiagnostics(
+  workflow: ParsedWorkflow
+): PriorityDiagnostic[] {
+  return workflow.diagnostics.map((diagnostic: WorkflowDiagnostic) => ({
+    title: "Ignored per-state concurrency entry",
+    summary: `${diagnostic.path} is ignored because it ${diagnostic.reason}.`,
+    remediation: diagnostic.remediation,
+    details: { path: diagnostic.path, reason: diagnostic.reason },
+  }));
+}
 
 type RepositoryLabelSnapshot = {
   repository: string;

--- a/packages/cli/src/priority-diagnostics.ts
+++ b/packages/cli/src/priority-diagnostics.ts
@@ -16,12 +16,17 @@ export type PriorityDiagnostic = {
 export function buildStateConcurrencyDiagnostics(
   workflow: ParsedWorkflow
 ): PriorityDiagnostic[] {
-  return workflow.diagnostics.map((diagnostic: WorkflowDiagnostic) => ({
-    title: "Ignored per-state concurrency entry",
-    summary: `${diagnostic.path} is ignored because it ${diagnostic.reason}.`,
-    remediation: diagnostic.remediation,
-    details: { path: diagnostic.path, reason: diagnostic.reason },
-  }));
+  return workflow.diagnostics
+    .filter(
+      (diagnostic: WorkflowDiagnostic) =>
+        diagnostic.code === "state_concurrency_entry_ignored"
+    )
+    .map((diagnostic) => ({
+      title: "Ignored per-state concurrency entry",
+      summary: `${diagnostic.path} is ignored: ${diagnostic.reason}.`,
+      remediation: diagnostic.remediation,
+      details: { path: diagnostic.path, reason: diagnostic.reason },
+    }));
 }
 
 type RepositoryLabelSnapshot = {

--- a/packages/core/src/workflow-loader.test.ts
+++ b/packages/core/src/workflow-loader.test.ts
@@ -777,7 +777,8 @@ Prompt`);
       expect.objectContaining({
         code: "state_concurrency_entry_ignored",
         path: "agent.max_concurrent_agents_by_state.Ready",
-        reason: expect.stringContaining("READY"),
+        reason:
+          'duplicates agent.max_concurrent_agents_by_state[" READY "] after state-name normalization',
       }),
       expect.objectContaining({
         code: "state_concurrency_entry_ignored",

--- a/packages/core/src/workflow-loader.test.ts
+++ b/packages/core/src/workflow-loader.test.ts
@@ -737,6 +737,24 @@ Prompt`);
     expect(workflow.agent.maxConcurrentAgentsByState).toEqual({
       "in progress": 2,
     });
+    expect(workflow.diagnostics).toEqual([
+      expect.objectContaining({
+        path: "agent.max_concurrent_agents_by_state.Ready",
+        reason: "must be greater than zero",
+      }),
+      expect.objectContaining({
+        path: "agent.max_concurrent_agents_by_state.Waiting",
+        reason: "must be greater than zero",
+      }),
+      expect.objectContaining({
+        path: "agent.max_concurrent_agents_by_state.Review",
+        reason: "must be a positive YAML integer",
+      }),
+      expect.objectContaining({
+        path: "agent.max_concurrent_agents_by_state.Done",
+        reason: "must be a positive YAML integer",
+      }),
+    ]);
   });
 
   it("preserves the path for an unresolved environment-backed workspace root", () => {

--- a/packages/core/src/workflow-loader.test.ts
+++ b/packages/core/src/workflow-loader.test.ts
@@ -12,6 +12,7 @@ import {
   resolveWorkflowRuntimeCommand,
   resolveWorkflowRuntimeTimeouts,
 } from "./workflow/config.js";
+import { calculateWorkflowVersionHash } from "./workflow/loader.js";
 
 const tempDirs: string[] = [];
 
@@ -755,6 +756,59 @@ Prompt`);
         reason: "must be a positive YAML integer",
       }),
     ]);
+  });
+
+  it("warns about blank and colliding per-state concurrency entries", () => {
+    const workflow = parseWorkflowMarkdown(`---
+tracker:
+  kind: github-project
+agent:
+  max_concurrent_agents_by_state:
+    Ready: 1
+    " READY ": 2
+    "  ": 3
+codex:
+  command: codex
+---
+Prompt`);
+
+    expect(workflow.agent.maxConcurrentAgentsByState).toEqual({ ready: 2 });
+    expect(workflow.diagnostics).toEqual([
+      expect.objectContaining({
+        code: "state_concurrency_entry_ignored",
+        path: "agent.max_concurrent_agents_by_state.Ready",
+        reason: expect.stringContaining("READY"),
+      }),
+      expect.objectContaining({
+        code: "state_concurrency_entry_ignored",
+        path: 'agent.max_concurrent_agents_by_state["  "]',
+        reason: "state name is blank after normalization",
+      }),
+    ]);
+  });
+
+  it("excludes derived diagnostics from the workflow version hash", () => {
+    const workflow = parseWorkflowMarkdown(`---
+tracker:
+  kind: github-project
+codex:
+  command: codex
+---
+Prompt`);
+
+    expect(
+      calculateWorkflowVersionHash({
+        ...workflow,
+        diagnostics: [
+          {
+            code: "state_concurrency_entry_ignored",
+            path: "agent.max_concurrent_agents_by_state.Ready",
+            reason: "must be greater than zero",
+            remediation: "Use a whole number greater than zero.",
+          },
+        ],
+      })
+    ).toBe(calculateWorkflowVersionHash(workflow));
   });
 
   it("preserves the path for an unresolved environment-backed workspace root", () => {

--- a/packages/core/src/workflow/config.ts
+++ b/packages/core/src/workflow/config.ts
@@ -79,6 +79,7 @@ export type WorkflowAgentConfig = {
 
 /** A non-fatal workflow configuration finding surfaced by validation tools. */
 export type WorkflowDiagnostic = {
+  code: "state_concurrency_entry_ignored";
   path: string;
   reason: string;
   remediation: string;

--- a/packages/core/src/workflow/config.ts
+++ b/packages/core/src/workflow/config.ts
@@ -77,6 +77,13 @@ export type WorkflowAgentConfig = {
   retryBaseDelayMs: number;
 };
 
+/** A non-fatal workflow configuration finding surfaced by validation tools. */
+export type WorkflowDiagnostic = {
+  path: string;
+  reason: string;
+  remediation: string;
+};
+
 export type RetryPolicyOptions = {
   baseDelayMs?: number;
   maxDelayMs?: number;
@@ -150,6 +157,7 @@ export type ParsedWorkflow = WorkflowDefinition & {
   agentCommand: string;
   hookPath: string | null;
   maxConcurrentByState: Record<string, number>;
+  diagnostics: WorkflowDiagnostic[];
 };
 
 export const DEFAULT_CODEX_COMMAND = "codex app-server";
@@ -251,6 +259,7 @@ export const DEFAULT_WORKFLOW_DEFINITION: ParsedWorkflow = {
   agentCommand: DEFAULT_CODEX_COMMAND,
   hookPath: null,
   maxConcurrentByState: {},
+  diagnostics: [],
 };
 
 export function resolveWorkflowRuntimeCommand(

--- a/packages/core/src/workflow/loader.ts
+++ b/packages/core/src/workflow/loader.ts
@@ -122,7 +122,10 @@ export function createInvalidWorkflowResolution(
 }
 
 export function calculateWorkflowVersionHash(workflow: ParsedWorkflow): string {
-  return createHash("sha256").update(JSON.stringify(workflow)).digest("hex");
+  const { diagnostics: _diagnostics, ...workflowConfig } = workflow;
+  return createHash("sha256")
+    .update(JSON.stringify(workflowConfig))
+    .digest("hex");
 }
 
 function toWorkflowResolution(

--- a/packages/core/src/workflow/parser.ts
+++ b/packages/core/src/workflow/parser.ts
@@ -764,6 +764,7 @@ function parseLegacyWorkflowMarkdown(markdown: string): ParsedWorkflow {
 
   return {
     ...DEFAULT_WORKFLOW_DEFINITION,
+    diagnostics: [],
     tracker: {
       ...DEFAULT_WORKFLOW_DEFINITION.tracker,
       activeStates: DEFAULT_WORKFLOW_LIFECYCLE.activeStates,
@@ -1460,11 +1461,13 @@ function readMaxConcurrentAgentsByState(
   }
 
   const result: Record<string, number> = {};
+  const sourcePaths: Record<string, string> = {};
   const diagnostics: WorkflowDiagnostic[] = [];
   for (const [entryKey, entryValue] of Object.entries(value)) {
-    const entryPath = `${path}.${entryKey}`;
+    const entryPath = formatWorkflowMapEntryPath(path, entryKey);
     if (typeof entryValue !== "number" || !Number.isInteger(entryValue)) {
       diagnostics.push({
+        code: "state_concurrency_entry_ignored",
         path: entryPath,
         reason: "must be a positive YAML integer",
         remediation:
@@ -1474,6 +1477,7 @@ function readMaxConcurrentAgentsByState(
     }
     if (entryValue <= 0) {
       diagnostics.push({
+        code: "state_concurrency_entry_ignored",
         path: entryPath,
         reason: "must be greater than zero",
         remediation:
@@ -1484,9 +1488,21 @@ function readMaxConcurrentAgentsByState(
 
     const normalizedKey = normalizeWorkflowState(entryKey);
     if (normalizedKey) {
+      const previousPath = sourcePaths[normalizedKey];
+      if (previousPath) {
+        diagnostics.push({
+          code: "state_concurrency_entry_ignored",
+          path: previousPath,
+          reason: `is overridden by ${entryPath} after state-name normalization`,
+          remediation:
+            "Remove one of the entries that normalize to the same state name.",
+        });
+      }
       result[normalizedKey] = entryValue;
+      sourcePaths[normalizedKey] = entryPath;
     } else {
       diagnostics.push({
+        code: "state_concurrency_entry_ignored",
         path: entryPath,
         reason: "state name is blank after normalization",
         remediation: "Use a non-blank state name, or remove the entry.",
@@ -1494,6 +1510,12 @@ function readMaxConcurrentAgentsByState(
     }
   }
   return { limits: result, diagnostics };
+}
+
+function formatWorkflowMapEntryPath(path: string, entryKey: string): string {
+  return entryKey.trim().length === 0
+    ? `${path}[${JSON.stringify(entryKey)}]`
+    : `${path}.${entryKey}`;
 }
 
 export function resolveEnvironmentValue(

--- a/packages/core/src/workflow/parser.ts
+++ b/packages/core/src/workflow/parser.ts
@@ -15,6 +15,7 @@ import {
   DEFAULT_WORKFLOW_DEFINITION,
   DEFAULT_WORKFLOW_TRACKER,
   type ParsedWorkflow,
+  type WorkflowDiagnostic,
   type WorkflowPriorityConfig,
   type WorkflowRuntimeConfig,
   type WorkflowRuntimeKind,
@@ -242,7 +243,7 @@ function parseWorkflowConfig(
     }) ?? []
   );
 
-  const maxConcurrentAgentsByState = readMaxConcurrentAgentsByState(
+  const stateConcurrency = readMaxConcurrentAgentsByState(
     agent,
     "max_concurrent_agents_by_state",
     "agent.max_concurrent_agents_by_state"
@@ -395,7 +396,7 @@ function parseWorkflowConfig(
           "max_retry_backoff_ms",
           "agent.max_retry_backoff_ms"
         ) ?? DEFAULT_MAX_RETRY_BACKOFF_MS,
-      maxConcurrentAgentsByState,
+      maxConcurrentAgentsByState: stateConcurrency.limits,
       maxFailureRetries:
         readOptionalIntegerLike(
           agent,
@@ -431,7 +432,8 @@ function parseWorkflowConfig(
     ),
     agentCommand,
     hookPath: readOptionalString(hooks, "after_create"),
-    maxConcurrentByState: maxConcurrentAgentsByState,
+    maxConcurrentByState: stateConcurrency.limits,
+    diagnostics: stateConcurrency.diagnostics,
   };
 
   return parsed;
@@ -1448,31 +1450,50 @@ function readMaxConcurrentAgentsByState(
   input: Record<string, WorkflowFrontMatterNode>,
   key: string,
   path = key
-): Record<string, number> {
+): { limits: Record<string, number>; diagnostics: WorkflowDiagnostic[] } {
   const value = input[key];
   if (value === undefined || value === null) {
-    return {};
+    return { limits: {}, diagnostics: [] };
   }
   if (typeof value !== "object" || Array.isArray(value)) {
     throw new Error(`Workflow front matter field "${path}" must be an object.`);
   }
 
   const result: Record<string, number> = {};
+  const diagnostics: WorkflowDiagnostic[] = [];
   for (const [entryKey, entryValue] of Object.entries(value)) {
-    if (
-      typeof entryValue !== "number" ||
-      !Number.isInteger(entryValue) ||
-      entryValue <= 0
-    ) {
+    const entryPath = `${path}.${entryKey}`;
+    if (typeof entryValue !== "number" || !Number.isInteger(entryValue)) {
+      diagnostics.push({
+        path: entryPath,
+        reason: "must be a positive YAML integer",
+        remediation:
+          "Use a whole number greater than zero, or remove the entry.",
+      });
+      continue;
+    }
+    if (entryValue <= 0) {
+      diagnostics.push({
+        path: entryPath,
+        reason: "must be greater than zero",
+        remediation:
+          "Use a whole number greater than zero, or remove the entry.",
+      });
       continue;
     }
 
     const normalizedKey = normalizeWorkflowState(entryKey);
     if (normalizedKey) {
       result[normalizedKey] = entryValue;
+    } else {
+      diagnostics.push({
+        path: entryPath,
+        reason: "state name is blank after normalization",
+        remediation: "Use a non-blank state name, or remove the entry.",
+      });
     }
   }
-  return result;
+  return { limits: result, diagnostics };
 }
 
 export function resolveEnvironmentValue(

--- a/packages/core/src/workflow/parser.ts
+++ b/packages/core/src/workflow/parser.ts
@@ -1493,7 +1493,7 @@ function readMaxConcurrentAgentsByState(
         diagnostics.push({
           code: "state_concurrency_entry_ignored",
           path: previousPath,
-          reason: `is overridden by ${entryPath} after state-name normalization`,
+          reason: `duplicates ${entryPath} after state-name normalization`,
           remediation:
             "Remove one of the entries that normalize to the same state name.",
         });
@@ -1513,7 +1513,7 @@ function readMaxConcurrentAgentsByState(
 }
 
 function formatWorkflowMapEntryPath(path: string, entryKey: string): string {
-  return entryKey.trim().length === 0
+  return entryKey !== entryKey.trim()
     ? `${path}[${JSON.stringify(entryKey)}]`
     : `${path}.${entryKey}`;
 }


### PR DESCRIPTION
## Issues — Closed #767

## TL;DR

`workflow validate` and `doctor` now emit actionable, non-fatal warnings for ignored per-state concurrency entries, while preserving valid limits in the same map.

## Change-point diagram

`WORKFLOW.md` parser → typed non-fatal diagnostics → `workflow validate` + `doctor` warnings

## Start here

- `packages/core/src/workflow/parser.ts` detects invalid, blank, padded, and colliding normalized state-limit entries.
- `packages/cli/src/priority-diagnostics.ts` converts state-concurrency diagnostics into CLI warnings.
- `.changeset/bright-state-concurrency-warnings.md` records the `@gh-symphony/cli` patch release.

## Changes

- Emit paths, reasons, and remediation for non-integer, non-positive, blank-normalized, and normalized-key-collision entries.
- Preserve effective valid limits and last-entry-wins collision behavior.
- Quote padded state keys in paths and render collision warnings grammatically.
- Keep derived diagnostics out of workflow revision hashes and correct doctor-command documentation.

## Evidence

- `pnpm lint`
- `pnpm test`
- `pnpm typecheck`
- `pnpm build`
- Focused parser, workflow validation, and doctor suites (174 tests).

## Risks & rollback

- Warnings are non-fatal and do not alter dispatch behavior.
- Reverting this PR removes the warning surface and returns to prior silent ignore behavior.

## Changed files

- Workflow parser/configuration diagnostics and revision hashing
- CLI warning rendering plus parser, validate, and doctor tests
- Configuration documentation and CLI patch changeset

## Post-merge / human validation

- [ ] Run `gh-symphony workflow validate` with valid, invalid, padded, and colliding per-state limits.
- [ ] Confirm `gh-symphony doctor` reports the same path-specific warnings.
