### PR TITLE
test(cli): make recover liveness deterministic

### DIFF
--- a/packages/cli/src/commands/lifecycle.test.ts
+++ b/packages/cli/src/commands/lifecycle.test.ts
@@ -601,9 +601,14 @@ describe("lifecycle command integration", () => {
       .spyOn(process.stdout, "write")
       .mockImplementation(() => true);
 
-    await recoverModule.default(["--dry-run"], baseOptions(configDir));
+    const isProcessRunning = vi.fn().mockReturnValue(false);
+
+    await recoverModule.default(["--dry-run"], baseOptions(configDir), {
+      isProcessRunning,
+    });
 
     expect(orchestratorRunCli).not.toHaveBeenCalled();
+    expect(isProcessRunning).toHaveBeenCalledWith(999_999);
     expect(
       stdout.mock.calls.some((call) =>
         String(call[0]).includes("acme/platform#7")

--- a/packages/cli/src/commands/recover.ts
+++ b/packages/cli/src/commands/recover.ts
@@ -2,9 +2,7 @@ import { readFile, readdir } from "node:fs/promises";
 import { join } from "node:path";
 import type { GlobalOptions } from "../index.js";
 import { runCli as orchestratorRunCli } from "@gh-symphony/orchestrator";
-import {
-  resolveRuntimeRoot,
-} from "../orchestrator-runtime.js";
+import { resolveRuntimeRoot } from "../orchestrator-runtime.js";
 import {
   handleMissingManagedProjectConfig,
   resolveManagedProjectConfig,
@@ -15,6 +13,10 @@ type RecoverCandidate = {
   issueIdentifier: string;
   status: string;
   reason: string;
+};
+
+type RecoverDependencies = {
+  isProcessRunning?: (pid: number) => boolean;
 };
 
 function parseRecoverArgs(args: string[]): {
@@ -37,7 +39,8 @@ function parseRecoverArgs(args: string[]): {
 
 const handler = async (
   args: string[],
-  options: GlobalOptions
+  options: GlobalOptions,
+  dependencies: RecoverDependencies = {}
 ): Promise<void> => {
   const parsed = parseRecoverArgs(args);
 
@@ -54,7 +57,11 @@ const handler = async (
   const projectId = projectConfig.projectId;
   if (parsed.dryRun) {
     process.stdout.write("Dry run — scanning for stalled runs...\n");
-    const candidates = await listRecoverCandidates(runtimeRoot, projectId);
+    const candidates = await listRecoverCandidates(
+      runtimeRoot,
+      projectId,
+      dependencies.isProcessRunning ?? isProcessRunning
+    );
     if (options.json) {
       process.stdout.write(JSON.stringify(candidates, null, 2) + "\n");
       return;
@@ -85,7 +92,8 @@ export default handler;
 
 async function listRecoverCandidates(
   runtimeRoot: string,
-  projectId: string
+  projectId: string,
+  isRunning: (pid: number) => boolean
 ): Promise<RecoverCandidate[]> {
   const runRoots = [
     join(runtimeRoot, "runs"),
@@ -119,7 +127,7 @@ async function listRecoverCandidates(
           continue;
         }
 
-        const reason = detectRecoveryReason(run);
+        const reason = detectRecoveryReason(run, isRunning);
         if (!reason) {
           continue;
         }
@@ -141,19 +149,23 @@ async function listRecoverCandidates(
   return candidates;
 }
 
-function detectRecoveryReason(run: {
-  status: string;
-  processId: number | null;
-  startedAt: string | null;
-  nextRetryAt: string | null;
-}): string | null {
+function detectRecoveryReason(
+  run: {
+    status: string;
+    processId: number | null;
+    startedAt: string | null;
+    nextRetryAt: string | null;
+  },
+  isRunning: (pid: number) => boolean
+): string | null {
   if (run.processId) {
     const startedAt = run.startedAt ? new Date(run.startedAt).getTime() : 0;
     const runningForMs = Date.now() - startedAt;
-    if (isProcessRunning(run.processId) && runningForMs > 30 * 60 * 1000) {
+    const processRunning = isRunning(run.processId);
+    if (processRunning && runningForMs > 30 * 60 * 1000) {
       return "worker appears stuck";
     }
-    if (!isProcessRunning(run.processId)) {
+    if (!processRunning) {
       return "worker process is no longer running";
     }
   }


### PR DESCRIPTION
## TL;DR

- Make the CLI lifecycle recovery test independent of the host OS process table.
- Inject and assert the recovery liveness probe used for the stale run while preserving the real probe as the production default.

## Change-point diagram

```text
lifecycle integration test
  -> recover command dependency seam
    -> injected false probe in test
    -> real process.kill probe by default
```

## Start here

- `packages/cli/src/commands/recover.ts` — recovery classification and dependency boundary.
- `packages/cli/src/commands/lifecycle.test.ts` — dry-run recovery integration coverage.

## Changes

- Added an optional recovery dependency seam for process liveness checks.
- Evaluated each run's process liveness once per recovery classification.
- Injected a deterministic dead-process result in the dry-run lifecycle test and asserted PID `999999` reaches the seam.

## Evidence

- `pnpm --filter @gh-symphony/cli test -- src/commands/lifecycle.test.ts` — 16 tests passed before implementation.
- Hostile PID simulation via `NODE_OPTIONS="--require /tmp/issue-769-process-kill-sim.cjs" pnpm --filter @gh-symphony/cli test` — 43 files, 609 tests passed with the listed positive and negative PIDs treated as live.
- `pnpm --filter @gh-symphony/cli test` repeated 10 consecutive times — 609/609 tests passed in every run.
- `pnpm lint` — passed.
- `pnpm test` — passed after the clean workspace packages were built.
- `pnpm typecheck` — passed.
- `pnpm build` — passed.

## Risks & rollback

- Risk is limited to an internal CLI dependency seam and single-snapshot liveness classification; production defaults remain unchanged.
- Roll back by reverting this PR.

## Changed files

- `packages/cli/src/commands/recover.ts` — injectable liveness dependency with production default.
- `packages/cli/src/commands/lifecycle.test.ts` — deterministic dry-run recovery coverage and seam assertion.

## Post-merge / human validation

- [ ] Confirm the dry-run recovery output remains unchanged (optional reviewer check; automated coverage passes).
- [ ] Confirm the test seam and PID assertion match the intended determinism boundary.

## Issues

Closed #769
