### PR TITLE
fix(core): attribute non-numeric issue workspaces

### DIFF
--- a/.changeset/clean-lions-recover.md
+++ b/.changeset/clean-lions-recover.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Preserve dirty recovery workspaces attributed by normalized `TEAM-123` branch or workpad identifiers for #782.

--- a/AGENT_TEST.md
+++ b/AGENT_TEST.md
@@ -437,6 +437,7 @@ idle → [inject issue + refresh]
 | `e2e/scenarios/18-dispatchable-eligibility.md`            | Verify non-dispatchable tracker records do not start workers while retaining an explainable reason                        |
 | `e2e/scenarios/19-required-label-routability.md`          | Verify required-label filtering cancels active runs without workspace cleanup and exposes the reason                      |
 | `e2e/scenarios/20-agent-child-isolation.md`               | Verify unconditional child credential/config isolation, host-only MCP tools, and post-run host Git push                   |
+| `e2e/scenarios/21-linear-dirty-workspace-recovery.md`     | Verify a dirty `DEV-54` branch/workpad survives incomplete-turn recovery without quarantine                               |
 | `e2e/scenarios/17-instance-registry.md`                   | Verify host-global instance listing, stale-registry diagnostics, and daemon PID recording only after lock acquisition     |
 | `e2e/scenarios/17-retry-fire-refresh.md`                  | Verify single-ID retry refresh, terminal cleanup, and retry backoff safety                                                |
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -73,6 +73,7 @@ touches a layer, check that its slice (and the linked documents) still holds.
   repository-local persistence divergence.
 - Shared bare clone cache (`<config-dir>/repos/<owner>/<repo>.git`), heartbeat locks, direct-clone degradation, safe inventory/eviction, worktree populate, and conservative agent-branch collection (only refs fully reachable from `origin/*` and not linked to a worktree): `repository-cache.ts`, `git.ts`; operator diagnostics and cleanup: `packages/cli/src/commands/cache.ts`
 - Issue workspace records remain in orchestrator state, while population, quarantine, terminal cleanup, and worktree removal operate on `<workspace.root>/<issue-key>` in repo-embedded and standalone modes.
+- Dirty-workspace recovery attribution is tracker-neutral core behavior in `packages/core/src/workflow/issue-identity.ts`, consumed by `packages/orchestrator/src/service.ts`. GitHub numeric identifiers and normalized `TEAM-123` identifiers both accept positive branch/workpad evidence; a different full tracker identifier overrides same-number evidence, and missing positive evidence remains fail-closed.
 - Workflow source resolution (declared external/repo sources): `service.ts` + core workflow config. The file is defensively re-read on every reconciliation tick; no filesystem watcher is installed (an explicit upstream divergence documented in [ADR 2026-08-26](adr/2026-08-26-workflow-reload-divergence.md)).
 
 ### 4. Execution — worker and agent subprocess

--- a/e2e/fixtures/linear-dirty-recovery.json
+++ b/e2e/fixtures/linear-dirty-recovery.json
@@ -1,0 +1,28 @@
+[
+  {
+    "id": "issue-linear-dirty-54",
+    "identifier": "DEV-54",
+    "number": 54,
+    "title": "Preserve attributed Linear dirty workspace",
+    "description": "The recovery worker must receive the original DEV-54 workspace.",
+    "priority": null,
+    "state": "Ready",
+    "branchName": null,
+    "url": "https://tracker.example.test/issues/DEV-54",
+    "labels": [],
+    "blockedBy": [],
+    "createdAt": "2026-09-02T00:00:00Z",
+    "updatedAt": "2026-09-02T00:00:00Z",
+    "repository": {
+      "owner": "test-owner",
+      "name": "test-repo",
+      "cloneUrl": "/e2e/repos/test-owner/test-repo"
+    },
+    "tracker": {
+      "adapter": "file",
+      "bindingId": "e2e-test",
+      "itemId": "issue-linear-dirty-54"
+    },
+    "metadata": {}
+  }
+]

--- a/e2e/run-e2e.sh
+++ b/e2e/run-e2e.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # E2E Test Runner — polls the standalone dashboard until the scenario completes.
 # Usage: ./e2e/run-e2e.sh [scenario] [timeout_seconds]
-#   scenario: happy (default), fail, stall, slow, transition-race, api-progress, api-progress-unknown, prompt-phase, retry-attempt, non-dispatchable, required-label-missing, required-label-removed
+#   scenario: happy (default), fail, stall, slow, transition-race, api-progress, api-progress-unknown, prompt-phase, retry-attempt, non-dispatchable, required-label-missing, required-label-removed, linear-dirty-recovery
 #   timeout:  30 (default)
 
 SCENARIO="${1:-happy}"
@@ -111,6 +111,8 @@ log "Initial state: idle"
 
 if [ "$SCENARIO" = "non-dispatchable" ]; then
   cp e2e/fixtures/non-dispatchable.json e2e/fixtures/issues.json
+elif [ "$SCENARIO" = "linear-dirty-recovery" ]; then
+  cp e2e/fixtures/linear-dirty-recovery.json e2e/fixtures/issues.json
 elif [ "$SCENARIO" = "required-label-missing" ]; then
   cp e2e/fixtures/required-label-missing.json e2e/fixtures/issues.json
 elif [ "$SCENARIO" = "required-label-removed" ]; then
@@ -210,6 +212,7 @@ SAW_REDACTED_STATE=false
 SCENARIO_RUN_ID=""
 ELAPSED=0
 LABEL_REMOVED=false
+LINEAR_RECOVERY_REACTIVATED=false
 
 log "Polling..."
 while [ "$ELAPSED" -lt "$TIMEOUT" ]; do
@@ -262,8 +265,26 @@ assert any(
   if [ "$RUN_STATUS" = "retrying" ]; then
     SAW_RETRY=true
     # Worker completed and orchestrator saw the exit — remove issues to stop retry loop
-    if [ "$SCENARIO" != "transition-race" ] && [ "$SCENARIO" != "api-progress" ] && [ "$SCENARIO" != "api-progress-unknown" ] && [ "$SCENARIO" != "prompt-phase" ] && [ "$SCENARIO" != "retry-attempt" ]; then
+    if [ "$SCENARIO" != "transition-race" ] && [ "$SCENARIO" != "api-progress" ] && [ "$SCENARIO" != "api-progress-unknown" ] && [ "$SCENARIO" != "prompt-phase" ] && [ "$SCENARIO" != "retry-attempt" ] && [ "$SCENARIO" != "linear-dirty-recovery" ]; then
       echo "[]" > e2e/fixtures/issues.json
+    fi
+  fi
+
+  if [ "$SCENARIO" = "linear-dirty-recovery" ] && [ "$LINEAR_RECOVERY_REACTIVATED" != true ]; then
+    if "${COMPOSE[@]}" exec -T symphony-e2e sh -c 'grep -R -q "incomplete-turn-dirty-workspace" /e2e/work 2>/dev/null'; then
+      python3 - <<'PY'
+import json
+from pathlib import Path
+
+path = Path("e2e/fixtures/issues.json")
+issues = json.loads(path.read_text())
+assert len(issues) == 1, issues
+issues[0]["state"] = "Ready"
+path.write_text(json.dumps(issues))
+PY
+      orch_curl -sf -X POST http://localhost:4680/api/v1/refresh >/dev/null
+      LINEAR_RECOVERY_REACTIVATED=true
+      log "Linear dirty recovery reactivated after incomplete-turn classification"
     fi
   fi
 
@@ -282,6 +303,38 @@ log "=== Worker Logs ==="
 echo ""
 log "=== Event Logs ==="
 "${COMPOSE[@]}" exec -T symphony-e2e sh -c 'find /e2e/work -name events.ndjson -exec cat {} \; 2>/dev/null' 2>/dev/null || true
+
+echo ""
+if [ "$SCENARIO" = "linear-dirty-recovery" ]; then
+  if [ "$SAW_RUNNING" != true ] || [ "$LINEAR_RECOVERY_REACTIVATED" != true ]; then
+    fail "Linear dirty recovery did not complete its initial and recovery dispatches"
+    exit 1
+  fi
+  if ! "${COMPOSE[@]}" exec -T symphony-e2e sh -c 'grep -R -q "linear dirty recovery verified" /e2e/work'; then
+    fail "Recovery worker did not verify the preserved Linear workspace"
+    exit 1
+  fi
+  if "${COMPOSE[@]}" exec -T symphony-e2e sh -c 'find /e2e/work -name events.ndjson -exec grep -H "recovery-quarantined" {} + 2>/dev/null | grep -q .'; then
+    fail "Linear dirty workspace was quarantined"
+    exit 1
+  fi
+  python3 - <<'PY'
+import json
+from pathlib import Path
+
+issues = json.loads(Path("e2e/fixtures/issues.json").read_text())
+assert len(issues) == 1, issues
+assert issues[0]["identifier"] == "DEV-54", issues[0]
+assert issues[0]["state"] == "Done", issues[0]
+PY
+  log "=== Result ==="
+  log "  Linear dirty workspace classified: YES"
+  log "  Recovery dispatch reactivated:     YES"
+  log "  Branch and workpad preserved:      YES"
+  log "  Quarantine event emitted:          NO"
+  log "PASSED"
+  exit 0
+fi
 
 echo ""
 if [ "$SCENARIO" = "required-label-removed" ]; then

--- a/e2e/scenarios/21-linear-dirty-workspace-recovery.md
+++ b/e2e/scenarios/21-linear-dirty-workspace-recovery.md
@@ -1,0 +1,34 @@
+# TC-21: Linear dirty-workspace recovery attribution
+
+## Setup
+
+Build and start the Docker E2E environment with the deterministic Linear dirty
+recovery scenario:
+
+```bash
+./e2e/run-e2e.sh linear-dirty-recovery 60
+```
+
+## Steps
+
+1. Inject the file-tracker fixture whose opaque identifier is `DEV-54`.
+2. Let the first worker create branch `dev-54-fix`, dirty
+   `.gh-symphony/workpads/DEV-54.md`, and a partial source artifact.
+3. Let that worker transition the issue to non-terminal `In review` before a
+   turn completes, causing incomplete-turn dirty-workspace classification.
+4. Reactivate `DEV-54` and trigger reconciliation.
+5. Require the recovery worker to observe the original branch, workpad,
+   partial artifact, recovery kind, and recovery prompt before completing.
+
+## Expected
+
+- The dirty workspace is attributed to `DEV-54` and reused.
+- The recovery worker sees branch `dev-54-fix` and the unchanged workpad and
+  partial artifact.
+- No `recovery-quarantined` event is emitted.
+- The recovered worker completes with the canonical fixture state `Done`.
+
+## Cleanup
+
+`e2e/run-e2e.sh` removes the Compose project, volumes, image, and injected
+fixture contents automatically.

--- a/e2e/stub-worker.ts
+++ b/e2e/stub-worker.ts
@@ -13,10 +13,13 @@
  *   api-progress-unknown — confirms Done, removes the canonical item, then completes
  *   required-label-removed — completes turn one, then proves a routability
  *                            refresh prevents turn two after its label is removed
+ *   linear-dirty-recovery — leaves DEV-54 dirty mid-turn, then verifies the
+ *                           same Linear workspace is reused on recovery
  */
 
 import { existsSync } from "node:fs";
-import { writeFile, mkdir } from "node:fs/promises";
+import { execFileSync } from "node:child_process";
+import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 
@@ -39,7 +42,8 @@ type Scenario =
   | "transition-race"
   | "api-progress"
   | "api-progress-unknown"
-  | "required-label-removed";
+  | "required-label-removed"
+  | "linear-dirty-recovery";
 const VALID_SCENARIOS: ReadonlySet<string> = new Set([
   "happy",
   "fail",
@@ -51,6 +55,7 @@ const VALID_SCENARIOS: ReadonlySet<string> = new Set([
   "api-progress",
   "api-progress-unknown",
   "required-label-removed",
+  "linear-dirty-recovery",
 ]);
 const rawScenario = process.env.STUB_SCENARIO ?? "happy";
 const SCENARIO: Scenario = VALID_SCENARIOS.has(rawScenario)
@@ -74,6 +79,7 @@ const SCENARIO_DURATIONS: Record<Scenario, { startMs: number; runMs: number }> =
     "api-progress": { startMs: 2000, runMs: 1000 },
     "api-progress-unknown": { startMs: 2000, runMs: 1000 },
     "required-label-removed": { startMs: 2000, runMs: 1000 },
+    "linear-dirty-recovery": { startMs: 100, runMs: 100 },
   };
 
 function resolveCoreModuleUrl(): string {
@@ -227,7 +233,9 @@ async function requestTransitionForRace(): Promise<void> {
   }
 }
 
-async function requestAndConfirmApiProgress(): Promise<void> {
+async function requestAndConfirmApiProgress(
+  targetState = "Done"
+): Promise<void> {
   if (!ORCHESTRATOR_URL || !ORCHESTRATOR_TOKEN || !RUN_ID) {
     throw new Error("stub_worker_orchestrator_context_missing");
   }
@@ -245,7 +253,7 @@ async function requestAndConfirmApiProgress(): Promise<void> {
       body: JSON.stringify({
         type: "transition-request",
         expected_state: expectedState,
-        target_state: "Done",
+        target_state: targetState,
         reason: "E2E API-side lifecycle progress",
       }),
     }
@@ -259,7 +267,7 @@ async function requestAndConfirmApiProgress(): Promise<void> {
     !transitionResponse.ok ||
     transition.ok !== true ||
     transition.outcome !== "confirmed" ||
-    transition.state !== "Done"
+    transition.state !== targetState
   ) {
     throw new Error(
       `stub_api_progress_transition_failed:${JSON.stringify(transition)}`
@@ -287,7 +295,7 @@ async function requestAndConfirmApiProgress(): Promise<void> {
     !readResponse.ok ||
     readback.ok !== true ||
     readback.outcome !== "confirmed" ||
-    readback.state !== "Done"
+    readback.state !== targetState
   ) {
     throw new Error(
       `stub_api_progress_readback_failed:${JSON.stringify(readback)}`
@@ -321,7 +329,11 @@ async function preventSecondTurnAfterLabelRemoval(): Promise<void> {
   }
   // Wait for the runner to update the fixture instead of racing its status
   // poll with a fixed delay. The bounded wait still fails loudly in CI.
-  for (let attempt = 0; attempt < 30 && !existsSync(labelRemovalSignal); attempt += 1) {
+  for (
+    let attempt = 0;
+    attempt < 30 && !existsSync(labelRemovalSignal);
+    attempt += 1
+  ) {
     await sleep(500);
   }
   if (!existsSync(labelRemovalSignal)) {
@@ -332,6 +344,60 @@ async function preventSecondTurnAfterLabelRemoval(): Promise<void> {
     throw new Error(`stub_turn_two_should_be_prevented:${state}`);
   }
   console.error("[stub-worker] turn=2 prevented by routability refresh");
+}
+
+async function exerciseLinearDirtyRecovery(): Promise<void> {
+  if (ISSUE_IDENTIFIER !== "DEV-54") {
+    throw new Error(
+      `stub_linear_issue_identifier_unexpected:${ISSUE_IDENTIFIER}`
+    );
+  }
+
+  const repositoryDirectory = process.env.WORKING_DIRECTORY ?? process.cwd();
+  const workpadPath = join(
+    repositoryDirectory,
+    ".gh-symphony",
+    "workpads",
+    "DEV-54.md"
+  );
+  const partialPath = join(repositoryDirectory, "linear-partial.txt");
+  const recoveryKind = process.env.SYMPHONY_RECOVERY_KIND ?? "";
+
+  if (recoveryKind === "") {
+    execFileSync("git", ["switch", "-c", "dev-54-fix"], {
+      cwd: repositoryDirectory,
+      stdio: "pipe",
+    });
+    await mkdir(dirname(workpadPath), { recursive: true });
+    await writeFile(workpadPath, "# DEV-54 recovery workpad\n", "utf8");
+    await writeFile(partialPath, "partial Linear issue work\n", "utf8");
+    console.error("[stub-worker] linear dirty workspace prepared");
+    await requestAndConfirmApiProgress("In review");
+    await sleep(Infinity);
+    return;
+  }
+
+  if (recoveryKind !== "incomplete-turn-dirty-workspace") {
+    throw new Error(`stub_linear_recovery_kind_unexpected:${recoveryKind}`);
+  }
+  const branch = execFileSync("git", ["branch", "--show-current"], {
+    cwd: repositoryDirectory,
+    encoding: "utf8",
+  }).trim();
+  if (branch !== "dev-54-fix") {
+    throw new Error(`stub_linear_recovery_branch_unexpected:${branch}`);
+  }
+  if (
+    (await readFile(workpadPath, "utf8")) !== "# DEV-54 recovery workpad\n" ||
+    (await readFile(partialPath, "utf8")) !== "partial Linear issue work\n"
+  ) {
+    throw new Error("stub_linear_recovery_dirty_files_changed");
+  }
+  if (!RENDERED_PROMPT.includes("Incomplete Turn Dirty Workspace")) {
+    throw new Error("stub_linear_recovery_prompt_missing");
+  }
+  console.error("[stub-worker] linear dirty recovery verified");
+  await requestAndConfirmApiProgress();
 }
 
 async function run() {
@@ -411,6 +477,9 @@ async function run() {
   }
   if (SCENARIO === "required-label-removed") {
     await preventSecondTurnAfterLabelRemoval();
+  }
+  if (SCENARIO === "linear-dirty-recovery") {
+    await exerciseLinearDirtyRecovery();
   }
   await sleep(durations.runMs);
 

--- a/packages/core/src/workflow/issue-identity.test.ts
+++ b/packages/core/src/workflow/issue-identity.test.ts
@@ -37,7 +37,7 @@ describe("extractIssueNumberFromIdentifier", () => {
     expect(extractIssueNumberFromIdentifier("acme/platform#507")).toBe(507);
     expect(extractIssueNumberFromIdentifier("#173")).toBe(173);
     expect(extractIssueNumberFromIdentifier("173")).toBe(173);
-    expect(extractIssueNumberFromIdentifier("ACME-42")).toBeNull();
+    expect(extractIssueNumberFromIdentifier("ACME-42")).toBe(42);
     expect(extractIssueNumberFromIdentifier("no-number")).toBeNull();
   });
 });
@@ -71,6 +71,48 @@ describe("extractIssueNumbersFromWorkpadFiles", () => {
 });
 
 describe("attributeDirtyWorkToIssue", () => {
+  it("attributes a Linear issue from its normalized branch identifier", () => {
+    const result = attributeDirtyWorkToIssue({
+      issueIdentifier: "DEV-54",
+      currentBranch: "dev-54-fix",
+      dirtyFiles: ["src/fix.ts"],
+    });
+
+    expect(result.attributed).toBe(true);
+  });
+
+  it("attributes a Linear issue from its workpad identifier", () => {
+    const result = attributeDirtyWorkToIssue({
+      issueIdentifier: "DEV-54",
+      currentBranch: "main",
+      dirtyFiles: [".gh-symphony/workpads/DEV-54.md"],
+    });
+
+    expect(result.attributed).toBe(true);
+  });
+
+  it("denies attribution when a branch names another Linear issue", () => {
+    const result = attributeDirtyWorkToIssue({
+      issueIdentifier: "DEV-54",
+      currentBranch: "eng-12-other",
+      dirtyFiles: ["src/other.ts"],
+    });
+
+    expect(result.attributed).toBe(false);
+    expect(result.reason).toContain("ENG-12");
+  });
+
+  it("denies a different Linear team with the same issue number", () => {
+    const result = attributeDirtyWorkToIssue({
+      issueIdentifier: "DEV-54",
+      currentBranch: "eng-54-other",
+      dirtyFiles: ["src/other.ts"],
+    });
+
+    expect(result.attributed).toBe(false);
+    expect(result.reason).toContain("ENG-54");
+  });
+
   it("denies attribution when the branch belongs to another issue", () => {
     const result = attributeDirtyWorkToIssue({
       issueIdentifier: "acme/platform#173",

--- a/packages/core/src/workflow/issue-identity.test.ts
+++ b/packages/core/src/workflow/issue-identity.test.ts
@@ -163,6 +163,36 @@ describe("attributeDirtyWorkToIssue", () => {
     expect(result.attributed).toBe(true);
   });
 
+  it("keeps a Linear workpad when a terminal branch token resembles a version", () => {
+    const result = attributeDirtyWorkToIssue({
+      issueIdentifier: "DEV-54",
+      currentBranch: "chore/next-15",
+      dirtyFiles: [".gh-symphony/workpads/DEV-54.md"],
+    });
+
+    expect(result.attributed).toBe(true);
+  });
+
+  it("keeps a GitHub workpad when a terminal branch token resembles a version", () => {
+    const result = attributeDirtyWorkToIssue({
+      issueIdentifier: "acme/platform#173",
+      currentBranch: "chore/react-19",
+      dirtyFiles: [".gh-symphony/workpads/173.md"],
+    });
+
+    expect(result.attributed).toBe(true);
+  });
+
+  it("attributes a Linear branch using a team key that resembles a version", () => {
+    const result = attributeDirtyWorkToIssue({
+      issueIdentifier: "GO-42",
+      currentBranch: "go-42-fix",
+      dirtyFiles: ["src/fix.ts"],
+    });
+
+    expect(result.attributed).toBe(true);
+  });
+
   it("denies attribution when the branch belongs to another issue", () => {
     const result = attributeDirtyWorkToIssue({
       issueIdentifier: "acme/platform#173",

--- a/packages/core/src/workflow/issue-identity.test.ts
+++ b/packages/core/src/workflow/issue-identity.test.ts
@@ -37,7 +37,7 @@ describe("extractIssueNumberFromIdentifier", () => {
     expect(extractIssueNumberFromIdentifier("acme/platform#507")).toBe(507);
     expect(extractIssueNumberFromIdentifier("#173")).toBe(173);
     expect(extractIssueNumberFromIdentifier("173")).toBe(173);
-    expect(extractIssueNumberFromIdentifier("ACME-42")).toBe(42);
+    expect(extractIssueNumberFromIdentifier("ACME-42")).toBeNull();
     expect(extractIssueNumberFromIdentifier("no-number")).toBeNull();
   });
 });
@@ -63,10 +63,11 @@ describe("extractIssueNumbersFromWorkpadFiles", () => {
     expect(
       extractIssueNumbersFromWorkpadFiles([
         ".gh-symphony/workpads/172.md",
+        ".gh-symphony/workpads/DEV2-54.md",
         "src/index.ts",
         "docs/172-notes.md",
       ])
-    ).toEqual([172]);
+    ).toEqual([172, 54]);
   });
 });
 
@@ -111,6 +112,55 @@ describe("attributeDirtyWorkToIssue", () => {
 
     expect(result.attributed).toBe(false);
     expect(result.reason).toContain("ENG-54");
+  });
+
+  it("attributes a digit-bearing Linear team key from its own workpad", () => {
+    const result = attributeDirtyWorkToIssue({
+      issueIdentifier: "DEV2-54",
+      currentBranch: "main",
+      dirtyFiles: [".gh-symphony/workpads/DEV2-54.md"],
+    });
+
+    expect(result.attributed).toBe(true);
+  });
+
+  it("fails closed for bare numeric artifacts on a Linear issue", () => {
+    const branch = attributeDirtyWorkToIssue({
+      issueIdentifier: "DEV-54",
+      currentBranch: "feat/54-other",
+      dirtyFiles: ["src/other.ts"],
+    });
+    const workpad = attributeDirtyWorkToIssue({
+      issueIdentifier: "DEV-54",
+      currentBranch: "main",
+      dirtyFiles: [".gh-symphony/workpads/54.md"],
+    });
+
+    expect(branch.attributed).toBe(false);
+    expect(branch.reason).toContain("no dirty artifact");
+    expect(workpad.attributed).toBe(false);
+    expect(workpad.reason).toContain("no dirty artifact");
+  });
+
+  it("denies a foreign Linear branch for a GitHub issue", () => {
+    const result = attributeDirtyWorkToIssue({
+      issueIdentifier: "acme/platform#173",
+      currentBranch: "dev-54-fix",
+      dirtyFiles: [".gh-symphony/workpads/173.md"],
+    });
+
+    expect(result.attributed).toBe(false);
+    expect(result.reason).toContain("DEV-54");
+  });
+
+  it("does not treat version-like branch fragments as foreign tracker evidence", () => {
+    const result = attributeDirtyWorkToIssue({
+      issueIdentifier: "DEV-54",
+      currentBranch: "chore/node-24",
+      dirtyFiles: [".gh-symphony/workpads/DEV-54.md"],
+    });
+
+    expect(result.attributed).toBe(true);
   });
 
   it("denies attribution when the branch belongs to another issue", () => {

--- a/packages/core/src/workflow/issue-identity.ts
+++ b/packages/core/src/workflow/issue-identity.ts
@@ -73,14 +73,6 @@ export function extractIssueNumbersFromBranch(branch: string): number[] {
 
 const WORKPAD_FILE_PATTERN = /(?:^|\/)\.gh-symphony\/workpads\/([^/]+)\.md$/;
 const TRACKER_IDENTIFIER_PATTERN = /^[A-Za-z][A-Za-z0-9]*-\d{1,9}$/;
-const VERSION_LIKE_TRACKER_KEYS = new Set([
-  "GO",
-  "JAVA",
-  "NODE",
-  "PHP",
-  "PYTHON",
-  "RUBY",
-]);
 
 function normalizeTrackerIdentifier(identifier: string): string | null {
   const normalized = identifier.trim();
@@ -89,23 +81,31 @@ function normalizeTrackerIdentifier(identifier: string): string | null {
     : null;
 }
 
-function isVersionLikeTrackerIdentifier(identifier: string): boolean {
-  const teamKey = identifier.split("-", 1)[0]!;
-  return VERSION_LIKE_TRACKER_KEYS.has(teamKey) || /^V\d+$/.test(teamKey);
-}
-
-function extractTrackerIdentifiersFromBranch(branch: string): string[] {
-  const identifiers = new Set<string>();
+/**
+ * Tracker identifiers encoded in a branch name.
+ *
+ * Positive evidence accepts any `key-number` token at a segment start.
+ * Foreign evidence additionally requires a slug after the token because a
+ * segment-terminal token is indistinguishable from a version fragment and
+ * must never outrank the issue's own evidence.
+ */
+function extractTrackerIdentifiersFromBranch(branch: string): {
+  positive: string[];
+  foreign: string[];
+} {
+  const positive = new Set<string>();
+  const foreign = new Set<string>();
   for (const match of branch.matchAll(
-    /(?:^|\/)([A-Za-z][A-Za-z0-9]*-\d{1,9})(?=[-_/]|$)/g
+    /(?:^|\/)([A-Za-z][A-Za-z0-9]*-\d{1,9})(?=([-_])|\/|$)/g
   )) {
     const identifier = match[1]!.toUpperCase();
-    if (!isVersionLikeTrackerIdentifier(identifier)) {
-      identifiers.add(identifier);
+    positive.add(identifier);
+    if (match[2]) {
+      foreign.add(identifier);
     }
   }
 
-  return [...identifiers];
+  return { positive: [...positive], foreign: [...foreign] };
 }
 
 function extractTrackerIdentifiersFromWorkpadFiles(
@@ -176,12 +176,12 @@ export function attributeDirtyWorkToIssue(
   const workpadNumbers = extractIssueNumbersFromWorkpadFiles(input.dirtyFiles);
   const branchTrackerIdentifiers = branch
     ? extractTrackerIdentifiersFromBranch(branch)
-    : [];
+    : { positive: [], foreign: [] };
   const workpadTrackerIdentifiers = extractTrackerIdentifiersFromWorkpadFiles(
     input.dirtyFiles
   );
 
-  const foreignBranchIdentifiers = branchTrackerIdentifiers.filter(
+  const foreignBranchIdentifiers = branchTrackerIdentifiers.foreign.filter(
     (identifier) => identifier !== trackerIdentifier
   );
   if (foreignBranchIdentifiers.length > 0) {
@@ -232,7 +232,7 @@ export function attributeDirtyWorkToIssue(
 
   if (
     trackerIdentifier &&
-    branchTrackerIdentifiers.includes(trackerIdentifier)
+    branchTrackerIdentifiers.positive.includes(trackerIdentifier)
   ) {
     return {
       attributed: true,

--- a/packages/core/src/workflow/issue-identity.ts
+++ b/packages/core/src/workflow/issue-identity.ts
@@ -41,16 +41,13 @@ export function buildIssueIdentityHeader(
 
 /**
  * Extract the numeric issue number from a canonical issue identifier such as
- * `owner/repo#507`, `#507`, `507`, or `TEAM-507`. Returns null when the
- * identifier is not a supported canonical shape.
+ * `owner/repo#507`, `#507`, or `507`. Tracker-native identifiers such as
+ * `TEAM-507` remain opaque here so legacy numeric consumers stay fail-closed.
  */
 export function extractIssueNumberFromIdentifier(
   identifier: string
 ): number | null {
-  const normalized = identifier.trim();
-  const match =
-    normalized.match(/(?:^|#|\/)(\d{1,9})$/) ??
-    normalized.match(/^[A-Za-z][A-Za-z0-9]*-(\d{1,9})$/);
+  const match = identifier.trim().match(/(?:^|#|\/)(\d{1,9})$/);
   if (!match) {
     return null;
   }
@@ -76,6 +73,14 @@ export function extractIssueNumbersFromBranch(branch: string): number[] {
 
 const WORKPAD_FILE_PATTERN = /(?:^|\/)\.gh-symphony\/workpads\/([^/]+)\.md$/;
 const TRACKER_IDENTIFIER_PATTERN = /^[A-Za-z][A-Za-z0-9]*-\d{1,9}$/;
+const VERSION_LIKE_TRACKER_KEYS = new Set([
+  "GO",
+  "JAVA",
+  "NODE",
+  "PHP",
+  "PYTHON",
+  "RUBY",
+]);
 
 function normalizeTrackerIdentifier(identifier: string): string | null {
   const normalized = identifier.trim();
@@ -84,12 +89,20 @@ function normalizeTrackerIdentifier(identifier: string): string | null {
     : null;
 }
 
+function isVersionLikeTrackerIdentifier(identifier: string): boolean {
+  const teamKey = identifier.split("-", 1)[0]!;
+  return VERSION_LIKE_TRACKER_KEYS.has(teamKey) || /^V\d+$/.test(teamKey);
+}
+
 function extractTrackerIdentifiersFromBranch(branch: string): string[] {
   const identifiers = new Set<string>();
   for (const match of branch.matchAll(
     /(?:^|\/)([A-Za-z][A-Za-z0-9]*-\d{1,9})(?=[-_/]|$)/g
   )) {
-    identifiers.add(match[1]!.toUpperCase());
+    const identifier = match[1]!.toUpperCase();
+    if (!isVersionLikeTrackerIdentifier(identifier)) {
+      identifiers.add(identifier);
+    }
   }
 
   return [...identifiers];
@@ -123,7 +136,7 @@ export function extractIssueNumbersFromWorkpadFiles(
     if (!match) {
       continue;
     }
-    const numeric = match[1]!.match(/(\d{1,9})/);
+    const numeric = match[1]!.match(/^(?:[A-Za-z][A-Za-z0-9]*-)?(\d{1,9})$/);
     if (numeric) {
       numbers.add(Number.parseInt(numeric[1]!, 10));
     }
@@ -168,11 +181,9 @@ export function attributeDirtyWorkToIssue(
     input.dirtyFiles
   );
 
-  const foreignBranchIdentifiers = trackerIdentifier
-    ? branchTrackerIdentifiers.filter(
-        (identifier) => identifier !== trackerIdentifier
-      )
-    : [];
+  const foreignBranchIdentifiers = branchTrackerIdentifiers.filter(
+    (identifier) => identifier !== trackerIdentifier
+  );
   if (foreignBranchIdentifiers.length > 0) {
     return {
       attributed: false,
@@ -180,11 +191,9 @@ export function attributeDirtyWorkToIssue(
     };
   }
 
-  const foreignWorkpadIdentifiers = trackerIdentifier
-    ? workpadTrackerIdentifiers.filter(
-        (identifier) => identifier !== trackerIdentifier
-      )
-    : [];
+  const foreignWorkpadIdentifiers = workpadTrackerIdentifiers.filter(
+    (identifier) => identifier !== trackerIdentifier
+  );
   if (foreignWorkpadIdentifiers.length > 0) {
     return {
       attributed: false,
@@ -192,24 +201,26 @@ export function attributeDirtyWorkToIssue(
     };
   }
 
-  const foreignBranchNumbers = branchNumbers.filter(
-    (number) => number !== issueNumber
-  );
-  if (foreignBranchNumbers.length > 0) {
-    return {
-      attributed: false,
-      reason: `current branch '${branch}' references issue #${foreignBranchNumbers[0]} instead of ${input.issueIdentifier}`,
-    };
-  }
+  if (!trackerIdentifier) {
+    const foreignBranchNumbers = branchNumbers.filter(
+      (number) => number !== issueNumber
+    );
+    if (foreignBranchNumbers.length > 0) {
+      return {
+        attributed: false,
+        reason: `current branch '${branch}' references issue #${foreignBranchNumbers[0]} instead of ${input.issueIdentifier}`,
+      };
+    }
 
-  const foreignWorkpadNumbers = workpadNumbers.filter(
-    (number) => number !== issueNumber
-  );
-  if (foreignWorkpadNumbers.length > 0) {
-    return {
-      attributed: false,
-      reason: `dirty workpad references issue #${foreignWorkpadNumbers[0]} instead of ${input.issueIdentifier}`,
-    };
+    const foreignWorkpadNumbers = workpadNumbers.filter(
+      (number) => number !== issueNumber
+    );
+    if (foreignWorkpadNumbers.length > 0) {
+      return {
+        attributed: false,
+        reason: `dirty workpad references issue #${foreignWorkpadNumbers[0]} instead of ${input.issueIdentifier}`,
+      };
+    }
   }
 
   if (branch && input.expectedBranches?.includes(branch)) {
@@ -239,14 +250,22 @@ export function attributeDirtyWorkToIssue(
     };
   }
 
-  if (issueNumber !== null && branchNumbers.includes(issueNumber)) {
+  if (
+    !trackerIdentifier &&
+    issueNumber !== null &&
+    branchNumbers.includes(issueNumber)
+  ) {
     return {
       attributed: true,
       reason: `current branch '${branch}' references ${input.issueIdentifier}`,
     };
   }
 
-  if (issueNumber !== null && workpadNumbers.includes(issueNumber)) {
+  if (
+    !trackerIdentifier &&
+    issueNumber !== null &&
+    workpadNumbers.includes(issueNumber)
+  ) {
     return {
       attributed: true,
       reason: `dirty workpad belongs to ${input.issueIdentifier}`,

--- a/packages/core/src/workflow/issue-identity.ts
+++ b/packages/core/src/workflow/issue-identity.ts
@@ -41,13 +41,16 @@ export function buildIssueIdentityHeader(
 
 /**
  * Extract the numeric issue number from a canonical issue identifier such as
- * `owner/repo#507`, `#507`, or `507`. Returns null when the identifier does
- * not end in a numeric fragment.
+ * `owner/repo#507`, `#507`, `507`, or `TEAM-507`. Returns null when the
+ * identifier is not a supported canonical shape.
  */
 export function extractIssueNumberFromIdentifier(
   identifier: string
 ): number | null {
-  const match = identifier.trim().match(/(?:^|#|\/)(\d{1,9})$/);
+  const normalized = identifier.trim();
+  const match =
+    normalized.match(/(?:^|#|\/)(\d{1,9})$/) ??
+    normalized.match(/^[A-Za-z][A-Za-z0-9]*-(\d{1,9})$/);
   if (!match) {
     return null;
   }
@@ -72,6 +75,40 @@ export function extractIssueNumbersFromBranch(branch: string): number[] {
 }
 
 const WORKPAD_FILE_PATTERN = /(?:^|\/)\.gh-symphony\/workpads\/([^/]+)\.md$/;
+const TRACKER_IDENTIFIER_PATTERN = /^[A-Za-z][A-Za-z0-9]*-\d{1,9}$/;
+
+function normalizeTrackerIdentifier(identifier: string): string | null {
+  const normalized = identifier.trim();
+  return TRACKER_IDENTIFIER_PATTERN.test(normalized)
+    ? normalized.toUpperCase()
+    : null;
+}
+
+function extractTrackerIdentifiersFromBranch(branch: string): string[] {
+  const identifiers = new Set<string>();
+  for (const match of branch.matchAll(
+    /(?:^|\/)([A-Za-z][A-Za-z0-9]*-\d{1,9})(?=[-_/]|$)/g
+  )) {
+    identifiers.add(match[1]!.toUpperCase());
+  }
+
+  return [...identifiers];
+}
+
+function extractTrackerIdentifiersFromWorkpadFiles(
+  dirtyFiles: string[]
+): string[] {
+  const identifiers = new Set<string>();
+  for (const file of dirtyFiles) {
+    const match = file.match(WORKPAD_FILE_PATTERN);
+    const identifier = match ? normalizeTrackerIdentifier(match[1]!) : null;
+    if (identifier) {
+      identifiers.add(identifier);
+    }
+  }
+
+  return [...identifiers];
+}
 
 /**
  * Extract issue numbers referenced by dirty workpad files
@@ -120,9 +157,40 @@ export function attributeDirtyWorkToIssue(
   input: DirtyWorkAttributionInput
 ): DirtyWorkAttribution {
   const issueNumber = extractIssueNumberFromIdentifier(input.issueIdentifier);
+  const trackerIdentifier = normalizeTrackerIdentifier(input.issueIdentifier);
   const branch = input.currentBranch?.trim() || null;
   const branchNumbers = branch ? extractIssueNumbersFromBranch(branch) : [];
   const workpadNumbers = extractIssueNumbersFromWorkpadFiles(input.dirtyFiles);
+  const branchTrackerIdentifiers = branch
+    ? extractTrackerIdentifiersFromBranch(branch)
+    : [];
+  const workpadTrackerIdentifiers = extractTrackerIdentifiersFromWorkpadFiles(
+    input.dirtyFiles
+  );
+
+  const foreignBranchIdentifiers = trackerIdentifier
+    ? branchTrackerIdentifiers.filter(
+        (identifier) => identifier !== trackerIdentifier
+      )
+    : [];
+  if (foreignBranchIdentifiers.length > 0) {
+    return {
+      attributed: false,
+      reason: `current branch '${branch}' references issue ${foreignBranchIdentifiers[0]} instead of ${input.issueIdentifier}`,
+    };
+  }
+
+  const foreignWorkpadIdentifiers = trackerIdentifier
+    ? workpadTrackerIdentifiers.filter(
+        (identifier) => identifier !== trackerIdentifier
+      )
+    : [];
+  if (foreignWorkpadIdentifiers.length > 0) {
+    return {
+      attributed: false,
+      reason: `dirty workpad references issue ${foreignWorkpadIdentifiers[0]} instead of ${input.issueIdentifier}`,
+    };
+  }
 
   const foreignBranchNumbers = branchNumbers.filter(
     (number) => number !== issueNumber
@@ -148,6 +216,26 @@ export function attributeDirtyWorkToIssue(
     return {
       attributed: true,
       reason: `current branch '${branch}' is tracker-linked to ${input.issueIdentifier}`,
+    };
+  }
+
+  if (
+    trackerIdentifier &&
+    branchTrackerIdentifiers.includes(trackerIdentifier)
+  ) {
+    return {
+      attributed: true,
+      reason: `current branch '${branch}' references ${input.issueIdentifier}`,
+    };
+  }
+
+  if (
+    trackerIdentifier &&
+    workpadTrackerIdentifiers.includes(trackerIdentifier)
+  ) {
+    return {
+      attributed: true,
+      reason: `dirty workpad belongs to ${input.issueIdentifier}`,
     };
   }
 

--- a/packages/worker/src/identity-preflight.test.ts
+++ b/packages/worker/src/identity-preflight.test.ts
@@ -100,6 +100,23 @@ describe("evaluateWorkerIdentityPreflight", () => {
     }
   });
 
+  it("fails closed for a bare numeric branch that collides with a Linear issue", () => {
+    const result = evaluateWorkerIdentityPreflight({
+      env: {
+        ...baseEnv,
+        SYMPHONY_ISSUE_IDENTIFIER: "DEV-54",
+        SYMPHONY_ISSUE_WORKSPACE_KEY: deriveIssueWorkspaceKey(
+          { adapter: "linear", issueSubjectId: "DEV-54" },
+          "DEV-54"
+        ),
+      },
+      originUrl: "https://github.com/acme/platform.git",
+      currentBranch: "feat/54-unrelated",
+    });
+
+    expect(result.ok).toBe(false);
+  });
+
   it("accepts neutral branches and missing git metadata", () => {
     expect(
       evaluateWorkerIdentityPreflight({


### PR DESCRIPTION
## Issues — Closed #782

## TL;DR

- Recover dirty Linear workspaces only when trusted branch/workpad evidence identifies the active full `TEAM-123` issue.
- Preserve GitHub numeric behavior and fail closed for ambiguous bare numbers, foreign tracker identifiers, and missing evidence.
- Treat terminal `name-number` branch fragments as non-foreign evidence, avoiding false quarantine of an issue's own workpad while retaining foreign detection for `key-number-slug` branches.

## Change-point diagram

```text
dirty branch/workpad evidence
            |
            v
full tracker token at segment start?
            |
            +-- own token ----------> positive evidence -> reuse
            |
            +-- foreign + slug -----> quarantine
            |
            +-- foreign terminal ---> non-evidence; own workpad may reuse
            |
            +-- no token -----------> legacy GitHub numeric evidence / fail closed
```

## Start here

1. `packages/core/src/workflow/issue-identity.ts` — separates tracker-native positive evidence from foreign branch evidence.
2. `packages/core/src/workflow/issue-identity.test.ts` — Linear, GitHub, ambiguous-number, foreign-token, terminal-token, and `GO-42` regressions.
3. `packages/worker/src/identity-preflight.test.ts` — preserves fail-closed worker preflight behavior.
4. `e2e/scenarios/21-linear-dirty-workspace-recovery.md` — Docker recovery lifecycle coverage.

## Changes

- Attribute `DEV-54` from `dev-54-*` or `DEV-54.md`, including digit-bearing team keys such as `DEV2-54`.
- Reject foreign full tracker evidence for both Linear and GitHub runs, but do not let a segment-terminal version-like token override an own workpad.
- Keep bare `54` branch/workpad artifacts ambiguous and non-positive for Linear runs, while retaining GitHub numeric matching.
- Remove the fixed version-key allowlist so valid team keys such as `GO-42` remain usable.

## Evidence

- Focused RED: three new structural-evidence regressions failed on `5757091`.
- Focused GREEN: `pnpm --filter @gh-symphony/core test -- issue-identity.test.ts` (23 tests) and `pnpm --filter @gh-symphony/worker test -- identity-preflight.test.ts` (8 tests) passed.
- `pnpm lint`, `pnpm test`, `pnpm typecheck`, and `pnpm build` passed.
- Docker black-box recovery lifecycle passed with a valid preloaded fixture: preserved workspace verified and no quarantine event emitted.
- Changeset: `.changeset/clean-lions-recover.md` — `@gh-symphony/cli` patch for #782.

## Risks & rollback

- Risk: a terminal `key-number` branch component is intentionally non-foreign because it is indistinguishable from a version fragment; without other positive evidence, recovery still fails closed.
- Rollback: revert the #782 commits and its changeset; recovery returns to the prior fail-closed behavior.

## Changed files

- Core behavior/tests: `packages/core/src/workflow/issue-identity.ts`, `packages/core/src/workflow/issue-identity.test.ts`
- Worker regression: `packages/worker/src/identity-preflight.test.ts`
- Docker TC and docs: `e2e/*linear-dirty-recovery*`, `AGENT_TEST.md`, `docs/architecture.md`
- Release: `.changeset/clean-lions-recover.md`

## Post-merge / human validation

- [ ] Confirm a live Linear recovery reuses a dirty workspace identified by `dev-54-fix` or `DEV-54.md`.
- [ ] Confirm foreign `eng-12-other` and ambiguous bare `54` artifacts remain quarantined for `DEV-54`.
- [ ] Confirm terminal version-like branch tokens do not override an issue-owned workpad.
