### PR TITLE
docs(reports): close upstream spec drift audit

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -56,7 +56,7 @@ Provider-specific compact adapter profiles and host-side agent-tool contracts:
 | [2026-06-25-spec-gap-analysis.md](reports/2026-06-25-spec-gap-analysis.md)                                       | Retired — living-map upkeep stopped, final snapshot                                    |
 | [2026-07-06-risk-audit-report.md](reports/2026-07-06-risk-audit-report.md)                                       | Awaiting review (issues not filed)                                                     |
 | [2026-07-19-github-api-rate-limit-audit.md](reports/2026-07-19-github-api-rate-limit-audit.md)                   | Partially implemented (R1.5 shipped)                                                   |
-| [2026-08-28-upstream-spec-drift-research.md](reports/2026-08-28-upstream-spec-drift-research.md)                 | Documentation follow-up: [#675](https://github.com/hojinzs/github-symphony/issues/675) |
+| [2026-08-28-upstream-spec-drift-research.md](reports/2026-08-28-upstream-spec-drift-research.md)                 | Complete (Epic #651 scope) — see its documented carve-outs; C1–C13/D1–D8 follow-up shipped in [#675](https://github.com/hojinzs/github-symphony/issues/675) |
 
 ## adr/
 

--- a/docs/adr/2026-08-28_priority-mapping-documented-different-mapping.md
+++ b/docs/adr/2026-08-28_priority-mapping-documented-different-mapping.md
@@ -29,12 +29,12 @@ mapping, not a change to the upstream specification. It applies to the values
 already supplied to the dispatch sorter; this ADR does not introduce a new
 priority configuration format or change tracker-adapter behavior.
 
-## Pending implementation
+## Adapter normalization
 
-Linear priority value `0` ("No priority") will be normalized to `null` rather
-than treated as the highest priority. The Linear adapter currently passes `0`
-through, so it currently sorts before positive values; adapter adoption is
-tracked in #660-B.
+Linear priority value `0` ("No priority") is normalized to `null` rather than
+treated as the highest priority. The Linear adapter ships this behavior in
+[#660](https://github.com/hojinzs/github-symphony/issues/660), so `0` sorts
+with absent priority after numeric values.
 
 ## Consequences
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -168,9 +168,9 @@ adapter behavior is unchanged.
 For dispatch priority, see [ADR 2026-08-28](adr/2026-08-28_priority-mapping-documented-different-mapping.md).
 The repository intentionally keeps numeric priorities, including non-integers,
 in ascending order and places `null` last, a documented different mapping under
-Symphony specification §8.2 and §11.3. Linear priority `0` currently passes
-through the adapter and sorts before positive values; normalization to `null`
-is pending adapter work in #660-B.
+Symphony specification §8.2 and §11.3. Linear priority `0` ("No priority") is
+normalized to `null` by the adapter, so it sorts after numeric priorities; this
+adapter normalization shipped in [#660](https://github.com/hojinzs/github-symphony/issues/660).
 
 ## Workflow Lifecycle Policy
 

--- a/docs/reports/2026-08-28-upstream-spec-drift-research.md
+++ b/docs/reports/2026-08-28-upstream-spec-drift-research.md
@@ -1,7 +1,7 @@
 # Upstream Spec Drift Research (2026-08-28)
 
 Date: 2026-08-28
-Status: Complete — every tracked closeout issue for the A/B findings, C1–C13 divergences, D1–D8 documentation corrections, and E-class defects is closed under Epic #651. The spec sync itself (S0/#652) shipped in PR #650 alongside this report; the final closeout audit completed on 2026-09-02.
+Status: Complete (Epic #651 scope) — every closeout issue tracked under Epic #651 for the applicable A/B findings, C1–C13 divergences, and D1–D8 documentation corrections is closed; the spec sync itself (S0/#652) shipped in PR #650 alongside this report; final closeout audit 2026-09-02. Carve-outs: B20 (Claude token accounting) moved to Epic #645; A20 is out of scope (MAY, nothing required); E5–E11 were never given tracked issues — E11 (silent poll-interval clamp) is still present. The tracked sub-issue range is #652–#679; documentation follow-up C1–C13/D1–D8 shipped in [#675](https://github.com/hojinzs/github-symphony/issues/675).
 Symphony Layers: Configuration, Coordination, Execution, Integration, Observability
 
 Baselines:

--- a/docs/reports/2026-08-28-upstream-spec-drift-research.md
+++ b/docs/reports/2026-08-28-upstream-spec-drift-research.md
@@ -1,7 +1,7 @@
 # Upstream Spec Drift Research (2026-08-28)
 
 Date: 2026-08-28
-Status: Research complete — findings tracked in Epic #651 (sub-issues #652–#679); the spec sync itself (S0/#652) ships in PR #650 alongside this report. Documentation follow-up for C1–C13 and D1–D8: [#675](https://github.com/hojinzs/github-symphony/issues/675)
+Status: Complete — every tracked closeout issue for the A/B findings, C1–C13 divergences, D1–D8 documentation corrections, and E-class defects is closed under Epic #651. The spec sync itself (S0/#652) shipped in PR #650 alongside this report; the final closeout audit completed on 2026-09-02.
 Symphony Layers: Configuration, Coordination, Execution, Integration, Observability
 
 Baselines:


### PR DESCRIPTION
## TL;DR

Completes the Epic #651 closeout documentation with accurate scope boundaries: all tracked remediation under the Epic is closed, while B20, A20, and untracked E5–E11 remain explicit carve-outs.

## Change-point diagram

```text
verified tracker behavior (#660)
          │
          ├── configuration guide + priority ADR
          │
Epic #651 closeout ──→ research report + report index
          │
          └── explicit scope and remaining carve-outs
```

## Start here

- Read the `Status` line in `docs/reports/2026-08-28-upstream-spec-drift-research.md` for the qualified Epic closeout and carve-outs.
- See `docs/configuration.md` and ADR `2026-08-28_priority-mapping-documented-different-mapping.md` for the shipped Linear priority-`0` normalization.

## Changed files

- `docs/reports/2026-08-28-upstream-spec-drift-research.md` — qualify the closeout and retain navigable issue pointers.
- `docs/configuration.md` — replace stale pending Linear-priority wording with shipped behavior.
- `docs/adr/2026-08-28_priority-mapping-documented-different-mapping.md` — record the completed adapter normalization.
- `docs/README.md` — update the report index to its scoped-complete status.

## Evidence

- Verified #660 is closed and `normalizeLinearIssue` maps priority `0` to `null`.
- Verified Epic #645 remains open; B20 is therefore retained as a carve-out.
- `pnpm lint`
- `pnpm test`
- `pnpm typecheck`
- `pnpm build`
- `pnpm format`
- `git diff --check`

## Risks & rollback

- Documentation-only change; the risk is limited to factual status wording.
- Roll back by reverting commit `1ce1a43` (and the initial closeout commit `5694920` if the full closeout needs reverting).

## Post-merge validation

- Confirm the report and index describe the same scoped-closeout status.

## Human validation

- [ ] Confirm the documented carve-outs accurately represent the remaining upstream-spec work.
- [ ] Confirm the priority-normalization wording matches the intended repository mapping.

## Issues — Closed #651
