### PR TITLE
chore(workflow): align WORKFLOW.md and worker skills with gh-symphony 1.1.0

### DIFF
--- a/.codex/skills/gh-pr-writeup/SKILL.md
+++ b/.codex/skills/gh-pr-writeup/SKILL.md
@@ -1,86 +1,171 @@
 ---
 name: gh-pr-writeup
-description: Draft, create, and update GitHub pull requests for implementation work. Use when opening or refreshing a PR that must clearly link the issue, include concise evidence from pre-PR validation, and add a human validation checklist for reviewers.
+description: Create and refresh GitHub pull requests through the host-side github_graphql tool. Use when opening the Draft PR after the first pushed commit, refreshing the PR body before handoff, or converting a draft PR to ready for review.
 ---
 
 # /gh-pr-writeup — GitHub PR Writeup Workflow
 
 ## Trigger
 
-Use this skill when creating or updating a GitHub PR for an implementation issue.
+Use this skill when creating or updating the PR for the assigned issue.
+
+- **Initial Draft** (WORKFLOW.md Step 2.4): the turn after your first commit, once the assigned branch exists on the remote.
+- **Refresh** (WORKFLOW.md Step 2.9): immediately before marking the PR ready, and again on rework cycles before re-handoff.
+
+The worker has no GitHub credentials: `gh pr create` / `gh pr edit` do not work. Every operation below is a `github_graphql` call with the body loaded from a scratch file outside the checkout (`jq -n --rawfile body "$scratch/pr-body.md" …`).
 
 ## Flow
 
-1. Confirm the issue number and repository context before drafting the PR body.
-2. Run a small but relevant validation pass before opening or refreshing the PR.
-3. Capture the exact commands you ran and the scope they validated.
-4. Draft or update the PR body using the template below.
-5. Create the PR if none exists; otherwise edit the existing PR so the body stays current.
+1. Confirm the issue number, repository, base branch (from the workpad), and the assigned branch (`git branch --show-current`).
+2. **Initial Draft only:** verify the branch is on the remote and ahead of the base:
 
-## Minimum Validation
+   ```graphql
+   query BranchState(
+     $owner: String!
+     $name: String!
+     $base: String!
+     $head: String!
+   ) {
+     repository(owner: $owner, name: $name) {
+       id
+       ref(qualifiedName: $base) {
+         compare(headRef: $head) {
+           aheadBy
+           behindBy
+         }
+       }
+     }
+   }
+   ```
 
-Before the PR is created or updated, run the smallest meaningful automated check that covers the changed area.
+   (`$base` = `refs/heads/<base>`, `$head` = `<branch>`.) If the ref is missing or `aheadBy == 0`, the previous host push did not land; record the diagnostic in the workpad and retry next turn.
 
-- Prefer targeted commands over full-repo suites when the change scope is narrow.
-- Use repository defaults when the scope is broad: `pnpm -r lint`, `pnpm -r test`, `pnpm -r build`.
-- If no automated test is available, record the gap explicitly in `Evidence` and explain the fallback manual check.
+3. Run the smallest meaningful validation for the changed area and capture the exact commands (targeted `npx vitest run <file>` for narrow scopes; the full Completion Bar commands before Refresh).
+4. Draft the body using the template below, then:
+   - **Create** (draft):
+
+     ```graphql
+     mutation CreateDraftPr(
+       $repositoryId: ID!
+       $base: String!
+       $head: String!
+       $title: String!
+       $body: String!
+     ) {
+       createPullRequest(
+         input: {
+           repositoryId: $repositoryId
+           baseRefName: $base
+           headRefName: $head
+           title: $title
+           body: $body
+           draft: true
+         }
+       ) {
+         pullRequest {
+           id
+           number
+           url
+           isDraft
+         }
+       }
+     }
+     ```
+
+   - **Refresh**:
+
+     ```graphql
+     mutation RefreshPr($pullRequestId: ID!, $title: String!, $body: String!) {
+       updatePullRequest(
+         input: { pullRequestId: $pullRequestId, title: $title, body: $body }
+       ) {
+         pullRequest {
+           id
+           url
+         }
+       }
+     }
+     ```
+
+   - **Ready for review** (Step 2.9 only, after Refresh):
+
+     ```graphql
+     mutation ReadyPr($pullRequestId: ID!) {
+       markPullRequestReadyForReview(input: { pullRequestId: $pullRequestId }) {
+         pullRequest {
+           isDraft
+         }
+       }
+     }
+     ```
+
+     On rework cycles also re-request review from the reviewers who requested changes: `requestReviews(input: { pullRequestId, userIds, union: true })` (user ids via `user(login:) { id }`).
+
+5. Record the PR URL (create) or the refresh timestamp in the workpad.
 
 ## PR Body Template
 
-Use this structure unless the repository already has a stricter template:
+Follow the repository's `.github/pull_request_template.md` when one exists; this structure satisfies it:
 
 ```md
 ## Issues
 
-- Fixes #<issue-number>
+- Closes #<issue-number>
 
 ## Summary
 
-- Short outcome summary
-- Key behavior change
+- TL;DR: what changed and why (2–3 bullets)
 
-## Changes
+## Change-point diagram
 
-- Implementation detail 1
-- Implementation detail 2
+- <package/module> → <what it now does> (text diagram or bullet chain of the affected components)
 
-## Evidence
+## Start here
 
-- `command run before PR`
-- `another command`
-- Manual check: what was verified and where
+- <file:line> — the entry point a reviewer should read first
+- <file:line> — the core change
 
-## Human Validation
+## User-Visible Behavior / Operational Impact
 
-- [ ] Confirm the main user flow works as expected
-- [ ] Confirm there is no obvious regression in adjacent behavior
-- [ ] Confirm reviewer-visible behavior matches the issue requirements
+- CLI/runtime behavior, deployment impact, or "None"
 
-## Risks
+## Validation
 
-- Remaining risk, rollout caveat, or reviewer focus area
+- `command` — pass/fail (Completion Bar results; flake exceptions cite the follow-up issue)
+- Docker E2E / blackbox evidence path or "not applicable: <reason>"
+
+## Changeset
+
+- `.changeset/<file>.md` (`<bump>`) or "Not needed because <reason>"
+
+## Risks & rollback
+
+- Remaining risk, reviewer focus area, rollback plan
+
+## Changed files
+
+- <path> — <one-line purpose>
+
+## Post-merge / human validation
+
+- [ ] Items the agent does not perform (deploy, external smoke, manual UX) — mirrored from the workpad Delegation section
+
+## Security
+
+- [ ] No real tokens, private keys, `.env` files, or generated installation tokens are committed
 ```
 
 ## Rules
 
-- Put the linked issue under `## Issues` and use an auto-close keyword such as `Fixes #<issue-number>`.
-- Keep `Human Validation` unchecked; it is for humans, not the agent.
-- In `Evidence`, include concrete commands or concrete manual checks, not vague statements like "tests passed".
-- When updating an existing PR after review, refresh `Summary`, `Changes`, and `Evidence` so they describe the latest diff.
-- If validation could not run, say exactly why in `Evidence` and in the final handoff.
-
-## Commands
-
-Use GitHub CLI if available:
-
-```bash
-gh pr create --title "<title>" --body-file <file>
-gh pr edit <pr-number> --title "<title>" --body-file <file>
-gh pr view --json number,title,body,url
-```
+- Keep `Post-merge / human validation` and `Security` unchecked; they are for humans.
+- `Closes #<n>` under `## Issues` is mandatory so GitHub links and auto-closes the issue.
+- Everything in English (WORKFLOW.md Posture 2).
+- In `Validation`, list concrete commands and outcomes, never "tests passed".
+- On Refresh, rewrite `Summary`, `Change-point diagram`, `Validation`, and `Changed files` so they describe the latest diff.
+- Never mark a PR ready before the Completion Bar and changeset policy pass.
 
 ## Related Skills
 
-- `/pull` — sync branch with latest base before PR handoff when needed
-- `/push` — publish verified commits before creating or updating the PR
+- `/pull` — merge the base branch into the assigned branch when behind (never rebase)
+- `/push` — how the host publishes your commits at turn end
 - `/land` — merge approved PRs after checks and approvals are green

--- a/.codex/skills/gh-project/SKILL.md
+++ b/.codex/skills/gh-project/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: gh-project
-description: Request run-scoped tracker states and transitions through the orchestrator.
+description: Request run-scoped tracker states and transitions through the orchestrator, and manage issue comments through the host-side github_graphql tool.
 license: MIT
 metadata:
   author: gh-symphony
-  version: "2.0"
+  version: "3.0"
   generatedBy: "gh-symphony"
 ---
 
@@ -14,6 +14,7 @@ metadata:
 
 Request issue-scoped tracker state reads and transitions from the orchestrator,
 supplying policy-authored lifecycle comment bodies for publication after confirmed readback.
+Issue comments (workpad, triage, blocker) are written with the host-side `github_graphql` tool.
 
 ## Prerequisites
 
@@ -21,6 +22,7 @@ supplying policy-authored lifecycle comment bodies for publication after confirm
 - `SYMPHONY_RUN_ID` identifies the current run
 - `SYMPHONY_ORCHESTRATOR_TOKEN` authenticates the worker without exposing the credential through status APIs
 - The orchestrator owns the canonical tracker item, provider quota, retry/backoff, mutation, and readback
+- The worker child has **no** GitHub credentials: `gh` is unauthenticated. Use the `github_graphql` tool for every GitHub read or write.
 
 ## Operations
 
@@ -37,11 +39,13 @@ curl --fail-with-body --silent --show-error \
 
 ### Request Issue Status Transition
 
+Write the transition body to a scratch file **outside the checkout** (`mktemp -d "${TMPDIR:-/tmp}/symphony-<issue>.XXXXXX"`), then run this script verbatim so every value is JSON-encoded by `jq`:
+
 ```bash
 expected_state="In progress"
 target_state="In review"
-reason="PR created; validation passed"
-comment_body_file="transition-comment.md"
+reason="PR ready; Completion Bar passed"
+comment_body_file="$scratch/transition.md"
 comment_body=$(<"$comment_body_file")
 payload=$(jq -n \
   --arg expected "$expected_state" \
@@ -60,20 +64,106 @@ jq -e --arg target "$target_state" \
   '.ok == true and .outcome == "confirmed" and .state == $target' <<<"$response"
 ```
 
-### Create Workpad Comment
+### Create Workpad or Issue Comment (`github_graphql`)
 
-Use `gh issue comment --body-file <file>` for multi-line comments.
+Load the body from the scratch file into the tool variables (for example `jq -n --arg id "$issue_id" --rawfile body "$scratch/workpad.md" '{subjectId:$id, body:$body}'`), then call:
+
+```graphql
+mutation AddIssueComment($subjectId: ID!, $body: String!) {
+  addComment(input: { subjectId: $subjectId, body: $body }) {
+    commentEdge {
+      node {
+        id
+        url
+      }
+    }
+  }
+}
+```
+
+The issue node id comes from:
+
+```graphql
+query IssueContext($owner: String!, $name: String!, $number: Int!) {
+  repository(owner: $owner, name: $name) {
+    id
+    issue(number: $number) {
+      id
+      comments(last: 50) {
+        nodes {
+          id
+          body
+          author {
+            login
+          }
+          createdAt
+        }
+      }
+      closedByPullRequestsReferences(first: 10, includeClosedPrs: true) {
+        nodes {
+          id
+          number
+          url
+          state
+          isDraft
+          merged
+          headRefName
+          baseRefName
+          reviewDecision
+          mergeCommit {
+            oid
+          }
+        }
+      }
+    }
+  }
+}
+```
 
 ### Update Existing Comment
 
-Use `gh api -X PATCH /repos/<owner>/<repo>/issues/comments/<comment-id> -F body=@<file>`.
+```graphql
+mutation UpdateIssueComment($id: ID!, $body: String!) {
+  updateIssueComment(input: { id: $id, body: $body }) {
+    issueComment {
+      id
+    }
+  }
+}
+```
+
+### Create Follow-up Issue
+
+```graphql
+mutation CreateFollowUp(
+  $repositoryId: ID!
+  $title: String!
+  $body: String!
+  $labelIds: [ID!]
+) {
+  createIssue(
+    input: {
+      repositoryId: $repositoryId
+      title: $title
+      body: $body
+      labelIds: $labelIds
+    }
+  ) {
+    issue {
+      number
+      url
+    }
+  }
+}
+```
 
 ## Rules
 
 - Always follow the `WORKFLOW.md` status map.
-- Never traverse provider boards or mutate tracker fields directly from a worker.
+- Never traverse provider boards or mutate tracker fields directly from a worker; never touch ProjectV2 objects through `github_graphql`.
 - Treat non-2xx responses, expected-state mismatches, and readback mismatches as failed transitions.
 - Do not post a standalone status-transition comment before or after the request; the orchestrator publishes the supplied `comment_body` only after confirmed readback.
 - Keep the transition reason and intended comment body in the workpad before requesting the transition. A failed transition produces no status comment and remains recoverable in the current worker.
 - When the response is not `.ok == true`, `.outcome == "confirmed"`, and the returned state matching the target, record the failure in the workpad and do not publish a correction status comment.
+- Before creating a workpad, re-query the newest comments and adopt an existing workpad with the same cycle number.
 - Before transitioning to a terminal state, verify the Completion Bar and merged PR requirements.

--- a/.codex/skills/land/SKILL.md
+++ b/.codex/skills/land/SKILL.md
@@ -166,7 +166,7 @@ All must pass before merging. If any fails, record the failure in the workpad an
 
 ## Failure Handling
 
-1. **Merged-PR precedence is always first.** Re-read the linked PR's `state` before classifying a failure. If it is `MERGED`, discard the pending failure classification, record the merge commit SHA, transition `Land` → `Done` through `/gh-project`, and exit.
+1. **Merged-PR precedence is always first.** Re-read the linked PR's `state` before classifying a failure. If it is `MERGED`, discard the pending failure classification, record the merge commit SHA, transition `Land` → `Done` through `/gh-project`, and exit. A deleted head branch is not rework after merge.
 2. Record the exact failure (operation, response excerpt, head SHA, timestamp) in the workpad `### Progress Log`.
 3. If immediately recoverable in this run (branch behind → server-side update; trivial conflict → `/pull` merge and end the turn so the host pushes), do so and re-run the merged guard plus pre-flight from scratch.
 4. Do not retry a non-recoverable Land pre-flight failure on later turns. First write its concrete classification, response excerpt, timestamp, exact transition reason, and `comment_body` into the workpad; then close the Land cycle after the orchestrator confirms the transition readback.

--- a/.codex/skills/land/SKILL.md
+++ b/.codex/skills/land/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: land
-description: Merge an approved PR during the Land state. Runs pre-flight checks, performs squash merge, completes post-merge bookkeeping, and transitions the issue to Done.
+description: Merge an approved PR during the Land state. Runs pre-flight checks through github_graphql, updates the branch server-side when behind, performs the squash merge, completes post-merge bookkeeping, and transitions the issue to Done.
 license: MIT
 metadata:
   author: gh-symphony
-  version: "1.0"
+  version: "2.0"
 ---
 
 # /land — Land State Merge Workflow
@@ -17,81 +17,170 @@ Work unattended. Do not ask humans for follow-up. Stop only on a genuine blocker
 
 ## Operating Rules
 
+- The worker has **no** GitHub credentials: `gh` is unauthenticated and `git push` is impossible. Every GitHub read and write in this skill goes through the host-side `github_graphql` tool with named operations and variables scoped to this PR/repository.
 - Use `/gh-project` for every tracker state read/transition. Never traverse provider boards or mutate tracker fields directly.
-- Use `/pull` when the head branch is behind its PR base — never `git merge`/`git rebase` by hand inside this skill.
-- All issue/PR comments are in the issue's report language; written via `gh ... --body-file <file>`, never with inline `\n` strings.
+- Land changes no source files. The only local Git operations allowed are `git pull --ff-only origin <head>` after a server-side branch update and resolving a **trivial conflict** (`.changeset/*`, `docs/**`, `CHANGELOG.md`, lockfile) with `git merge origin/<base>` per `/pull`. Never rebase, amend, or switch branches — the host pushes the assigned branch fast-forward only at turn end.
+- Land must finish within one or two turns (WORKFLOW.md Runtime Contract 5): waiting for CI happens inside a single turn.
+- All issue/PR comments are English, written from a scratch file outside the checkout, passed as GraphQL variables.
 - Never modify the issue body.
-- Never hardcode `origin/main` for branch-freshness checks — always use the PR's actual base branch (it may be an Epic working branch).
-- **Squash merge only** for this repository. Other merge strategies are not used.
+- Never hardcode `main` for branch-freshness checks — always use the PR's actual base branch (it may be an Epic working branch).
+- **Squash merge only** for this repository.
 - Record every merge attempt, blocker, and outcome in the Land cycle workpad comment.
-- Treat a Project status transition as the final lifecycle mutation for the Land turn. Before requesting it, finish the pre-flight/merge decision, write its exact evidence, reason, and policy-authored `comment_body` into the workpad Validation/Progress Log, then send the body through `/gh-project`. The orchestrator publishes it only after confirmed readback; do not post a duplicate status comment or correction comment. A confirmed transition out of `Land` makes the issue non-active, and reconciliation can terminate this worker immediately afterward.
+- Treat a Project status transition as the final lifecycle mutation for the Land turn. Before requesting it, finish the pre-flight/merge decision, write its exact evidence, reason, and policy-authored `comment_body` into the workpad Validation/Progress Log, then send the body through `/gh-project`. The orchestrator publishes it only after confirmed readback; do not post a duplicate status comment or correction comment. A confirmed transition out of `Land` makes the issue non-active, and the worker stops immediately afterward.
 
 ## Required Context
 
 Before acting, collect:
 
 1. Issue: state, identifier, title, labels, description, URL, repository.
-2. Land cycle workpad comment for this issue. (Step 4 created it. If absent, create one before proceeding.)
-3. PR: number, URL, base branch, head branch, `state`, `mergeCommit`, reviews, CI checks, head SHA. Collect `mergeStateStatus` only after the Merged-PR Precedence Guard confirms the PR remains open.
-4. Changeset file path, if the issue carries a `changeset:major|minor|patch` label.
+2. Land cycle workpad comment for this issue (Step 4 created it; adopt one already created for this cycle number by a retried worker; if absent, create one before proceeding).
+3. PR (`LandContext` query below): id, number, URL, base branch, head branch, `state`, `merged`, `mergeCommit`, `headRefOid`, `reviewDecision`, reviews, review threads, `mergeable`, `mergeStateStatus`, and the head commit's `statusCheckRollup` with `isRequired` per context.
+4. Changeset file path, if the issue carries a `changeset:major|minor|patch` label (`git ls-files .changeset` on the checked-out head).
 
 If no PR is linked to the issue, record the blocker in the workpad and exit.
 
-**Sibling skills.** This skill delegates to `/gh-project` for the Done transition and `/pull` for branch freshness. Both were updated alongside this skill to target the Moncher Stack project and accept the PR's actual base branch — no special workaround is required. If either fails at runtime (e.g. authentication, board re-configuration), record the specific failure in the workpad and exit with a `⛔ Blocker` comment.
+```graphql
+query LandContext($owner: String!, $name: String!, $number: Int!) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      id
+      number
+      url
+      state
+      merged
+      isDraft
+      baseRefName
+      headRefName
+      headRefOid
+      mergeCommit {
+        oid
+      }
+      mergeable
+      mergeStateStatus
+      reviewDecision
+      reviews(last: 30) {
+        nodes {
+          state
+          author {
+            login
+          }
+          submittedAt
+          commit {
+            oid
+          }
+        }
+      }
+      reviewThreads(first: 100) {
+        nodes {
+          id
+          isResolved
+          isOutdated
+          path
+        }
+      }
+      commits(last: 1) {
+        nodes {
+          commit {
+            oid
+            statusCheckRollup {
+              state
+              contexts(first: 100) {
+                nodes {
+                  ... on CheckRun {
+                    name
+                    status
+                    conclusion
+                    isRequired(pullRequestNumber: $number)
+                  }
+                  ... on StatusContext {
+                    context
+                    state
+                    isRequired(pullRequestNumber: $number)
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
 
 ## Merged-PR Precedence Guard
 
 Run this guard immediately after loading Required Context and before every pre-flight check or failure classification:
 
-1. Read the linked PR's `state` and `mergeCommit` with `gh pr view <pr-number> --json state,mergeCommit`.
+1. Read the linked PR's `state`, `merged`, and `mergeCommit`.
 2. If `state` is `MERGED`, skip approval, CI, branch freshness, changeset, mergeability, and every failure classification. Record the merged commit SHA and changeset path (if any) in the Land workpad, prepare the `Land` → `Done` body, transition through `/gh-project`, and exit.
-3. Never transition a merged PR's issue to `Ready`, even if its deleted head branch makes a later freshness or mergeability command fail.
+3. Never transition a merged PR's issue to `Ready`, even if its deleted head branch makes a later freshness or mergeability check fail.
 
 ## Pre-flight Checks
 
 All must pass before merging. If any fails, record the failure in the workpad and **do not** merge.
 
-1. **At least one human approval.** `gh pr view <pr-number> --json reviews --jq '[.reviews[] | select(.state == "APPROVED")] | length'` must be ≥ 1.
-2. **All required CI checks green.** Use `gh pr checks <pr-number> --required` — no failing or pending **required** checks. Optional checks do not gate Land pre-flight. Before `/pull`, capture the required-check names from `gh pr checks <pr-number> --required --json name,bucket`. If no required checks are configured, this gate passes and must not wait for a check suite. If this run's `/pull` or another fresh head update has re-queued previously observed required CI:
-   - First poll `gh pr checks <pr-number> --required --json name,bucket` every 10 seconds until the previously observed required checks appear. Do not invoke `--watch` while the result is empty: GitHub can register a new head before its check suite exists, and `--watch` exits immediately when no checks are reported.
-   - Keep `Land` while waiting for registration, for at most 5 minutes. If no required check appears by then, classify it as an external CI-registration wait, record the exact head SHA and polling evidence in the workpad, then follow Failure Handling step 6 (`Land` → `In review`). Do not hide GitHub API/authentication errors as an empty result; those are external blockers.
-   - Once required checks appear, wait with `gh pr checks <pr-number> --required --watch --interval 10`. Do not transition to `In review` merely because newly-triggered required CI is still running. Once the checks reach terminal states, restart the Merged-PR Precedence Guard and the full pre-flight sequence.
-3. **Branch up-to-date with the PR base.**
-   ```bash
-   base=$(gh pr view <pr-number> --json baseRefName --jq .baseRefName)
-   git fetch origin "$base"
-   git merge-base --is-ancestor "origin/$base" HEAD
-   ```
-   If behind: run `/pull`, then **restart the Merged-PR Precedence Guard and the full pre-flight sequence** (pushing the rebase invalidates prior CI runs and any prior approval).
-4. **Changeset present if labeled.** If the issue has a `changeset:major|minor|patch` label, confirm at least one `.changeset/*.md` file exists on the head branch (excluding `README.md` / `config.json`). If absent, record the blocker, do not merge.
-5. **PR mergeable.** `gh pr view <pr-number> --json mergeStateStatus --jq .mergeStateStatus` must be `CLEAN` / `HAS_HOOKS` / `UNSTABLE` (the last allowed only when failing checks are all non-required). `BLOCKED` / `DIRTY` / `BEHIND` → not mergeable.
+1. **At least one human approval on the current head.** A review with `state == APPROVED` from a human (not the orchestration account) whose `commit.oid` is the current `headRefOid`, **or** whose approved commit is an ancestor of the current head where every commit after it is a base-branch merge commit produced by this Land cycle (server-side `updatePullRequestBranch` or a trivial-conflict `git merge`). A merge-update never invalidates an approval under this policy; if branch protection dismissed it anyway, that is an external wait (Failure Handling 6).
+2. **All required checks green on the head commit.** From `statusCheckRollup.contexts`, consider only entries with `isRequired: true`. Every required `CheckRun` must be `COMPLETED` with conclusion `SUCCESS`/`NEUTRAL`/`SKIPPED`; every required `StatusContext` must be `SUCCESS`. If no required contexts exist, this gate passes without waiting. Optional checks never gate Land.
+3. **Branch not behind its base.** `repository { ref(qualifiedName: "refs/heads/<base>") { compare(headRef: "<head>") { aheadBy behindBy } } }` must report `behindBy == 0`. If behind: run the server-side update (`updatePullRequestBranch(input: { pullRequestId, updateMethod: MERGE })`), then `git pull --ff-only origin <head>` locally so the host push at turn end is a no-op, then **restart the Merged-PR Precedence Guard and the full pre-flight sequence** including the CI wait in step 5.
+4. **Changeset present if labeled.** If the issue has a `changeset:major|minor|patch` label, confirm at least one `.changeset/*.md` file exists on the head (excluding `README.md` / `config.json`). If absent, this is a rework failure.
+5. **CI wait after a fresh head.** When step 3 or a trivial-conflict merge produced a new head, poll `LandContext` every 10 seconds until the previously observed required contexts register on the new head (at most 5 minutes), then keep polling until every required context is terminal (at most 30 minutes). Stay in this turn while waiting. If registration or completion exceeds the limit, classify as Failure Handling 6.
+6. **PR mergeable.** `mergeStateStatus` must be `CLEAN` / `HAS_HOOKS` / `UNSTABLE` (the last allowed only when failing checks are all non-required). `BLOCKED` / `DIRTY` / `BEHIND` / `UNKNOWN` (after re-querying twice) → not mergeable; classify per Failure Handling.
 
 ## Flow
 
-1. Load context and run the Merged-PR Precedence Guard. The human-owned `In review` → `Land` transition is already confirmed before this worker is dispatched; record it as the Land-cycle trigger and do not issue a duplicate `/gh-project` request or status comment for it. Only transitions requested by this skill carry a policy-authored `comment_body` through `/gh-project`.
+1. Load context and run the Merged-PR Precedence Guard. The human-owned `In review` → `Land` transition is already confirmed before this worker is dispatched; record it as the Land-cycle trigger and do not issue a duplicate `/gh-project` request or status comment for it.
 2. If the PR remains open, run all Pre-flight Checks.
-3. Squash-merge with branch deletion: `gh pr merge <pr-number> --squash --delete-branch`.
-4. Capture the merge commit SHA: `gh pr view <pr-number> --json mergeCommit --jq .mergeCommit.oid`.
-5. Update the Land cycle workpad's `### Validation` and `### Progress Log` sections with merge commit SHA, changeset path (if any), timestamp, and the exact `Land → Done` reason. Complete all Land-cycle evidence before the tracker transition.
-6. Prepare the `🔁 Status: Land → Done` body (cycle close: land) and include it as `comment_body` in the `/gh-project` request. Do not defer any outcome details until after the transition.
-7. Transition the issue to `Done` via `/gh-project` as the last action of the turn (WORKFLOW.md Posture 5 ordering). The orchestrator publishes the body after confirmed exact-item readback. If the response is not confirmed, record the failure in the workpad and do not publish a correction status comment.
+3. Squash-merge:
+
+   ```graphql
+   mutation LandMerge(
+     $pullRequestId: ID!
+     $expectedHeadOid: GitObjectID!
+     $headline: String!
+   ) {
+     mergePullRequest(
+       input: {
+         pullRequestId: $pullRequestId
+         mergeMethod: SQUASH
+         expectedHeadOid: $expectedHeadOid
+         commitHeadline: $headline
+       }
+     ) {
+       pullRequest {
+         merged
+         mergeCommit {
+           oid
+         }
+       }
+     }
+   }
+   ```
+
+   `commitHeadline` is the PR title followed by ` (#<number>)`. `expectedHeadOid` is the head you verified in pre-flight; a mismatch means the head moved — restart pre-flight.
+
+4. Delete the head branch: `repository { ref(qualifiedName: "refs/heads/<head>") { id } }` then `deleteRef(input: { refId })`. A failure to delete is recorded but is not a blocker.
+5. Update the Land cycle workpad's `### Validation` and `### Progress Log` sections with merge commit SHA, changeset path (if any), timestamp from `date -u`, and the exact `Land → Done` reason. Complete all Land-cycle evidence before the tracker transition.
+6. Prepare the `🔁 Status: Land → Done` body (cycle close: land) and include it as `comment_body` in the `/gh-project` request.
+7. Transition the issue to `Done` via `/gh-project` as the last action of the turn. If the response is not confirmed, record the failure in the workpad and do not publish a correction status comment.
 
 ## Failure Handling
 
-1. **Merged-PR precedence is always first.** Re-read the linked PR's `state` before classifying a failure. If it is `MERGED`, discard the pending failure classification, record the merge commit SHA, transition `Land` → `Done` through `/gh-project`, and exit. A deleted head branch is not rework after merge.
-2. Record the exact failure (command, exit code, output excerpt, timestamp) in the workpad `### Progress Log`.
-3. If immediately recoverable in this run (branch behind → run `/pull`), do so and re-run the merged guard plus pre-flight from scratch. If `/pull` fails, classify that failure using step 6.
-4. Do not retry a non-recoverable Land pre-flight failure on later polling turns. First write its concrete classification, command output excerpt, timestamp, exact transition reason, and `comment_body` into the workpad; then close the Land cycle after the orchestrator confirms the transition readback, and append the workpad `### Status Transitions` line if the worker remains alive.
-5. **Required CI pending or registering** — when a pre-refresh check found one or more required checks, keep `Land` while those required checks are registering or running. Poll `gh pr checks <pr-number> --required --json name,bucket` every 10 seconds until the previously observed required checks appear (maximum 5 minutes), then wait with `gh pr checks <pr-number> --required --watch --interval 10`. If no required checks were configured before the fresh head, this gate passes without a registration wait. When checks complete, restart the merged guard and all pre-flight checks. A failed required check is a rework failure; a green result proceeds to merge. If expected required checks do not register within the limit, record the head SHA and polling evidence, then classify it as the external wait-only failure in step 6. Do not use `Land` → `In review` solely because CI was re-queued by `/pull` or another fresh head update.
-6. **Approval or other external wait-only failure** — no human `APPROVED` review or another condition awaiting human/external review after CI is terminal: prepare a status body naming the concrete gate that failed, the head SHA it was evaluated against, and what a human must do; send it as `comment_body` while transitioning `Land` → `In review` via `/gh-project`. This is not a `⛔ Blocker`.
-7. **Rework failure** — failed required CI, merge conflict, missing labeled Changeset, unresolved actionable review feedback, or another PR/code condition the worker can address: prepare a status body with reason `Land-return rework: <cause>`, then transition `Land` → `Ready` via `/gh-project` with that body. The Ready-return rework guard must open the next work cycle and route the item to `In progress`; do not treat it as a fresh pickup.
+1. **Merged-PR precedence is always first.** Re-read the linked PR's `state` before classifying a failure. If it is `MERGED`, discard the pending failure classification, record the merge commit SHA, transition `Land` → `Done` through `/gh-project`, and exit.
+2. Record the exact failure (operation, response excerpt, head SHA, timestamp) in the workpad `### Progress Log`.
+3. If immediately recoverable in this run (branch behind → server-side update; trivial conflict → `/pull` merge and end the turn so the host pushes), do so and re-run the merged guard plus pre-flight from scratch.
+4. Do not retry a non-recoverable Land pre-flight failure on later turns. First write its concrete classification, response excerpt, timestamp, exact transition reason, and `comment_body` into the workpad; then close the Land cycle after the orchestrator confirms the transition readback.
+5. **Required CI pending or registering** — keep `Land` and wait inside this turn per Pre-flight step 5. When checks complete, restart the merged guard and all pre-flight checks. A failed required check is a rework failure; a green result proceeds to merge.
+6. **Approval or other external wait-only failure** — no valid human `APPROVED` review on the current head (per Pre-flight step 1), a dismissed approval, `mergeStateStatus: BLOCKED` by a protection rule the worker cannot satisfy, or a CI wait that exceeded the limits: prepare a status body naming the concrete gate that failed, the head SHA it was evaluated against, and what a human must do; send it as `comment_body` while transitioning `Land` → `In review` via `/gh-project`. This is not a `⛔ Blocker`.
+7. **Rework failure** — failed required CI, a source-file merge conflict (`mergeable: CONFLICTING` outside the trivial set), missing labeled Changeset, unresolved actionable review feedback, or another PR/code condition the worker can address: prepare a status body with reason `Land-return rework: <cause>`, then transition `Land` → `Ready` via `/gh-project` with that body. The Ready-return rework guard opens the next work cycle and routes the item to `In progress`.
 8. **External or permission blocker** — missing required context, authentication/board failure, or an external dependency the worker cannot resolve: write a `⛔ Blocker` comment with what · why · how to unblock, prepare a status body stating the unblock condition, then transition `Land` → `Backlog` via `/gh-project` with that body.
 
 ## Guardrails
 
-- Do not merge without ≥1 approval and green required CI.
+- Do not merge without ≥1 valid approval and green required CI.
 - Do not use merge / rebase / auto-merge — only squash with branch deletion.
 - Do not transition the issue to `Done` before the merge succeeds.
 - Do not traverse provider boards or mutate tracker fields directly; use `/gh-project`.
 - Do not modify the issue body.
+- Do not edit source files in a Land cycle; conflicts outside `.changeset/`, `docs/`, `CHANGELOG.md`, and the lockfile go back to `Ready`.
 - Do not leave a non-recoverable failure in active `Land`; return it to `In review`, `Ready`, or `Backlog` according to Failure Handling.

--- a/.codex/skills/pull/SKILL.md
+++ b/.codex/skills/pull/SKILL.md
@@ -1,72 +1,47 @@
 ---
 name: pull
-description: Sync the current branch with the latest base branch (PR base if a PR exists, otherwise origin/main).
+description: Bring the assigned branch up to date with its base branch by merging (never rebasing), so the host-owned fast-forward push still succeeds.
 license: MIT
 metadata:
   author: gh-symphony
-  version: "2.0"
+  version: "3.0"
   generatedBy: "gh-symphony"
 ---
 
-# /pull — Branch Sync Workflow
+# /pull — Branch Sync Workflow (merge only)
 
 ## Trigger
 
-Use this skill to bring the current branch up to date with its base branch:
+Use this skill to bring the assigned branch up to date with its base branch:
 
-- Before creating a PR.
-- Before starting a new work session on an existing branch.
-- When the `/land` skill's pre-flight check 3 (branch up-to-date with PR base) fails.
+- At the start of a rework cycle when the PR is behind its base.
+- Before the handoff when `main` moved and your change touches the same files.
+- During a Land cycle only for a **trivial conflict** (`.changeset/*`, `docs/**`, `CHANGELOG.md`, lockfile); otherwise Land uses the server-side `updatePullRequestBranch` mutation.
+
+## Why merge, never rebase
+
+The worker child has no push credentials. The host pushes `$SYMPHONY_ASSIGNED_BRANCH` at the end of every turn and **refuses** the push when `origin/<branch>` is not an ancestor of your local head. A rebase, amend, reset, or squash of commits that are already on the remote makes the push impossible and strands your work. A merge commit keeps history fast-forwardable and keeps prior human approvals valid.
 
 ## Flow
 
-1. Determine the base branch:
+1. Confirm you are on the assigned branch: `git branch --show-current` must equal `$SYMPHONY_ASSIGNED_BRANCH`. Never switch branches.
+2. Determine the base branch: the PR's `baseRefName` when a PR exists (from the workpad or the `IssueContext` query), otherwise `main`.
+3. Refresh the base ref. The orchestrator refreshed `origin/<base>` in the shared cache at dispatch; try `git fetch origin <base>` for a newer ref, and if it fails for lack of credentials (private repository), continue with the cached `origin/<base>`.
+4. Merge:
 
    ```bash
-   # If a PR exists for the current branch:
-   pr_number=$(gh pr view --json number --jq .number 2>/dev/null)
-   if [ -n "$pr_number" ]; then
-     base=$(gh pr view --json baseRefName --jq .baseRefName)
-   else
-     base="main"
-   fi
+   git merge --no-edit "origin/$base"
    ```
 
-2. Fetch latest:
-
-   ```bash
-   git fetch origin "$base"
-   ```
-
-3. Rebase the current branch onto the base:
-
-   ```bash
-   git rebase "origin/$base"
-   ```
-
-   - `rebase` (not `merge`) keeps the branch history linear and avoids creating merge commits — required for the squash-merge policy used by `/land`.
-
-4. If conflicts arise:
-   - Resolve each conflict file.
-   - `git rebase --continue` after staging the resolution.
-   - Re-run tests to confirm the integrated state is clean.
-
-5. After a successful rebase, the local branch has new commit SHAs. If the branch was already pushed (e.g. a Draft PR exists), force-push with lease:
-
-   ```bash
-   git push --force-with-lease origin <branch-name>
-   ```
-
-   `--force-with-lease` is safer than `--force`: it refuses to overwrite if the remote moved since your last fetch.
-
-6. Record the pull skill evidence in the workpad `### Validation` section:
-   - base branch (e.g. `origin/feature/epic-x` or `origin/main`)
-   - result: `clean` or `conflicts resolved`
-   - resulting HEAD short SHA: `git rev-parse --short HEAD`
+5. On conflicts:
+   - Resolve them in the worktree, run the relevant validation (Completion Bar for source files; `pnpm install --lockfile-only` or `npm install --package-lock-only` when the lockfile conflicted), then `git add` and `git commit --no-edit`.
+   - If you cannot resolve them in this turn, `git merge --abort` before the turn ends — never leave a merge in progress.
+   - In a Land cycle, a conflict outside the trivial set is a rework failure: abort and let `/land` classify it.
+6. Verify `git status --porcelain` is empty and `git log --oneline -1` shows the merge commit. The host pushes it at turn end.
+7. Record the merge (base SHA merged, conflicts resolved) in the workpad Progress Log.
 
 ## Rules
 
-- Always use the PR's actual base branch (not hardcoded `origin/main`) when a PR exists. An Epic working branch must rebase against the Epic base, not `main`.
-- Use `git rebase` (not `git merge`) to keep history linear for the squash-merge policy.
-- After rebase + force-push, treat the branch as having new commit SHAs — any prior approval on the PR is invalidated; re-run pre-flight checks.
-- Record the rebase evidence in the workpad before proceeding to PR creation or merge.
+- Never `git rebase`, `git commit --amend`, `git reset --hard`, or `git push --force*`.
+- Never merge into `main` locally or check it out.
+- Do not re-run a merge that already produced a merge commit this turn; the branch is up to date once `git merge-base --is-ancestor origin/$base HEAD` succeeds.

--- a/.codex/skills/push/SKILL.md
+++ b/.codex/skills/push/SKILL.md
@@ -1,37 +1,58 @@
 ---
 name: push
-description: Publish verified local commits to the remote branch without unsafe force pushes.
+description: Explains the host-owned push of the assigned branch and the turn-end checklist that makes it succeed. There is no agent-side push command.
 license: MIT
 metadata:
   author: gh-symphony
-  version: "1.0"
+  version: "2.0"
   generatedBy: "gh-symphony"
 ---
 
-# /push — Git Push Workflow
+# /push — Host-owned Branch Publication
 
-## Trigger
+## How publishing works
 
-Use this skill when publishing local commits to the remote branch.
+The worker child has no GitHub credentials, so `git push` from the agent fails. Instead, at the end of **every turn** (and again at session end) the worker host:
 
-## Flow
+1. verifies the worktree is still on `$SYMPHONY_ASSIGNED_BRANCH` (refuses otherwise),
+2. copies that ref into a temporary bare repository,
+3. fetches `origin/<branch>` and checks it is an ancestor of your head (refuses non-fast-forward),
+4. pushes with repository hooks disabled to the orchestrator-owned target URL,
+5. records any tracked or untracked files still in the worktree as **unpublished work**, which blocks cleanup and triggers dirty-workspace recovery on the next dispatch.
 
-1. Run local tests and lint — ensure they pass before pushing
-2. Push to remote:
-   ```bash
-   git push origin <branch>        # subsequent pushes
-   git push -u origin <branch>     # first push (sets upstream)
-   ```
-3. If push is rejected (non-fast-forward):
-   - Run `git fetch origin && git merge origin/main`
-   - Resolve any conflicts
-   - Re-run tests
-   - Push again
-4. Record push result in workpad Notes
+## Turn-end checklist (run before you finish the message)
+
+```bash
+git branch --show-current            # must equal $SYMPHONY_ASSIGNED_BRANCH
+git status --porcelain               # must be empty: commit everything, delete scratch files
+git rev-parse --verify MERGE_HEAD 2>/dev/null && echo "merge in progress — finish or abort"
+git log --oneline origin/"$SYMPHONY_ASSIGNED_BRANCH"..HEAD 2>/dev/null   # commits the host will push
+```
+
+- Scratch files (comment bodies, PR bodies, transition bodies) live under `mktemp -d "${TMPDIR:-/tmp}/symphony-<issue>.XXXXXX"`, never in the checkout.
+- Run the relevant validation before committing; a broken intermediate commit still gets pushed.
+- Conventional commit messages via `/commit`.
+
+## Verifying the push next turn
+
+The branch exists on the remote when this query returns a target:
+
+```graphql
+query BranchOnRemote($owner: String!, $name: String!, $ref: String!) {
+  repository(owner: $owner, name: $name) {
+    ref(qualifiedName: $ref) {
+      target {
+        oid
+      }
+    }
+  }
+}
+```
+
+(`$ref` = `refs/heads/<branch>`.) Compare the returned `oid` with `git rev-parse HEAD`. If the branch is missing or stale, the previous push was refused; the worker output names the reason (`refusing to push …`). Fix the cause (wrong branch, non-fast-forward history) and end the turn again.
 
 ## Rules
 
-- Never use `--force` (destructive)
-- Only use `--force-with-lease` if absolutely necessary — record the reason in workpad
-- Verify CI starts after push (check GitHub Actions tab)
-- Do not push directly to `main` or `master`
+- Never `git push`, never add credentials, never edit `origin`.
+- Never `--force`, `--force-with-lease`, rebase, amend, or reset commits that may already be on the remote.
+- Never push to `main`; the assigned branch is the only publication target.

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -160,7 +160,7 @@ These facts describe what your process can and cannot do. Every instruction belo
 
 When entering `Ready`, before treating it as a fresh pickup, board drift, or resume, inspect linked PR state:
 
-1. Resolve the **current delivery PR** (Posture 11). Once the current delivery PR is merged, the issue is terminal; follow-up work opens a new issue (Posture 13), never a new cycle on this one.
+1. Resolve the **current delivery PR** (Posture 11): the PR recorded in the newest workpad, else the primary PR from the _Linked pull request context_, else the issue's `closedByPullRequestsReferences` / `closingIssuesReferences` relationship. A text-search match alone is never linked evidence. Once the current delivery PR is merged, the issue is terminal; follow-up work opens a new issue (Posture 13), never a new cycle on this one.
 2. **Merged-PR precedence guard:** if the current delivery PR is `MERGED`, refresh its merged commit SHA into the current workpad when one exists, prepare the `🔁 Status: Ready → Done` body, and send it as `comment_body` through `/gh-project`. After confirmed readback, append the matching workpad Status Transitions line when the worker remains alive, then exit. Do not open a new cycle, inspect review feedback, or enter any rework path.
 3. For each remaining open linked PR, read `reviewDecision`, latest human reviews, review threads (`prReviewState` query), top-level PR comments, and recent issue comments.
 4. If any open linked PR has `CHANGES_REQUESTED`, unresolved actionable review threads, a human instruction indicating rework, or a recent `Land` → `Ready` transition recorded as a **Land-return rework**, this `Ready` state means **review rework return** — not a fresh pickup and not drift.

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -1,50 +1,66 @@
 ---
 tracker:
   kind: github-project
-  provider:
-    # 🧩 Moncher Stack (hojinzs/projects/14)
-    project_id: PVT_kwHOAPiKdM4BYPVD
-    state_field: Status
-    blocker_check_states:
-      - Ready
   active_states:
     - Ready
     - In progress
     - Land
   terminal_states:
     - Done
+  provider:
+    # 🧩 Moncher Stack (hojinzs/projects/14)
+    project_id: PVT_kwHOAPiKdM4BYPVD
+    state_field: Status
+    blocker_check_states:
+      - Ready
+    planning_states: []
+    pickup_labels:
+      # Epics are tracking parents. Humans close them; workers never pick them up.
+      exclude:
+        - epic
+repository:
+  base_branch: main
+  branch_template: symphony/{sanitized_issue_id}
 polling:
   interval_ms: 30000
 workspace:
   root: .runtime/symphony-workspaces
 hooks:
-  after_create: null
-  before_run: null
-  after_run: null
-  before_remove: null
-  timeout_ms: 60000
+  # Runs once per fresh issue worktree (pnpm install + build). The daemon host
+  # must export SYMPHONY_ALLOW_WORKFLOW_HOOKS=1; otherwise hooks are skipped.
+  after_create: hooks/after_create.sh
+  timeout_ms: 600000
 agent:
-  max_concurrent_agents: 10
+  max_concurrent_agents: 8
+  max_concurrent_agents_by_state:
+    Ready: 3
+    In progress: 5
+    Land: 2
+  max_failure_retries: 3
   max_retry_backoff_ms: 30000
   retry_base_delay_ms: 10000
   max_turns: 20
-codex:
-  command: codex app-server
-  read_timeout_ms: 5000
-  turn_timeout_ms: 3600000
-  stall_timeout_ms: 900000
+runtime:
+  kind: codex-app-server
+  command: codex
+  args:
+    - app-server
+  timeouts:
+    read_timeout_ms: 5000
+    turn_timeout_ms: 3600000
+    stall_timeout_ms: 900000
 ---
 
 ## Status Map
 
-| Status          | Role     | Agent Action                                                                                                                                                                                                                                             |
-| --------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Backlog**     | wait     | Agent ignores. Exit quietly without commenting. Also the parking lane for code-blocked issues — agent moves the issue here with a `⛔ Blocker` comment when a blocker is hit; human resolves and moves back to `Ready`.                                  |
-| **Ready**       | active   | Apply merged-PR precedence first. Otherwise triage scope and clarity; unresolved review feedback means **rework re-entry** (see _Ready-return rework guard_ in Step 0) and opens a new work cycle before code changes.                                   |
-| **In progress** | active   | Implement → test → create or update PR. Each work cycle gets exactly one workpad comment; within the same cycle, update it in place.                                                                                                                     |
-| **In review**   | wait     | Pure human-review wait. Agent does **nothing** here except: if the PR has been merged, transition to `Done`; otherwise exit. Review rework is initiated by a human moving the issue back to `Ready` (or by the human approving and moving it to `Land`). |
-| **Land**        | active   | The human has approved the PR. Run `/land` skill: pre-flight checks (approval, CI, branch freshness) → squash merge → post-merge actions → transition to `Done`.                                                                                         |
-| **Done**        | terminal | Completed. Agent exits immediately.                                                                                                                                                                                                                      |
+| Status          | Role     | Agent Action                                                                                                                                                                                                                                                                                                                                                                                 |
+| --------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Backlog**     | wait     | Agent ignores. Exit quietly without commenting. Also the parking lane for code-blocked issues — agent moves the issue here with a `⛔ Blocker` comment when a blocker is hit; human resolves and moves back to `Ready`.                                                                                                                                                                      |
+| **Ready**       | active   | Apply merged-PR precedence first. Otherwise triage scope and clarity, open the work cycle, and transition to `In progress` **before** any implementation. Unresolved review feedback means **rework re-entry** (see _Ready-return rework guard_ in Step 0).                                                                                                                                  |
+| **In progress** | active   | Implement → test → create or update PR. Each work cycle gets exactly one workpad comment; within the same cycle, update it in place. Hand off to `In review` in the same turn the Completion Bar is met.                                                                                                                                                                                     |
+| **In review**   | wait     | Pure human-review wait. Agent does **nothing** here except: if the PR has been merged, transition to `Done`; otherwise exit. Review rework is initiated by a human moving the issue back to `Ready` (or by the human approving and moving it to `Land`).                                                                                                                                     |
+| **Land**        | active   | The human has approved the PR. Run `/land` skill: merged-PR guard → pre-flight (approval, required CI, freshness, changeset) → server-side branch update if behind → squash merge through `github_graphql` → transition to `Done`. Only base-branch merge commits and conflict resolution inside `.changeset/`, `docs/`, or the lockfile are permitted here; source conflicts go to `Ready`. |
+| **Done**        | terminal | Completed. Agent exits immediately.                                                                                                                                                                                                                                                                                                                                                          |
 
 ## Agent Instructions
 
@@ -52,22 +68,59 @@ You are an AI coding agent working on issue {{issue.identifier}}: "{{issue.title
 
 **Repository:** {{issue.repository}}
 **Current state:** {{issue.state}}
+**Issue URL:** {{issue.url}}
+**Labels:** {{issue.labels | join: ", "}}
+{% if attempt %}**Retry attempt:** {{attempt}} — a previous run of this issue failed or was cut short. Read the newest workpad and the issue comments before acting; adopt existing work instead of redoing it.{% endif %}
 
-> Temporary compatibility note: this workflow intentionally avoids `pull_request_context` template variables so older installed `gh-symphony` daemons can render prompts until the runtime is upgraded.
+### Linked pull request context
+
+{% if pull_request_context.has_primary_pr %}The orchestrator resolved a **current delivery PR** for this issue and checked out its head branch as your assigned branch:
+
+- PR #{{pull_request_context.primary_pull_request.number}} — {{pull_request_context.primary_pull_request.url}}
+- state: `{{pull_request_context.primary_pull_request.state}}` · draft: `{{pull_request_context.primary_pull_request.isDraft}}` · merged: `{{pull_request_context.primary_pull_request.merged}}`
+- head: `{{pull_request_context.primary_pull_request.headRefName}}` → base: `{{pull_request_context.primary_pull_request.baseRefName}}`
+
+Treat this PR as the current delivery PR (Posture 11) unless the newest workpad records a different open PR.{% else %}No linked pull request was resolved for this issue. Your assigned branch is a fresh branch created from `main` by the orchestrator; the Draft PR is created in Step 2 after your first commit has been pushed by the host.{% endif %}
 
 ### Task
 
 {{issue.description}}
 
+### Runtime Contract (gh-symphony ≥ 1.1.0)
+
+These facts describe what your process can and cannot do. Every instruction below assumes them.
+
+1. **You have no GitHub credentials.** `gh` is not authenticated, and `git push` / authenticated `git fetch` fail. Do not try to log in, copy tokens, or edit `origin`. All GitHub reads and writes (issue comments, PR create/update/merge, reviews, checks, follow-up issues) go through the host-side **`github_graphql`** tool (one query or mutation per call, always scoped to this issue or its repository). See _GitHub GraphQL Cookbook_ below.
+2. **Tracker state is orchestrator-owned.** Read and transition the Project status only through the `/gh-project` skill (orchestrator API with `SYMPHONY_ORCHESTRATOR_URL` / `SYMPHONY_RUN_ID` / `SYMPHONY_ORCHESTRATOR_TOKEN`). Never mutate the Project through `github_graphql`.
+3. **You work on one assigned branch.** The orchestrator checked it out before you started (`$SYMPHONY_ASSIGNED_BRANCH`; a linked PR's head branch, otherwise `symphony/<issue-key>` from `main`). Never `git checkout -b`, never switch branches, never detach HEAD. The host refuses to push when the worktree is on any other branch.
+4. **The host pushes your branch after every turn, fast-forward only.** Commit locally; at the end of each turn the worker pushes `$SYMPHONY_ASSIGNED_BRANCH` to the orchestrator-owned remote. The push is refused if `origin/<branch>` is not an ancestor of your head — so **never rebase, amend, reset, or force-rewrite commits that may already be on the remote**. Bring in base-branch changes with `git merge` (see `/pull`). A branch that exists on the remote is the precondition for creating a PR, so PR creation happens in the turn **after** the first commit.
+5. **Turns continue automatically.** After each of your turns the worker refreshes the tracker state and starts the next turn while the issue stays in an active state (`Ready`, `In progress`, `Land`), up to `agent.max_turns`. A turn ends when you finish your message. The session ends when the issue leaves the active states (your `In review` / `Backlog` / `Done` transition), when `max_turns` is reached, or after **3 consecutive non-productive turns** (no commit, no workspace change, or the same error repeated) — that convergence failure counts against the issue's failure budget. Cycles that change no files (Land, terminal repairs, verification-only work) must therefore finish within one or two turns; do the waiting (for example CI polling) **inside** a single turn.
+6. **The worktree must be clean at every turn end.** Untracked or modified files at turn end are recorded as unpublished work, block workspace cleanup, and trigger dirty-workspace recovery on the next dispatch. Write **all** scratch content (comment bodies, transition bodies, PR bodies, reply drafts, notes) outside the repository:
+
+   ```bash
+   scratch="$(mktemp -d "${TMPDIR:-/tmp}/symphony-{{issue.number}}.XXXXXX")"
+   ```
+
+   Never create files such as `.tmp-*.md`, `.workpad-*.md`, `.pr-*-body.md`, `.transition-*.md`, or anything under `.codex/` inside the checkout. Never leave a merge, rebase, or cherry-pick in progress at turn end; resolve it or abort it (`git merge --abort`) first.
+
+7. **Recovery context.** If the prompt carries a `## Recovery Context — Incomplete Turn Dirty Workspace` section, inspect the listed dirty files first. Scratch files matching the patterns above are never work product: delete them. Real partial work that belongs to this issue is validated and committed; work that belongs to another issue is left untouched and reported as a `⛔ Blocker`. Never commit files you did not intend to ship.
+8. **Repository dependencies.** A fresh worktree has `node_modules` and `dist/` installed by the `after_create` hook when the host allows hooks. If `pnpm` commands fail with missing binaries (for example `vitest: command not found`), run `pnpm install --frozen-lockfile && pnpm build` once and continue; that is an environment step, not a blocker.
+
 ### Default Posture
 
-1. This is an unattended orchestration session. Do not ask humans for follow-up actions.
-2. **Blocker = code-blocking only.** A blocker is something that prevents the _code change itself_ from being completed (missing required secret, unrecoverable test-infra failure, contradictory requirements that need a human decision). Review feedback, deploy concerns, and UI polish are **not** blockers. On a code-blocker: post a `⛔ Blocker` issue comment (what · why · how to unblock), transition Status → `Backlog` via `/gh-project`, then exit. Never leave a blocked issue in `In progress` with a draft PR.
-3. In your final message, report only what was completed and any blockers. Do not include "next steps".
-4. **Report language**: detect from the issue body and apply consistently to workpad, progress/blocker/transition comments, and PR review replies. If the language is unclear or mixed, default to English. Keep code, commands, identifiers, and raw tool output in their original form when translating reports.
-5. **Log every status transition through the orchestrator-owned `/gh-project` request.** The agent supplies the policy-authored `comment_body`; the orchestrator publishes that exact body only after `ok: true` + `outcome: confirmed` + exact target-state readback. The agent must not post a duplicate standalone status-transition comment or a correction status comment with `gh issue comment`.
+1. This is an unattended orchestration session. Do not ask humans for follow-up actions and never end a turn waiting for a human answer inside an active state.
+2. **Language: English only.** Everything you publish — workpad, comments, transition bodies, PR titles/bodies, commit messages, review replies, follow-up issues — is written in English regardless of the issue's language. Keep code, commands, identifiers, and raw tool output verbatim.
+3. **Blocker = code-blocking only.** A blocker is something that prevents the _code change itself_ from being completed: a missing required secret, contradictory requirements that need a human decision, or a dependency on another unmerged issue. Review feedback, deploy concerns, UI polish, and **environment flakes are not blockers** (see the _Flake Protocol_). On a code-blocker: post a `⛔ Blocker` issue comment (what · why · how to unblock), transition Status → `Backlog` via `/gh-project`, then exit. Never leave a blocked issue in `In progress` with a draft PR.
+4. **Flake Protocol.** When a test, lint, build, or E2E step fails and the failure is in code you did not touch (compare against `git diff --name-only origin/main...HEAD`), or involves ports, containers, timeouts, stale processes, or shared-host resources:
+   - Re-run the failing step once in isolation (for example `npx vitest run <file>`; for Docker E2E follow the isolation notes in [AGENT_TEST.md](AGENT_TEST.md)).
+   - If it passes, record both runs in the workpad `### Validation` and continue.
+   - If it still fails but is unrelated to your change, record the exact command, output excerpt, and your reasoning in `### Validation`, open a follow-up issue through `github_graphql` (`createIssue`, label `bug`), reference it in the workpad, mark the Completion Bar line as `pass (documented exception: #<n>)`, and proceed to handoff. Do **not** park the issue in `Backlog` for this.
+   - Only a failure caused by your change is yours to fix; only a failure that makes your change impossible is a blocker.
+5. **Scope-proportional validation.** The full Completion Bar applies to code changes. For docs-only or comment-only changes, run `pnpm format` and `pnpm lint`; skip test/typecheck/build/Docker E2E and note the reason. Run Docker E2E only when integration behavior changed (orchestrator dispatch, worker lifecycle, tracker adapters, status API, CLI runtime commands).
+6. In your final message of each turn, report only what was completed this turn and any blockers. Do not include "next steps"; the workpad Plan is the plan.
+7. **Log every status transition through the orchestrator-owned `/gh-project` request.** You supply the policy-authored `comment_body`; the orchestrator publishes that exact body only after `ok: true` + `outcome: confirmed` + exact target-state readback. Never post a standalone or corrective status-transition comment yourself.
 
-   Prepare the body in a temporary file and pass its contents as `comment_body`:
+   Prepare the body in the scratch directory and pass its contents as `comment_body`:
 
    ```
    🔁 Status: `FROM` → `TO`
@@ -76,25 +129,24 @@ You are an AI coding agent working on issue {{issue.identifier}}: "{{issue.title
    Cycle: <N> open|close
    ```
 
-   Reason = _why this transition now_, not a restatement of the target state ("review blocking 2 items rework", not "moved to In progress"). Keep the exact body and intended workpad line in the current workpad before requesting the transition. After a confirmed readback, append the matching line to `### Status Transitions` if the worker remains alive.
+   Reason = _why this transition now_, not a restatement of the target state ("review blocking 2 items rework", not "moved to In progress"). Record the exact body and the intended workpad line in the current workpad before requesting the transition. After confirmed readback, append the matching line to `### Status Transitions` if the worker remains alive.
 
-   If the response is not `ok: true` + `outcome: confirmed` + the requested target state, no status comment was published. Record the returned state/error and the failed transition in the workpad, then follow the failure handling for the current step. Do not publish a correction status comment.
+   If the response is not `ok: true` + `outcome: confirmed` + the requested target state, no status comment was published. Record the returned state/error and the failed transition in the workpad, then follow the failure handling for the current step. Use the `/gh-project` script verbatim (it JSON-encodes with `jq`); hand-built payloads have caused `transition_comment_body_required` and `invalid_tracker_state_request` rejections.
 
-   **Lifecycle finalization order.** Treat a Project status transition as the final lifecycle mutation for the turn, not as a progress signal. Before requesting it, complete the scoped implementation/rebase/merge decision, collect final validation output, refresh the PR/workpad narrative, and record the transition reason, exact `comment_body`, and evidence in the workpad's Validation/Progress Log sections. Then request the state transition. The only permitted work after the request is recording a failed response if the worker remains alive; the orchestrator owns the public transition comment.
+   **Lifecycle finalization order.** A Project status transition out of an active state is the last action of the turn: the worker stops after it. Before requesting it, finish the implementation/merge decision, collect final validation output, refresh the PR body and workpad narrative, and record the transition reason, exact `comment_body`, and evidence in the workpad. Transitions that stay inside the active set (`Ready` → `In progress`) happen **early** in the turn, before implementation, so the board reflects real work-in-progress.
 
-6. Treat Issue cards as the canonical project item for planning, workpad lifecycle, and state transitions. The PR card supplies PR context only. If an issue has an open PR, inspect it from the issue timeline before deciding whether to create a new branch.
-7. If the issue re-enters `Ready`, `In progress`, or `Land` while a PR already exists, run the relevant merged-PR guard first. A merged current delivery PR completes the issue without opening a cycle; otherwise treat the entry as a **new work cycle** and create a **new workpad comment** before any code change. Within the same cycle, always update the existing workpad in place — never create a second workpad comment.
-8. Use the `/gh-project` skill for all tracker status reads and transitions. Workers send intent to the run-scoped orchestrator API and never traverse provider boards or mutate tracker fields directly.
-9. **Multi-line GitHub comments**: never pass escaped `\n` strings as `--body`. Write the body to a temporary markdown file and post with `gh ... --body-file <file>`. This applies to workpad comments, triage/blocker comments, PR comments, and review replies. Status-transition bodies are supplied as `/gh-project` `comment_body`; do not post them directly.
-10. Do not edit the issue body for planning or progress tracking.
-11. If you discover out-of-scope improvements during the work, open a separate issue rather than expanding the current scope.
-12. **Merged-PR invariant.** A current delivery PR in `MERGED` state always takes precedence over pickup, rework, pre-flight, and failure classification. Transition the canonical Issue directly to `Done` and exit. An issue whose current delivery PR is merged must never transition to `Ready`.
+8. Treat Issue cards as the canonical project item for planning, workpad lifecycle, and state transitions. The PR card supplies PR context only.
+9. **Timestamps are real.** Every ISO timestamp you write comes from `date -u +%Y-%m-%dT%H:%M:%SZ` executed at that moment. Never type a placeholder such as `2026-01-01T00:00:00Z`, never reuse an earlier timestamp, and never write a close time earlier than the open time.
+10. **Multi-line GitHub content** is written to a scratch file and passed as a `github_graphql` variable read with `--rawfile` (see the cookbook). Never embed escaped `\n` strings in shell arguments.
+11. **Merged-PR invariant.** A current delivery PR in `MERGED` state always takes precedence over pickup, rework, pre-flight, and failure classification. Transition the canonical Issue directly to `Done` and exit. An issue whose current delivery PR is merged must never transition to `Ready`. The **current delivery PR** is the PR recorded in the newest workpad; when no workpad records one, it is the primary PR from the _Linked pull request context_ above, then the issue's `closedByPullRequestsReferences`. A text-search match alone is never linked evidence.
+12. Do not edit the issue body for planning or progress tracking.
+13. If you discover out-of-scope improvements, open a separate issue (`createIssue`) rather than expanding the current scope.
 
 ### Workflow
 
 #### Step 0: Determine current state and route
 
-1. Read `{{issue.state}}` and detect the report language from the issue body before writing any human-facing text.
+1. Read `{{issue.state}}`, the newest workpad, and the last 50 issue comments (`issueContext` query) before writing anything.
 2. Route by state:
    - `Backlog` → Exit quietly without commenting.
    - `Ready` → run the **Ready-return rework guard** below, then proceed to Step 1 (or to Step 2 if the guard re-classifies as rework).
@@ -102,22 +154,22 @@ You are an AI coding agent working on issue {{issue.identifier}}: "{{issue.title
    - `In review` → proceed to Step 3.
    - `Land` → proceed to Step 4.
    - `Done` → Exit immediately without commenting.
-   - Any other state → leave a short blocker comment in the report language explaining the state is unsupported, then exit.
+   - Any other state → the worker is normally stopped before this happens; if you are here, exit without commenting.
 
 ##### Ready-return rework guard
 
 When entering `Ready`, before treating it as a fresh pickup, board drift, or resume, inspect linked PR state:
 
-1. Resolve the **current delivery PR** from the newest workpad's recorded PR, or, when no workpad records one, from the issue timeline's closing-PR relationship. Use `gh pr list --state all --search "<issue-number>"` only to collect candidates, then verify each candidate through the workpad or `closingIssuesReferences`; a text-search match alone is never linked evidence. When the newest workpad records a PR, it takes precedence over older closing PRs. Once the current delivery PR is merged, the issue is terminal; follow-up work opens a new issue (Posture 11), never a new cycle on this one.
-2. **Merged-PR precedence guard:** if the current delivery PR is `MERGED`, refresh its merged commit SHA into the current workpad when one exists, prepare the `🔁 Status: Ready → Done` body, and send it as `comment_body` through `/gh-project`. After confirmed readback, append the matching workpad Status Transitions line when the worker remains alive, then exit. Do not open a new cycle, inspect review feedback, check out the deleted head branch, or enter any rework path.
-3. For each remaining open linked PR, read `reviewDecision`, latest human reviews, inline review comments (`gh api repos/<owner>/<repo>/pulls/<N>/comments --paginate`), top-level PR comments, and recent issue comments.
-4. If any open linked PR has `CHANGES_REQUESTED`, unresolved actionable review comments, a human instruction indicating rework, or a recent `Land` → `Ready` transition recorded as a **Land-return rework**, this `Ready` state means **review rework return** — not a fresh pickup and not drift.
-5. For rework return: open a new work cycle (new `## Workpad` comment), prepare the `🔁 Status: Ready → In progress` body, and pass it as `comment_body` through `/gh-project`. Append the matching workpad line only after confirmed readback, then proceed to Step 2 and execute the rework preamble (Step 2.2). Do not transition back to `In review` until feedback is addressed, the Completion Bar (Step 2.6) passes again, every inline comment has a reply, and re-review is requested.
+1. Resolve the **current delivery PR** (Posture 11). Once the current delivery PR is merged, the issue is terminal; follow-up work opens a new issue (Posture 13), never a new cycle on this one.
+2. **Merged-PR precedence guard:** if the current delivery PR is `MERGED`, refresh its merged commit SHA into the current workpad when one exists, prepare the `🔁 Status: Ready → Done` body, and send it as `comment_body` through `/gh-project`. After confirmed readback, append the matching workpad Status Transitions line when the worker remains alive, then exit. Do not open a new cycle, inspect review feedback, or enter any rework path.
+3. For each remaining open linked PR, read `reviewDecision`, latest human reviews, review threads (`prReviewState` query), top-level PR comments, and recent issue comments.
+4. If any open linked PR has `CHANGES_REQUESTED`, unresolved actionable review threads, a human instruction indicating rework, or a recent `Land` → `Ready` transition recorded as a **Land-return rework**, this `Ready` state means **review rework return** — not a fresh pickup and not drift.
+5. For rework return: open a new work cycle (new `## Workpad` comment; adopt an existing one for the same cycle number if a retried worker already created it), prepare the `🔁 Status: Ready → In progress` body, and pass it as `comment_body` through `/gh-project`. Append the matching workpad line only after confirmed readback, then proceed to Step 2 and execute the rework preamble (Step 2.2). Do not transition back to `In review` until feedback is addressed, the Completion Bar (Step 2.6) passes again, every review thread has a reply, and re-review is requested.
 6. Otherwise (no actionable feedback or Land-return rework marker on any linked PR): proceed to Step 1 normally as a fresh pickup or resume.
 
 ##### Stalled-handoff safety net
 
-When entering `In progress`, before continuing implementation, check: if the agent-verifiable Completion Bar (Step 2.6) is already met, the PR is still a **Draft**, and there is no open `⛔ Blocker` comment, then the previous turn missed the handoff. Run Step 2.8 (changeset → PR ready / refresh body → status comment → transition to `In review`) immediately this turn — do not look for more Plan work. This rescues an issue that would otherwise sit stalled on the next polling tick.
+When entering `In progress`, before continuing implementation, check whether the previous turn missed the handoff: the agent-verifiable Completion Bar (Step 2.6) is already met, there is no open `⛔ Blocker` comment, and **either** the PR is still a Draft **or** the PR is already ready-for-review with every review thread answered and no unaddressed `CHANGES_REQUESTED` review. In that case run Step 2.8 (changeset → PR ready / refresh body → status comment → transition to `In review`) immediately this turn — do not look for more Plan work. This rescues an issue that would otherwise sit stalled until a human intervenes.
 
 #### Step 1: Ready triage
 
@@ -125,119 +177,121 @@ This step is entered only when the Step 0 _Ready-return rework guard_ classified
 
 1. Read the issue body and existing comments to understand the requested work.
 2. **Triage actionability:**
-   - **Requirements unclear** → write a triage comment in the report language requesting clarification, prepare the `🔁 Status: Ready → Backlog` body with `Cycle: — (triage rejection)`, and send it as `comment_body` through `/gh-project`, then exit.
+   - **Human override check first.** If this issue already carries a `Ready → Backlog` triage comment from a previous cycle and a human moved it back to `Ready`, the human has overridden that triage verdict. Do not reject again for the same reason. Proceed; if the scope is still too large, split it yourself by opening child issues through `createIssue`, implement the first slice here, and list the rest in the workpad `### Delegation` section.
+   - **Requirements unclear** → write a triage comment requesting clarification, prepare the `🔁 Status: Ready → Backlog` body with `Cycle: — (triage rejection)`, send it as `comment_body` through `/gh-project`, then exit.
    - **Scope too large** (likely >20 files or >3 packages) → write a triage comment requesting issue splitting, prepare the transition body, and send it as `comment_body` through `/gh-project`. State explicitly whether the reason is unclear requirements, oversized scope, or both.
-3. **Resume check (idempotent).** If a `feat/<issue-number>-…` branch or Draft PR for this issue already exists from a prior cycle (e.g. parked in `Backlog` then moved back), adopt them — do **not** recreate.
+   - **Depends on an unmerged issue** the body names as a prerequisite → this is a code-blocker (Posture 3): `⛔ Blocker` comment naming the dependency, then `Ready → Backlog`.
+3. **Resume check (idempotent).** If a Draft PR or prior workpad for this issue already exists from a prior cycle (for example parked in `Backlog` then moved back), adopt them — do **not** recreate. The orchestrator already checked out the PR's head branch when a linked PR exists.
 4. **Open the new work cycle:**
-   - Create a new `## Workpad — {{issue.identifier}} — Cycle N` comment using the Workpad Template (see _Workpad Lifecycle_). N is the next cycle number after the most recent workpad on the issue (1 if none).
-   - Determine the base branch: `main` by default. If the issue body explicitly references an Epic working branch, use that; otherwise stay on `main`.
-   - Create a `feat/<issue-number>-<short-description>` branch from the base branch (unless the resume check above adopted one).
-   - Push the branch and create a **Draft PR** targeting the same base branch using the `/gh-pr-writeup` skill to scaffold the body (TL;DR, change-point diagram, start-here guide, risks & rollback, changed files — finalized in Step 2.8). Include `## Issues — Closed #<issue-number>` so GitHub auto-links.
-   - Record the Draft PR URL and base branch in the workpad.
-5. Prepare the `🔁 Status: Ready → In progress` body, pass it as `comment_body` to `/gh-project`, and append the matching workpad `### Status Transitions` line only after confirmed readback. If the request does not return confirmed readback for `In progress`, record the failure and stop without publishing a status comment.
-6. Proceed to Step 2.
+   - Re-query the newest comments. If a `## Workpad — {{issue.identifier}} — Cycle N` for the next cycle number already exists (created by a retried worker), adopt it. Otherwise create it using the Workpad Template (see _Workpad Lifecycle_). N is the next cycle number after the most recent workpad on the issue (1 if none).
+   - Record the assigned branch (`git branch --show-current`) and base branch (`main` unless a linked PR targets an Epic working branch) in the workpad. Draft PR stays `not yet created` until Step 2.
+5. Prepare the `🔁 Status: Ready → In progress` body, pass it as `comment_body` to `/gh-project`, and append the matching workpad `### Status Transitions` line only after confirmed readback. If the request does not return confirmed readback for `In progress`, record the failure and stop without publishing a status comment. **This transition precedes all implementation.**
+6. Proceed to Step 2 in the same turn.
 
 #### Step 2: In progress / Execution
 
 Entered from one of:
 
-- **Step 1** (fresh pickup / resume) — first work cycle, Draft PR already exists.
-- **Step 0 _Ready-return rework guard_** (review rework) — new cycle opened by the guard, Draft PR already exists.
+- **Step 1** (fresh pickup / resume) — first work cycle, transition already confirmed, no PR yet (fresh) or an adopted PR (resume).
+- **Step 0 _Ready-return rework guard_** (review rework) — new cycle opened by the guard, PR already exists.
 - **Step 0 _stalled-handoff safety net_** — skip directly to Step 2.8 this turn.
 
-1. **Workpad continuity.** The current cycle's workpad was created by Step 1 or the rework guard. Update it in place throughout this cycle. Never create a second workpad for the same cycle.
+1. **Workpad continuity.** The current cycle's workpad was created by Step 1 or the rework guard. Update it in place throughout this cycle (`updateIssueComment`). Never create a second workpad for the same cycle.
 
 2. **Rework preamble — only when entered via rework return.** Before any code change:
-   - Read all PR review activity: latest reviews, top-level PR comments, inline review comments (`gh api repos/<owner>/<repo>/pulls/<N>/comments --paginate`), failing checks.
+   - Read all PR review activity: latest reviews, top-level PR comments, review threads (`prReviewState`), failing checks (`prChecks`).
    - Distill the main merge blockers into a prioritized list and record them in the workpad `### Rework / PR Feedback` section with the revised plan.
-   - As you address each inline comment, reply to it in the report language with a concrete resolution summary or rationale. Never leave an inline comment unanswered.
+   - As you address each review thread, reply on that thread (`addPullRequestReviewThreadReply`) with a concrete resolution summary or rationale, then resolve it (`resolveReviewThread`). Never leave a thread unanswered; never resolve a thread without a reply.
+   - If the branch is behind its base, run `/pull` (merge, never rebase) before editing.
 
-3. **Implementation — one Plan item per turn.** Explore relevant code, implement, write/update tests, commit in logical units (conventional commit format). Push to the branch after each turn — the Draft PR auto-updates.
+3. **Implementation — one Plan item per turn.** Explore relevant code, implement, write/update tests, commit in logical units (conventional commit format, `/commit`). The host pushes your commits at turn end; the Draft PR (once it exists) updates automatically.
 
-4. **Turn-end checklist.** Before ending a turn:
-   - workpad Plan item marked `[x]` and a Progress Log entry added.
+4. **Draft PR creation — the turn after the first commit.** When the workpad still says `Draft PR: not yet created` and `prBranchOnRemote` confirms your branch exists on the remote with at least one commit ahead of the base, create the Draft PR now through `/gh-pr-writeup` (`createPullRequest` with `draft: true`, base = the recorded base branch, body scaffold with TL;DR · change-point diagram · start-here guide · risks & rollback · changed files · `## Issues — Closed #{{issue.number}}` · post-merge/human validation). Record the PR URL in the workpad. If the branch is not on the remote yet, the previous push failed: record the transport diagnostic from the worker output in the workpad and continue with the next Plan item; retry PR creation next turn.
+
+5. **Turn-end checklist.** Before ending a turn:
+   - workpad Plan item marked `[x]` and a Progress Log entry added (real timestamp, Posture 9).
    - For a lifecycle handoff, merge outcome, or failure classification: all final evidence, exact reason, intended next action, and transition `comment_body` are already recorded in the workpad before requesting the Project state transition. Only recording the confirmed response/workpad line is deferred.
-   - Any confirmed status transition this turn is logged by the orchestrator's exact `comment_body` publication plus the workpad Status Transitions line when the worker remains alive.
-   - All changes committed; no broken intermediate state.
-   - **Resting-state rule** — ending a turn in `In progress` is valid only when **(a)** an unchecked, in-scope Plan item remains, or **(b)** a code-blocker was hit, parked to `Backlog` per Posture 2.
+   - `git status --porcelain` is empty: everything committed, no scratch files in the checkout, no merge or rebase in progress.
+   - `git branch --show-current` equals the assigned branch.
+   - **Resting-state rule** — ending a turn in `In progress` is valid only when **(a)** an unchecked, in-scope Plan item remains, or **(b)** a code-blocker was hit and parked to `Backlog` per Posture 3.
 
-5. **Re-verify against the original issue** (coverage, not mechanics). Re-read `{{issue.description}}` requirement-by-requirement and match each one to a file/test that satisfies it. If anything is unmet or partial, add a Plan item and handle it next turn — do not mark the PR ready.
+6. **Re-verify against the original issue** (coverage, not mechanics). Re-read the task requirement-by-requirement and match each one to a file/test that satisfies it. If anything is unmet or partial, add a Plan item and handle it next turn — do not mark the PR ready.
 
-6. **Completion Bar — agent-verifiable.** All must hold before marking the PR ready:
+7. **Completion Bar — agent-verifiable.** All must hold before marking the PR ready (subject to Posture 5 scope-proportional validation and the Posture 4 Flake Protocol):
    - [ ] All in-scope requirements from the issue description are implemented.
    - [ ] `pnpm lint` passes.
    - [ ] `pnpm test` passes.
    - [ ] `pnpm typecheck` passes.
    - [ ] `pnpm build` passes.
-   - [ ] If the change affects integration behavior (orchestrator dispatch, worker lifecycle, tracker adapters, status API, etc.), a short TC was added and a Docker E2E blackbox run completed per [AGENT_TEST.md](AGENT_TEST.md). Results recorded in the workpad `### Validation` section.
+   - [ ] If the change affects integration behavior, a short TC was added and a Docker E2E blackbox run completed per [AGENT_TEST.md](AGENT_TEST.md). Results recorded in the workpad `### Validation` section.
    - [ ] Tests written for new functionality (or justified N/A and noted).
    - [ ] Code follows the conventions in [CLAUDE.md](CLAUDE.md) (strict TypeScript, Prettier, conventional commits).
-   - [ ] All inline review comments answered (rework cycles only).
+   - [ ] All review threads answered and resolved (rework cycles only).
 
-7. **Changeset policy — mandatory immediately before marking the PR ready (or before re-handoff after rework).**
+8. **Changeset policy — mandatory immediately before marking the PR ready (or before re-handoff after rework).**
    - If the issue has one of `changeset:major`, `changeset:minor`, `changeset:patch`, create a Changeset.
    - The release package must be `@gh-symphony/cli` only. Do not add private/internal workspace packages.
    - Bump type follows the label; with multiple labels, use the highest impact (`major` > `minor` > `patch`) and note the ambiguity in the workpad.
    - The Changeset summary describes the user-visible CLI/runtime behavior change and references the issue identifier when practical.
    - Record the Changeset file path in the workpad `### Validation` section.
 
-8. **Mandatory handoff gate.** The moment Steps 5–7 are satisfied, in **this same turn**:
-   1. Run `/gh-pr-writeup` to refresh the PR body so TL;DR · change-point diagram · start-here guide · risks & rollback · changed files · `## Issues — Closed #<N>` · post-merge/human validation sections are current.
-   2. Complete the current workpad's Completion Bar, final Validation results, and Progress Log entry, including the exact handoff reason, before its lifecycle transition.
-   3. Mark the Draft PR ready: `gh pr ready <pr-number>`.
-   4. Prepare the `🔁 Status: In progress → In review` body and include it as `comment_body` in the `/gh-project` request.
-   5. Transition the issue to `In review` via `/gh-project` as the last action of the turn. The orchestrator publishes the body after confirmed exact-item readback; if the request fails, record the failure and keep the cycle open.
+9. **Mandatory handoff gate.** The moment Steps 6–8 are satisfied, in **this same turn**:
+   1. Commit everything (the changeset included). The host pushes at turn end, so the PR body you write now must describe the committed state.
+   2. Run `/gh-pr-writeup` in refresh mode (`updatePullRequest`) so TL;DR · change-point diagram · start-here guide · risks & rollback · changed files · `## Issues — Closed #{{issue.number}}` · post-merge/human validation sections are current.
+   3. Complete the current workpad's Completion Bar, final Validation results, and Progress Log entry, including the exact handoff reason.
+   4. Mark the Draft PR ready: `markPullRequestReadyForReview`. On rework cycles, additionally request re-review from the reviewers who requested changes (`requestReviews`).
+   5. Prepare the `🔁 Status: In progress → In review` body and include it as `comment_body` in the `/gh-project` request.
+   6. Transition the issue to `In review` via `/gh-project` as the last action of the turn. The orchestrator publishes the body after confirmed exact-item readback; if the request fails, record the failure and keep the cycle open.
 
-   **Never end a turn with the Completion Bar met and the PR still Draft.** That state deadlocks the workflow (Step 3 only fires on merge; the worker won't be re-dispatched). The Step 0 stalled-handoff safety net rescues it on the next polling tick as a backstop, but it should not be needed.
+   **Never end a turn with the Completion Bar met and the issue still in `In progress`.** That state deadlocks the workflow (Step 3 only fires on merge). The Step 0 stalled-handoff safety net rescues it on a later dispatch as a backstop, but it should not be needed.
 
 #### Step 3: In review — pure wait
 
-This is a human-review wait state. `In review` is **not** in `active_states`, so the dispatcher does not normally wake the worker here. If the worker is invoked at this state (e.g. a PR-card merge event triggers re-dispatch, or a future poll catches a stale in-review issue whose PR was merged outside the normal flow), perform a single defensive check:
+This is a human-review wait state. `In review` is **not** in `active_states`, so the dispatcher does not normally wake the worker here. If the worker is invoked at this state (for example a PR-card event triggers re-dispatch), perform a single defensive check:
 
-1. If the PR has been merged: refresh the merged commit SHA into the workpad, prepare the `🔁 Status: In review → Done` body, and send it as `comment_body` through `/gh-project`. After confirmed readback, append the matching workpad Status Transitions line when the worker remains alive, then exit.
-2. Otherwise: exit immediately. Do **not** process review feedback. Do **not** reply to inline comments. Do **not** transition the issue.
+1. If the current delivery PR has been merged: refresh the merged commit SHA into the workpad, prepare the `🔁 Status: In review → Done` body, and send it as `comment_body` through `/gh-project`. After confirmed readback, append the matching workpad Status Transitions line when the worker remains alive, then exit.
+2. Otherwise: exit immediately. Do **not** process review feedback. Do **not** reply to review threads. Do **not** transition the issue.
 
 Rework feedback is initiated by a human moving the issue back to `Ready` — the Step 0 _Ready-return rework guard_ then opens the rework cycle (Step 2). PR approval and the actual merge happen when a human moves the issue to `Land` — Step 4 (`/land`) performs the squash merge.
 
 #### Step 4: Land — squash merge and complete
 
-**Trigger:** `{{issue.state}}` = `Land`. A human has approved the PR and moved the issue here.
+**Trigger:** `{{issue.state}}` = `Land`. A human has approved the PR and moved the issue here. Land changes no source files; it must complete within one or two turns (Runtime Contract 5).
 
-1. **Open the land cycle.** Create a new `## Workpad — {{issue.identifier}} — Cycle N (Land)` comment (do not reuse the prior `In progress` cycle's workpad — see _Workpad Lifecycle_). The human-owned `In review` → `Land` transition has already been confirmed before this worker is dispatched; record it as the cycle trigger, but do not replay it through `/gh-project` or publish a duplicate status comment. All agent-owned transitions in this cycle (including `Land` → `Done` and classified exits) must carry their policy-authored body as `comment_body` through `/gh-project`.
+1. **Open the land cycle.** Create a new `## Workpad — {{issue.identifier}} — Cycle N (Land)` comment (adopt one already created for this cycle number by a retried worker; do not reuse the prior `In progress` cycle's workpad). The human-owned `In review` → `Land` transition has already been confirmed before this worker is dispatched; record it as the cycle trigger, but do not replay it through `/gh-project` or publish a duplicate status comment. All agent-owned transitions in this cycle (including `Land` → `Done` and classified exits) must carry their policy-authored body as `comment_body` through `/gh-project`.
 
-2. **Invoke the `/land` skill** (defined at `.codex/skills/land/SKILL.md`). The skill is responsible for:
-   - Running the **merged-PR precedence guard before any pre-flight check**: if the linked PR is already `MERGED`, skip branch freshness, mergeability, review, and failure classification; record the merged commit SHA and transition `Land` → `Done` through `/gh-project`, then exit.
-   - Pre-flight checks (approval, required CI checks, base-branch freshness, changeset presence if labeled — see the skill for the exact list).
-   - Running `/pull` if the branch is behind, then re-running pre-flight from scratch.
-   - Squash merge: `gh pr merge <pr-number> --squash --delete-branch`.
+2. **Invoke the `/land` skill.** The skill is responsible for:
+   - Running the **merged-PR precedence guard before any pre-flight check**: if the linked PR is already `MERGED`, skip everything else, record the merged commit SHA, and transition `Land` → `Done` through `/gh-project`, then exit.
+   - Pre-flight checks through `github_graphql`: ≥1 human `APPROVED` review, required checks green on the head commit, branch not behind base, changeset present if labeled, `mergeStateStatus` mergeable.
+   - **Freshness without rebase.** If the head is behind its base, update it server-side with `updatePullRequestBranch` (`updateMethod: MERGE`), then `git pull --ff-only origin <head>` locally so the host push at turn end is a no-op, wait for the re-queued required checks inside the same turn, and re-run pre-flight. A merge-update never rewrites approved commits: a prior human approval remains valid when the only commits after the approved commit are base-branch merge commits produced by this Land cycle. If branch protection still dismisses the approval, that is an external wait (`Land` → `In review`), not rework.
+   - Squash merge: `mergePullRequest` (`mergeMethod: SQUASH`, `expectedHeadOid` = the head you verified), then delete the head branch with `deleteRef`.
    - Recording the merged commit SHA and changeset path (if any) in the workpad.
    - Supplying the `🔁 Status: Land → Done` body as `comment_body` to `/gh-project`; the orchestrator publishes it after confirmed readback and the worker records the matching workpad line if it remains alive.
-   - Transitioning the issue to `Done` via `/gh-project` afterwards, as the last action of the turn (Posture 5 ordering).
+   - Transitioning the issue to `Done` via `/gh-project` afterwards, as the last action of the turn (Posture 7 ordering).
 
-3. **Close the land cycle.** Once `/land` completes, verify the orchestrator confirmed the `Land → Done` request and the workpad Status Transitions line was appended (cycle N close: land) if the worker remains alive. If `/land` exited before this step (e.g. due to dependency-skill failure noted in `.codex/skills/land/SKILL.md` Required Context), do not retry blindly — the skill's failure handling already recorded the cause.
+3. **Close the land cycle.** Once `/land` completes, verify the orchestrator confirmed the `Land → Done` request and the workpad Status Transitions line was appended (cycle N close: land) if the worker remains alive. If `/land` exited before this step, do not retry blindly — the skill's failure handling already recorded the cause.
 
 4. **On `/land` failure or wait.** The skill records the final evidence before any lifecycle transition, classifies it, and exits without merging only when it cannot safely complete the Land cycle:
    - **Merged-PR precedence guard (always first)** — before applying any classification below, re-read the linked PR state. If it is `MERGED`, record the merged commit SHA, prepare the `🔁 Status: Land → Done` body, and transition through `/gh-project`, then exit. Never classify a merged PR as rework or transition it to `Ready`, even when its deleted head branch makes freshness or mergeability checks fail.
-   - **Required CI pending or registering** — keep the issue in `Land` and wait in the current Land turn. This includes checks re-queued because `/pull` refreshed the branch. Only required checks gate this path: before `/pull`, record the required-check names returned by `gh pr checks <pr-number> --required --json name,bucket`. If that result is empty, no required CI is configured and this gate passes without a registration wait. Otherwise, poll every 10 seconds until those previously observed required checks appear on the fresh head, then use `gh pr checks <pr-number> --required --watch --interval 10` until it reaches a terminal state. Do not invoke `--watch` while no check suite is registered, because it exits immediately instead of waiting for a future suite. Limit check-registration polling to 5 minutes; if the expected required checks do not appear, record the new head SHA and polling evidence, then classify it as the external wait-only failure below. Do not treat a newly-running required check as a `Land` → `In review` failure. Once CI reaches a terminal state, re-run the **entire** Land pre-flight (approval, checks, freshness, changeset, mergeability, and review feedback): merge if it passes; otherwise classify the resulting concrete failure below.
-   - **Approval or other external wait-only failure** — no human `APPROVED` review or another condition awaiting human/external review after CI is terminal: complete the workpad evidence, prepare a status body stating the concrete pre-flight finding (which gate failed, on which head SHA, and what a human must do), and send it as `comment_body` while transitioning `Land` → `In review` via `/gh-project`. Do **not** write a `⛔ Blocker` comment.
-   - **Rework failure** — failed required CI, merge conflict, missing labeled Changeset, unresolved actionable review feedback, or another PR/code condition that the worker can address: prepare a status body with reason `Land-return rework: <cause>`, then transition `Land` → `Ready` via `/gh-project` with that body. The Ready-return rework guard opens the next cycle and routes it to `In progress`.
+   - **Required CI pending or registering** — keep the issue in `Land` and wait in the current Land turn: poll `prChecks` every 10 seconds until the previously observed required checks appear on the fresh head (at most 5 minutes), then keep polling until they reach a terminal state (at most 30 minutes). If no required checks are configured, this gate passes without a registration wait. Once CI reaches a terminal state, re-run the **entire** pre-flight: merge if it passes; otherwise classify the resulting concrete failure below. Do not spend more than one turn waiting; if the limits are exceeded, classify as the external wait-only failure.
+   - **Approval or other external wait-only failure** — no human `APPROVED` review on the current head (and the merge-update exemption above does not apply), or another condition awaiting human/external review after CI is terminal: complete the workpad evidence, prepare a status body stating the concrete pre-flight finding (which gate failed, on which head SHA, and what a human must do), and send it as `comment_body` while transitioning `Land` → `In review` via `/gh-project`. Do **not** write a `⛔ Blocker` comment.
+   - **Trivial conflict** — the server-side update reports a conflict confined to `.changeset/*`, `docs/**`, `CHANGELOG.md`, or `pnpm-lock.yaml`: resolve it locally with `git merge origin/<base>` (keep both changesets; regenerate the lockfile with the repository package manager (`pnpm install --lockfile-only` or `npm install --package-lock-only`) when needed), commit the merge, end the turn so the host pushes it, and re-run pre-flight next turn. No other file may be edited in a Land cycle.
+   - **Rework failure** — failed required CI, a source-file merge conflict, missing labeled Changeset, unresolved actionable review feedback, or another PR/code condition that the worker can address: prepare a status body with reason `Land-return rework: <cause>`, then transition `Land` → `Ready` via `/gh-project` with that body. The Ready-return rework guard opens the next cycle and routes it to `In progress`.
    - **External or permission blocker** — missing required context, authentication/board failure, or an external dependency the worker cannot resolve: write a `⛔ Blocker` comment, prepare a status body stating the unblock condition, then transition `Land` → `Backlog` via `/gh-project` with that body.
-   - **Immediately recoverable branch freshness** — when the branch is behind, run `/pull` and re-run the complete pre-flight sequence. Keep `Land` only for this in-run recovery path; if `/pull` fails, classify the failure using the rules above.
-
-This step performs no code edits, commits, or pushes itself — only the workpad/comment bookkeeping around the skill call. Any rework code change must come through the `Land` → `Ready` → `In progress` path.
 
 ### Guardrails
 
-- Write everything you publish — PR titles and bodies, commit messages, workpad comments, status transition comments, and any new issues — in English, regardless of the language the issue was written in.
+- Publish everything in English (Posture 2).
 - Do not edit the issue body for planning or progress tracking.
 - If the issue is in a terminal state, do nothing and exit.
 - If you find out-of-scope improvements, open a separate issue rather than expanding the current scope.
-- When moving an issue from `Ready` back to `Backlog`, always explain whether the reason is unclear requirements, oversized scope, or both.
+- When moving an issue from `Ready` back to `Backlog`, always explain whether the reason is unclear requirements, oversized scope, or both — and never repeat a triage rejection a human has already overridden.
 - Do not start implementation for issues sent back to `Backlog` in the same run.
-- When a PR exists, do not ignore inline review comments; read them all and reply to each one.
+- When a PR exists, read every review thread and reply to each one before handoff; resolve threads only after replying.
 - When an issue re-enters `Ready` or `In progress` with an existing PR, do not silently resume work; inspect the main merge blockers first and create a new workpad comment that restates the plan for the new work cycle. Within that cycle, update the same workpad comment — never create a second one.
 - If both an Issue and its linked PR appear in the Project, the Issue is the canonical item for planning, workpad lifecycle, and state transitions. The PR card supplies PR context only.
-- Current limitation: if only the PR card status changes while the canonical Issue card does not move into an active state, the worker may not be re-dispatched from that PR card status change alone.
+- Never rebase, amend, force-push, or switch branches (Runtime Contract 3–4). Never write scratch files inside the checkout (Runtime Contract 6).
+- Never mutate the Project board, labels of other issues, or unrelated repositories through `github_graphql`.
 
 ### Workpad Lifecycle
 
@@ -257,7 +311,7 @@ A **work cycle** is one continuous active stretch on an issue. It opens when the
 
 **Rules:**
 
-- Each cycle gets exactly **one** `## Workpad — {{issue.identifier}} — Cycle N` comment.
+- Each cycle gets exactly **one** `## Workpad — {{issue.identifier}} — Cycle N` comment. Before creating one, re-query the newest comments and adopt an existing workpad with the same cycle number (retried workers must not duplicate it).
 - Within a cycle, **edit** the existing workpad in place. Never create a second workpad for the same cycle.
 - When a new cycle opens, create a **new** workpad comment. Prior cycle workpads remain as historical audit records — do not silently rewrite them.
 - The "current" workpad is the newest open cycle comment. Identify it by searching for the most recent comment whose body starts with `## Workpad —`.
@@ -266,7 +320,7 @@ A **work cycle** is one continuous active stretch on an issue. It opens when the
 
 ### Status Transition Log
 
-(See Posture 5 for the orchestrator-owned publication rule.) For every requested lifecycle transition, the agent prepares this exact body and sends it as `/gh-project` `comment_body`:
+(See Posture 7 for the orchestrator-owned publication rule.) For every requested lifecycle transition, the agent prepares this exact body and sends it as `/gh-project` `comment_body`:
 
 ```md
 🔁 Status: `FROM` → `TO`
@@ -278,7 +332,7 @@ Cycle: <N> open|close
 After confirmed readback, the orchestrator publishes the body exactly once (or reports `unchanged` when the exact body already exists). The agent appends one matching line to the current workpad's `### Status Transitions` section if it remains alive:
 
 ```md
-- <ISO-8601 UTC ts> · `<FROM>` → `<TO>` · <reason> (cycle <N> open|close)
+- <ISO-8601 UTC ts from date -u> · `<FROM>` → `<TO>` · <reason> (cycle <N> open|close)
 ```
 
 On a failed request, no status comment is published; record the returned state/error and a failure line in the workpad. `reason` is _why this transition now_ — not a restatement of `TO`.
@@ -291,9 +345,9 @@ Used for all cycles. Land-cycle workpads keep Plan/Validation/Progress Log fille
 ## Workpad — {{issue.identifier}} — Cycle {N}
 
 **Type:** {fresh pickup | rework cycle (PR #X) | resume after blocker | land}
-**Branch:** {branch name}
+**Branch:** {assigned branch from `git branch --show-current`}
 **Draft PR:** {PR URL or `not yet created`}
-**Cycle opened:** {ISO ts} · **Trigger:** {one-line reason}
+**Cycle opened:** {ISO ts from date -u} · **Trigger:** {one-line reason}
 
 ### Status Transitions
 
@@ -304,10 +358,12 @@ Used for all cycles. Land-cycle workpads keep Plan/Validation/Progress Log fille
 
 ### Plan
 
-<!-- one item per turn (Step 2.3). LAST item is always the handoff.
-     Out-of-scope items go under Delegation below, never here. -->
+<!-- one item per turn (Step 2.3). Item 1 must produce a commit so the host
+     can push the branch; the Draft PR is opened the following turn (Step 2.4).
+     LAST item is always the handoff. Out-of-scope items go under Delegation. -->
 
-- [ ] 1. {task item}
+- [ ] 1. {first shippable slice — ends with a commit}
+- [ ] 2. Open Draft PR via /gh-pr-writeup (branch is on the remote now)
 - [ ] N. Wrap-up: re-verify the original issue · pass the Completion Bar · changeset (if needed) · PR ready · transition to In review
 
 ### Rework / PR Feedback
@@ -319,7 +375,7 @@ Used for all cycles. Land-cycle workpads keep Plan/Validation/Progress Log fille
 
 ### Completion Bar
 
-<!-- mirror of WORKFLOW.md Step 2.6; in-progress cycles only -->
+<!-- mirror of WORKFLOW.md Step 2.7; in-progress cycles only -->
 
 - [ ] In-scope requirements implemented
 - [ ] `pnpm lint`
@@ -329,21 +385,21 @@ Used for all cycles. Land-cycle workpads keep Plan/Validation/Progress Log fille
 - [ ] Docker E2E (if integration behavior changed)
 - [ ] Tests for new functionality (or justified N/A)
 - [ ] Code conventions (CLAUDE.md)
-- [ ] Inline review comments answered (rework only)
+- [ ] Review threads answered and resolved (rework only)
 
 ### Validation
 
-<!-- evidence: command, outcome, artifacts -->
+<!-- evidence: command, outcome, artifacts; flake exceptions cite the follow-up issue -->
 
-- {command} — {pass/fail}
+- {command} — {pass/fail | pass (documented exception: #n)}
 - Changeset: `{path or N/A}`
 - Docker E2E evidence: `{path or N/A}`
 - Merge commit (Land cycle only): `{SHA}`
 
 ### Delegation (out-of-scope / human / post-merge)
 
-<!-- items from {{issue.description}} that the agent does NOT do: deploy,
-     external URL smoke test, manual UX. Mirror into the PR body's
+<!-- items from the issue that the agent does NOT do: deploy, external URL
+     smoke test, manual UX, child issues split off. Mirror into the PR body's
      post-merge/human validation section. NOT blockers, NOT Plan checkboxes. -->
 
 - {none | item}
@@ -354,21 +410,41 @@ Used for all cycles. Land-cycle workpads keep Plan/Validation/Progress Log fille
 
 ### Blockers
 
-<!-- code-blockers only (Posture 2). On a code-blocker: write ⛔ here + as a
+<!-- code-blockers only (Posture 3). On a code-blocker: write ⛔ here + as a
      standalone issue comment, then park Status → Backlog. -->
 
 None
 ```
 
+### GitHub GraphQL Cookbook
+
+All GitHub reads and writes use the host-side `github_graphql` tool with a named operation and variables. Keep every operation scoped to `{{issue.repository}}` and this issue/PR. Read multi-line bodies from scratch files (`jq -n --rawfile body "$scratch/body.md" '{body: $body}'`) and pass them as variables — never inline them.
+
+| Need                                  | Operation                                                                                                                                                                                                                                                                                                                    |
+| ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Issue context (id, comments, PRs)     | `issueContext`: `repository(owner,name){ id issue(number){ id comments(last:50){nodes{id body author{login} createdAt}} closedByPullRequestsReferences(first:10, includeClosedPrs:true){nodes{id number url state isDraft merged headRefName baseRefName reviewDecision mergeCommit{oid}}} } }`                              |
+| Create / update workpad or comment    | `addComment(input:{subjectId, body}){commentEdge{node{id url}}}` · `updateIssueComment(input:{id, body}){issueComment{id}}`                                                                                                                                                                                                  |
+| Branch on remote?                     | `prBranchOnRemote`: `repository{ ref(qualifiedName:"refs/heads/<branch>"){ target{oid} } }` — also `compare` via `repository{ ref(qualifiedName:"refs/heads/main"){ compare(headRef:"<branch>"){ aheadBy behindBy } } }`                                                                                                     |
+| Create Draft PR                       | `createPullRequest(input:{repositoryId, baseRefName, headRefName, title, body, draft:true}){pullRequest{id number url}}`                                                                                                                                                                                                     |
+| Refresh PR body / mark ready          | `updatePullRequest(input:{pullRequestId, title, body})` · `markPullRequestReadyForReview(input:{pullRequestId}){pullRequest{isDraft}}` · `requestReviews(input:{pullRequestId, userIds, union:true})`                                                                                                                        |
+| Review state                          | `prReviewState`: `pullRequest(number){ id headRefOid reviewDecision reviews(last:30){nodes{state author{login} submittedAt commit{oid}}} reviewThreads(first:100){nodes{id isResolved isOutdated path comments(first:30){nodes{id body author{login} createdAt}}}} comments(last:30){nodes{body author{login} createdAt}} }` |
+| Reply to / resolve a review thread    | `addPullRequestReviewThreadReply(input:{pullRequestReviewThreadId, body}){comment{id}}` · `resolveReviewThread(input:{threadId}){thread{isResolved}}`                                                                                                                                                                        |
+| Checks and mergeability               | `prChecks`: `pullRequest(number){ mergeable mergeStateStatus headRefOid commits(last:1){nodes{commit{oid statusCheckRollup{state contexts(first:100){nodes{ ... on CheckRun{name status conclusion isRequired(pullRequestNumber:<n>)} ... on StatusContext{context state isRequired(pullRequestNumber:<n>)} }}}}}} }`        |
+| Update branch from base (Land only)   | `updatePullRequestBranch(input:{pullRequestId, updateMethod:MERGE}){pullRequest{headRefOid}}`                                                                                                                                                                                                                                |
+| Squash merge and delete branch (Land) | `mergePullRequest(input:{pullRequestId, mergeMethod:SQUASH, expectedHeadOid, commitHeadline}){pullRequest{merged mergeCommit{oid}}}` · `deleteRef(input:{refId})` where `refId` comes from `repository{ ref(qualifiedName:"refs/heads/<head>"){id} }`                                                                        |
+| Follow-up issue                       | `createIssue(input:{repositoryId, title, body, labelIds}){issue{number url}}` (label ids via `repository{ labels(first:50){nodes{id name}} }`)                                                                                                                                                                               |
+
+Do not use `gh` for any of these; it is unauthenticated inside the worker. Local `git` remains available for commits, diffs, and unauthenticated fetches of this public repository.
+
 ### Related Skills
 
-All skills referenced by this workflow live under `.codex/skills/<name>/SKILL.md` so the codex-driven worker can discover them.
+Skills live under `.codex/skills/<name>/SKILL.md` for the Codex runtime (the orchestrator layers `~/.gh-symphony/skills` and `.agent/skills` on top per run).
 
-- **`/gh-project`** — request run-scoped state reads/transitions from the orchestrator. The orchestrator owns canonical item identity, provider quota, mutation, retry/backoff, and exact-item readback; comments/workpad updates follow confirmed success only (Posture 8).
-- **`/gh-pr-writeup`** — scaffold or refresh the PR body. Two modes:
-  - _Initial Draft_ (Step 1): create a new Draft PR with TL;DR · change-point diagram · start-here guide · risks & rollback · changed files · `## Issues — Closed #<N>` · post-merge/human validation placeholders.
-  - _Refresh_ (Step 2.8): update the same PR body before `gh pr ready`.
+- **`/gh-project`** — request run-scoped state reads/transitions from the orchestrator. The orchestrator owns canonical item identity, provider quota, mutation, retry/backoff, and exact-item readback; comments/workpad updates follow confirmed success only (Posture 7).
+- **`/gh-pr-writeup`** — scaffold or refresh the PR body through `github_graphql`. Two modes:
+  - _Initial Draft_ (Step 2.4): `createPullRequest` with TL;DR · change-point diagram · start-here guide · risks & rollback · changed files · `## Issues — Closed #<N>` · post-merge/human validation placeholders.
+  - _Refresh_ (Step 2.9): `updatePullRequest` before `markPullRequestReadyForReview`.
 - **`/commit`** — produce logical-unit commits in conventional commit format.
-- **`/push`** — push the feature branch to origin; updates the Draft PR automatically.
-- **`/pull`** — rebase or merge the PR base branch into the head branch. Used by the `/land` skill's branch-freshness step.
-- **`/land`** — execute the Land workflow: pre-flight checks → squash merge → post-merge bookkeeping → transition to `Done`. Triggered by Step 4.
+- **`/push`** — explains the host-owned push (fast-forward only, assigned branch only) and the turn-end checklist. There is no agent-side push command.
+- **`/pull`** — merge the PR base branch into the assigned branch (never rebase). Used for rework and trivial Land conflicts.
+- **`/land`** — execute the Land workflow: merged-PR guard → pre-flight → server-side branch update → squash merge → post-merge bookkeeping → transition to `Done`. Triggered by Step 4.

--- a/hooks/after_create.sh
+++ b/hooks/after_create.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# gh-symphony `hooks.after_create` — runs once when a fresh issue worktree is
+# populated (SYMPHONY_REPOSITORY_PATH is the checkout). The daemon host must
+# export SYMPHONY_ALLOW_WORKFLOW_HOOKS=1 for hooks to execute; otherwise the
+# worker installs dependencies itself per WORKFLOW.md Runtime Contract 8.
+set -euo pipefail
+
+cd "${SYMPHONY_REPOSITORY_PATH:-$(pwd)}"
+
+if ! command -v pnpm >/dev/null 2>&1; then
+  corepack enable >/dev/null 2>&1 || true
+fi
+
+pnpm install --frozen-lockfile
+pnpm build


### PR DESCRIPTION
## Summary

Rewrites `WORKFLOW.md` and the worker skills for the gh-symphony **1.1.0** runtime and folds in fixes for problems observed during orchestrated work on the Moncher Stack board.

### 1.1.0 alignment (the daemon must be upgraded and re-initialized)

- Front matter: `tracker.provider.*` form (flat `tracker.*` keys are rejected since 1.0.0), `runtime:` block instead of the legacy `codex:` block, explicit `planning_states: []`, `agent.max_failure_retries: 3` (default 10), per-state concurrency caps, `repository.branch_template`/`base_branch`, and an `after_create` hook for dependency install.
- Prompt body now states the 1.0.0+ child-isolation contract: the agent has **no GitHub credentials** (`gh` unauthenticated, no `git push`); every GitHub read/write goes through the host-side `github_graphql` tool; the host pushes the **assigned branch** fast-forward-only at every turn end (so never rebase/amend/switch branches); PR creation happens the turn after the first commit.
- Uses the supported `pull_request_context` and `attempt` template variables instead of the stale "temporary compatibility note" and `gh pr list --search` heuristics.
- Skills (`gh-project`, `land`, `pull`, `push`, `gh-pr-writeup`) rewritten to the same contract: GraphQL comment/PR/merge operations, server-side `updatePullRequestBranch` in Land, merge-only `/pull`, host-owned push explanation.

### Workflow improvements from observed problems

- **Scratch files in the worktree** (`.tmp-reply-*.md`, `.tmp-pr-*-body.md`, `.transition-*.md`, `.codex/issue-*`) caused dirty-workspace recovery loops and quarantines → all scratch content goes to `mktemp -d` outside the checkout; clean `git status` is a hard turn-end rule; explicit recovery-context handling.
- **Environment flakes parked as `⛔ Blocker` → Backlog** (ports, containers, stale processes, missing deps) → Flake Protocol (isolated rerun, unrelated-failure exception with follow-up issue) and scope-proportional validation; `after_create` hook installs dependencies.
- **`Ready → In progress` after implementation** (board WIP invisible) → transition precedes implementation.
- **Stalled handoff not rescued when the PR was already non-draft** → safety net covers ready PRs with answered threads.
- **`/pull` rebase invalidated approvals → Land↔In review loops** → merge-only updates; approvals survive base-merge commits; trivial conflicts (changeset/docs/lockfile) resolved inside Land, source conflicts go to `Ready`.
- **Repeated oversized-scope triage rejections on epics/overridden issues** → `pickup_labels.exclude: [epic]` and a human-override rule (no repeated rejection; agent splits via child issues).
- **Fabricated timestamps, duplicate workpads from retried workers, unresolved review threads, Korean/English mix** → `date -u` only, adopt existing workpad for the same cycle, reply-then-resolve threads, English-only.
- Convergence rule made explicit: cycles without file changes (Land, terminal repairs) finish in 1–2 turns; CI waits happen inside one turn.

## Operator follow-up (not part of this PR)

1. Upgrade the daemon to `@gh-symphony/cli` ≥ 1.1.0 (the running daemon is 0.17.0) and re-initialize per the repo-embedded workspace-root migration: `gh-symphony repo stop && mv .runtime/orchestrator .runtime/orchestrator.pre-workspace-root && gh-symphony repo init && gh-symphony repo start`.
2. Export `SYMPHONY_ALLOW_WORKFLOW_HOOKS=1` in the daemon environment so `hooks/after_create.sh` runs; otherwise workers install dependencies themselves (Runtime Contract 8).

## Validation

- `gh-symphony workflow validate` (1.1.0 build from `packages/cli/dist`) — passed, no warnings
- `gh-symphony workflow preview --sample` — Liquid body renders (fresh and retry attempt)
## Changeset

- Not needed because this changes repository workflow policy and skills only, not the published CLI.

## Security

- No tokens or generated credentials are committed; `hooks/after_create.sh` only runs `pnpm install --frozen-lockfile && pnpm build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011JJ8vUT6surkSK3aonrtU7
