### PR TITLE
chore(workflow): raise codex read_timeout_ms to 30s

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -46,7 +46,7 @@ runtime:
   args:
     - app-server
   timeouts:
-    read_timeout_ms: 5000
+    read_timeout_ms: 30000
     turn_timeout_ms: 3600000
     stall_timeout_ms: 900000
 ---


### PR DESCRIPTION
## TL;DR

- `runtime.timeouts.read_timeout_ms` 5000 → 30000 in WORKFLOW.md.
- Policy-only change (no code, no changeset).

## Why

`thread/start` covers Codex app-server initialization including MCP server startup. On 2026-09-04 (host load average ~97) every attempt for #647 / #804 / #806 hit `response_timeout: thread/start timed out after 5000ms`, was recovered twice and then failure-suppressed (`max_failure_retries_exceeded`), so nothing could be dispatched. The same timeout already caused the first-attempt stalls on 2026-09-03. 30s still bounds a hung app-server (turn/stall timeouts are unchanged) while tolerating slow startups.

Part of the #808 recovery. The operator host currently runs with the same value as a local override until this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ByFE4XwtWX8x4nihCL5QgQ