### PR TITLE
test(cli): relax doctor entrypoint timeout

### DIFF
--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -546,7 +546,7 @@ describe("Commander CLI entrypoint", () => {
     }
 
     expect(JSON.parse(stdout.output())).toMatchObject({ projectId });
-  });
+  }, 15_000);
 });
 
 describe("config directory export", () => {


### PR DESCRIPTION
## Issues

- Closes #846

## Summary

- Raises the `doctor --project-dir` Commander-entrypoint test timeout from Vitest’s 5-second default to 15 seconds.
- Keeps the timeout local to the full doctor invocation so lightweight sibling CLI cases retain the default budget.

## Change-point diagram

- `packages/cli/src/index.test.ts` → Commander argument-forwarding TC → realistic CI timeout budget

## Start here

- `packages/cli/src/index.test.ts:519` — the doctor entrypoint forwarding test and its local timeout

## User-Visible Behavior / Operational Impact

- None. This changes only the test runner budget; CLI behavior and doctor checks are unchanged.

## Validation

- `pnpm exec vitest run packages/cli/src/index.test.ts` — pass (45 tests)
- `pnpm lint` — pass
- `pnpm test` — pass
- `pnpm typecheck` — pass
- `pnpm build` — pass
- `pnpm exec prettier --check packages/cli/src/index.test.ts` — pass
- Docker E2E / blackbox: not applicable because integration behavior did not change

## Changeset

- Not needed because this is a test-only reliability adjustment with no released behavior change.

## Risks & rollback

- Low risk: a genuinely stuck doctor entrypoint test now takes up to 15 seconds to fail. Revert commit `58813d9` to restore the former budget.

## Changed files

- `packages/cli/src/index.test.ts` — gives the full doctor entrypoint TC a CI-realistic timeout

## Post-merge / human validation

- [ ] None required

## Security

- [ ] No real tokens, private keys, `.env` files, or generated installation tokens are committed
