### PR TITLE
feat(observability): surface worker environment digest

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ gh-symphony project status --project-dir <path>                  # Show current 
 gh-symphony project status --project-dir <path> --watch          # Live terminal status
 ```
 
-For each active run, the status view labels and displays the opaque
+For each active run that has a recorded digest, the status view labels and displays the opaque
 `sha256:...` project-environment digest. Compare this value across runs to
 detect project `.env` changes; Symphony never exposes environment names or
 values through this surface.

--- a/README.md
+++ b/README.md
@@ -178,6 +178,11 @@ gh-symphony project status --project-dir <path>                  # Show current 
 gh-symphony project status --project-dir <path> --watch          # Live terminal status
 ```
 
+For each active run, the status view labels and displays the opaque
+`sha256:...` project-environment digest. Compare this value across runs to
+detect project `.env` changes; Symphony never exposes environment names or
+values through this surface.
+
 ### Observability Surfaces
 
 Use `gh-symphony project start --project-dir <path> --web` when you want the browser-based

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -87,6 +87,9 @@ the tracker adapter:
   snapshots that file after workspace hooks and uses the same snapshot for
   worker credential resolution, the missing-credential diagnostic, worker
   spawn, and a value-free persisted environment digest.
+- `packages/core/src/observability/snapshot-builder.ts` copies that opaque
+  project-environment digest into active-run status contracts, and the CLI
+  status renderers label it without exposing environment names or values.
 
 ### 3. Coordination — the orchestrator
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -406,6 +406,10 @@ gh-symphony project status --project-dir <path>                  # Show current 
 gh-symphony project status --project-dir <path> --watch          # Live dashboard
 ```
 
+Active-run rows include an opaque `sha256:...` project-environment digest.
+Operators can compare the digest across runs to detect project `.env` changes;
+the status surface never expands it into environment names or values.
+
 ### Repository Cache Maintenance
 
 ```bash

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -406,7 +406,8 @@ gh-symphony project status --project-dir <path>                  # Show current 
 gh-symphony project status --project-dir <path> --watch          # Live dashboard
 ```
 
-Active-run rows include an opaque `sha256:...` project-environment digest.
+Active-run rows with a recorded digest include the opaque `sha256:...`
+project-environment digest.
 Operators can compare the digest across runs to detect project `.env` changes;
 the status surface never expands it into environment names or values.
 

--- a/packages/cli/src/commands/status.test.ts
+++ b/packages/cli/src/commands/status.test.ts
@@ -213,6 +213,28 @@ describe("status command", () => {
     );
   });
 
+  it("omits the project-environment line when an active run has no digest", async () => {
+    const configDir = await createConfigFixture();
+    const statusPath = join(configDir, "status.json");
+    const status = JSON.parse(await readFile(statusPath, "utf8"));
+    status.activeRuns[0].environmentDigest = null;
+    await writeFile(statusPath, JSON.stringify(status));
+    const stdout = captureWrites(process.stdout);
+
+    try {
+      await statusCommand([], {
+        configDir,
+        verbose: false,
+        json: false,
+        noColor: true,
+      });
+    } finally {
+      stdout.restore();
+    }
+
+    expect(stdout.output()).not.toContain("Project environment:");
+  });
+
   it("labels a suffixless legacy workspace key", async () => {
     const configDir = await createConfigFixture();
     const stdout = captureWrites(process.stdout);

--- a/packages/cli/src/commands/status.test.ts
+++ b/packages/cli/src/commands/status.test.ts
@@ -102,6 +102,8 @@ async function createConfigFixture(
         activeRuns: [
           {
             runId: "run-1",
+            environmentDigest:
+              "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
             issueIdentifier: "acme/repo#1",
             issueWorkspaceKey: "acme_repo_1",
             issueState: "In Progress",
@@ -191,6 +193,26 @@ afterEach(() => {
 });
 
 describe("status command", () => {
+  it("shows the opaque project-environment digest for active runs", async () => {
+    const configDir = await createConfigFixture();
+    const stdout = captureWrites(process.stdout);
+
+    try {
+      await statusCommand([], {
+        configDir,
+        verbose: false,
+        json: false,
+        noColor: true,
+      });
+    } finally {
+      stdout.restore();
+    }
+
+    expect(stdout.output()).toContain(
+      "Project environment: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+    );
+  });
+
   it("labels a suffixless legacy workspace key", async () => {
     const configDir = await createConfigFixture();
     const stdout = captureWrites(process.stdout);

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -199,6 +199,9 @@ function renderLegacyStatus(
       lines.push(
         `    ${runIdDisplay}  ${run.issueIdentifier}  ${stateStr}  ${statusStr}`
       );
+      if (run.environmentDigest) {
+        lines.push(`      Project environment: ${run.environmentDigest}`);
+      }
       if (
         run.issueWorkspaceKey ===
           deriveLegacyWorkspaceKey(run.issueIdentifier) &&

--- a/packages/cli/src/dashboard/renderer.test.ts
+++ b/packages/cli/src/dashboard/renderer.test.ts
@@ -129,6 +129,50 @@ describe("renderDashboard", () => {
     );
   });
 
+  it("wraps the complete project-environment digest in a narrow terminal", () => {
+    const snapshot = loadFixture("busy");
+    const digest =
+      "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    snapshot.activeRuns[0] = {
+      ...snapshot.activeRuns[0],
+      environmentDigest: digest,
+    };
+
+    const output = renderDashboard([snapshot], {
+      terminalWidth: 80,
+      noColor: true,
+      now: NOW,
+    });
+    const lines = output.split("\n");
+    const digestStart = lines.findIndex((line) =>
+      line.includes("Project environment:")
+    );
+    const renderedDigest = lines
+      .slice(digestStart, digestStart + 2)
+      .join("")
+      .replace(/\s+/g, " ")
+      .replace(" Project environment: ", "")
+      .replaceAll(" ", "");
+
+    expect(renderedDigest).toBe(digest);
+  });
+
+  it("omits the project-environment line when an active run has no digest", () => {
+    const snapshot = loadFixture("busy");
+    snapshot.activeRuns[0] = {
+      ...snapshot.activeRuns[0],
+      environmentDigest: null,
+    };
+
+    const output = renderDashboard([snapshot], {
+      terminalWidth: 115,
+      noColor: true,
+      now: NOW,
+    });
+
+    expect(output).not.toContain("Project environment:");
+  });
+
   it("noColor=true produces no ANSI escape sequences", () => {
     const snapshot = loadFixture("busy");
     const output = renderDashboard([snapshot], {

--- a/packages/cli/src/dashboard/renderer.test.ts
+++ b/packages/cli/src/dashboard/renderer.test.ts
@@ -110,6 +110,25 @@ describe("renderDashboard", () => {
     expect(output).toContain("EVENT");
   });
 
+  it("renders the opaque project-environment digest for an active run", () => {
+    const snapshot = loadFixture("busy");
+    snapshot.activeRuns[0] = {
+      ...snapshot.activeRuns[0],
+      environmentDigest:
+        "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+    };
+
+    const output = renderDashboard([snapshot], {
+      terminalWidth: 115,
+      noColor: true,
+      now: NOW,
+    });
+
+    expect(output).toContain(
+      "Project environment: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+    );
+  });
+
   it("noColor=true produces no ANSI escape sequences", () => {
     const snapshot = loadFixture("busy");
     const output = renderDashboard([snapshot], {

--- a/packages/cli/src/dashboard/renderer.ts
+++ b/packages/cli/src/dashboard/renderer.ts
@@ -352,6 +352,9 @@ export function renderDashboard(
       for (const rawRun of snap.activeRuns) {
         const run = rawRun as ActiveRunView;
         lines.push(activeRunRow(run, now, evtWidth, c));
+        if (run.environmentDigest) {
+          lines.push(`    Project environment: ${run.environmentDigest}`);
+        }
       }
     }
     lines.push("");

--- a/packages/cli/src/dashboard/renderer.ts
+++ b/packages/cli/src/dashboard/renderer.ts
@@ -100,6 +100,29 @@ function compactSessionId(id: string | null | undefined): string {
   return `${id.slice(0, 4)}...${id.slice(-6)}`;
 }
 
+function wrapProjectEnvironmentDigest(digest: string, width: number): string[] {
+  const indent = "    ";
+  const label = "Project environment:";
+  const prefix = `${indent}${label} `;
+  if (prefix.length + digest.length <= width) return [`${prefix}${digest}`];
+
+  const lines: string[] = [];
+  const firstChunkLength = Math.max(0, width - prefix.length);
+  let offset = firstChunkLength;
+  lines.push(
+    firstChunkLength > 0
+      ? `${prefix}${digest.slice(0, firstChunkLength)}`
+      : `${indent}${label}`
+  );
+
+  const continuationWidth = Math.max(1, width - indent.length);
+  while (offset < digest.length) {
+    lines.push(`${indent}${digest.slice(offset, offset + continuationWidth)}`);
+    offset += continuationWidth;
+  }
+  return lines;
+}
+
 function fmtTokens(n: number): string {
   return n.toLocaleString("en-US");
 }
@@ -353,7 +376,9 @@ export function renderDashboard(
         const run = rawRun as ActiveRunView;
         lines.push(activeRunRow(run, now, evtWidth, c));
         if (run.environmentDigest) {
-          lines.push(`    Project environment: ${run.environmentDigest}`);
+          lines.push(
+            ...wrapProjectEnvironmentDigest(run.environmentDigest, width)
+          );
         }
       }
     }

--- a/packages/core/src/contracts/status-surface.ts
+++ b/packages/core/src/contracts/status-surface.ts
@@ -220,7 +220,7 @@ export type OrchestratorRunRecord = {
   issueWorkspaceKey: string | null;
   workspaceRuntimeDir: string;
   workflowPath: string | null;
-  /** SHA-256 digest of the effective worker host environment at spawn time. */
+  /** SHA-256 digest of the project environment snapshot consumed at spawn time. */
   environmentDigest?: string | null;
   retryKind: RetryKind | null;
   /** Persisted thread state shared across worker sessions. */
@@ -363,6 +363,8 @@ export type ProjectStatusSnapshot = {
     status: OrchestratorRunStatus;
     retryKind: RetryKind | null;
     port: number | null;
+    /** Opaque SHA-256 digest of the project environment; never contains names or values. */
+    environmentDigest?: string | null;
     processId?: number | null;
     turnCount?: number;
     startedAt?: string | null;

--- a/packages/core/src/observability/snapshot-builder.test.ts
+++ b/packages/core/src/observability/snapshot-builder.test.ts
@@ -1011,6 +1011,8 @@ describe("buildProjectSnapshot", () => {
   it("passes through processId, turnCount, startedAt, lastEvent, lastEventAt, tokenUsage to activeRuns", () => {
     const run = mockRun({
       runId: "run-live-001",
+      environmentDigest:
+        "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
       issueId: "issue-live-001",
       processId: 54321,
       turnCount: 5,
@@ -1036,6 +1038,9 @@ describe("buildProjectSnapshot", () => {
 
     expect(snapshot.activeRuns).toHaveLength(1);
     expect(snapshot.activeRuns[0].processId).toBe(54321);
+    expect(snapshot.activeRuns[0].environmentDigest).toBe(
+      "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+    );
     expect(snapshot.activeRuns[0].turnCount).toBe(5);
     expect(snapshot.activeRuns[0].startedAt).toBe("2024-01-01T00:01:00Z");
     expect(snapshot.activeRuns[0].lastEvent).toBe("Analyzing code structure");

--- a/packages/core/src/observability/snapshot-builder.test.ts
+++ b/packages/core/src/observability/snapshot-builder.test.ts
@@ -1008,7 +1008,7 @@ describe("buildProjectSnapshot", () => {
     expect(snapshot.retryQueue).toHaveLength(0);
   });
 
-  it("passes through processId, turnCount, startedAt, lastEvent, lastEventAt, tokenUsage to activeRuns", () => {
+  it("passes through processId, environmentDigest, turnCount, startedAt, lastEvent, lastEventAt, tokenUsage to activeRuns", () => {
     const run = mockRun({
       runId: "run-live-001",
       environmentDigest:
@@ -1053,6 +1053,20 @@ describe("buildProjectSnapshot", () => {
       1200
     );
     expect(snapshot.activeRuns[0].tokenUsage?.cumulativeTotalTokens).toBe(3700);
+  });
+
+  it("normalizes an absent environment digest to null", () => {
+    const input: SnapshotInput = {
+      project: mockProject(),
+      activeRuns: [mockRun({ environmentDigest: undefined })],
+      summary: { dispatched: 1, suppressed: 0, recovered: 0 },
+      lastTickAt: "2024-01-01T00:10:00Z",
+      lastError: null,
+    };
+
+    const snapshot = buildProjectSnapshot(input);
+
+    expect(snapshot.activeRuns[0].environmentDigest).toBeNull();
   });
 
   it("annotates active run token usage with cumulative issue totals", () => {

--- a/packages/core/src/observability/snapshot-builder.ts
+++ b/packages/core/src/observability/snapshot-builder.ts
@@ -98,6 +98,7 @@ export function buildProjectSnapshot(
       status: run.status,
       retryKind: run.retryKind,
       port: run.port,
+      environmentDigest: run.environmentDigest ?? null,
       runtimeSession: run.runtimeSession ?? null,
       // New fields from live worker data
       processId: run.processId ?? null,


### PR DESCRIPTION
## Issues

- Closes #864

## Summary

- Exposes each active run's opaque project-environment digest through the shared status snapshot and both CLI status presentations.
- Preserves the complete digest in narrow live-dashboard views by wrapping it onto width-safe continuation lines.
- Keeps legacy runs quiet when no digest was recorded and never exposes environment names or values.

## Change-point diagram

- persisted run record → shared status snapshot → legacy status and live terminal dashboard
- terminal width → digest wrapper → complete `sha256:...` value across bounded lines

## Start here

- `packages/core/src/observability/snapshot-builder.ts:101` — copies or null-normalizes the digest into the operator-facing contract
- `packages/cli/src/dashboard/renderer.ts:103` — wraps the full digest for narrow terminal widths
- `packages/cli/src/commands/status.ts:203` — renders the labeled digest in legacy status

## User-Visible Behavior / Operational Impact

- Active CLI status rows include `Project environment: sha256:...` when the run has a recorded digest.
- Narrow live dashboards wrap rather than silently truncate the digest, preserving all characters for comparison.
- Legacy runs without a recorded digest show no project-environment line.
- No environment name or value is included in the status snapshot or presentation.

## Validation

- `pnpm exec vitest run packages/core/src/observability/snapshot-builder.test.ts packages/cli/src/commands/status.test.ts packages/cli/src/dashboard/renderer.test.ts` — pass (71 tests; narrow-width regression observed red before implementation)
- `pnpm exec prettier --check README.md packages/cli/README.md packages/cli/src/dashboard/renderer.ts packages/cli/src/dashboard/renderer.test.ts packages/cli/src/commands/status.test.ts packages/core/src/observability/snapshot-builder.test.ts` — pass
- `pnpm lint` — pass on final merged head
- `pnpm test` — pass on final merged head
- `pnpm typecheck` — pass on final merged head
- `pnpm build` — pass on final merged head
- Docker E2E — not rerun for presentation-only rework; original integration validation environment exception is tracked in #866

## Changeset

- Not needed because issue #864 has no changeset label.

## Risks & rollback

- Low risk: the field remains optional, rendering is conditional, and wrapping only affects digest lines wider than the terminal. Revert `0dd3e59` to remove the rework while retaining the original surface.

## Changed files

- `packages/core/src/contracts/status-surface.ts` — documents the value-free status contract field
- `packages/core/src/observability/snapshot-builder.ts` — propagates and null-normalizes the persisted digest
- `packages/cli/src/commands/status.ts` — renders the digest in legacy status
- `packages/cli/src/dashboard/renderer.ts` — renders and width-wraps the complete digest in the live dashboard
- `packages/core/src/observability/snapshot-builder.test.ts` — covers present and absent digest contract behavior
- `packages/cli/src/commands/status.test.ts` — covers present and absent legacy presentation
- `packages/cli/src/dashboard/renderer.test.ts` — covers present, absent, and narrow-width presentation
- `README.md`, `packages/cli/README.md`, and `docs/architecture.md` — document the operator surface and compatibility behavior

## Post-merge / human validation

- [ ] Confirm the digest is readable in a live operator terminal with a real active run.

## Security

- [ ] No real tokens, private keys, `.env` files, or generated installation tokens are committed
