### PR TITLE
fix(tracker-github): reconcile tracker secret declarations

### DIFF
--- a/packages/runtime-claude/src/adapter.test.ts
+++ b/packages/runtime-claude/src/adapter.test.ts
@@ -75,6 +75,39 @@ describe("ClaudePrintRuntimeAdapter", () => {
     );
   });
 
+  it("strips tracker credentials from the adapter declaration", async () => {
+    const calls: Array<NodeJS.ProcessEnv | undefined> = [];
+    const { child, stdout, stderr } = createStubChild();
+    const adapter = new ClaudePrintRuntimeAdapter(
+      {
+        workingDirectory: "/workspace",
+        env: {
+          TRACKER_ADAPTER_SECRET: "secret",
+          UNDECLARED_TRACKER_VALUE: "visible",
+          SYMPHONY_TRACKER_SECRET_ENVIRONMENT_NAMES: JSON.stringify([
+            "TRACKER_ADAPTER_SECRET",
+          ]),
+        },
+      },
+      {
+        spawnImpl: (_command, _args, options) => {
+          calls.push(options.env);
+          queueMicrotask(() => {
+            stdout.end();
+            stderr.end();
+            child.emit("close", 0, null);
+          });
+          return child;
+        },
+      }
+    );
+
+    await adapter.spawnTurn({ messages: [] });
+
+    expect(calls[0]?.TRACKER_ADAPTER_SECRET).toBeUndefined();
+    expect(calls[0]?.UNDECLARED_TRACKER_VALUE).toBe("visible");
+  });
+
   it("strips every declared credential name at the agent-child boundary", async () => {
     const calls: Array<NodeJS.ProcessEnv | undefined> = [];
     const { child, stdout, stderr } = createStubChild();

--- a/packages/runtime-codex/src/runtime.test.ts
+++ b/packages/runtime-codex/src/runtime.test.ts
@@ -121,6 +121,21 @@ describe("createCodexDynamicToolSpecs", () => {
 });
 
 describe("buildCodexRuntimePlan", () => {
+  it("strips tracker credentials from the adapter declaration", () => {
+    const plan = buildCodexRuntimePlan({
+      projectId: "workspace-123",
+      workingDirectory: "/tmp/workspace-123",
+      trackerSecretEnvironmentNames: ["TRACKER_ADAPTER_SECRET"],
+      extraEnv: {
+        TRACKER_ADAPTER_SECRET: "secret",
+        UNDECLARED_TRACKER_VALUE: "visible",
+      },
+    });
+
+    expect(plan.env.TRACKER_ADAPTER_SECRET).toBeUndefined();
+    expect(plan.env.UNDECLARED_TRACKER_VALUE).toBe("visible");
+  });
+
   it("strips every declared credential name at the agent-child boundary", () => {
     const injectedCredentials = Object.fromEntries(
       AGENT_CHILD_CREDENTIAL_ENVIRONMENT_NAMES.map((name) => [name, "secret"])

--- a/packages/tracker-github/src/tracker-github.test.ts
+++ b/packages/tracker-github/src/tracker-github.test.ts
@@ -1282,6 +1282,15 @@ Prompt`,
         daemon: {},
       }
     );
+    // Keep one fixture per resolveWorkerCredentials return branch.
+    expect(directCredentials).toEqual({
+      GITHUB_GRAPHQL_TOKEN: "github-token",
+    });
+    expect(brokerCredentials).toEqual({
+      GITHUB_TOKEN_BROKER_URL: "https://broker.example/token",
+      GITHUB_TOKEN_BROKER_SECRET: "broker-secret",
+      GITHUB_TOKEN_CACHE_PATH: "/runtime/github-token.json",
+    });
     const injectedNames = new Set([
       ...Object.keys(directCredentials ?? {}),
       ...Object.keys(brokerCredentials ?? {}),

--- a/packages/tracker-github/src/tracker-github.test.ts
+++ b/packages/tracker-github/src/tracker-github.test.ts
@@ -1259,6 +1259,39 @@ Prompt`,
     });
   });
 
+  it("declares every GitHub credential environment name it can inject", () => {
+    const adapter = resolveTrackerAdapter({
+      adapter: "github-project",
+      bindingId: "project-123",
+    });
+    const directCredentials = adapter.resolveWorkerCredentials?.(
+      makeProjectConfig(),
+      {
+        project: { GITHUB_GRAPHQL_TOKEN: "github-token" },
+        daemon: {},
+      }
+    );
+    const brokerCredentials = adapter.resolveWorkerCredentials?.(
+      makeProjectConfig(),
+      {
+        project: {
+          GITHUB_TOKEN_BROKER_URL: "https://broker.example/token",
+          GITHUB_TOKEN_BROKER_SECRET: "broker-secret",
+          GITHUB_TOKEN_CACHE_PATH: "/runtime/github-token.json",
+        },
+        daemon: {},
+      }
+    );
+    const injectedNames = new Set([
+      ...Object.keys(directCredentials ?? {}),
+      ...Object.keys(brokerCredentials ?? {}),
+    ]);
+
+    expect(adapter.secretEnvironmentNames()).toEqual(
+      expect.arrayContaining([...injectedNames])
+    );
+  });
+
   it("propagates the configured GitHub GraphQL endpoint into worker env", () => {
     const adapter = resolveTrackerAdapter({
       adapter: "github-project",

--- a/packages/tracker-linear/src/tracker-linear.test.ts
+++ b/packages/tracker-linear/src/tracker-linear.test.ts
@@ -1499,6 +1499,10 @@ Prompt`,
       }
     );
 
+    expect(credentials).toEqual({
+      LINEAR_AUTHORIZATION: "Bearer lin-authorization",
+      LINEAR_API_KEY: "lin_api_key",
+    });
     expect(linearTrackerAdapter.secretEnvironmentNames()).toEqual(
       expect.arrayContaining(Object.keys(credentials ?? {}))
     );

--- a/packages/tracker-linear/src/tracker-linear.test.ts
+++ b/packages/tracker-linear/src/tracker-linear.test.ts
@@ -1487,6 +1487,23 @@ Prompt`,
     expect(env).toEqual({ LINEAR_API_KEY: "lin_project_key" });
   });
 
+  it("declares every Linear credential environment name it can inject", () => {
+    const credentials = linearTrackerAdapter.resolveWorkerCredentials?.(
+      makeProject(),
+      {
+        project: {
+          LINEAR_API_KEY: "lin_api_key",
+          LINEAR_AUTHORIZATION: "Bearer lin-authorization",
+        },
+        daemon: {},
+      }
+    );
+
+    expect(linearTrackerAdapter.secretEnvironmentNames()).toEqual(
+      expect.arrayContaining(Object.keys(credentials ?? {}))
+    );
+  });
+
   it("defaults blank tracker apiUrl to the Linear GraphQL endpoint", () => {
     const env = linearTrackerAdapter.buildWorkerEnvironment(
       makeProject({ apiUrl: "   " }),


### PR DESCRIPTION
## Issues

- Closes #869

## Summary

- Adds regression coverage proving GitHub and Linear tracker declarations include every credential key their adapters inject.
- Verifies both Codex and Claude strip synthetic tracker credentials supplied exclusively through adapter declarations.
- Strengthens adapter coverage so it fails if credential resolution unexpectedly returns nothing.

## Change-point diagram

- tracker-github / tracker-linear resolver outputs → pinned non-empty credential maps → declared secret-name superset assertions
- tracker adapter declarations → `SYMPHONY_TRACKER_SECRET_ENVIRONMENT_NAMES` → Codex and Claude child-environment stripping tests

## Start here

- `packages/tracker-github/src/tracker-github.test.ts:1262` — GitHub injection/declaration contract and resolver-branch fixtures
- `packages/tracker-linear/src/tracker-linear.test.ts:1490` — Linear injection/declaration contract
- `packages/runtime-codex/src/runtime.test.ts` — Codex declaration-driven stripping
- `packages/runtime-claude/src/adapter.test.ts` — Claude declaration-driven stripping

## User-Visible Behavior / Operational Impact

- None. The source corrections are already present on the base branch; this PR adds durable regression coverage.

## Validation

- `pnpm exec prettier --check packages/tracker-github/src/tracker-github.test.ts packages/tracker-linear/src/tracker-linear.test.ts` — pass
- `pnpm exec vitest run packages/tracker-github/src/tracker-github.test.ts packages/tracker-linear/src/tracker-linear.test.ts` — pass (163 tests)
- `pnpm lint` — pass
- `pnpm test` — pass
- `pnpm typecheck` — pass
- `pnpm build` — pass
- Docker E2E — not applicable: the diff is deterministic unit-test coverage only and changes no integration behavior

## Changeset

- Not needed because the PR changes tests only and has no shipped behavior.

## Risks & rollback

- Low risk: four test files only, with no production code changes.
- Reviewer focus: credential fixtures must enumerate every resolver return branch and remain non-empty.
- Rollback by reverting commits `6102416` and `a7cbe93`.

## Changed files

- `packages/tracker-github/src/tracker-github.test.ts` — asserts declared GitHub secrets cover pinned direct and broker injection results
- `packages/tracker-linear/src/tracker-linear.test.ts` — asserts declared Linear secrets cover pinned injection results
- `packages/runtime-codex/src/runtime.test.ts` — asserts Codex strips adapter-declared tracker credentials only
- `packages/runtime-claude/src/adapter.test.ts` — asserts Claude strips adapter-declared tracker credentials only

## Post-merge / human validation

- [ ] None

## Security

- [ ] No real tokens, private keys, `.env` files, or generated installation tokens are committed
