### PR TITLE
fix(cli): report effective workflow timeouts

### DIFF
--- a/.changeset/tidy-pandas-report.md
+++ b/.changeset/tidy-pandas-report.md
@@ -1,0 +1,5 @@
+---
+"@gh-symphony/cli": patch
+---
+
+Report the effective runtime timeout values and their configuration source from `workflow validate`, including a stable three-field JSON timeout object (#882).

--- a/README.md
+++ b/README.md
@@ -801,7 +801,7 @@ gh-symphony workflow init --non-interactive --project PVT_xxx --output WORKFLOW.
 gh-symphony workflow init --non-interactive --project PVT_xxx --dry-run
 ```
 
-`gh-symphony workflow validate` parses the target file, strictly renders the prompt body and continuation guidance with canonical sample variables, and prints a compact runtime/lifecycle summary.
+`gh-symphony workflow validate` parses the target file, strictly renders the prompt body and continuation guidance with canonical sample variables, and prints a compact runtime/lifecycle summary. Its `runtime.timeouts.*` values are the effective runtime settings: `runtime.timeouts` takes precedence over the legacy `codex.*_timeout_ms` fields, with documented defaults used when neither is configured.
 
 `gh-symphony workflow preview --issue owner/repo#123` is the fastest validation step after `workflow init`: it resolves the active managed project (or `--project-id`) and renders the exact worker prompt from the live GitHub Project issue. Linear workflows can preview a single issue with `gh-symphony workflow preview ENG-123`, which routes through the configured Linear tracker adapter and `LINEAR_API_KEY`. Keep `--sample <path-to-json>` for fixture-based debugging, and use `--attempt <n>` to inspect retry prompts before changing policy files.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -83,6 +83,11 @@ negative, that threshold is disabled, but the orchestrator still applies a hard
 30-minute elapsed-run fallback to prevent an indefinitely stuck worker. This is
 an intentional implementation-defined safety limit.
 
+`runtime.timeouts` is the preferred timeout configuration and takes precedence
+over the legacy `codex.*_timeout_ms` fields. `gh-symphony workflow validate`
+prints the effective values under `runtime.timeouts.*`, matching the values the
+orchestrator injects into a worker.
+
 Hooks are opt-in repository-local extensions, not shell snippets. Each hook
 value must be a path to an executable script; shell syntax and inline commands
 are rejected. Set `SYMPHONY_ALLOW_WORKFLOW_HOOKS=1` (or `true`) in the host

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -172,6 +172,11 @@ resets it; it is not a total turn-duration cap.
 the legacy `codex.*_timeout_ms` fields; documented defaults apply when neither
 location provides a value.
 
+In JSON output, effective timeout values are exposed as
+`summary.runtimeTimeouts.{readTimeoutMs,stallTimeoutMs,turnTimeoutMs}`. These
+replace the former `summary.codex.*TimeoutMs` fields, which could report values
+that the runtime did not use; no compatibility aliases are emitted.
+
 Lifecycle generation enables blocker checks for the first configured active
 state (`Todo` with built-in defaults) while leaving planning states disabled.
 An explicit `tracker.provider.blocker_check_states: []` disables blocker gating; this is

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -167,6 +167,11 @@ unanswerable request. To migrate an existing workflow, change either value to
 maximum silence interval for a Codex app-server turn. Every app-server output
 resets it; it is not a total turn-duration cap.
 
+`gh-symphony workflow validate` reports the effective values under
+`runtime.timeouts.*`. An explicit `runtime.timeouts` block takes precedence over
+the legacy `codex.*_timeout_ms` fields; documented defaults apply when neither
+location provides a value.
+
 Lifecycle generation enables blocker checks for the first configured active
 state (`Todo` with built-in defaults) while leaving planning states disabled.
 An explicit `tracker.provider.blocker_check_states: []` disables blocker gating; this is

--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -138,6 +138,7 @@ codex:
   stall_timeout_ms: 60000
   turn_timeout_ms: 120000`,
       expected: [30000, 900000, 1800000],
+      expectedSource: "runtime.timeouts",
     },
     {
       name: "legacy codex timeout fallback",
@@ -146,15 +147,30 @@ codex:
   stall_timeout_ms: 60000
   turn_timeout_ms: 120000`,
       expected: [7000, 60000, 120000],
+      expectedSource: "codex/defaults",
+    },
+    {
+      name: "runtime defaults over legacy codex timeouts",
+      frontMatter: `runtime:
+  kind: codex-app-server
+  command: codex
+  args: [app-server]
+codex:
+  read_timeout_ms: 7000
+  stall_timeout_ms: 60000
+  turn_timeout_ms: 120000`,
+      expected: [5000, 300000, 3600000],
+      expectedSource: "runtime.timeouts",
     },
     {
       name: "documented timeout defaults",
       frontMatter: "codex:\n  command: codex app-server",
       expected: [5000, 300000, 3600000],
+      expectedSource: "codex/defaults",
     },
   ])(
     "reports $name as effective runtime timeouts",
-    async ({ frontMatter, expected }) => {
+    async ({ frontMatter, expected, expectedSource }) => {
       const root = await mkdtemp(join(tmpdir(), "workflow-validate-timeouts-"));
       const workflowPath = join(root, "WORKFLOW.md");
       const stdout = captureWrites(process.stdout);
@@ -186,6 +202,32 @@ codex:
         `runtime.timeouts.turn_timeout_ms=${expected[2]}`
       );
       expect(stdout.output()).not.toContain("codex.read_timeout_ms=");
+      expect(stdout.output()).toContain(`(source: ${expectedSource})`);
+
+      const jsonStdout = captureWrites(process.stdout);
+      try {
+        await workflowCommand(["validate", "--file", workflowPath], {
+          configDir: root,
+          verbose: false,
+          json: true,
+          noColor: false,
+        });
+      } finally {
+        jsonStdout.restore();
+      }
+
+      const report = JSON.parse(jsonStdout.output()) as {
+        summary: {
+          runtimeTimeouts: Record<string, number>;
+          runtimeTimeoutSource: string;
+        };
+      };
+      expect(report.summary.runtimeTimeouts).toEqual({
+        readTimeoutMs: expected[0],
+        stallTimeoutMs: expected[1],
+        turnTimeoutMs: expected[2],
+      });
+      expect(report.summary.runtimeTimeoutSource).toBe(expectedSource);
     }
   );
 

--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -122,6 +122,73 @@ describe("workflow command handler", () => {
     expect(stdout.output()).toContain("active_states=Ready, In progress");
   });
 
+  it.each([
+    {
+      name: "runtime timeout precedence",
+      frontMatter: `runtime:
+  kind: codex-app-server
+  command: codex
+  args: [app-server]
+  timeouts:
+    read_timeout_ms: 30000
+    stall_timeout_ms: 900000
+    turn_timeout_ms: 1800000
+codex:
+  read_timeout_ms: 7000
+  stall_timeout_ms: 60000
+  turn_timeout_ms: 120000`,
+      expected: [30000, 900000, 1800000],
+    },
+    {
+      name: "legacy codex timeout fallback",
+      frontMatter: `codex:
+  read_timeout_ms: 7000
+  stall_timeout_ms: 60000
+  turn_timeout_ms: 120000`,
+      expected: [7000, 60000, 120000],
+    },
+    {
+      name: "documented timeout defaults",
+      frontMatter: "codex:\n  command: codex app-server",
+      expected: [5000, 300000, 3600000],
+    },
+  ])(
+    "reports $name as effective runtime timeouts",
+    async ({ frontMatter, expected }) => {
+      const root = await mkdtemp(join(tmpdir(), "workflow-validate-timeouts-"));
+      const workflowPath = join(root, "WORKFLOW.md");
+      const stdout = captureWrites(process.stdout);
+
+      await writeFile(
+        workflowPath,
+        `---\ntracker:\n  kind: github-project\n${frontMatter}\n---\nPrompt {{ issue.identifier }}\n`,
+        "utf8"
+      );
+
+      try {
+        await workflowCommand(["validate", "--file", workflowPath], {
+          configDir: root,
+          verbose: false,
+          json: false,
+          noColor: false,
+        });
+      } finally {
+        stdout.restore();
+      }
+
+      expect(stdout.output()).toContain(
+        `runtime.timeouts.read_timeout_ms=${expected[0]}`
+      );
+      expect(stdout.output()).toContain(
+        `runtime.timeouts.stall_timeout_ms=${expected[1]}`
+      );
+      expect(stdout.output()).toContain(
+        `runtime.timeouts.turn_timeout_ms=${expected[2]}`
+      );
+      expect(stdout.output()).not.toContain("codex.read_timeout_ms=");
+    }
+  );
+
   it("prints a typed error when a removed flat tracker key is configured", async () => {
     const root = await mkdtemp(join(tmpdir(), "workflow-validate-priority-"));
     const workflowPath = join(root, "WORKFLOW.md");

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -112,6 +112,7 @@ type WorkflowValidationReport = {
       stallTimeoutMs: number;
       turnTimeoutMs: number;
     };
+    runtimeTimeoutSource: "runtime.timeouts" | "codex/defaults";
     hooks: {
       afterCreate: string | null;
       beforeRun: string | null;
@@ -846,6 +847,7 @@ function validateWorkflow(
         return "pass" as const;
       })()
     : ("skip" as const);
+  const effectiveTimeouts = resolveWorkflowRuntimeTimeouts(workflow);
 
   return {
     ok: true,
@@ -882,7 +884,14 @@ function validateWorkflow(
         threadSandbox: workflow.codex.threadSandbox,
         turnSandboxPolicy: workflow.codex.turnSandboxPolicy,
       },
-      runtimeTimeouts: resolveWorkflowRuntimeTimeouts(workflow),
+      runtimeTimeouts: {
+        readTimeoutMs: effectiveTimeouts.readTimeoutMs,
+        stallTimeoutMs: effectiveTimeouts.stallTimeoutMs,
+        turnTimeoutMs: effectiveTimeouts.turnTimeoutMs,
+      },
+      runtimeTimeoutSource: workflow.runtime
+        ? "runtime.timeouts"
+        : "codex/defaults",
       hooks: {
         afterCreate: workflow.hooks.afterCreate,
         beforeRun: workflow.hooks.beforeRun,
@@ -921,9 +930,9 @@ Runtime
   codex.approval_policy=${report.summary.codex.approvalPolicy ?? "unset"}
   codex.thread_sandbox=${report.summary.codex.threadSandbox ?? "unset"}
   codex.turn_sandbox_policy=${report.summary.codex.turnSandboxPolicy ?? "unset"}
-  runtime.timeouts.read_timeout_ms=${report.summary.runtimeTimeouts.readTimeoutMs}
-  runtime.timeouts.stall_timeout_ms=${report.summary.runtimeTimeouts.stallTimeoutMs}
-  runtime.timeouts.turn_timeout_ms=${report.summary.runtimeTimeouts.turnTimeoutMs}
+  runtime.timeouts.read_timeout_ms=${report.summary.runtimeTimeouts.readTimeoutMs} (source: ${report.summary.runtimeTimeoutSource})
+  runtime.timeouts.stall_timeout_ms=${report.summary.runtimeTimeouts.stallTimeoutMs} (source: ${report.summary.runtimeTimeoutSource})
+  runtime.timeouts.turn_timeout_ms=${report.summary.runtimeTimeouts.turnTimeoutMs} (source: ${report.summary.runtimeTimeoutSource})
 
 Hooks
   after_create=${report.summary.hooks.afterCreate ?? "unset"}

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -7,6 +7,7 @@ import {
   WorkflowValidationError,
   renderPrompt,
   resolveWorkflowExecutionPhase,
+  resolveWorkflowRuntimeTimeouts,
   type TrackedIssue,
 } from "@gh-symphony/core";
 import {
@@ -105,6 +106,8 @@ type WorkflowValidationReport = {
       approvalPolicy: string | null;
       threadSandbox: string | null;
       turnSandboxPolicy: string | null;
+    };
+    runtimeTimeouts: {
       readTimeoutMs: number;
       stallTimeoutMs: number;
       turnTimeoutMs: number;
@@ -878,10 +881,8 @@ function validateWorkflow(
         approvalPolicy: workflow.codex.approvalPolicy,
         threadSandbox: workflow.codex.threadSandbox,
         turnSandboxPolicy: workflow.codex.turnSandboxPolicy,
-        readTimeoutMs: workflow.codex.readTimeoutMs,
-        stallTimeoutMs: workflow.codex.stallTimeoutMs,
-        turnTimeoutMs: workflow.codex.turnTimeoutMs,
       },
+      runtimeTimeouts: resolveWorkflowRuntimeTimeouts(workflow),
       hooks: {
         afterCreate: workflow.hooks.afterCreate,
         beforeRun: workflow.hooks.beforeRun,
@@ -920,9 +921,9 @@ Runtime
   codex.approval_policy=${report.summary.codex.approvalPolicy ?? "unset"}
   codex.thread_sandbox=${report.summary.codex.threadSandbox ?? "unset"}
   codex.turn_sandbox_policy=${report.summary.codex.turnSandboxPolicy ?? "unset"}
-  codex.read_timeout_ms=${report.summary.codex.readTimeoutMs}
-  codex.stall_timeout_ms=${report.summary.codex.stallTimeoutMs}
-  codex.turn_timeout_ms=${report.summary.codex.turnTimeoutMs}
+  runtime.timeouts.read_timeout_ms=${report.summary.runtimeTimeouts.readTimeoutMs}
+  runtime.timeouts.stall_timeout_ms=${report.summary.runtimeTimeouts.stallTimeoutMs}
+  runtime.timeouts.turn_timeout_ms=${report.summary.runtimeTimeouts.turnTimeoutMs}
 
 Hooks
   after_create=${report.summary.hooks.afterCreate ?? "unset"}


### PR DESCRIPTION
## Issues

- Closes #882

## Summary

- TL;DR: make `workflow validate` report the effective timeout values used by the runtime.
- Resolve precedence through the shared core helper, expose a stable three-field JSON object, and identify the effective configuration source.
- Cover explicit runtime settings, legacy `codex` fallback, parser-materialized runtime defaults, and documented defaults.

## Change-point diagram

- `WORKFLOW.md` → core parser → `resolveWorkflowRuntimeTimeouts` → narrowed CLI validation summary → text/JSON report

## Start here

- `packages/cli/src/commands/workflow.ts:847` — resolves and narrows effective runtime timeouts for the report.
- `packages/cli/src/commands/workflow.test.ts:125` — pins precedence, all four front-matter shapes, sources, and the JSON key set.

## User-Visible Behavior / Operational Impact

- Text output reports the values the runtime uses under `runtime.timeouts.*` and identifies `runtime.timeouts` versus `codex/defaults`.
- JSON output moves effective values from the misleading `summary.codex.*TimeoutMs` fields to `summary.runtimeTimeouts.*`; no compatibility aliases preserve the incorrect fields.
- Runtime execution and timeout precedence are unchanged. The separate parser/resolver precedence defect is tracked in #888.

## Validation

- `pnpm exec prettier --check packages/cli/src/commands/workflow.ts packages/cli/src/commands/workflow.test.ts packages/cli/README.md .changeset/tidy-pandas-report.md` — pass
- `pnpm exec vitest run packages/cli/src/commands/workflow.test.ts` — pass (23 tests)
- Repository `WORKFLOW.md` smoke validation — pass (`30000`, `900000`, `3600000`, source `runtime.timeouts`)
- `pnpm lint` — pass
- `pnpm test` — pass
- `pnpm typecheck` — pass
- `pnpm build` — pass
- Docker E2E — not applicable: CLI reporting only; runtime/integration behavior is unchanged

## Changeset

- `.changeset/tidy-pandas-report.md` (patch)

## Risks & rollback

- Low risk: the change reuses the runtime resolver and explicitly narrows its result. JSON consumers must migrate to the documented truthful keys; rollback is commits `2a51e85` and `fc43c5b`.

## Changed files

- `packages/cli/src/commands/workflow.ts` — report narrowed effective timeouts and their source.
- `packages/cli/src/commands/workflow.test.ts` — cover precedence, fallback, defaults, mixed runtime configuration, labels, and JSON shape.
- `README.md` — document effective validation output.
- `packages/cli/README.md` — document timeout semantics and the JSON key migration.
- `docs/configuration.md` — document timeout precedence and worker parity.
- `.changeset/tidy-pandas-report.md` — release-note the CLI behavior fix.

## Post-merge / human validation

- [ ] None

## Security

- [ ] No real tokens, private keys, `.env` files, or generated installation tokens are committed
